### PR TITLE
refactor(config): introduce registry handler for self-init

### DIFF
--- a/internal/config/selfinit_handlers.go
+++ b/internal/config/selfinit_handlers.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type selfInitRequestDataHandler func(req openbaov1alpha1.SelfInitRequest) (cty.Value, error)
+
+type selfInitRequestDataHandlerRegistration struct {
+	Prefix  string
+	Handler selfInitRequestDataHandler
+}
+
+var selfInitRequestDataHandlers = []selfInitRequestDataHandlerRegistration{
+	{
+		Prefix:  "sys/audit/",
+		Handler: selfInitAuditDeviceDataHandler,
+	},
+	{
+		Prefix:  "sys/auth/",
+		Handler: selfInitAuthMethodDataHandler,
+	},
+	{
+		Prefix:  "sys/mounts/",
+		Handler: selfInitSecretEngineDataHandler,
+	},
+	{
+		Prefix:  "sys/policies/",
+		Handler: selfInitPolicyDataHandler,
+	},
+}
+
+func resolveSelfInitRequestStructuredData(req openbaov1alpha1.SelfInitRequest) (cty.Value, bool, error) {
+	handler, ok := findSelfInitRequestDataHandler(req.Path)
+	if !ok {
+		return cty.NilVal, false, nil
+	}
+
+	val, err := handler(req)
+	if err != nil {
+		return cty.NilVal, true, err
+	}
+	return val, true, nil
+}
+
+func findSelfInitRequestDataHandler(path string) (selfInitRequestDataHandler, bool) {
+	bestIdx := -1
+	bestLen := -1
+	for i, reg := range selfInitRequestDataHandlers {
+		if !strings.HasPrefix(path, reg.Prefix) {
+			continue
+		}
+		if len(reg.Prefix) > bestLen {
+			bestIdx = i
+			bestLen = len(reg.Prefix)
+		}
+	}
+
+	if bestIdx == -1 {
+		return nil, false
+	}
+	return selfInitRequestDataHandlers[bestIdx].Handler, true
+}
+
+func selfInitAuditDeviceDataHandler(req openbaov1alpha1.SelfInitRequest) (cty.Value, error) {
+	if req.AuditDevice == nil {
+		return cty.NilVal, fmt.Errorf("audit device request %q at path %q must use structured auditDevice field, not raw data", req.Name, req.Path)
+	}
+
+	dataVal, err := buildAuditDeviceData(req.AuditDevice)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("failed to build audit device data for request %q: %w", req.Name, err)
+	}
+
+	return dataVal, nil
+}
+
+func selfInitAuthMethodDataHandler(req openbaov1alpha1.SelfInitRequest) (cty.Value, error) {
+	if req.AuthMethod == nil {
+		return cty.NilVal, fmt.Errorf("auth method request %q at path %q must use structured authMethod field, not raw data", req.Name, req.Path)
+	}
+
+	dataVal, err := buildAuthMethodData(req.AuthMethod)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("failed to build auth method data for request %q: %w", req.Name, err)
+	}
+
+	return dataVal, nil
+}
+
+func selfInitSecretEngineDataHandler(req openbaov1alpha1.SelfInitRequest) (cty.Value, error) {
+	if req.SecretEngine == nil {
+		return cty.NilVal, fmt.Errorf("secret engine request %q at path %q must use structured secretEngine field, not raw data", req.Name, req.Path)
+	}
+
+	dataVal, err := buildSecretEngineData(req.SecretEngine)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("failed to build secret engine data for request %q: %w", req.Name, err)
+	}
+
+	return dataVal, nil
+}
+
+func selfInitPolicyDataHandler(req openbaov1alpha1.SelfInitRequest) (cty.Value, error) {
+	if req.Policy == nil {
+		return cty.NilVal, fmt.Errorf("policy request %q at path %q must use structured policy field, not raw data", req.Name, req.Path)
+	}
+
+	dataVal, err := buildPolicyData(req.Policy)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("failed to build policy data for request %q: %w", req.Name, err)
+	}
+
+	return dataVal, nil
+}

