### PR TITLE
fix(infra): exclude job pods from pdb

### DIFF
--- a/internal/infra/pdb_test.go
+++ b/internal/infra/pdb_test.go
@@ -1,0 +1,241 @@
+package infra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/constants"
+)
+
+func TestEnsurePodDisruptionBudget(t *testing.T) {
+	k8sClient := newTestClient(t)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system", "", nil)
+
+	cluster := newMinimalCluster("pdb-test", "default")
+	cluster.Spec.Replicas = 3
+
+	ctx := context.Background()
+
+	if err := manager.ensurePodDisruptionBudget(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensurePodDisruptionBudget() error = %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      pdbName(cluster),
+	}, pdb)
+	if err != nil {
+		t.Fatalf("expected PDB to exist: %v", err)
+	}
+
+	// Verify name
+	expectedName := cluster.Name + "-pdb"
+	if pdb.Name != expectedName {
+		t.Errorf("expected PDB name %q, got %q", expectedName, pdb.Name)
+	}
+
+	// Verify MaxUnavailable is 1
+	if pdb.Spec.MaxUnavailable == nil {
+		t.Fatal("expected MaxUnavailable to be set")
+	}
+	if pdb.Spec.MaxUnavailable.IntValue() != 1 {
+		t.Errorf("expected MaxUnavailable=1, got %d", pdb.Spec.MaxUnavailable.IntValue())
+	}
+
+	// Verify selector has correct labels
+	if pdb.Spec.Selector == nil {
+		t.Fatal("expected PDB Selector to be set")
+	}
+	expectedLabels := map[string]string{
+		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
+		constants.LabelAppInstance:    cluster.Name,
+		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelOpenBaoCluster: cluster.Name,
+	}
+	for key, expectedVal := range expectedLabels {
+		if pdb.Spec.Selector.MatchLabels[key] != expectedVal {
+			t.Errorf("expected PDB selector label %s=%s, got %s", key, expectedVal, pdb.Spec.Selector.MatchLabels[key])
+		}
+	}
+}
+
+func TestEnsurePodDisruptionBudgetExcludesJobPods(t *testing.T) {
+	k8sClient := newTestClient(t)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system", "", nil)
+
+	cluster := newMinimalCluster("pdb-exclude-jobs", "default")
+	cluster.Spec.Replicas = 3
+
+	ctx := context.Background()
+
+	if err := manager.ensurePodDisruptionBudget(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensurePodDisruptionBudget() error = %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      pdbName(cluster),
+	}, pdb)
+	if err != nil {
+		t.Fatalf("expected PDB to exist: %v", err)
+	}
+
+	// Verify MatchExpressions excludes Job pods (backup, restore, upgrade-snapshot)
+	if pdb.Spec.Selector == nil {
+		t.Fatal("expected PDB Selector to be set")
+	}
+	if len(pdb.Spec.Selector.MatchExpressions) == 0 {
+		t.Fatal("expected PDB Selector to have MatchExpressions for excluding Job pods")
+	}
+
+	// Find the expression that excludes Job components
+	foundExclusion := false
+	for _, expr := range pdb.Spec.Selector.MatchExpressions {
+		if expr.Key == constants.LabelOpenBaoComponent &&
+			expr.Operator == metav1.LabelSelectorOpNotIn {
+			foundExclusion = true
+
+			// Verify all Job components are excluded
+			expectedValues := map[string]bool{
+				"backup":           false,
+				"restore":          false,
+				"upgrade-snapshot": false,
+			}
+			for _, v := range expr.Values {
+				if _, ok := expectedValues[v]; ok {
+					expectedValues[v] = true
+				}
+			}
+			for val, found := range expectedValues {
+				if !found {
+					t.Errorf("expected MatchExpressions to exclude %q component", val)
+				}
+			}
+			break
+		}
+	}
+	if !foundExclusion {
+		t.Error("expected MatchExpressions to contain NotIn expression for openbao.org/component")
+	}
+}
+
+func TestEnsurePodDisruptionBudgetSkipsSingleReplica(t *testing.T) {
+	k8sClient := newTestClient(t)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system", "", nil)
+
+	cluster := newMinimalCluster("pdb-single", "default")
+	cluster.Spec.Replicas = 1
+
+	ctx := context.Background()
+
+	if err := manager.ensurePodDisruptionBudget(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensurePodDisruptionBudget() error = %v", err)
+	}
+
+	// PDB should NOT be created for single-replica clusters
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      pdbName(cluster),
+	}, pdb)
+	if err == nil {
+		t.Fatal("expected PDB to NOT be created for single-replica cluster")
+	}
+}
+
+func TestEnsurePodDisruptionBudgetLabels(t *testing.T) {
+	k8sClient := newTestClient(t)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system", "", nil)
+
+	cluster := newMinimalCluster("pdb-labels", "default")
+	cluster.Spec.Replicas = 5
+
+	ctx := context.Background()
+
+	if err := manager.ensurePodDisruptionBudget(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensurePodDisruptionBudget() error = %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      pdbName(cluster),
+	}, pdb)
+	if err != nil {
+		t.Fatalf("expected PDB to exist: %v", err)
+	}
+
+	// Verify PDB metadata labels
+	expectedLabels := map[string]string{
+		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
+		constants.LabelAppInstance:    cluster.Name,
+		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelOpenBaoCluster: cluster.Name,
+	}
+	for key, expectedVal := range expectedLabels {
+		if pdb.Labels[key] != expectedVal {
+			t.Errorf("expected PDB label %s=%s, got %s", key, expectedVal, pdb.Labels[key])
+		}
+	}
+}
+
+func TestEnsurePodDisruptionBudgetIsIdempotent(t *testing.T) {
+	k8sClient := newTestClient(t)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system", "", nil)
+
+	cluster := newMinimalCluster("pdb-idempotent", "default")
+	cluster.Spec.Replicas = 3
+
+	ctx := context.Background()
+
+	// Create PDB first time
+	if err := manager.ensurePodDisruptionBudget(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensurePodDisruptionBudget() first call error = %v", err)
+	}
+
+	// Get initial resource version
+	pdb1 := &policyv1.PodDisruptionBudget{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      pdbName(cluster),
+	}, pdb1); err != nil {
+		t.Fatalf("expected PDB to exist: %v", err)
+	}
+
+	// Call again (should be idempotent)
+	if err := manager.ensurePodDisruptionBudget(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensurePodDisruptionBudget() second call error = %v", err)
+	}
+
+	// Verify PDB still exists
+	pdb2 := &policyv1.PodDisruptionBudget{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      pdbName(cluster),
+	}, pdb2); err != nil {
+		t.Fatalf("expected PDB to still exist: %v", err)
+	}
+}
+
+func TestPDBName(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+		},
+	}
+
+	expectedName := "my-cluster-pdb"
+	actualName := pdbName(cluster)
+	if actualName != expectedName {
+		t.Errorf("expected pdbName() = %q, got %q", expectedName, actualName)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where the PodDisruptionBudget (PDB) selector was incorrectly matching backup, restore, and upgrade snapshot Job pods. Kubernetes Jobs do not support the scale sub resource required by PDBs, causing controllers (like ArgoCD) to report errors such as `CalculateExpectedPodCountFailed: jobs.batch does not implement the scale subresource`.

The fix involves updating the PDB selector in `internal/infra/pdb.go` to explicitly exclude pods with the `openbao.org/component` label set to `backup`, `restore`, or `upgrade-snapshot` using `MatchExpressions`.

Additionally, unit tests have been added in `internal/infra/pdb_test.go` to verify PDB creation, correct selector logic, single-replica skipping, and idempotency.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.

## Verification Process

1. Deploy the operator with these changes.
2. Trigger a backup job (e.g., via cron schedule or manual job creation).
3. Inspect the PDB status: `kubectl get pdb -n <namespace> <pdb-name> -o yaml`.
4. Verify that the PDB status does not show `CalculateExpectedPodCountFailed` errors.
5. Verify that the PDB selector correctly excludes the backup job pods: `kubectl get pdb <pdb-name> -o jsonpath='{.spec.selector}'` should show the `MatchExpressions` exclusion.