### PR TITLE
refactor(provisioner): move rbac logic from manager to rbac.go

### DIFF
--- a/internal/provisioner/rbac.go
+++ b/internal/provisioner/rbac.go
@@ -4,6 +4,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/constants"
 )
 
@@ -309,4 +310,107 @@ func GenerateTenantSecretsWriterRoleBinding(namespace string, operatorSA Operato
 			},
 		},
 	}
+}
+
+// SecretPermission describes access requirements for a named Secret.
+type SecretPermission struct {
+	Name       string // Secret name
+	Permission string // "read" or "write"
+}
+
+// Permission constants.
+const (
+	PermissionRead  = "read"
+	PermissionWrite = "write"
+)
+
+// GetRequiredSecretPermissions returns all Secrets the given cluster needs access to.
+// This encapsulates the business logic for determining secret permissions based
+// on TLS mode, unseal type, and configured secret references.
+//
+// Writer permissions are granted for operator-owned secrets that the operator
+// must create/update. Reader permissions are granted for user-provided secrets
+// that the operator only needs to read.
+func GetRequiredSecretPermissions(c *openbaov1alpha1.OpenBaoCluster) []SecretPermission {
+	if c == nil || c.Name == "" {
+		return nil
+	}
+
+	var perms []SecretPermission
+
+	// TLS secrets: writer if OperatorManaged, reader otherwise
+	tlsCA := c.Name + constants.SuffixTLSCA
+	tlsServer := c.Name + constants.SuffixTLSServer
+
+	if c.Spec.TLS.Mode == "" || c.Spec.TLS.Mode == openbaov1alpha1.TLSModeOperatorManaged {
+		perms = append(perms,
+			SecretPermission{Name: tlsCA, Permission: PermissionWrite},
+			SecretPermission{Name: tlsServer, Permission: PermissionWrite},
+		)
+	} else {
+		perms = append(perms,
+			SecretPermission{Name: tlsCA, Permission: PermissionRead},
+			SecretPermission{Name: tlsServer, Permission: PermissionRead},
+		)
+	}
+
+	// Root token: writer if SelfInit is not enabled
+	selfInitEnabled := c.Spec.SelfInit != nil && c.Spec.SelfInit.Enabled
+	if !selfInitEnabled {
+		perms = append(perms, SecretPermission{
+			Name:       c.Name + constants.SuffixRootToken,
+			Permission: PermissionWrite,
+		})
+	}
+
+	// Unseal key: writer if static unseal
+	if IsStaticUnseal(c) {
+		perms = append(perms, SecretPermission{
+			Name:       c.Name + constants.SuffixUnsealKey,
+			Permission: PermissionWrite,
+		})
+	}
+
+	// Referenced secrets from spec (read-only)
+	if c.Spec.Unseal != nil && c.Spec.Unseal.CredentialsSecretRef != nil {
+		perms = append(perms, SecretPermission{
+			Name:       c.Spec.Unseal.CredentialsSecretRef.Name,
+			Permission: PermissionRead,
+		})
+	}
+
+	if c.Spec.Backup != nil {
+		if c.Spec.Backup.Target.CredentialsSecretRef != nil {
+			perms = append(perms, SecretPermission{
+				Name:       c.Spec.Backup.Target.CredentialsSecretRef.Name,
+				Permission: PermissionRead,
+			})
+		}
+		if c.Spec.Backup.TokenSecretRef != nil {
+			perms = append(perms, SecretPermission{
+				Name:       c.Spec.Backup.TokenSecretRef.Name,
+				Permission: PermissionRead,
+			})
+		}
+	}
+
+	if c.Spec.Upgrade != nil && c.Spec.Upgrade.TokenSecretRef != nil {
+		perms = append(perms, SecretPermission{
+			Name:       c.Spec.Upgrade.TokenSecretRef.Name,
+			Permission: PermissionRead,
+		})
+	}
+
+	return perms
+}
+
+// IsStaticUnseal returns true if the cluster uses static (Shamir) unsealing.
+func IsStaticUnseal(c *openbaov1alpha1.OpenBaoCluster) bool {
+	if c == nil || c.Spec.Unseal == nil {
+		return true
+	}
+	if c.Spec.Unseal.Type == "" {
+		return true
+	}
+	return c.Spec.Unseal.Type == "static"
 }

