### PR TITLE
refactor(controller): simplify status reconciling

### DIFF
--- a/internal/controller/openbaocluster/cluster_state.go
+++ b/internal/controller/openbaocluster/cluster_state.go
@@ -1,0 +1,244 @@
+package openbaocluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/constants"
+	openbaolabels "github.com/dc-tec/openbao-operator/internal/openbao"
+	"github.com/dc-tec/openbao-operator/internal/revision"
+)
+
+// clusterState holds the observed state used for status computation.
+// This separates API calls from condition logic to reduce cyclomatic complexity.
+type clusterState struct {
+	// StatefulSet observed state
+	StatefulSet   *appsv1.StatefulSet
+	ReadyReplicas int32
+	Available     bool
+	StatusStale   bool // StatefulSet status may lag behind reality
+
+	// Pod state
+	Pods             []corev1.Pod
+	Pod0             *corev1.Pod
+	LeaderName       string
+	LeaderCount      int
+	Initialized      bool
+	InitializedKnown bool
+	Sealed           bool
+	SealedKnown      bool
+
+	// Backup state
+	BackupJobName    string
+	BackupInProgress bool
+
+	// Upgrade state (computed from cluster.Status)
+	UpgradeFailed            bool
+	UpgradeInProgress        bool
+	RollingUpgradeInProgress bool
+	BlueGreenInProgress      bool
+
+	// Active revision for blue/green deployments
+	ActiveRevision string
+}
+
+// gatherClusterState performs all API calls to observe cluster state.
+// This separates data gathering from condition computation.
+func (r *OpenBaoClusterReconciler) gatherClusterState(
+	ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster,
+) (*clusterState, error) {
+	state := &clusterState{}
+
+	// Compute upgrade state from cluster.Status
+	state.RollingUpgradeInProgress = cluster.Status.Upgrade != nil
+	if state.RollingUpgradeInProgress && cluster.Status.Upgrade.LastErrorReason != "" {
+		state.UpgradeFailed = true
+	}
+
+	state.BlueGreenInProgress = cluster.Status.BlueGreen != nil &&
+		cluster.Status.BlueGreen.Phase != "" &&
+		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle
+
+	state.UpgradeInProgress = (state.RollingUpgradeInProgress && !state.UpgradeFailed) || state.BlueGreenInProgress
+
+	// Find active backup job
+	if err := r.gatherBackupState(ctx, cluster, state); err != nil {
+		return nil, err
+	}
+
+	// Get StatefulSet state
+	if err := r.gatherStatefulSetState(ctx, logger, cluster, state); err != nil {
+		return nil, err
+	}
+
+	// Get pod state
+	if err := r.gatherPodState(ctx, cluster, state); err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+func (r *OpenBaoClusterReconciler) gatherBackupState(
+	ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, state *clusterState,
+) error {
+	jobList := &batchv1.JobList{}
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		constants.LabelAppInstance:      cluster.Name,
+		constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelOpenBaoCluster:   cluster.Name,
+		constants.LabelOpenBaoComponent: constants.ComponentBackup,
+	})
+
+	if err := r.List(ctx, jobList,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
+		return fmt.Errorf("failed to list backup Jobs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	}
+
+	for i := range jobList.Items {
+		job := &jobList.Items[i]
+		if job.Status.Succeeded == 0 && job.Status.Failed == 0 {
+			state.BackupJobName = job.Name
+			state.BackupInProgress = true
+			break
+		}
+	}
+
+	return nil
+}
+
+func (r *OpenBaoClusterReconciler) gatherStatefulSetState(
+	ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, state *clusterState,
+) error {
+	statefulSetName := types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Name,
+	}
+
+	// Compute active revision for blue/green deployments
+	if cluster.Spec.UpdateStrategy.Type == openbaov1alpha1.UpdateStrategyBlueGreen {
+		state.ActiveRevision = revision.OpenBaoClusterRevision(cluster.Spec.Version, cluster.Spec.Image, cluster.Spec.Replicas)
+		if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.BlueRevision != "" {
+			state.ActiveRevision = cluster.Status.BlueGreen.BlueRevision
+			if cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseDemotingBlue ||
+				cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseCleanup {
+				if cluster.Status.BlueGreen.GreenRevision != "" {
+					state.ActiveRevision = cluster.Status.BlueGreen.GreenRevision
+				}
+			}
+		}
+		statefulSetName.Name = fmt.Sprintf("%s-%s", cluster.Name, state.ActiveRevision)
+	}
+
+	statefulSet := &appsv1.StatefulSet{}
+	err := r.Get(ctx, statefulSetName, statefulSet)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get StatefulSet %s/%s for status update: %w", cluster.Namespace, statefulSetName.Name, err)
+		}
+		// StatefulSet not found - cluster is initializing
+		state.ReadyReplicas = 0
+		state.Available = false
+		return nil
+	}
+
+	state.StatefulSet = statefulSet
+	state.ReadyReplicas = statefulSet.Status.ReadyReplicas
+	desiredReplicas := cluster.Spec.Replicas
+	state.Available = state.ReadyReplicas == desiredReplicas && state.ReadyReplicas > 0
+
+	// Check if StatefulSet status may be stale
+	statefulSetStillScaling := statefulSet.Status.ObservedGeneration < statefulSet.Generation ||
+		statefulSet.Status.Replicas < desiredReplicas
+
+	statusPotentiallyStale := statefulSet.Status.Replicas == desiredReplicas &&
+		statefulSet.Status.ReadyReplicas < statefulSet.Status.Replicas &&
+		statefulSet.Status.ReadyReplicas < desiredReplicas
+
+	state.StatusStale = statefulSetStillScaling || statusPotentiallyStale
+
+	logger.Info("StatefulSet status read for ReadyReplicas calculation",
+		"statefulSetReadyReplicas", statefulSet.Status.ReadyReplicas,
+		"statefulSetReplicas", statefulSet.Status.Replicas,
+		"statefulSetCurrentReplicas", statefulSet.Status.CurrentReplicas,
+		"statefulSetUpdatedReplicas", statefulSet.Status.UpdatedReplicas,
+		"statefulSetObservedGeneration", statefulSet.Status.ObservedGeneration,
+		"statefulSetGeneration", statefulSet.Generation,
+		"desiredReplicas", desiredReplicas,
+		"calculatedReadyReplicas", state.ReadyReplicas,
+		"available", state.Available,
+		"statusStale", state.StatusStale)
+
+	return nil
+}
+
+func (r *OpenBaoClusterReconciler) gatherPodState(
+	ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, state *clusterState,
+) error {
+	podSelector := map[string]string{
+		constants.LabelAppInstance:  cluster.Name,
+		constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
+		constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+	}
+	if cluster.Spec.UpdateStrategy.Type == openbaov1alpha1.UpdateStrategyBlueGreen && state.ActiveRevision != "" {
+		podSelector[constants.LabelOpenBaoRevision] = state.ActiveRevision
+	}
+
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels(podSelector),
+	); err != nil {
+		return fmt.Errorf("failed to list pods for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	}
+
+	state.Pods = pods.Items
+
+	// Find pod0 and leader
+	pod0Name := fmt.Sprintf("%s-0", cluster.Name)
+	if cluster.Spec.UpdateStrategy.Type == openbaov1alpha1.UpdateStrategyBlueGreen && state.ActiveRevision != "" {
+		pod0Name = fmt.Sprintf("%s-%s-0", cluster.Name, state.ActiveRevision)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Name == pod0Name {
+			state.Pod0 = pod
+
+			// Parse initialized label
+			initialized, present, err := openbaolabels.ParseBoolLabel(pod.Labels, openbaolabels.LabelInitialized)
+			if err == nil {
+				state.Initialized = initialized
+				state.InitializedKnown = present
+			}
+
+			// Parse sealed label
+			sealed, present, err := openbaolabels.ParseBoolLabel(pod.Labels, openbaolabels.LabelSealed)
+			if err == nil {
+				state.Sealed = sealed
+				state.SealedKnown = present
+			}
+		}
+
+		// Check for active leader
+		active, present, err := openbaolabels.ParseBoolLabel(pod.Labels, openbaolabels.LabelActive)
+		if err == nil && present && active {
+			state.LeaderCount++
+			state.LeaderName = pod.Name
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/openbaocluster/status.go
+++ b/internal/controller/openbaocluster/status.go
@@ -5,13 +5,10 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,8 +16,6 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/constants"
 	controllerutil "github.com/dc-tec/openbao-operator/internal/controller"
-	openbaolabels "github.com/dc-tec/openbao-operator/internal/openbao"
-	"github.com/dc-tec/openbao-operator/internal/revision"
 )
 
 func (r *OpenBaoClusterReconciler) updateStatusForPaused(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
@@ -121,344 +116,27 @@ func (r *OpenBaoClusterReconciler) updateStatusForProfileNotSet(ctx context.Cont
 	return nil
 }
 
-//nolint:gocyclo // Status computation is intentionally explicit to keep reconciliation readable and auditable.
 func (r *OpenBaoClusterReconciler) updateStatus(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (ctrl.Result, error) {
 	// Capture original state for status patching to avoid optimistic locking conflicts
 	original := cluster.DeepCopy()
 
-	findActiveBackupJob := func() (string, bool, error) {
-		jobList := &batchv1.JobList{}
-		labelSelector := labels.SelectorFromSet(map[string]string{
-			constants.LabelAppInstance:      cluster.Name,
-			constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
-			constants.LabelOpenBaoCluster:   cluster.Name,
-			constants.LabelOpenBaoComponent: constants.ComponentBackup,
-		})
-		if err := r.List(ctx, jobList,
-			client.InNamespace(cluster.Namespace),
-			client.MatchingLabelsSelector{Selector: labelSelector},
-		); err != nil {
-			return "", false, fmt.Errorf("failed to list backup Jobs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
-		}
+	// Set TLSReady early (evaluated separately from clusterState)
+	r.setTLSReadyCondition(ctx, cluster)
 
-		for i := range jobList.Items {
-			job := &jobList.Items[i]
-			if job.Status.Succeeded == 0 && job.Status.Failed == 0 {
-				return job.Name, true, nil
-			}
-		}
-		return "", false, nil
-	}
-
-	upgradeFailed := false
-	rollingUpgradeInProgress := cluster.Status.Upgrade != nil
-	if rollingUpgradeInProgress && cluster.Status.Upgrade.LastErrorReason != "" {
-		upgradeFailed = true
-	}
-
-	blueGreenInProgress := cluster.Status.BlueGreen != nil &&
-		cluster.Status.BlueGreen.Phase != "" &&
-		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle
-
-	upgradeInProgress := (rollingUpgradeInProgress && !upgradeFailed) || blueGreenInProgress
-
-	backupJobName, backupInProgress, err := findActiveBackupJob()
+	// 1. Gather all observed state (API calls)
+	state, err := r.gatherClusterState(ctx, logger, cluster)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// Set TLSReady early so it is present even when we return early to requeue
-	// due to StatefulSet status propagation delays.
-	tlsNow := metav1.Now()
-	if !cluster.Spec.TLS.Enabled {
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               string(openbaov1alpha1.ConditionTLSReady),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: cluster.Generation,
-			LastTransitionTime: tlsNow,
-			Reason:             "Disabled",
-			Message:            "TLS is disabled",
-		})
-	} else {
-		tlsMode := cluster.Spec.TLS.Mode
-		if tlsMode == "" {
-			tlsMode = openbaov1alpha1.TLSModeOperatorManaged
-		}
+	// 2. Compute and set all conditions (pure logic)
+	now := metav1.Now()
+	applyAllConditions(cluster, state, r.AdmissionStatus, now)
 
-		switch tlsMode {
-		case openbaov1alpha1.TLSModeACME:
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionTLSReady),
-				Status:             metav1.ConditionUnknown,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: tlsNow,
-				Reason:             constants.ReasonUnknown,
-				Message:            "TLS is managed by OpenBao via ACME; the operator does not evaluate certificate readiness",
-			})
-		default:
-			serverSecret := &corev1.Secret{}
-			if err := r.Get(ctx, types.NamespacedName{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name + constants.SuffixTLSServer,
-			}, serverSecret); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return ctrl.Result{}, fmt.Errorf("failed to get server TLS Secret for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
-				}
-
-				meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-					Type:               string(openbaov1alpha1.ConditionTLSReady),
-					Status:             metav1.ConditionFalse,
-					ObservedGeneration: cluster.Generation,
-					LastTransitionTime: tlsNow,
-					Reason:             ReasonTLSSecretMissing,
-					Message:            "Server TLS Secret is not present yet",
-				})
-			} else {
-				hasCert := len(serverSecret.Data["tls.crt"]) > 0
-				hasKey := len(serverSecret.Data["tls.key"]) > 0
-				if hasCert && hasKey {
-					meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-						Type:               string(openbaov1alpha1.ConditionTLSReady),
-						Status:             metav1.ConditionTrue,
-						ObservedGeneration: cluster.Generation,
-						LastTransitionTime: tlsNow,
-						Reason:             constants.ReasonReady,
-						Message:            "TLS assets are provisioned",
-					})
-				} else {
-					meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-						Type:               string(openbaov1alpha1.ConditionTLSReady),
-						Status:             metav1.ConditionFalse,
-						ObservedGeneration: cluster.Generation,
-						LastTransitionTime: tlsNow,
-						Reason:             ReasonTLSSecretInvalid,
-						Message:            "Server TLS Secret is missing required keys (tls.crt/tls.key)",
-					})
-				}
-			}
-		}
-	}
-
-	// Fetch the StatefulSet to get ready replicas count
-	statefulSet := &appsv1.StatefulSet{}
-	statefulSetName := types.NamespacedName{
-		Namespace: cluster.Namespace,
-		Name:      cluster.Name,
-	}
-	activeRevision := ""
-	if cluster.Spec.UpdateStrategy.Type == openbaov1alpha1.UpdateStrategyBlueGreen {
-		activeRevision = revision.OpenBaoClusterRevision(cluster.Spec.Version, cluster.Spec.Image, cluster.Spec.Replicas)
-		if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.BlueRevision != "" {
-			activeRevision = cluster.Status.BlueGreen.BlueRevision
-			if cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseDemotingBlue ||
-				cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseCleanup {
-				if cluster.Status.BlueGreen.GreenRevision != "" {
-					activeRevision = cluster.Status.BlueGreen.GreenRevision
-				}
-			}
-		}
-		statefulSetName.Name = fmt.Sprintf("%s-%s", cluster.Name, activeRevision)
-	}
-
-	var readyReplicas int32
-	var available bool
-	err = r.Get(ctx, statefulSetName, statefulSet)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to get StatefulSet %s/%s for status update: %w", cluster.Namespace, cluster.Name, err)
-		}
-		// StatefulSet not found - cluster is initializing
-		readyReplicas = 0
-		available = false
-	} else {
-		readyReplicas = statefulSet.Status.ReadyReplicas
-		desiredReplicas := cluster.Spec.Replicas
-		available = readyReplicas == desiredReplicas && readyReplicas > 0
-
-		// Check if StatefulSet controller is still processing (hasn't caught up with spec changes)
-		// or if status fields are potentially stale (pods may be ready but status not updated yet)
-		statefulSetStillScaling := statefulSet.Status.ObservedGeneration < statefulSet.Generation ||
-			statefulSet.Status.Replicas < desiredReplicas
-
-		// Even when StatefulSet controller has caught up, ReadyReplicas might be stale
-		// if pods are ready but the status update hasn't propagated yet.
-		// If we have the desired number of replicas but ReadyReplicas is less,
-		// we should requeue to catch the status update.
-		statusPotentiallyStale := statefulSet.Status.Replicas == desiredReplicas &&
-			statefulSet.Status.ReadyReplicas < statefulSet.Status.Replicas &&
-			statefulSet.Status.ReadyReplicas < desiredReplicas
-
-		logger.Info("StatefulSet status read for ReadyReplicas calculation",
-			"statefulSetReadyReplicas", statefulSet.Status.ReadyReplicas,
-			"statefulSetReplicas", statefulSet.Status.Replicas,
-			"statefulSetCurrentReplicas", statefulSet.Status.CurrentReplicas,
-			"statefulSetUpdatedReplicas", statefulSet.Status.UpdatedReplicas,
-			"statefulSetObservedGeneration", statefulSet.Status.ObservedGeneration,
-			"statefulSetGeneration", statefulSet.Generation,
-			"desiredReplicas", desiredReplicas,
-			"calculatedReadyReplicas", readyReplicas,
-			"available", available,
-			"statefulSetStillScaling", statefulSetStillScaling,
-			"statusPotentiallyStale", statusPotentiallyStale)
-
-		// If StatefulSet is still scaling or status is potentially stale, set phase and persist status before requeue
-		if statefulSetStillScaling || statusPotentiallyStale {
-			logger.V(1).Info("StatefulSet status may be stale; setting phase and requeuing to check status",
-				"observedGeneration", statefulSet.Status.ObservedGeneration,
-				"generation", statefulSet.Generation,
-				"currentReplicas", statefulSet.Status.Replicas,
-				"readyReplicas", statefulSet.Status.ReadyReplicas,
-				"desiredReplicas", desiredReplicas,
-				"stillScaling", statefulSetStillScaling,
-				"statusStale", statusPotentiallyStale)
-
-			// Set phase and ready replicas before requeuing to ensure status is persisted
-			cluster.Status.ReadyReplicas = readyReplicas
-
-			// Update per-cluster metrics for ready replicas
-			clusterMetrics := controllerutil.NewClusterMetrics(cluster.Namespace, cluster.Name)
-			clusterMetrics.SetReadyReplicas(readyReplicas)
-
-			cluster.Status.Phase = openbaov1alpha1.ClusterPhaseInitializing
-			if upgradeFailed {
-				cluster.Status.Phase = openbaov1alpha1.ClusterPhaseFailed
-			} else if upgradeInProgress {
-				cluster.Status.Phase = openbaov1alpha1.ClusterPhaseUpgrading
-			} else if backupInProgress {
-				cluster.Status.Phase = openbaov1alpha1.ClusterPhaseBackingUp
-			}
-
-			clusterMetrics.SetPhase(cluster.Status.Phase)
-
-			// Set basic conditions before requeuing to ensure they're persisted
-			now := metav1.Now()
-			availableStatus := metav1.ConditionFalse
-			availableReason := ReasonNotReady
-			availableMessage := fmt.Sprintf("Only %d/%d replicas are ready", readyReplicas, cluster.Spec.Replicas)
-			if available {
-				availableStatus = metav1.ConditionTrue
-				availableReason = ReasonAllReplicasReady
-				availableMessage = fmt.Sprintf("All %d replicas are ready", readyReplicas)
-			} else if readyReplicas == 0 {
-				availableStatus = metav1.ConditionFalse
-				availableReason = ReasonNoReplicasReady
-				availableMessage = "No replicas are ready yet"
-			}
-
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionAvailable),
-				Status:             availableStatus,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             availableReason,
-				Message:            availableMessage,
-			})
-
-			degradedStatus := metav1.ConditionFalse
-			degradedReason := constants.ReasonReconciling
-			degradedMessage := "No degradation has been recorded by the controller"
-
-			if cluster.Status.BreakGlass != nil && cluster.Status.BreakGlass.Active {
-				degradedStatus = metav1.ConditionTrue
-				degradedReason = constants.ReasonBreakGlassRequired
-				degradedMessage = "Break glass required; see status.breakGlass for recovery steps"
-			} else if cluster.Spec.Sentinel != nil && cluster.Spec.Sentinel.Enabled && r.AdmissionStatus != nil && !r.AdmissionStatus.SentinelReady {
-				degradedStatus = metav1.ConditionTrue
-				degradedReason = ReasonAdmissionPoliciesNotReady
-				degradedMessage = "Sentinel is enabled but required admission policies are missing or misbound; Sentinel will not be deployed. " + r.AdmissionStatus.SummaryMessage()
-			} else if upgradeFailed && cluster.Status.Upgrade != nil {
-				degradedStatus = metav1.ConditionTrue
-				degradedReason = cluster.Status.Upgrade.LastErrorReason
-				degradedMessage = cluster.Status.Upgrade.LastErrorMessage
-			} else if cluster.Status.Workload != nil && cluster.Status.Workload.LastError != nil {
-				degradedStatus = metav1.ConditionTrue
-				degradedReason = cluster.Status.Workload.LastError.Reason
-				degradedMessage = cluster.Status.Workload.LastError.Message
-			} else if cluster.Status.AdminOps != nil && cluster.Status.AdminOps.LastError != nil {
-				degradedStatus = metav1.ConditionTrue
-				degradedReason = cluster.Status.AdminOps.LastError.Reason
-				degradedMessage = cluster.Status.AdminOps.LastError.Message
-			} else {
-				selfInitEnabled := cluster.Spec.SelfInit != nil && cluster.Spec.SelfInit.Enabled
-				if !selfInitEnabled {
-					degradedStatus = metav1.ConditionTrue
-					degradedReason = ReasonRootTokenStored
-					degradedMessage = "SelfInit is disabled. The operator is storing the root token in a Secret, which violates Zero Trust principles. Anyone with Secret read access in this namespace can access the root token. Strongly consider enabling SelfInit (spec.selfInit.enabled=true) for production deployments."
-				}
-			}
-
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionDegraded),
-				Status:             degradedStatus,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             degradedReason,
-				Message:            degradedMessage,
-			})
-
-			upgradeCondStatus := metav1.ConditionFalse
-			upgradeCondReason := constants.ReasonIdle
-			upgradeCondMessage := "No upgrade is currently in progress"
-			if upgradeFailed && cluster.Status.Upgrade != nil {
-				upgradeCondStatus = metav1.ConditionFalse
-				upgradeCondReason = cluster.Status.Upgrade.LastErrorReason
-				upgradeCondMessage = cluster.Status.Upgrade.LastErrorMessage
-			} else if upgradeInProgress {
-				upgradeCondStatus = metav1.ConditionTrue
-				upgradeCondReason = ReasonInProgress
-				if rollingUpgradeInProgress && cluster.Status.Upgrade != nil {
-					upgradeCondMessage = fmt.Sprintf("Rolling upgrade from %s to %s (partition=%d)", cluster.Status.Upgrade.FromVersion, cluster.Status.Upgrade.TargetVersion, cluster.Status.Upgrade.CurrentPartition)
-				} else if blueGreenInProgress && cluster.Status.BlueGreen != nil {
-					upgradeCondMessage = fmt.Sprintf("Blue/green upgrade phase %s", cluster.Status.BlueGreen.Phase)
-				} else {
-					upgradeCondMessage = "Upgrade in progress"
-				}
-			}
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionUpgrading),
-				Status:             upgradeCondStatus,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             upgradeCondReason,
-				Message:            upgradeCondMessage,
-			})
-
-			backupCondStatus := metav1.ConditionFalse
-			backupCondReason := constants.ReasonIdle
-			backupCondMessage := "No backup is currently in progress"
-			if backupInProgress {
-				backupCondStatus = metav1.ConditionTrue
-				backupCondReason = ReasonInProgress
-				if backupJobName != "" {
-					backupCondMessage = fmt.Sprintf("Backup Job %s is running", backupJobName)
-				} else {
-					backupCondMessage = "Backup in progress"
-				}
-			}
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionBackingUp),
-				Status:             backupCondStatus,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             backupCondReason,
-				Message:            backupCondMessage,
-			})
-
-			// Persist status before requeuing
-			if err := r.Status().Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update status before requeue: %w", err)
-			}
-
-			return ctrl.Result{RequeueAfter: constants.RequeueShort}, nil
-		}
-	}
-
-	cluster.Status.ReadyReplicas = readyReplicas
-
-	// Update per-cluster metrics for ready replicas and phase. Metrics are
-	// derived from the status view and do not influence reconciliation logic.
-	clusterMetrics := controllerutil.NewClusterMetrics(cluster.Namespace, cluster.Name)
-	clusterMetrics.SetReadyReplicas(readyReplicas)
+	// 3. Update status fields
+	cluster.Status.ReadyReplicas = state.ReadyReplicas
+	cluster.Status.ActiveLeader = state.LeaderName
+	cluster.Status.Phase = computePhase(state)
 
 	// Set initial CurrentVersion if empty (first reconcile after initialization)
 	if cluster.Status.CurrentVersion == "" && cluster.Status.Initialized {
@@ -466,315 +144,10 @@ func (r *OpenBaoClusterReconciler) updateStatus(ctx context.Context, logger logr
 		logger.Info("Set initial CurrentVersion", "version", cluster.Spec.Version)
 	}
 
-	cluster.Status.Phase = openbaov1alpha1.ClusterPhaseInitializing
-	if upgradeFailed {
-		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseFailed
-	} else if upgradeInProgress {
-		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseUpgrading
-	} else if backupInProgress {
-		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseBackingUp
-	} else if available {
-		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseRunning
-	}
-
+	// Update per-cluster metrics
+	clusterMetrics := controllerutil.NewClusterMetrics(cluster.Namespace, cluster.Name)
+	clusterMetrics.SetReadyReplicas(state.ReadyReplicas)
 	clusterMetrics.SetPhase(cluster.Status.Phase)
-
-	now := metav1.Now()
-
-	podSelector := map[string]string{
-		constants.LabelAppInstance:  cluster.Name,
-		constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-		constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
-	}
-	if cluster.Spec.UpdateStrategy.Type == openbaov1alpha1.UpdateStrategyBlueGreen && activeRevision != "" {
-		podSelector[constants.LabelOpenBaoRevision] = activeRevision
-	}
-
-	var pods corev1.PodList
-	if err := r.List(ctx, &pods,
-		client.InNamespace(cluster.Namespace),
-		client.MatchingLabels(podSelector),
-	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list pods for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
-	}
-
-	var leaderCount int
-	var leaderName string
-	var pod0 *corev1.Pod
-	pod0Name := fmt.Sprintf("%s-0", cluster.Name)
-	if cluster.Spec.UpdateStrategy.Type == openbaov1alpha1.UpdateStrategyBlueGreen && activeRevision != "" {
-		pod0Name = fmt.Sprintf("%s-%s-0", cluster.Name, activeRevision)
-	}
-
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		if pod.Name == pod0Name {
-			pod0 = pod
-		}
-
-		active, present, err := openbaolabels.ParseBoolLabel(pod.Labels, openbaolabels.LabelActive)
-		if err != nil {
-			logger.V(1).Info("Invalid OpenBao active label value", "pod", pod.Name, "error", err)
-			continue
-		}
-		if present && active {
-			leaderCount++
-			leaderName = pod.Name
-		}
-	}
-
-	cluster.Status.ActiveLeader = leaderName
-
-	if pod0 != nil {
-		initialized, present, err := openbaolabels.ParseBoolLabel(pod0.Labels, openbaolabels.LabelInitialized)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("invalid %q label on pod %s: %w", openbaolabels.LabelInitialized, pod0.Name, err)
-		}
-		if present {
-			status := metav1.ConditionFalse
-			reason := "NotInitialized"
-			message := "OpenBao reports not initialized"
-			if initialized {
-				status = metav1.ConditionTrue
-				reason = "Initialized"
-				message = "OpenBao reports initialized"
-			}
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionOpenBaoInitialized),
-				Status:             status,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             reason,
-				Message:            message,
-			})
-		} else {
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionOpenBaoInitialized),
-				Status:             metav1.ConditionUnknown,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             constants.ReasonUnknown,
-				Message:            "OpenBao initialization state is not yet available via service registration",
-			})
-		}
-
-		sealed, present, err := openbaolabels.ParseBoolLabel(pod0.Labels, openbaolabels.LabelSealed)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("invalid %q label on pod %s: %w", openbaolabels.LabelSealed, pod0.Name, err)
-		}
-		if present {
-			status := metav1.ConditionFalse
-			reason := "Unsealed"
-			message := "OpenBao reports unsealed"
-			if sealed {
-				status = metav1.ConditionTrue
-				reason = "Sealed"
-				message = "OpenBao reports sealed"
-			}
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionOpenBaoSealed),
-				Status:             status,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             reason,
-				Message:            message,
-			})
-		} else {
-			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-				Type:               string(openbaov1alpha1.ConditionOpenBaoSealed),
-				Status:             metav1.ConditionUnknown,
-				ObservedGeneration: cluster.Generation,
-				LastTransitionTime: now,
-				Reason:             constants.ReasonUnknown,
-				Message:            "OpenBao seal state is not yet available via service registration",
-			})
-		}
-	}
-
-	switch leaderCount {
-	case 0:
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               string(openbaov1alpha1.ConditionOpenBaoLeader),
-			Status:             metav1.ConditionUnknown,
-			ObservedGeneration: cluster.Generation,
-			LastTransitionTime: now,
-			Reason:             ReasonLeaderUnknown,
-			Message:            "No active leader label observed on pods",
-		})
-	case 1:
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               string(openbaov1alpha1.ConditionOpenBaoLeader),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: cluster.Generation,
-			LastTransitionTime: now,
-			Reason:             ReasonLeaderFound,
-			Message:            fmt.Sprintf("Leader is %s", leaderName),
-		})
-	default:
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               string(openbaov1alpha1.ConditionOpenBaoLeader),
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: cluster.Generation,
-			LastTransitionTime: now,
-			Reason:             ReasonMultipleLeaders,
-			Message:            fmt.Sprintf("Multiple leaders detected via pod labels (%d)", leaderCount),
-		})
-	}
-
-	availableStatus := metav1.ConditionFalse
-	availableReason := "NotReady"
-	availableMessage := fmt.Sprintf("Only %d/%d replicas are ready", readyReplicas, cluster.Spec.Replicas)
-	if available {
-		availableStatus = metav1.ConditionTrue
-		availableReason = "AllReplicasReady"
-		availableMessage = fmt.Sprintf("All %d replicas are ready", readyReplicas)
-	} else if readyReplicas == 0 {
-		availableStatus = metav1.ConditionFalse
-		availableReason = "NoReplicasReady"
-		availableMessage = "No replicas are ready yet"
-	}
-
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(openbaov1alpha1.ConditionAvailable),
-		Status:             availableStatus,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: now,
-		Reason:             availableReason,
-		Message:            availableMessage,
-	})
-
-	degradedStatus := metav1.ConditionFalse
-	degradedReason := constants.ReasonReconciling
-	degradedMessage := "No degradation has been recorded by the controller"
-
-	if cluster.Status.BreakGlass != nil && cluster.Status.BreakGlass.Active {
-		degradedStatus = metav1.ConditionTrue
-		degradedReason = constants.ReasonBreakGlassRequired
-		degradedMessage = "Break glass required; see status.breakGlass for recovery steps"
-	} else if cluster.Spec.Sentinel != nil && cluster.Spec.Sentinel.Enabled && r.AdmissionStatus != nil && !r.AdmissionStatus.SentinelReady {
-		degradedStatus = metav1.ConditionTrue
-		degradedReason = ReasonAdmissionPoliciesNotReady
-		degradedMessage = "Sentinel is enabled but required admission policies are missing or misbound; Sentinel will not be deployed. " + r.AdmissionStatus.SummaryMessage()
-	} else if upgradeFailed && cluster.Status.Upgrade != nil {
-		degradedStatus = metav1.ConditionTrue
-		degradedReason = cluster.Status.Upgrade.LastErrorReason
-		degradedMessage = cluster.Status.Upgrade.LastErrorMessage
-	} else if cluster.Status.Workload != nil && cluster.Status.Workload.LastError != nil {
-		degradedStatus = metav1.ConditionTrue
-		degradedReason = cluster.Status.Workload.LastError.Reason
-		degradedMessage = cluster.Status.Workload.LastError.Message
-	} else if cluster.Status.AdminOps != nil && cluster.Status.AdminOps.LastError != nil {
-		degradedStatus = metav1.ConditionTrue
-		degradedReason = cluster.Status.AdminOps.LastError.Reason
-		degradedMessage = cluster.Status.AdminOps.LastError.Message
-	} else {
-		selfInitEnabled := cluster.Spec.SelfInit != nil && cluster.Spec.SelfInit.Enabled
-		if !selfInitEnabled {
-			degradedStatus = metav1.ConditionTrue
-			degradedReason = ReasonRootTokenStored
-			degradedMessage = "SelfInit is disabled. The operator is storing the root token in a Secret, which violates Zero Trust principles. Anyone with Secret read access in this namespace can access the root token. Strongly consider enabling SelfInit (spec.selfInit.enabled=true) for production deployments."
-		}
-	}
-
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(openbaov1alpha1.ConditionDegraded),
-		Status:             degradedStatus,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: now,
-		Reason:             degradedReason,
-		Message:            degradedMessage,
-	})
-
-	upgradeCondStatus := metav1.ConditionFalse
-	upgradeCondReason := constants.ReasonIdle
-	upgradeCondMessage := "No upgrade is currently in progress"
-	if upgradeFailed && cluster.Status.Upgrade != nil {
-		upgradeCondStatus = metav1.ConditionFalse
-		upgradeCondReason = cluster.Status.Upgrade.LastErrorReason
-		upgradeCondMessage = cluster.Status.Upgrade.LastErrorMessage
-	} else if upgradeInProgress {
-		upgradeCondStatus = metav1.ConditionTrue
-		upgradeCondReason = ReasonInProgress
-		if rollingUpgradeInProgress && cluster.Status.Upgrade != nil {
-			upgradeCondMessage = fmt.Sprintf("Rolling upgrade from %s to %s (partition=%d)", cluster.Status.Upgrade.FromVersion, cluster.Status.Upgrade.TargetVersion, cluster.Status.Upgrade.CurrentPartition)
-		} else if blueGreenInProgress && cluster.Status.BlueGreen != nil {
-			upgradeCondMessage = fmt.Sprintf("Blue/green upgrade phase %s", cluster.Status.BlueGreen.Phase)
-		} else {
-			upgradeCondMessage = "Upgrade in progress"
-		}
-	}
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(openbaov1alpha1.ConditionUpgrading),
-		Status:             upgradeCondStatus,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: now,
-		Reason:             upgradeCondReason,
-		Message:            upgradeCondMessage,
-	})
-
-	backupCondStatus := metav1.ConditionFalse
-	backupCondReason := constants.ReasonIdle
-	backupCondMessage := "No backup is currently in progress"
-	if backupInProgress {
-		backupCondStatus = metav1.ConditionTrue
-		backupCondReason = ReasonInProgress
-		if backupJobName != "" {
-			backupCondMessage = fmt.Sprintf("Backup Job %s is running", backupJobName)
-		} else {
-			backupCondMessage = "Backup in progress"
-		}
-	}
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(openbaov1alpha1.ConditionBackingUp),
-		Status:             backupCondStatus,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: now,
-		Reason:             backupCondReason,
-		Message:            backupCondMessage,
-	})
-
-	// Set etcd encryption warning condition.
-	// The operator cannot verify etcd encryption status, but it should warn users
-	// that security relies on underlying K8s secret encryption at rest.
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(openbaov1alpha1.ConditionEtcdEncryptionWarning),
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: now,
-		Reason:             ReasonEtcdEncryptionUnknown,
-		Message:            "The operator cannot verify etcd encryption status. Ensure etcd encryption at rest is enabled in your Kubernetes cluster to protect Secrets (including unseal keys and root tokens) stored in etcd.",
-	})
-
-	// Set SecurityRisk condition for Development profile
-	if cluster.Spec.Profile == openbaov1alpha1.ProfileDevelopment {
-		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-			Type:               string(openbaov1alpha1.ConditionSecurityRisk),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: cluster.Generation,
-			LastTransitionTime: now,
-			Reason:             ReasonDevelopmentProfile,
-			Message:            "Cluster is using Development profile with relaxed security. Not suitable for production.",
-		})
-	} else {
-		// Remove condition if profile is Hardened or not set
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionSecurityRisk))
-	}
-
-	// Set ProductionReady condition based on security posture and bootstrap configuration.
-	admissionReady := r.AdmissionStatus == nil || r.AdmissionStatus.OverallReady
-	admissionSummary := ""
-	if r.AdmissionStatus != nil {
-		admissionSummary = r.AdmissionStatus.SummaryMessage()
-	}
-	productionReadyStatus, productionReadyReason, productionReadyMessage := evaluateProductionReady(cluster, admissionReady, admissionSummary)
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(openbaov1alpha1.ConditionProductionReady),
-		Status:             productionReadyStatus,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: now,
-		Reason:             productionReadyReason,
-		Message:            productionReadyMessage,
-	})
 
 	// SECURITY: Warn when SelfInit is disabled - the operator will store the root token.
 	selfInitEnabled := cluster.Spec.SelfInit != nil && cluster.Spec.SelfInit.Enabled
