### PR TITLE
refactor(core): implement ssa for status updates

### DIFF
--- a/internal/controller/openbaocluster/security_events.go
+++ b/internal/controller/openbaocluster/security_events.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -22,6 +23,7 @@ func (r *OpenBaoClusterReconciler) emitSecurityWarningEvents(ctx context.Context
 	now := time.Now().UTC()
 	annotationUpdates := make(map[string]string)
 
+	// Helper to check and potentially add warning
 	maybeWarn := func(annotationKey, reason, message string) {
 		if !shouldEmitSecurityWarning(cluster.Annotations, annotationKey, now) {
 			return
@@ -51,16 +53,37 @@ func (r *OpenBaoClusterReconciler) emitSecurityWarningEvents(ctx context.Context
 		return nil
 	}
 
-	original := cluster.DeepCopy()
+	// Prepare SSA patch for annotations
+	// We only include the annotations we want to update. SSA will merge these.
+	// We must ensure the object has proper TypeMeta for SSA.
+	patch := &openbaov1alpha1.OpenBaoCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: openbaov1alpha1.GroupVersion.String(),
+			Kind:       "OpenBaoCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        cluster.Name,
+			Namespace:   cluster.Namespace,
+			Annotations: annotationUpdates,
+		},
+	}
+
+	// Apply partial patch with specific field owner for security events
+	patchOpts := []client.PatchOption{
+		client.FieldOwner("openbao-security-events"),
+		client.ForceOwnership,
+	}
+
+	if err := r.Patch(ctx, patch, client.Apply, patchOpts...); err != nil {
+		return fmt.Errorf("failed to persist security warning timestamps on OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	}
+
+	// Update the in-memory object to reflect the changes so subsequent logic sees them
 	if cluster.Annotations == nil {
 		cluster.Annotations = make(map[string]string)
 	}
 	for k, v := range annotationUpdates {
 		cluster.Annotations[k] = v
-	}
-
-	if err := r.Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
-		return fmt.Errorf("failed to persist security warning timestamps on OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 	}
 
 	logger.V(1).Info("Emitted security warning events", "count", len(annotationUpdates))


### PR DESCRIPTION
## Description

This PR refactors status updates across multiple controllers to use **Server-Side Apply (SSA)** instead of traditional `Update` or `MergePatch` operations. SSA provides cleaner conflict resolution, explicit field ownership, and eliminates the need for manual read-modify-write cycles that can cause race conditions.

### Key Changes

- **Backup Manager**: Added `patchStatusSSA()` helper for backup status updates with `openbao-backup-controller` field owner
- **Certs Manager**: Added `applySecret()` helper using SSA for CA and server TLS secrets with `openbao-cert-manager` field owner
- **Security Events**: Added `patchStatusSSA()` for security event status updates with `openbao-security-events` field owner  
- **Split Reconcilers**: Added `patchStatusSSA()` for workload reconciler status with `openbao-workload-controller` field owner
- **Status Controller**: Added `patchStatusSSA()` for main status updates with `openbao-status-controller` field owner
- **Provisioner Controller**: Refactored to use SSA for tenant status updates with `openbao-tenant-controller` field owner
- **Restore Manager**: Added `patchStatusSSA()` for restore status with `openbao-restore-controller` field owner
- **Rolling Upgrade**: Refactored status updates to use SSA with `openbao-upgrade-controller` field owner

### Benefits

- **Conflict-free updates**: Each controller owns specific status fields, eliminating races
- **Cleaner code**: Removes manual Get/Update cycles and comparison logic
- **Better observability**: Field ownership is visible in resource metadata

## Related Issues

<!-- Closes #XX -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

1. Run unit/integration tests:
   ```bash
   make test-ci
   ```
2. Run e2e tests:
   ```bash
   make test-e2e E2E_PARALLEL_NODES=2
   ```