### PR TITLE
fix(sentinel): rely on uuids instead of timestamps as sentinel triggerid

### DIFF
--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -298,7 +299,9 @@ func (r *SentinelReconciler) triggerReconciliation(ctx context.Context, resource
 		return fmt.Errorf("failed to get OpenBaoCluster: %w", err)
 	}
 
-	triggerID := time.Now().UTC().Format(time.RFC3339Nano)
+	// Use UUID instead of timestamp to avoid timing-related race conditions
+	// when the operator processes triggers.
+	triggerID := string(uuid.NewUUID())
 	original := cluster.DeepCopy()
 
 	if cluster.Status.Sentinel == nil {

--- a/internal/controller/openbaocluster/controller_test.go
+++ b/internal/controller/openbaocluster/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -1413,7 +1414,8 @@ var _ = Describe("OpenBaoCluster Multi-Tenancy", func() {
 				if updatedCluster.Status.Sentinel == nil {
 					updatedCluster.Status.Sentinel = &openbaov1alpha1.SentinelStatus{}
 				}
-				updatedCluster.Status.Sentinel.TriggerID = "2025-01-15T10:30:45.123456789Z"
+				// Use UUID instead of timestamp to avoid timing-related issues
+				updatedCluster.Status.Sentinel.TriggerID = string(uuid.NewUUID())
 				now := metav1.Now()
 				updatedCluster.Status.Sentinel.TriggeredAt = &now
 				updatedCluster.Status.Sentinel.TriggerResource = "StatefulSet/test-sentinel-cluster"

--- a/test/e2e/07_sentinel_drift_detection_test.go
+++ b/test/e2e/07_sentinel_drift_detection_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -318,7 +319,8 @@ var _ = Describe("Sentinel: Drift Detection and Fast-Path Reconciliation", Label
 		By("verifying the operator responds to a Sentinel trigger via status")
 		// Simulate Sentinel emitting a drift trigger by patching status.sentinel.*.
 		// This avoids relying on non-deterministic timing of real drift detection.
-		triggerID := time.Now().UTC().Format(time.RFC3339Nano)
+		// Use UUID instead of timestamp to avoid flakiness from timing differences.
+		triggerID := string(uuid.NewUUID())
 		cluster := &openbaov1alpha1.OpenBaoCluster{}
 		Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: f.Namespace}, cluster)).To(Succeed())
 		original := cluster.DeepCopy()


### PR DESCRIPTION
## Description

The sentinel relied on timestamps for triggerId's, which isn't robust. Instead of relying on timestamps we now use UUID's, this also prevents timing related flakiness in the sentinel tests.

## Related Issues

N/A

## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.

## Verification Process

Verified by running: `make test-e2e E2E_PARALLEL_NODES=4 E2E_LABEL_FILTER="sentinel"`
