### PR TITLE
refactor(controller): unify image verification handling

### DIFF
--- a/internal/controller/openbaocluster/infra_reconciler_test.go
+++ b/internal/controller/openbaocluster/infra_reconciler_test.go
@@ -1,0 +1,163 @@
+package openbaocluster
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/constants"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/errors"
+)
+
+func TestInfraReconcilerVerifyMainImageDigest_DisabledDoesNotCallVerifier(t *testing.T) {
+	t.Parallel()
+
+	called := 0
+	r := &infraReconciler{
+		verifyImageFunc: func(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (string, error) {
+			called++
+			return "", nil
+		},
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "ns1"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Image: "example/openbao:test",
+		},
+	}
+
+	digest, err := r.verifyMainImageDigest(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("verifyMainImageDigest() error = %v, want nil", err)
+	}
+	if digest != "" {
+		t.Fatalf("verifyMainImageDigest() digest = %q, want empty", digest)
+	}
+	if called != 0 {
+		t.Fatalf("verifyImageFunc called %d times, want 0", called)
+	}
+}
+
+func TestInfraReconcilerVerifyMainImageDigest_BlockReturnsReasonedError(t *testing.T) {
+	t.Parallel()
+
+	r := &infraReconciler{
+		verifyImageFunc: func(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (string, error) {
+			return "", errors.New("verification failed")
+		},
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "ns1"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Image: "example/openbao:test",
+			ImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled:       true,
+				FailurePolicy: constants.ImageVerificationFailurePolicyBlock,
+			},
+		},
+	}
+
+	_, err := r.verifyMainImageDigest(context.Background(), logr.Discard(), cluster)
+	if err == nil {
+		t.Fatalf("verifyMainImageDigest() error = nil, want non-nil")
+	}
+	if reason, ok := operatorerrors.Reason(err); !ok || reason != constants.ReasonImageVerificationFailed {
+		t.Fatalf("verifyMainImageDigest() reason = (%q,%t), want (%q,true)", reason, ok, constants.ReasonImageVerificationFailed)
+	}
+}
+
+func TestInfraReconcilerVerifyMainImageDigest_WarnEmitsEvent(t *testing.T) {
+	t.Parallel()
+
+	recorder := record.NewFakeRecorder(1)
+	r := &infraReconciler{
+		verifyImageFunc: func(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (string, error) {
+			return "", errors.New("verification failed")
+		},
+		recorder: recorder,
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "ns1"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Image: "example/openbao:test",
+			ImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled:       true,
+				FailurePolicy: constants.ImageVerificationFailurePolicyWarn,
+			},
+		},
+	}
+
+	digest, err := r.verifyMainImageDigest(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("verifyMainImageDigest() error = %v, want nil", err)
+	}
+	if digest != "" {
+		t.Fatalf("verifyMainImageDigest() digest = %q, want empty", digest)
+	}
+
+	select {
+	case evt := <-recorder.Events:
+		if !strings.Contains(evt, constants.ReasonImageVerificationFailed) {
+			t.Fatalf("event %q missing reason %q", evt, constants.ReasonImageVerificationFailed)
+		}
+		if !strings.Contains(evt, "Image verification failed but proceeding due to Warn policy") {
+			t.Fatalf("event %q missing expected message", evt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected an event but none was emitted")
+	}
+}
+
+func TestInfraReconcilerVerifyOperatorImageDigest_WarnEmitsEvent(t *testing.T) {
+	t.Parallel()
+
+	recorder := record.NewFakeRecorder(1)
+	r := &infraReconciler{
+		verifyOperatorImageFunc: func(ctx context.Context, logger logr.Logger, kubeClient client.Client, cluster *openbaov1alpha1.OpenBaoCluster, imageRef string) (string, error) {
+			return "", errors.New("verification failed")
+		},
+		recorder: recorder,
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "ns1"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Image: "example/openbao:test",
+			OperatorImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled:       true,
+				FailurePolicy: constants.ImageVerificationFailurePolicyWarn,
+			},
+		},
+	}
+
+	digest, err := r.verifyOperatorImageDigest(context.Background(), logr.Discard(), cluster, "example/sentinel:test", constants.ReasonSentinelImageVerificationFailed, "Sentinel image verification failed")
+	if err != nil {
+		t.Fatalf("verifyOperatorImageDigest() error = %v, want nil", err)
+	}
+	if digest != "" {
+		t.Fatalf("verifyOperatorImageDigest() digest = %q, want empty", digest)
+	}
+
+	select {
+	case evt := <-recorder.Events:
+		if !strings.Contains(evt, constants.ReasonSentinelImageVerificationFailed) {
+			t.Fatalf("event %q missing reason %q", evt, constants.ReasonSentinelImageVerificationFailed)
+		}
+		if !strings.Contains(evt, "Sentinel image verification failed but proceeding due to Warn policy") {
+			t.Fatalf("event %q missing expected message", evt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected an event but none was emitted")
+	}
+}


### PR DESCRIPTION
## Description

Unifies image verification handling in the workload (infra) reconciler so main OpenBao images and operator-managed helper images (sentinel/init) follow the same verification flow: timeout, digest return on success, and consistent Block vs Warn behavior (including emitting Warning Events on Warn).

This reduces drift between verification paths, makes behavior easier to reason about, and improves testability by extracting shared policy logic and adding focused unit tests.

## Related Issues

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- Run `go test ./...`
- (Optional) Run focused tests: `go test ./internal/controller/openbaocluster -run TestInfraReconciler -count=1`
