### PR TITLE
refactor(infra): Introduce seal wiring providers for all unseal types

### DIFF
--- a/internal/infra/seal_wiring.go
+++ b/internal/infra/seal_wiring.go
@@ -1,0 +1,298 @@
+package infra
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+const (
+	sealCredsVolumeName      = "seal-creds"
+	sealCredsVolumeMountPath = "/etc/bao/seal-creds"
+)
+
+type sealWiringProvider interface {
+	EnvVars() []corev1.EnvVar
+	VolumeMounts() []corev1.VolumeMount
+	Volumes() []corev1.Volume
+}
+
+func envVarFromCredentialsSecret(cluster *openbaov1alpha1.OpenBaoCluster, envName string, secretKey string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: envName,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: cluster.Spec.Unseal.CredentialsSecretRef.Name,
+				},
+				Key:      secretKey,
+				Optional: ptr.To(true),
+			},
+		},
+	}
+}
+
+func newSealWiringProvider(cluster *openbaov1alpha1.OpenBaoCluster) sealWiringProvider {
+	if usesStaticSeal(cluster) {
+		return &staticSealWiringProvider{cluster: cluster}
+	}
+
+	switch cluster.Spec.Unseal.Type {
+	case "transit":
+		return &transitSealWiringProvider{cluster: cluster}
+	case "gcpckms":
+		return &gcpCKMSSealWiringProvider{cluster: cluster}
+	case "awskms":
+		return &awsKMSSealWiringProvider{cluster: cluster}
+	case "azurekeyvault":
+		return &azureKeyVaultSealWiringProvider{cluster: cluster}
+	case "kmip":
+		return &kmipSealWiringProvider{cluster: cluster}
+	case "ocikms":
+		return &ociKMSSealWiringProvider{cluster: cluster}
+	case "pkcs11":
+		return &pkcs11SealWiringProvider{cluster: cluster}
+	default:
+		// Preserve current behavior: treat unknown non-static seal types as requiring
+		// only credentials Secret wiring (if provided).
+		return &credentialsSecretSealWiringProvider{cluster: cluster}
+	}
+}
+
+type staticSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *staticSealWiringProvider) EnvVars() []corev1.EnvVar { return nil }
+
+func (p *staticSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      unsealVolumeName,
+			MountPath: openBaoUnsealMountPath,
+			ReadOnly:  true,
+		},
+	}
+}
+
+func (p *staticSealWiringProvider) Volumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: unsealVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  unsealSecretName(p.cluster),
+					DefaultMode: ptr.To(secretFileMode),
+				},
+			},
+		},
+	}
+}
+
+// credentialsSecretSealWiringProvider wires an optional credentials Secret into the
+// pod as a volume. Most external seal types don't require additional env wiring.
+type credentialsSecretSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *credentialsSecretSealWiringProvider) EnvVars() []corev1.EnvVar { return nil }
+
+func (p *credentialsSecretSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+	return []corev1.VolumeMount{
+		{
+			Name:      sealCredsVolumeName,
+			MountPath: sealCredsVolumeMountPath,
+			ReadOnly:  true,
+		},
+	}
+}
+
+func (p *credentialsSecretSealWiringProvider) Volumes() []corev1.Volume {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+	return []corev1.Volume{
+		{
+			Name: sealCredsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  p.cluster.Spec.Unseal.CredentialsSecretRef.Name,
+					DefaultMode: ptr.To(secretFileMode),
+				},
+			},
+		},
+	}
+}
+
+type awsKMSSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *awsKMSSealWiringProvider) EnvVars() []corev1.EnvVar {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		envVarFromCredentialsSecret(p.cluster, "AWS_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID"),
+		envVarFromCredentialsSecret(p.cluster, "AWS_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY"),
+		envVarFromCredentialsSecret(p.cluster, "AWS_SESSION_TOKEN", "AWS_SESSION_TOKEN"),
+	}
+}
+
+func (p *awsKMSSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *awsKMSSealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}
+
+type azureKeyVaultSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *azureKeyVaultSealWiringProvider) EnvVars() []corev1.EnvVar {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		envVarFromCredentialsSecret(p.cluster, "AZURE_TENANT_ID", "AZURE_TENANT_ID"),
+		envVarFromCredentialsSecret(p.cluster, "AZURE_CLIENT_ID", "AZURE_CLIENT_ID"),
+		envVarFromCredentialsSecret(p.cluster, "AZURE_CLIENT_SECRET", "AZURE_CLIENT_SECRET"),
+		envVarFromCredentialsSecret(p.cluster, "AZURE_ENVIRONMENT", "AZURE_ENVIRONMENT"),
+		envVarFromCredentialsSecret(p.cluster, "AZURE_AD_RESOURCE", "AZURE_AD_RESOURCE"),
+	}
+}
+
+func (p *azureKeyVaultSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *azureKeyVaultSealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}
+
+type kmipSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *kmipSealWiringProvider) EnvVars() []corev1.EnvVar { return nil }
+
+func (p *kmipSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *kmipSealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}
+
+type ociKMSSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *ociKMSSealWiringProvider) EnvVars() []corev1.EnvVar { return nil }
+
+func (p *ociKMSSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *ociKMSSealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}
+
+type pkcs11SealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *pkcs11SealWiringProvider) EnvVars() []corev1.EnvVar {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		envVarFromCredentialsSecret(p.cluster, "BAO_HSM_PIN", "BAO_HSM_PIN"),
+	}
+}
+
+func (p *pkcs11SealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *pkcs11SealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}
+
+type transitSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *transitSealWiringProvider) EnvVars() []corev1.EnvVar {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+
+	// Read token from the mounted secret file and set as VAULT_TOKEN.
+	// This allows the seal to use the "token" parameter instead of "token_file",
+	// avoiding issues with trailing newlines in mounted Secret files.
+	return []corev1.EnvVar{
+		{
+			Name: "VAULT_TOKEN",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "token",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: p.cluster.Spec.Unseal.CredentialsSecretRef.Name,
+					},
+				},
+			},
+		},
+		{
+			// If the credentials Secret provides a CA bundle, surface it via VAULT_CACERT
+			// so transit seal HTTP calls verify infra-bao TLS.
+			Name:  "VAULT_CACERT",
+			Value: sealCredsVolumeMountPath + "/ca.crt",
+		},
+	}
+}
+
+func (p *transitSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *transitSealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}
+
+type gcpCKMSSealWiringProvider struct {
+	cluster *openbaov1alpha1.OpenBaoCluster
+}
+
+func (p *gcpCKMSSealWiringProvider) EnvVars() []corev1.EnvVar {
+	if p.cluster.Spec.Unseal == nil || p.cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+
+	// The credentials secret must contain a key named "credentials.json" with the
+	// GCP service account JSON credentials. This will be mounted at
+	// /etc/bao/seal-creds/credentials.json and referenced by the environment variable.
+	return []corev1.EnvVar{
+		{
+			Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+			Value: sealCredsVolumeMountPath + "/credentials.json",
+		},
+	}
+}
+
+func (p *gcpCKMSSealWiringProvider) VolumeMounts() []corev1.VolumeMount {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).VolumeMounts()
+}
+
+func (p *gcpCKMSSealWiringProvider) Volumes() []corev1.Volume {
+	return (&credentialsSecretSealWiringProvider{cluster: p.cluster}).Volumes()
+}