--- a/internal/config/selfinit_handlers_test.go
+++ b/internal/config/selfinit_handlers_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestRenderSelfInitStanzas_StructuredPrefixRequiresStructuredFields_EvenWithRawData(t *testing.T) {
+	file := hclwrite.NewEmptyFile()
+
+	err := renderSelfInitStanzas(file.Body(), []openbaov1alpha1.SelfInitRequest{
+		{
+			Name:      "enable-audit",
+			Operation: openbaov1alpha1.SelfInitOperationUpdate,
+			Path:      "sys/audit/stdout",
+			Data:      &apiextensionsv1.JSON{Raw: []byte(`{"type":"file"}`)},
+		},
+	})
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	want := `audit device request "enable-audit" at path "sys/audit/stdout" must use structured auditDevice field, not raw data`
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRenderSelfInitStanzas_UnknownPrefix_UsesRawData(t *testing.T) {
+	file := hclwrite.NewEmptyFile()
+
+	err := renderSelfInitStanzas(file.Body(), []openbaov1alpha1.SelfInitRequest{
+		{
+			Name:      "configure-jwt",
+			Operation: openbaov1alpha1.SelfInitOperationUpdate,
+			Path:      "auth/jwt/config",
+			Data:      &apiextensionsv1.JSON{Raw: []byte(`{"foo":"bar"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderSelfInitStanzas() error = %v", err)
+	}
+
+	got := string(file.Bytes())
+	if !strings.Contains(got, `path      = "auth/jwt/config"`) {
+		t.Fatalf("expected output to include request path, got:\n%s", got)
+	}
+	if !strings.Contains(got, "data {") || !strings.Contains(got, `foo = "bar"`) {
+		t.Fatalf("expected output to include data block, got:\n%s", got)
+	}
+}
+
+func TestRenderSelfInitStanzas_KnownPrefix_IgnoresRawDataAndUsesStructured(t *testing.T) {
+	file := hclwrite.NewEmptyFile()
+
+	err := renderSelfInitStanzas(file.Body(), []openbaov1alpha1.SelfInitRequest{
+		{
+			Name:      "enable-jwt",
+			Operation: openbaov1alpha1.SelfInitOperationUpdate,
+			Path:      "sys/auth/jwt",
+			AuthMethod: &openbaov1alpha1.SelfInitAuthMethod{
+				Type: "jwt",
+			},
+			Data: &apiextensionsv1.JSON{Raw: []byte(`{"type":"kubernetes"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderSelfInitStanzas() error = %v", err)
+	}
+
+	got := string(file.Bytes())
+	if !strings.Contains(got, `type = "jwt"`) {
+		t.Fatalf("expected output to use structured auth method type, got:\n%s", got)
+	}
+	if strings.Contains(got, "kubernetes") {
+		t.Fatalf("expected raw data to be ignored for structured prefixes, got:\n%s", got)
+	}
+}
+
+func TestResolveSelfInitRequestStructuredData_PicksMostSpecificPrefix(t *testing.T) {
+	original := selfInitRequestDataHandlers
+	selfInitRequestDataHandlers = []selfInitRequestDataHandlerRegistration{
+		{
+			Prefix: "sys/",
+			Handler: func(_ openbaov1alpha1.SelfInitRequest) (cty.Value, error) {
+				return cty.StringVal("broad"), nil
+			},
+		},
+		{
+			Prefix: "sys/auth/",
+			Handler: func(_ openbaov1alpha1.SelfInitRequest) (cty.Value, error) {
+				return cty.StringVal("specific"), nil
+			},
+		},
+	}
+	t.Cleanup(func() { selfInitRequestDataHandlers = original })
+
+	val, handled, err := resolveSelfInitRequestStructuredData(openbaov1alpha1.SelfInitRequest{
+		Name: "test",
+		Path: "sys/auth/jwt",
+	})
+	if err != nil {
+		t.Fatalf("resolveSelfInitRequestStructuredData() error = %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected handled=true, got false")
+	}
+	if val.Type() != cty.String || val.AsString() != "specific" {
+		t.Fatalf("expected most specific handler, got %s", val.GoString())
+	}
+}


### PR DESCRIPTION
## Description

This refactors self-init stanza rendering to replace the growing `if/else` prefix chain in `renderSelfInitStanzas` with a small handler registry keyed by API path prefix. It keeps behavior the same (known prefixes require structured fields; unknown prefixes use raw `data`) while making it a one-line change to add new supported self-init paths.

## Related Issues

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- Run `go test ./internal/config` (covers new dispatch tests and existing golden tests).
- Optionally run `go test ./...` to ensure no regressions across the repo.