@@ -785,29 +158,123 @@ func (r *OpenBaoClusterReconciler) updateStatus(ctx context.Context, logger logr
 			"secret_name", cluster.Name+"-root-token")
 	}
 
+	// 4. Persist status (single API call)
 	if err := r.Status().Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update status for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 	}
 
-	logger.Info("Updated status for OpenBaoCluster", "readyReplicas", readyReplicas, "phase", cluster.Status.Phase, "currentVersion", cluster.Status.CurrentVersion)
+	logger.Info("Updated status for OpenBaoCluster",
+		"readyReplicas", state.ReadyReplicas,
+		"phase", cluster.Status.Phase,
+		"currentVersion", cluster.Status.CurrentVersion)
 
-	// Requeue logic to ensure status updates promptly when replicas become ready.
-	// Since we don't watch StatefulSets directly (for security reasons), we need to requeue
-	// to catch when pods transition to ready state.
+	// 5. Determine requeue
 	previousReadyReplicas := original.Status.ReadyReplicas
-	readyReplicasChanged := readyReplicas != previousReadyReplicas
+	readyReplicasChanged := state.ReadyReplicas != previousReadyReplicas
 
-	if !available && readyReplicas > 0 {
-		// Not all replicas are ready yet - requeue to check again
-		logger.V(1).Info("Not all replicas are ready; requeuing to check status", "readyReplicas", readyReplicas, "desiredReplicas", cluster.Spec.Replicas)
+	if state.StatusStale {
+		logger.V(1).Info("StatefulSet status may be stale; requeuing to check status")
 		return ctrl.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 
-	if available && readyReplicasChanged {
-		// All replicas just became ready - requeue once to ensure status is persisted and visible
-		logger.V(1).Info("All replicas became ready; requeuing once to ensure status is persisted", "readyReplicas", readyReplicas, "previousReadyReplicas", previousReadyReplicas)
+	if !state.Available && state.ReadyReplicas > 0 {
+		logger.V(1).Info("Not all replicas are ready; requeuing to check status",
+			"readyReplicas", state.ReadyReplicas,
+			"desiredReplicas", cluster.Spec.Replicas)
+		return ctrl.Result{RequeueAfter: constants.RequeueShort}, nil
+	}
+
+	if state.Available && readyReplicasChanged {
+		logger.V(1).Info("All replicas became ready; requeuing once to ensure status is persisted",
+			"readyReplicas", state.ReadyReplicas,
+			"previousReadyReplicas", previousReadyReplicas)
 		return ctrl.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// setTLSReadyCondition evaluates and sets the TLSReady condition.
+func (r *OpenBaoClusterReconciler) setTLSReadyCondition(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) {
+	now := metav1.Now()
+
+	if !cluster.Spec.TLS.Enabled {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionTLSReady),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cluster.Generation,
+			LastTransitionTime: now,
+			Reason:             "Disabled",
+			Message:            "TLS is disabled",
+		})
+		return
+	}
+
+	tlsMode := cluster.Spec.TLS.Mode
+	if tlsMode == "" {
+		tlsMode = openbaov1alpha1.TLSModeOperatorManaged
+	}
+
+	if tlsMode == openbaov1alpha1.TLSModeACME {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionTLSReady),
+			Status:             metav1.ConditionUnknown,
+			ObservedGeneration: cluster.Generation,
+			LastTransitionTime: now,
+			Reason:             constants.ReasonUnknown,
+			Message:            "TLS is managed by OpenBao via ACME; the operator does not evaluate certificate readiness",
+		})
+		return
+	}
+
+	// Check for server TLS secret
+	serverSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Name + constants.SuffixTLSServer,
+	}, serverSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:               string(openbaov1alpha1.ConditionTLSReady),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: cluster.Generation,
+				LastTransitionTime: now,
+				Reason:             ReasonTLSSecretMissing,
+				Message:            "Server TLS Secret is not present yet",
+			})
+			return
+		}
+		// For other errors, mark as unknown
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionTLSReady),
+			Status:             metav1.ConditionUnknown,
+			ObservedGeneration: cluster.Generation,
+			LastTransitionTime: now,
+			Reason:             constants.ReasonUnknown,
+			Message:            "Failed to get TLS secret",
+		})
+		return
+	}
+
+	hasCert := len(serverSecret.Data["tls.crt"]) > 0
+	hasKey := len(serverSecret.Data["tls.key"]) > 0
+	if hasCert && hasKey {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionTLSReady),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: cluster.Generation,
+			LastTransitionTime: now,
+			Reason:             constants.ReasonReady,
+			Message:            "TLS assets are provisioned",
+		})
+	} else {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionTLSReady),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: cluster.Generation,
+			LastTransitionTime: now,
+			Reason:             ReasonTLSSecretInvalid,
+			Message:            "Server TLS Secret is missing required keys (tls.crt/tls.key)",
+		})
+	}
 }