--- a/internal/provisioner/rbac_test.go
+++ b/internal/provisioner/rbac_test.go
@@ -1,9 +1,13 @@
 package provisioner
 
 import (
+	"sort"
 	"testing"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 //nolint:gocyclo // Table-driven test with multiple assertions
@@ -208,4 +212,402 @@ func TestGenerateTenantRoleBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetRequiredSecretPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     *openbaov1alpha1.OpenBaoCluster
+		wantWriters []string
+		wantReaders []string
+	}{
+		{
+			name:    "nil cluster returns nil",
+			cluster: nil,
+		},
+		{
+			name:    "empty name returns nil",
+			cluster: &openbaov1alpha1.OpenBaoCluster{},
+		},
+		{
+			name: "OperatorManaged TLS mode - TLS secrets are writable",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("test-cluster"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+				},
+			},
+			wantWriters: []string{
+				"test-cluster-root-token",
+				"test-cluster-tls-ca",
+				"test-cluster-tls-server",
+				"test-cluster-unseal-key",
+			},
+		},
+		{
+			name: "empty TLS mode defaults to OperatorManaged",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("bao"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    "", // empty defaults to OperatorManaged
+					},
+				},
+			},
+			wantWriters: []string{
+				"bao-root-token",
+				"bao-tls-ca",
+				"bao-tls-server",
+				"bao-unseal-key",
+			},
+		},
+		{
+			name: "External TLS mode - TLS secrets are readable",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("ext"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeExternal,
+					},
+				},
+			},
+			wantWriters: []string{
+				"ext-root-token",
+				"ext-unseal-key",
+			},
+			wantReaders: []string{
+				"ext-tls-ca",
+				"ext-tls-server",
+			},
+		},
+		{
+			name: "ACME TLS mode - TLS secrets are readable",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("acme"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeACME,
+					},
+				},
+			},
+			wantWriters: []string{
+				"acme-root-token",
+				"acme-unseal-key",
+			},
+			wantReaders: []string{
+				"acme-tls-ca",
+				"acme-tls-server",
+			},
+		},
+		{
+			name: "SelfInit enabled - no root token written",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("selfinit"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					SelfInit: &openbaov1alpha1.SelfInitConfig{
+						Enabled: true,
+					},
+				},
+			},
+			wantWriters: []string{
+				"selfinit-tls-ca",
+				"selfinit-tls-server",
+				"selfinit-unseal-key",
+			},
+		},
+		{
+			name: "Cloud unseal (awskms) - no unseal key written",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("cloud"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "awskms",
+						CredentialsSecretRef: &corev1.LocalObjectReference{
+							Name: "aws-creds",
+						},
+					},
+				},
+			},
+			wantWriters: []string{
+				"cloud-root-token",
+				"cloud-tls-ca",
+				"cloud-tls-server",
+			},
+			wantReaders: []string{
+				"aws-creds",
+			},
+		},
+		{
+			name: "Static unseal - unseal key written",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("static"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "static",
+					},
+				},
+			},
+			wantWriters: []string{
+				"static-root-token",
+				"static-tls-ca",
+				"static-tls-server",
+				"static-unseal-key",
+			},
+		},
+		{
+			name: "Backup with credentials and token",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("backup"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					Backup: &openbaov1alpha1.BackupSchedule{
+						Schedule: "0 3 * * *",
+						Target: openbaov1alpha1.BackupTarget{
+							CredentialsSecretRef: &corev1.LocalObjectReference{
+								Name: "backup-creds",
+							},
+						},
+						TokenSecretRef: &corev1.LocalObjectReference{
+							Name: "backup-token",
+						},
+					},
+				},
+			},
+			wantWriters: []string{
+				"backup-root-token",
+				"backup-tls-ca",
+				"backup-tls-server",
+				"backup-unseal-key",
+			},
+			wantReaders: []string{
+				"backup-creds",
+				"backup-token",
+			},
+		},
+		{
+			name: "Upgrade with token",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("upgrade"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					Upgrade: &openbaov1alpha1.UpgradeConfig{
+						TokenSecretRef: &corev1.LocalObjectReference{
+							Name: "upgrade-token",
+						},
+					},
+				},
+			},
+			wantWriters: []string{
+				"upgrade-root-token",
+				"upgrade-tls-ca",
+				"upgrade-tls-server",
+				"upgrade-unseal-key",
+			},
+			wantReaders: []string{
+				"upgrade-token",
+			},
+		},
+		{
+			name: "Full configuration with all secret types",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("full"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "static",
+						CredentialsSecretRef: &corev1.LocalObjectReference{
+							Name: "unseal-creds",
+						},
+					},
+					Backup: &openbaov1alpha1.BackupSchedule{
+						Schedule: "0 3 * * *",
+						Target: openbaov1alpha1.BackupTarget{
+							CredentialsSecretRef: &corev1.LocalObjectReference{
+								Name: "backup-creds",
+							},
+						},
+						TokenSecretRef: &corev1.LocalObjectReference{
+							Name: "backup-token",
+						},
+					},
+					Upgrade: &openbaov1alpha1.UpgradeConfig{
+						TokenSecretRef: &corev1.LocalObjectReference{
+							Name: "upgrade-token",
+						},
+					},
+				},
+			},
+			wantWriters: []string{
+				"full-root-token",
+				"full-tls-ca",
+				"full-tls-server",
+				"full-unseal-key",
+			},
+			wantReaders: []string{
+				"backup-creds",
+				"backup-token",
+				"unseal-creds",
+				"upgrade-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perms := GetRequiredSecretPermissions(tt.cluster)
+
+			gotWriters := filterByPermission(perms, PermissionWrite)
+			gotReaders := filterByPermission(perms, PermissionRead)
+
+			sort.Strings(gotWriters)
+			sort.Strings(gotReaders)
+			sort.Strings(tt.wantWriters)
+			sort.Strings(tt.wantReaders)
+
+			if !stringSlicesEqual(gotWriters, tt.wantWriters) {
+				t.Errorf("writers = %v, want %v", gotWriters, tt.wantWriters)
+			}
+			if !stringSlicesEqual(gotReaders, tt.wantReaders) {
+				t.Errorf("readers = %v, want %v", gotReaders, tt.wantReaders)
+			}
+		})
+	}
+}
+
+func TestIsStaticUnseal(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *openbaov1alpha1.OpenBaoCluster
+		want    bool
+	}{
+		{
+			name:    "nil cluster is static",
+			cluster: nil,
+			want:    true,
+		},
+		{
+			name: "nil Unseal is static",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("test"),
+				Spec:       openbaov1alpha1.OpenBaoClusterSpec{},
+			},
+			want: true,
+		},
+		{
+			name: "empty type is static",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("test"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "explicit static type",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("test"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "static",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "awskms is not static",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("test"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "awskms",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "gcpkms is not static",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("test"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "gcpkms",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsStaticUnseal(tt.cluster)
+			if got != tt.want {
+				t.Errorf("IsStaticUnseal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// objectMeta creates a minimal ObjectMeta for testing.
+func objectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: "default",
+	}
+}
+
+// filterByPermission extracts secret names with the given permission type.
+func filterByPermission(perms []SecretPermission, permission string) []string {
+	var result []string
+	for _, p := range perms {
+		if p.Permission == permission {
+			result = append(result, p.Name)
+		}
+	}
+	return result
+}
+
+// stringSlicesEqual compares two string slices for equality.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Description

Refactor `accumulateTenantSecretNames()` by extracting secret permission logic into dedicated `GetRequiredSecretPermissions()` and `IsStaticUnseal()` functions in `rbac.go`. Improves code organization and testability within the provisioner package.

## Type of Change

- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

```bash
make test && make lint
```