--- a/internal/infra/seal_wiring_test.go
+++ b/internal/infra/seal_wiring_test.go
@@ -1,0 +1,196 @@
+package infra
+
+import (
+	"path"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestSealWiring_StaticDefault_MountsUnseal(t *testing.T) {
+	cluster := newMinimalCluster("seal-static-default", "default")
+
+	env := buildContainerEnv(cluster)
+	mounts := buildContainerVolumeMounts(cluster, path.Dir(openBaoRenderedConfig))
+	volumes := buildStatefulSetVolumes(cluster, "", false)
+
+	if hasVolume(volumes, sealCredsVolumeName) {
+		t.Fatalf("expected %q volume to be absent for static seal", sealCredsVolumeName)
+	}
+	if hasVolumeMount(mounts, sealCredsVolumeName) {
+		t.Fatalf("expected %q volume mount to be absent for static seal", sealCredsVolumeName)
+	}
+	if hasEnvVar(env, "VAULT_TOKEN") || hasEnvVar(env, "VAULT_CACERT") || hasEnvVar(env, "GOOGLE_APPLICATION_CREDENTIALS") {
+		t.Fatalf("expected no external-seal env vars for static seal")
+	}
+
+	unsealVol, ok := getVolume(volumes, unsealVolumeName)
+	if !ok {
+		t.Fatalf("expected %q volume to be present for static seal", unsealVolumeName)
+	}
+	if unsealVol.Secret == nil || unsealVol.Secret.SecretName != unsealSecretName(cluster) {
+		t.Fatalf("expected %q volume to use secret %q", unsealVolumeName, unsealSecretName(cluster))
+	}
+	if !hasVolumeMountWithPath(mounts, unsealVolumeName, openBaoUnsealMountPath) {
+		t.Fatalf("expected %q volume mount at %q for static seal", unsealVolumeName, openBaoUnsealMountPath)
+	}
+}
+
+func TestSealWiring_ExternalTypes_WithCredentials_MountsSealCredsAndEnv(t *testing.T) {
+	cases := []struct {
+		name         string
+		unsealType   string
+		expectEnvVar []string
+	}{
+		{name: "transit", unsealType: "transit", expectEnvVar: []string{"VAULT_TOKEN", "VAULT_CACERT"}},
+		{name: "gcpckms", unsealType: "gcpckms", expectEnvVar: []string{"GOOGLE_APPLICATION_CREDENTIALS"}},
+		{name: "awskms", unsealType: "awskms", expectEnvVar: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"}},
+		{name: "azurekeyvault", unsealType: "azurekeyvault", expectEnvVar: []string{"AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_ENVIRONMENT", "AZURE_AD_RESOURCE"}},
+		{name: "kmip", unsealType: "kmip"},
+		{name: "ocikms", unsealType: "ocikms"},
+		{name: "pkcs11", unsealType: "pkcs11", expectEnvVar: []string{"BAO_HSM_PIN"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := newMinimalCluster("seal-"+tc.name, "default")
+			cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+				Type: tc.unsealType,
+				CredentialsSecretRef: &corev1.LocalObjectReference{
+					Name: "provider-creds",
+				},
+			}
+
+			env := buildContainerEnv(cluster)
+			mounts := buildContainerVolumeMounts(cluster, path.Dir(openBaoRenderedConfig))
+			volumes := buildStatefulSetVolumes(cluster, "", false)
+
+			if hasVolume(volumes, unsealVolumeName) {
+				t.Fatalf("expected %q volume to be absent for external seal type %q", unsealVolumeName, tc.unsealType)
+			}
+			if hasVolumeMount(mounts, unsealVolumeName) {
+				t.Fatalf("expected %q volume mount to be absent for external seal type %q", unsealVolumeName, tc.unsealType)
+			}
+
+			sealCredsVol, ok := getVolume(volumes, sealCredsVolumeName)
+			if !ok {
+				t.Fatalf("expected %q volume to be present when credentialsSecretRef is set", sealCredsVolumeName)
+			}
+			if sealCredsVol.Secret == nil || sealCredsVol.Secret.SecretName != "provider-creds" {
+				t.Fatalf("expected %q volume to use secret %q", sealCredsVolumeName, "provider-creds")
+			}
+			if !hasVolumeMountWithPath(mounts, sealCredsVolumeName, sealCredsVolumeMountPath) {
+				t.Fatalf("expected %q volume mount at %q when credentialsSecretRef is set", sealCredsVolumeName, sealCredsVolumeMountPath)
+			}
+
+			for _, envName := range tc.expectEnvVar {
+				if !hasEnvVar(env, envName) {
+					t.Fatalf("expected env var %q for seal type %q", envName, tc.unsealType)
+				}
+			}
+
+			if tc.unsealType == "transit" {
+				vaultToken := findEnvVar(env, "VAULT_TOKEN")
+				if vaultToken == nil || vaultToken.ValueFrom == nil || vaultToken.ValueFrom.SecretKeyRef == nil {
+					t.Fatalf("expected VAULT_TOKEN to come from SecretKeyRef for transit seal")
+				}
+				if vaultToken.ValueFrom.SecretKeyRef.Name != "provider-creds" || vaultToken.ValueFrom.SecretKeyRef.Key != "token" {
+					t.Fatalf("expected VAULT_TOKEN SecretKeyRef to be %q/%q, got %q/%q", "provider-creds", "token", vaultToken.ValueFrom.SecretKeyRef.Name, vaultToken.ValueFrom.SecretKeyRef.Key)
+				}
+			}
+		})
+	}
+}
+
+func TestSealWiring_ExternalTypes_WithoutCredentials_DoesNotMountSealCredsOrEnv(t *testing.T) {
+	types := []string{"transit", "gcpckms", "awskms", "azurekeyvault", "kmip", "ocikms", "pkcs11"}
+
+	for _, unsealType := range types {
+		t.Run(unsealType, func(t *testing.T) {
+			cluster := newMinimalCluster("seal-"+unsealType, "default")
+			cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{Type: unsealType}
+
+			env := buildContainerEnv(cluster)
+			mounts := buildContainerVolumeMounts(cluster, path.Dir(openBaoRenderedConfig))
+			volumes := buildStatefulSetVolumes(cluster, "", false)
+
+			if hasVolume(volumes, sealCredsVolumeName) || hasVolumeMount(mounts, sealCredsVolumeName) {
+				t.Fatalf("expected %q volume/mount to be absent when credentialsSecretRef is not set", sealCredsVolumeName)
+			}
+			if hasEnvVar(env, "VAULT_TOKEN") || hasEnvVar(env, "VAULT_CACERT") || hasEnvVar(env, "GOOGLE_APPLICATION_CREDENTIALS") {
+				t.Fatalf("expected no credentials-derived env vars when credentialsSecretRef is not set")
+			}
+		})
+	}
+}
+
+func TestSealWiring_StaticExplicitAndImplicit_StillMountsUnseal(t *testing.T) {
+	cases := []struct {
+		name   string
+		unseal *openbaov1alpha1.UnsealConfig
+	}{
+		{name: "explicit-static", unseal: &openbaov1alpha1.UnsealConfig{Type: "static"}},
+		{name: "implicit-empty-type", unseal: &openbaov1alpha1.UnsealConfig{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := newMinimalCluster("seal-"+tc.name, "default")
+			cluster.Spec.Unseal = tc.unseal
+
+			mounts := buildContainerVolumeMounts(cluster, path.Dir(openBaoRenderedConfig))
+			volumes := buildStatefulSetVolumes(cluster, "", false)
+
+			if !hasVolume(volumes, unsealVolumeName) || !hasVolumeMount(mounts, unsealVolumeName) {
+				t.Fatalf("expected %q volume and mount for static seal case %q", unsealVolumeName, tc.name)
+			}
+		})
+	}
+}
+
+func hasEnvVar(env []corev1.EnvVar, name string) bool {
+	return findEnvVar(env, name) != nil
+}
+
+func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == name {
+			return &env[i]
+		}
+	}
+	return nil
+}
+
+func hasVolume(volumes []corev1.Volume, name string) bool {
+	_, ok := getVolume(volumes, name)
+	return ok
+}
+
+func getVolume(volumes []corev1.Volume, name string) (*corev1.VolumeSource, bool) {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i].VolumeSource, true
+		}
+	}
+	return nil, false
+}
+
+func hasVolumeMount(mounts []corev1.VolumeMount, name string) bool {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeMountWithPath(mounts []corev1.VolumeMount, name, mountPath string) bool {
+	for i := range mounts {
+		if mounts[i].Name == name && mounts[i].MountPath == mountPath {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description

This change introduces a dedicated seal wiring abstraction (`sealWiringProvider`) to decouple seal-type-specific Kubernetes pod wiring (env vars, volumes, mounts) from the StatefulSet builder.

It standardizes how the operator wires credentials into the OpenBao pod for each unseal type:
- Static seal mounts the operator-managed unseal Secret.
- External seal types mount an optional `credentialsSecretRef` as `/etc/bao/seal-creds`.
- Seal types that rely on environment variables (e.g., transit token/TLS CA, GCP credentials path, AWS/Azure env-based credentials, PKCS#11 PIN) now get explicit env var wiring sourced from `credentialsSecretRef`.

This reduces conditional logic in the StatefulSet build path and makes it easier to extend/maintain wiring per provider going forward.

## Related Issues

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- Run unit tests:
  - `go test ./...`
- Specifically verify seal wiring behavior:
  - `go test ./internal/infra -run TestSealWiring`
- Review `internal/infra/statefulset_builder.go` to confirm seal wiring is applied via:
  - env: `newSealWiringProvider(cluster).EnvVars()`
  - mounts: `newSealWiringProvider(cluster).VolumeMounts()`
  - volumes: `newSealWiringProvider(cluster).Volumes()`