--- a/internal/controller/openbaocluster/status_helpers.go
+++ b/internal/controller/openbaocluster/status_helpers.go
@@ -1,9 +1,14 @@
 package openbaocluster
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/admission"
+	"github.com/dc-tec/openbao-operator/internal/constants"
 )
 
 func evaluateProductionReady(cluster *openbaov1alpha1.OpenBaoCluster, admissionReady bool, admissionSummary string) (metav1.ConditionStatus, string, string) {
@@ -46,4 +51,377 @@ func isStaticUnseal(cluster *openbaov1alpha1.OpenBaoCluster) bool {
 		return true
 	}
 	return cluster.Spec.Unseal.Type == unsealTypeStatic
+}
+
+// buildAvailableCondition builds the Available condition based on replica counts.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildAvailableCondition(cluster *openbaov1alpha1.OpenBaoCluster, readyReplicas int32) metav1.Condition {
+	available := readyReplicas == cluster.Spec.Replicas && readyReplicas > 0
+
+	if available {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionAvailable),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonAllReplicasReady,
+			Message: fmt.Sprintf("All %d replicas are ready", readyReplicas),
+		}
+	}
+
+	if readyReplicas == 0 {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonNoReplicasReady,
+			Message: "No replicas are ready yet",
+		}
+	}
+
+	return metav1.Condition{
+		Type:    string(openbaov1alpha1.ConditionAvailable),
+		Status:  metav1.ConditionFalse,
+		Reason:  ReasonNotReady,
+		Message: fmt.Sprintf("Only %d/%d replicas are ready", readyReplicas, cluster.Spec.Replicas),
+	}
+}
+
+// buildDegradedCondition builds the Degraded condition based on cluster state.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildDegradedCondition(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	admissionStatus *admission.Status,
+	upgradeFailed bool,
+) metav1.Condition {
+	// Check break glass first
+	if cluster.Status.BreakGlass != nil && cluster.Status.BreakGlass.Active {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionDegraded),
+			Status:  metav1.ConditionTrue,
+			Reason:  constants.ReasonBreakGlassRequired,
+			Message: "Break glass required; see status.breakGlass for recovery steps",
+		}
+	}
+
+	// Check admission policies for Sentinel
+	sentinelEnabled := cluster.Spec.Sentinel != nil && cluster.Spec.Sentinel.Enabled
+	if sentinelEnabled && admissionStatus != nil && !admissionStatus.SentinelReady {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionDegraded),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonAdmissionPoliciesNotReady,
+			Message: "Sentinel is enabled but required admission policies are missing or misbound; Sentinel will not be deployed. " + admissionStatus.SummaryMessage(),
+		}
+	}
+
+	// Check upgrade failure
+	if upgradeFailed && cluster.Status.Upgrade != nil {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionDegraded),
+			Status:  metav1.ConditionTrue,
+			Reason:  cluster.Status.Upgrade.LastErrorReason,
+			Message: cluster.Status.Upgrade.LastErrorMessage,
+		}
+	}
+
+	// Check workload error
+	if cluster.Status.Workload != nil && cluster.Status.Workload.LastError != nil {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionDegraded),
+			Status:  metav1.ConditionTrue,
+			Reason:  cluster.Status.Workload.LastError.Reason,
+			Message: cluster.Status.Workload.LastError.Message,
+		}
+	}
+
+	// Check admin ops error
+	if cluster.Status.AdminOps != nil && cluster.Status.AdminOps.LastError != nil {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionDegraded),
+			Status:  metav1.ConditionTrue,
+			Reason:  cluster.Status.AdminOps.LastError.Reason,
+			Message: cluster.Status.AdminOps.LastError.Message,
+		}
+	}
+
+	// Check self-init disabled warning
+	selfInitEnabled := cluster.Spec.SelfInit != nil && cluster.Spec.SelfInit.Enabled
+	if !selfInitEnabled {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionDegraded),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonRootTokenStored,
+			Message: "SelfInit is disabled. The operator is storing the root token in a Secret, which violates Zero Trust principles. Anyone with Secret read access in this namespace can access the root token. Strongly consider enabling SelfInit (spec.selfInit.enabled=true) for production deployments.",
+		}
+	}
+
+	return metav1.Condition{
+		Type:    string(openbaov1alpha1.ConditionDegraded),
+		Status:  metav1.ConditionFalse,
+		Reason:  constants.ReasonReconciling,
+		Message: "No degradation has been recorded by the controller",
+	}
+}
+
+// buildUpgradingCondition builds the Upgrading condition based on upgrade state.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildUpgradingCondition(cluster *openbaov1alpha1.OpenBaoCluster) metav1.Condition {
+	rollingUpgradeInProgress := cluster.Status.Upgrade != nil
+	upgradeFailed := rollingUpgradeInProgress && cluster.Status.Upgrade.LastErrorReason != ""
+
+	blueGreenInProgress := cluster.Status.BlueGreen != nil &&
+		cluster.Status.BlueGreen.Phase != "" &&
+		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle
+
+	if upgradeFailed && cluster.Status.Upgrade != nil {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionUpgrading),
+			Status:  metav1.ConditionFalse,
+			Reason:  cluster.Status.Upgrade.LastErrorReason,
+			Message: cluster.Status.Upgrade.LastErrorMessage,
+		}
+	}
+
+	if rollingUpgradeInProgress && !upgradeFailed {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionUpgrading),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonInProgress,
+			Message: fmt.Sprintf("Rolling upgrade from %s to %s (partition=%d)", cluster.Status.Upgrade.FromVersion, cluster.Status.Upgrade.TargetVersion, cluster.Status.Upgrade.CurrentPartition),
+		}
+	}
+
+	if blueGreenInProgress && cluster.Status.BlueGreen != nil {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionUpgrading),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonInProgress,
+			Message: fmt.Sprintf("Blue/green upgrade phase %s", cluster.Status.BlueGreen.Phase),
+		}
+	}
+
+	return metav1.Condition{
+		Type:    string(openbaov1alpha1.ConditionUpgrading),
+		Status:  metav1.ConditionFalse,
+		Reason:  constants.ReasonIdle,
+		Message: "No upgrade is currently in progress",
+	}
+}
+
+// buildBackupCondition builds the BackingUp condition based on backup job state.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildBackupCondition(backupInProgress bool, backupJobName string) metav1.Condition {
+	if backupInProgress {
+		message := "Backup in progress"
+		if backupJobName != "" {
+			message = fmt.Sprintf("Backup Job %s is running", backupJobName)
+		}
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionBackingUp),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonInProgress,
+			Message: message,
+		}
+	}
+
+	return metav1.Condition{
+		Type:    string(openbaov1alpha1.ConditionBackingUp),
+		Status:  metav1.ConditionFalse,
+		Reason:  constants.ReasonIdle,
+		Message: "No backup is currently in progress",
+	}
+}
+
+// buildInitializedCondition builds the OpenBaoInitialized condition from pod labels.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildInitializedCondition(initialized, present bool) metav1.Condition {
+	if !present {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoInitialized),
+			Status:  metav1.ConditionUnknown,
+			Reason:  constants.ReasonUnknown,
+			Message: "OpenBao initialization state is not yet available via service registration",
+		}
+	}
+
+	if initialized {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoInitialized),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Initialized",
+			Message: "OpenBao reports initialized",
+		}
+	}
+
+	return metav1.Condition{
+		Type:    string(openbaov1alpha1.ConditionOpenBaoInitialized),
+		Status:  metav1.ConditionFalse,
+		Reason:  "NotInitialized",
+		Message: "OpenBao reports not initialized",
+	}
+}
+
+// buildSealedCondition builds the OpenBaoSealed condition from pod labels.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildSealedCondition(sealed, present bool) metav1.Condition {
+	if !present {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoSealed),
+			Status:  metav1.ConditionUnknown,
+			Reason:  constants.ReasonUnknown,
+			Message: "OpenBao seal state is not yet available via service registration",
+		}
+	}
+
+	if sealed {
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoSealed),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Sealed",
+			Message: "OpenBao reports sealed",
+		}
+	}
+
+	return metav1.Condition{
+		Type:    string(openbaov1alpha1.ConditionOpenBaoSealed),
+		Status:  metav1.ConditionFalse,
+		Reason:  "Unsealed",
+		Message: "OpenBao reports unsealed",
+	}
+}
+
+// buildLeaderCondition builds the OpenBaoLeader condition from leader count.
+// ObservedGeneration and LastTransitionTime must be set by the caller.
+func buildLeaderCondition(leaderCount int, leaderName string) metav1.Condition {
+	switch leaderCount {
+	case 0:
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoLeader),
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonLeaderUnknown,
+			Message: "No active leader label observed on pods",
+		}
+	case 1:
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoLeader),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonLeaderFound,
+			Message: fmt.Sprintf("Leader is %s", leaderName),
+		}
+	default:
+		return metav1.Condition{
+			Type:    string(openbaov1alpha1.ConditionOpenBaoLeader),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonMultipleLeaders,
+			Message: fmt.Sprintf("Multiple leaders detected via pod labels (%d)", leaderCount),
+		}
+	}
+}
+
+// applyAllConditions computes and sets all status conditions from cluster state.
+// This consolidates condition logic to eliminate duplicate code paths.
+func applyAllConditions(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	state *clusterState,
+	admissionStatus *admission.Status,
+	now metav1.Time,
+) {
+	gen := cluster.Generation
+
+	// OpenBao initialized condition (from pod0 labels)
+	initCond := buildInitializedCondition(state.Initialized, state.InitializedKnown)
+	initCond.ObservedGeneration = gen
+	initCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, initCond)
+
+	// OpenBao sealed condition (from pod0 labels)
+	sealedCond := buildSealedCondition(state.Sealed, state.SealedKnown)
+	sealedCond.ObservedGeneration = gen
+	sealedCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, sealedCond)
+
+	// Leader condition
+	leaderCond := buildLeaderCondition(state.LeaderCount, state.LeaderName)
+	leaderCond.ObservedGeneration = gen
+	leaderCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, leaderCond)
+
+	// Available condition
+	availableCond := buildAvailableCondition(cluster, state.ReadyReplicas)
+	availableCond.ObservedGeneration = gen
+	availableCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, availableCond)
+
+	// Degraded condition
+	degradedCond := buildDegradedCondition(cluster, admissionStatus, state.UpgradeFailed)
+	degradedCond.ObservedGeneration = gen
+	degradedCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, degradedCond)
+
+	// Upgrading condition
+	upgradingCond := buildUpgradingCondition(cluster)
+	upgradingCond.ObservedGeneration = gen
+	upgradingCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, upgradingCond)
+
+	// Backup condition
+	backupCond := buildBackupCondition(state.BackupInProgress, state.BackupJobName)
+	backupCond.ObservedGeneration = gen
+	backupCond.LastTransitionTime = now
+	meta.SetStatusCondition(&cluster.Status.Conditions, backupCond)
+
+	// Etcd encryption warning (always set)
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               string(openbaov1alpha1.ConditionEtcdEncryptionWarning),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: gen,
+		LastTransitionTime: now,
+		Reason:             ReasonEtcdEncryptionUnknown,
+		Message:            "The operator cannot verify etcd encryption status. Ensure etcd encryption at rest is enabled in your Kubernetes cluster to protect Secrets (including unseal keys and root tokens) stored in etcd.",
+	})
+
+	// Security risk condition for Development profile
+	if cluster.Spec.Profile == openbaov1alpha1.ProfileDevelopment {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionSecurityRisk),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: gen,
+			LastTransitionTime: now,
+			Reason:             ReasonDevelopmentProfile,
+			Message:            "Cluster is using Development profile with relaxed security. Not suitable for production.",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionSecurityRisk))
+	}
+
+	// Production ready condition
+	admissionReady := admissionStatus == nil || admissionStatus.OverallReady
+	admissionSummary := ""
+	if admissionStatus != nil {
+		admissionSummary = admissionStatus.SummaryMessage()
+	}
+	productionStatus, productionReason, productionMessage := evaluateProductionReady(cluster, admissionReady, admissionSummary)
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               string(openbaov1alpha1.ConditionProductionReady),
+		Status:             productionStatus,
+		ObservedGeneration: gen,
+		LastTransitionTime: now,
+		Reason:             productionReason,
+		Message:            productionMessage,
+	})
+}
+
+// computePhase determines the cluster phase from state.
+func computePhase(state *clusterState) openbaov1alpha1.ClusterPhase {
+	if state.UpgradeFailed {
+		return openbaov1alpha1.ClusterPhaseFailed
+	}
+	if state.UpgradeInProgress {
+		return openbaov1alpha1.ClusterPhaseUpgrading
+	}
+	if state.BackupInProgress {
+		return openbaov1alpha1.ClusterPhaseBackingUp
+	}
+	if state.Available {
+		return openbaov1alpha1.ClusterPhaseRunning
+	}
+	return openbaov1alpha1.ClusterPhaseInitializing
 }

