### PR TITLE
refactor(infra): remove duplication in network reconciliation flow for optional network resources

### DIFF
--- a/internal/infra/optional_resource.go
+++ b/internal/infra/optional_resource.go
@@ -1,0 +1,99 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/errors"
+)
+
+type optionalResourceOptions struct {
+	kind       string
+	apiVersion string
+
+	enabled bool
+	name    types.NamespacedName
+
+	logger logr.Logger
+
+	logKey string
+
+	deleteDisabledMsg string
+	deleteInvalidMsg  string
+
+	newEmpty     func() client.Object
+	buildDesired func() (client.Object, bool, error)
+
+	get    func(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error
+	delete func(context.Context, client.Object) error
+	apply  func(context.Context, client.Object) error
+
+	degradeOnCRDMissing bool
+}
+
+func reconcileOptionalResource(ctx context.Context, opts optionalResourceOptions) error {
+	if opts.get == nil || opts.delete == nil || opts.apply == nil {
+		return fmt.Errorf("optional %s %s/%s: missing get/delete/apply functions", opts.kind, opts.name.Namespace, opts.name.Name)
+	}
+
+	deleteIfExists := func(msg string) error {
+		empty := opts.newEmpty()
+		if empty == nil {
+			return fmt.Errorf("optional %s %s/%s: newEmpty returned nil", opts.kind, opts.name.Namespace, opts.name.Name)
+		}
+
+		if err := opts.get(ctx, opts.name, empty); err != nil {
+			if operatorerrors.IsCRDMissingError(err) || apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to get %s %s/%s: %w", opts.kind, opts.name.Namespace, opts.name.Name, err)
+		}
+
+		if msg != "" {
+			if opts.logKey != "" {
+				opts.logger.Info(msg, opts.logKey, opts.name.Name)
+			} else {
+				opts.logger.Info(msg, "name", opts.name.Name)
+			}
+		}
+
+		if err := opts.delete(ctx, empty); err != nil {
+			if operatorerrors.IsCRDMissingError(err) || apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to delete %s %s/%s: %w", opts.kind, opts.name.Namespace, opts.name.Name, err)
+		}
+
+		return nil
+	}
+
+	if !opts.enabled {
+		return deleteIfExists(opts.deleteDisabledMsg)
+	}
+
+	desired, valid, err := opts.buildDesired()
+	if err != nil {
+		return err
+	}
+	if !valid || desired == nil {
+		return deleteIfExists(opts.deleteInvalidMsg)
+	}
+
+	gvk := schema.FromAPIVersionAndKind(opts.apiVersion, opts.kind)
+	desired.GetObjectKind().SetGroupVersionKind(gvk)
+
+	if err := opts.apply(ctx, desired); err != nil {
+		if opts.degradeOnCRDMissing && operatorerrors.IsCRDMissingError(err) {
+			return ErrGatewayAPIMissing
+		}
+		return fmt.Errorf("failed to ensure %s %s/%s: %w", opts.kind, opts.name.Namespace, opts.name.Name, err)
+	}
+
+	return nil
+}

--- a/internal/infra/optional_resource_test.go
+++ b/internal/infra/optional_resource_test.go
@@ -1,0 +1,333 @@
+package infra
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestReconcileOptionalResource_Disabled_NoopsWhenNotFound(t *testing.T) {
+	t.Parallel()
+
+	var getCalls, deleteCalls, applyCalls int
+
+	opts := optionalResourceOptions{
+		kind:              "ConfigMap",
+		apiVersion:        "v1",
+		enabled:           false,
+		name:              types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:            logr.Discard(),
+		deleteDisabledMsg: "disabled; deleting",
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			t.Fatalf("buildDesired should not be called")
+			return nil, false, nil
+		},
+		get: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "x")
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return nil
+		},
+		apply: func(_ context.Context, _ client.Object) error {
+			applyCalls++
+			return nil
+		},
+	}
+
+	if err := reconcileOptionalResource(context.Background(), opts); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if getCalls != 1 || deleteCalls != 0 || applyCalls != 0 {
+		t.Fatalf("unexpected calls: get=%d delete=%d apply=%d", getCalls, deleteCalls, applyCalls)
+	}
+}
+
+func TestReconcileOptionalResource_Disabled_DeletesWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	var getCalls, deleteCalls, applyCalls int
+
+	opts := optionalResourceOptions{
+		kind:              "ConfigMap",
+		apiVersion:        "v1",
+		enabled:           false,
+		name:              types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:            logr.Discard(),
+		deleteDisabledMsg: "disabled; deleting",
+		logKey:            "configmap",
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			t.Fatalf("buildDesired should not be called")
+			return nil, false, nil
+		},
+		get: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return nil
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return nil
+		},
+		apply: func(_ context.Context, _ client.Object) error {
+			applyCalls++
+			return nil
+		},
+	}
+
+	if err := reconcileOptionalResource(context.Background(), opts); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if getCalls != 1 || deleteCalls != 1 || applyCalls != 0 {
+		t.Fatalf("unexpected calls: get=%d delete=%d apply=%d", getCalls, deleteCalls, applyCalls)
+	}
+}
+
+func TestReconcileOptionalResource_Enabled_InvalidConfig_DeletesWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	var getCalls, deleteCalls, applyCalls int
+
+	opts := optionalResourceOptions{
+		kind:             "ConfigMap",
+		apiVersion:       "v1",
+		enabled:          true,
+		name:             types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:           logr.Discard(),
+		deleteInvalidMsg: "invalid; deleting",
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			return nil, false, nil
+		},
+		get: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return nil
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return nil
+		},
+		apply: func(_ context.Context, _ client.Object) error {
+			applyCalls++
+			return nil
+		},
+	}
+
+	if err := reconcileOptionalResource(context.Background(), opts); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if getCalls != 1 || deleteCalls != 1 || applyCalls != 0 {
+		t.Fatalf("unexpected calls: get=%d delete=%d apply=%d", getCalls, deleteCalls, applyCalls)
+	}
+}
+
+func TestReconcileOptionalResource_Enabled_ValidConfig_Applies(t *testing.T) {
+	t.Parallel()
+
+	var getCalls, deleteCalls, applyCalls int
+
+	opts := optionalResourceOptions{
+		kind:       "ConfigMap",
+		apiVersion: "v1",
+		enabled:    true,
+		name:       types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:     logr.Discard(),
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "x",
+					Namespace: "default",
+				},
+			}, true, nil
+		},
+		get: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return nil
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return nil
+		},
+		apply: func(_ context.Context, obj client.Object) error {
+			applyCalls++
+			got := obj.GetObjectKind().GroupVersionKind()
+			want := schema.FromAPIVersionAndKind("v1", "ConfigMap")
+			if got != want {
+				t.Fatalf("unexpected GVK: got=%v want=%v", got, want)
+			}
+			return nil
+		},
+	}
+
+	if err := reconcileOptionalResource(context.Background(), opts); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if getCalls != 0 || deleteCalls != 0 || applyCalls != 1 {
+		t.Fatalf("unexpected calls: get=%d delete=%d apply=%d", getCalls, deleteCalls, applyCalls)
+	}
+}
+
+func TestReconcileOptionalResource_Enabled_BuildError_Propagates(t *testing.T) {
+	t.Parallel()
+
+	sentinelErr := errors.New("boom")
+
+	var getCalls, deleteCalls, applyCalls int
+
+	opts := optionalResourceOptions{
+		kind:       "ConfigMap",
+		apiVersion: "v1",
+		enabled:    true,
+		name:       types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:     logr.Discard(),
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			return nil, false, sentinelErr
+		},
+		get: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return nil
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return nil
+		},
+		apply: func(_ context.Context, _ client.Object) error {
+			applyCalls++
+			return nil
+		},
+	}
+
+	err := reconcileOptionalResource(context.Background(), opts)
+	if !errors.Is(err, sentinelErr) {
+		t.Fatalf("expected %v, got %v", sentinelErr, err)
+	}
+	if getCalls != 0 || deleteCalls != 0 || applyCalls != 0 {
+		t.Fatalf("unexpected calls: get=%d delete=%d apply=%d", getCalls, deleteCalls, applyCalls)
+	}
+}
+
+func TestReconcileOptionalResource_CRDMissingOnApply_DegradesWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	crdMissingErr := errors.New("no matches for kind \"HTTPRoute\" in version \"gateway.networking.k8s.io/v1\"")
+
+	opts := optionalResourceOptions{
+		kind:                "HTTPRoute",
+		apiVersion:          "gateway.networking.k8s.io/v1",
+		enabled:             true,
+		name:                types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:              logr.Discard(),
+		degradeOnCRDMissing: true,
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "default"},
+			}, true, nil
+		},
+		get:    func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error { return nil },
+		delete: func(_ context.Context, _ client.Object) error { return nil },
+		apply:  func(_ context.Context, _ client.Object) error { return crdMissingErr },
+	}
+
+	err := reconcileOptionalResource(context.Background(), opts)
+	if !errors.Is(err, ErrGatewayAPIMissing) {
+		t.Fatalf("expected ErrGatewayAPIMissing, got %T: %v", err, err)
+	}
+}
+
+func TestReconcileOptionalResource_CRDMissingOnApply_DoesNotDegradeWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	crdMissingErr := errors.New("no matches for kind \"HTTPRoute\" in version \"gateway.networking.k8s.io/v1\"")
+
+	opts := optionalResourceOptions{
+		kind:       "HTTPRoute",
+		apiVersion: "gateway.networking.k8s.io/v1",
+		enabled:    true,
+		name:       types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:     logr.Discard(),
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "default"},
+			}, true, nil
+		},
+		get:    func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error { return nil },
+		delete: func(_ context.Context, _ client.Object) error { return nil },
+		apply:  func(_ context.Context, _ client.Object) error { return crdMissingErr },
+	}
+
+	err := reconcileOptionalResource(context.Background(), opts)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if errors.Is(err, ErrGatewayAPIMissing) {
+		t.Fatalf("did not expect ErrGatewayAPIMissing, got %T: %v", err, err)
+	}
+}
+
+func TestReconcileOptionalResource_CRDMissingOnDelete_IsIgnored(t *testing.T) {
+	t.Parallel()
+
+	crdMissingErr := errors.New("could not find the requested resource")
+
+	var getCalls, deleteCalls int
+
+	opts := optionalResourceOptions{
+		kind:              "HTTPRoute",
+		apiVersion:        "gateway.networking.k8s.io/v1",
+		enabled:           false,
+		name:              types.NamespacedName{Namespace: "default", Name: "x"},
+		logger:            logr.Discard(),
+		deleteDisabledMsg: "disabled; deleting",
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			t.Fatalf("buildDesired should not be called")
+			return nil, false, nil
+		},
+		get: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return nil
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return crdMissingErr
+		},
+		apply: func(_ context.Context, _ client.Object) error { return nil },
+	}
+
+	if err := reconcileOptionalResource(context.Background(), opts); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if getCalls != 1 || deleteCalls != 1 {
+		t.Fatalf("unexpected calls: get=%d delete=%d", getCalls, deleteCalls)
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces a small optional-resource reconciliation helper to reduce repeated “enabled/disabled/invalid/delete/apply” flow for optional infra resources. It refactors `ensureIngress`, `ensureHTTPRoute`, `ensureTLSRoute`, and `ensureBackendTLSPolicy` to use the helper while preserving existing behavior, including Gateway API CRD-missing handling (degraded via `ErrGatewayAPIMissing` only when enabled + apply requires missing CRDs).

## Related Issues

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- Run unit tests: `make test`
- Run e2e tests: `make test-e2e E2E_PARALLEL_NODES=2 E2E_LABEL_FILTER="gateway-api"`