--- a/internal/controller/openbaocluster/status_helpers_test.go
+++ b/internal/controller/openbaocluster/status_helpers_test.go
@@ -1,0 +1,357 @@
+package openbaocluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/admission"
+)
+
+func TestBuildAvailableCondition(t *testing.T) {
+	tests := []struct {
+		name          string
+		replicas      int32
+		readyReplicas int32
+		wantStatus    metav1.ConditionStatus
+		wantReason    string
+	}{
+		{
+			name:          "all replicas ready",
+			replicas:      3,
+			readyReplicas: 3,
+			wantStatus:    metav1.ConditionTrue,
+			wantReason:    ReasonAllReplicasReady,
+		},
+		{
+			name:          "no replicas ready",
+			replicas:      3,
+			readyReplicas: 0,
+			wantStatus:    metav1.ConditionFalse,
+			wantReason:    ReasonNoReplicasReady,
+		},
+		{
+			name:          "partial replicas ready",
+			replicas:      3,
+			readyReplicas: 2,
+			wantStatus:    metav1.ConditionFalse,
+			wantReason:    ReasonNotReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: tt.replicas,
+				},
+			}
+
+			cond := buildAvailableCondition(cluster, tt.readyReplicas)
+
+			assert.Equal(t, string(openbaov1alpha1.ConditionAvailable), cond.Type)
+			assert.Equal(t, tt.wantStatus, cond.Status)
+			assert.Equal(t, tt.wantReason, cond.Reason)
+		})
+	}
+}
+
+func TestBuildDegradedCondition(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         *openbaov1alpha1.OpenBaoCluster
+		admissionStatus *admission.Status
+		upgradeFailed   bool
+		wantStatus      metav1.ConditionStatus
+		wantReason      string
+	}{
+		{
+			name: "no degradation with selfInit enabled",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: true},
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "degraded when selfInit disabled",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{},
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: ReasonRootTokenStored,
+		},
+		{
+			name: "degraded when break glass active",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: true},
+				},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					BreakGlass: &openbaov1alpha1.BreakGlassStatus{Active: true},
+				},
+			},
+			wantStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := buildDegradedCondition(tt.cluster, tt.admissionStatus, tt.upgradeFailed)
+
+			assert.Equal(t, string(openbaov1alpha1.ConditionDegraded), cond.Type)
+			assert.Equal(t, tt.wantStatus, cond.Status)
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, cond.Reason)
+			}
+		})
+	}
+}
+
+func TestBuildUpgradingCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		cluster    *openbaov1alpha1.OpenBaoCluster
+		wantStatus metav1.ConditionStatus
+	}{
+		{
+			name:       "no upgrade in progress",
+			cluster:    &openbaov1alpha1.OpenBaoCluster{},
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "rolling upgrade in progress",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Upgrade: &openbaov1alpha1.UpgradeProgress{
+						FromVersion:   "2.0.0",
+						TargetVersion: "2.1.0",
+					},
+				},
+			},
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "upgrade failed",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Upgrade: &openbaov1alpha1.UpgradeProgress{
+						LastErrorReason:  "PodNotReady",
+						LastErrorMessage: "Pod failed to become ready",
+					},
+				},
+			},
+			wantStatus: metav1.ConditionFalse, // Failed upgrade shows as not upgrading
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := buildUpgradingCondition(tt.cluster)
+
+			assert.Equal(t, string(openbaov1alpha1.ConditionUpgrading), cond.Type)
+			assert.Equal(t, tt.wantStatus, cond.Status)
+		})
+	}
+}
+
+func TestBuildBackupCondition(t *testing.T) {
+	tests := []struct {
+		name             string
+		backupInProgress bool
+		backupJobName    string
+		wantStatus       metav1.ConditionStatus
+	}{
+		{
+			name:             "no backup in progress",
+			backupInProgress: false,
+			wantStatus:       metav1.ConditionFalse,
+		},
+		{
+			name:             "backup in progress with job name",
+			backupInProgress: true,
+			backupJobName:    "my-backup-job",
+			wantStatus:       metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := buildBackupCondition(tt.backupInProgress, tt.backupJobName)
+
+			assert.Equal(t, string(openbaov1alpha1.ConditionBackingUp), cond.Type)
+			assert.Equal(t, tt.wantStatus, cond.Status)
+		})
+	}
+}
+
+func TestBuildLeaderCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		leaderCount int
+		leaderName  string
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+	}{
+		{
+			name:        "no leader",
+			leaderCount: 0,
+			wantStatus:  metav1.ConditionUnknown,
+			wantReason:  ReasonLeaderUnknown,
+		},
+		{
+			name:        "single leader",
+			leaderCount: 1,
+			leaderName:  "my-cluster-0",
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  ReasonLeaderFound,
+		},
+		{
+			name:        "multiple leaders (split brain)",
+			leaderCount: 2,
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  ReasonMultipleLeaders,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := buildLeaderCondition(tt.leaderCount, tt.leaderName)
+
+			assert.Equal(t, string(openbaov1alpha1.ConditionOpenBaoLeader), cond.Type)
+			assert.Equal(t, tt.wantStatus, cond.Status)
+			assert.Equal(t, tt.wantReason, cond.Reason)
+		})
+	}
+}
+
+func TestBuildInitializedCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialized bool
+		present     bool
+		wantStatus  metav1.ConditionStatus
+	}{
+		{
+			name:       "state not known",
+			present:    false,
+			wantStatus: metav1.ConditionUnknown,
+		},
+		{
+			name:        "initialized",
+			initialized: true,
+			present:     true,
+			wantStatus:  metav1.ConditionTrue,
+		},
+		{
+			name:        "not initialized",
+			initialized: false,
+			present:     true,
+			wantStatus:  metav1.ConditionFalse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := buildInitializedCondition(tt.initialized, tt.present)
+
+			assert.Equal(t, string(openbaov1alpha1.ConditionOpenBaoInitialized), cond.Type)
+			assert.Equal(t, tt.wantStatus, cond.Status)
+		})
+	}
+}
+
+func TestComputePhase(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     *clusterState
+		wantPhase openbaov1alpha1.ClusterPhase
+	}{
+		{
+			name:      "initializing",
+			state:     &clusterState{Available: false},
+			wantPhase: openbaov1alpha1.ClusterPhaseInitializing,
+		},
+		{
+			name:      "running",
+			state:     &clusterState{Available: true},
+			wantPhase: openbaov1alpha1.ClusterPhaseRunning,
+		},
+		{
+			name:      "upgrading",
+			state:     &clusterState{UpgradeInProgress: true},
+			wantPhase: openbaov1alpha1.ClusterPhaseUpgrading,
+		},
+		{
+			name:      "backing up",
+			state:     &clusterState{BackupInProgress: true},
+			wantPhase: openbaov1alpha1.ClusterPhaseBackingUp,
+		},
+		{
+			name:      "failed",
+			state:     &clusterState{UpgradeFailed: true},
+			wantPhase: openbaov1alpha1.ClusterPhaseFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			phase := computePhase(tt.state)
+			assert.Equal(t, tt.wantPhase, phase)
+		})
+	}
+}
+
+func TestEvaluateProductionReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		cluster    *openbaov1alpha1.OpenBaoCluster
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name: "profile not set",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: ReasonProfileNotSet,
+		},
+		{
+			name: "development profile",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Profile: openbaov1alpha1.ProfileDevelopment,
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: ReasonDevelopmentProfile,
+		},
+		{
+			name: "hardened but static unseal",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Profile:  openbaov1alpha1.ProfileHardened,
+					SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: true},
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeExternal,
+					},
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: ReasonStaticUnsealInUse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, reason, _ := evaluateProductionReady(tt.cluster, true, "")
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Refactors the `updateStatus` function in `internal/controller/openbaocluster/status.go` to significantly reduce complexity and improve maintainability. The function was previously 689 lines long with high cyclomatic complexity (`//nolint:gocyclo`).

Key changes:
- **Separation of Concnerns**: Extracted data gathering into a new `gatherClusterState` method and `clusterState` struct in `cluster_state.go`.
- **Pure Logic Extraction**: Moved all condition logic into `applyAllConditions` and pure helper functions in `status_helpers.go`.
- **Simplification**: The main `updateStatus` function is reduced to ~80 lines, following a clear gather -> compute -> persist -> requeue pattern.
- **Removed Tech Debt**: Removed the `//nolint:gocyclo` directive as the complexity is now well within limits.

## Related Issues

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.

## Verification Process

Run the new unit tests for the helper functions:

```sh
make test
```

Run the upgrade e2e tests (these verify status through cluster behavior):

```sh
make test-e2e E2E_PARALLEL_NODES=4 E2E_LABEL_FILTER="upgrade"
```