### PR TITLE
refactor(certs): move sans computation upgrade strategy out of certs package

### DIFF
--- a/internal/certs/manager_test.go
+++ b/internal/certs/manager_test.go
@@ -88,7 +88,7 @@ func TestBuildServerSANsIncludesDefaultsAndExtraSANs(t *testing.T) {
 		Host:    host,
 	}
 
-	dnsNames, ipAddresses, err := buildServerSANs(cluster)
+	dnsNames, ipAddresses, err := buildServerSANs(cluster, nil)
 	if err != nil {
 		t.Fatalf("buildServerSANs() error = %v", err)
 	}

--- a/internal/cluster/sans.go
+++ b/internal/cluster/sans.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"fmt"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+// ComputeRequiredDNSSANs calculates DNS names that should be included in server certificate SANs
+// based on cluster configuration and upgrade strategy status (e.g., Blue/Green revisions).
+// This function extracts upgrade-strategy-specific logic from the certificate manager,
+// allowing the cert manager to remain agnostic to upgrade strategy implementation details.
+func ComputeRequiredDNSSANs(cluster *openbaov1alpha1.OpenBaoCluster) []string {
+	if cluster == nil {
+		return nil
+	}
+
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
+	replicas := cluster.Spec.Replicas
+
+	if namespace == "" || clusterName == "" {
+		return nil
+	}
+
+	var dnsNames []string
+
+	// For Blue/Green upgrades, explicitly add SANs for the revision-specific pod names.
+	// Wildcards like *.bluegreen-cluster.svc work for standard pods, but for Green pods
+	// like bluegreen-cluster-hash-0, we want to be explicit to ensure TLS validation works.
+	if cluster.Status.BlueGreen != nil {
+		revisions := []string{}
+		if cluster.Status.BlueGreen.BlueRevision != "" {
+			revisions = append(revisions, cluster.Status.BlueGreen.BlueRevision)
+		}
+		if cluster.Status.BlueGreen.GreenRevision != "" {
+			revisions = append(revisions, cluster.Status.BlueGreen.GreenRevision)
+		}
+
+		for _, rev := range revisions {
+			for i := int32(0); i < replicas; i++ {
+				podName := fmt.Sprintf("%s-%s-%d", clusterName, rev, i)
+				dnsNames = append(dnsNames,
+					fmt.Sprintf("%s.%s.%s.svc", podName, clusterName, namespace),
+					fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, clusterName, namespace),
+				)
+			}
+		}
+	}
+
+	return dnsNames
+}

--- a/internal/cluster/sans_test.go
+++ b/internal/cluster/sans_test.go
@@ -1,0 +1,145 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestComputeRequiredDNSSANs_NoBlueGreen(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+		},
+	}
+
+	dnsNames := ComputeRequiredDNSSANs(cluster)
+	if len(dnsNames) != 0 {
+		t.Errorf("Expected no DNS names for cluster without Blue/Green status, got %d", len(dnsNames))
+	}
+}
+
+func TestComputeRequiredDNSSANs_BlueRevisionOnly(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueRevision: "abc123",
+			},
+		},
+	}
+
+	dnsNames := ComputeRequiredDNSSANs(cluster)
+	expectedCount := 6 // 3 replicas * 2 DNS suffixes (.svc and .svc.cluster.local)
+	if len(dnsNames) != expectedCount {
+		t.Errorf("Expected %d DNS names, got %d", expectedCount, len(dnsNames))
+	}
+
+	// Verify expected DNS names are present
+	expectedDNS := map[string]bool{
+		"test-cluster-abc123-0.test-cluster.default.svc":               false,
+		"test-cluster-abc123-0.test-cluster.default.svc.cluster.local": false,
+		"test-cluster-abc123-1.test-cluster.default.svc":               false,
+		"test-cluster-abc123-1.test-cluster.default.svc.cluster.local": false,
+		"test-cluster-abc123-2.test-cluster.default.svc":               false,
+		"test-cluster-abc123-2.test-cluster.default.svc.cluster.local": false,
+	}
+
+	for _, dnsName := range dnsNames {
+		if _, ok := expectedDNS[dnsName]; ok {
+			expectedDNS[dnsName] = true
+		}
+	}
+
+	for dnsName, found := range expectedDNS {
+		if !found {
+			t.Errorf("Expected DNS name %q not found in results", dnsName)
+		}
+	}
+}
+
+func TestComputeRequiredDNSSANs_BothRevisions(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "production",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 2,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueRevision:  "blue-rev",
+				GreenRevision: "green-rev",
+			},
+		},
+	}
+
+	dnsNames := ComputeRequiredDNSSANs(cluster)
+	expectedCount := 8 // 2 revisions * 2 replicas * 2 DNS suffixes
+	if len(dnsNames) != expectedCount {
+		t.Errorf("Expected %d DNS names, got %d", expectedCount, len(dnsNames))
+	}
+
+	// Verify both revisions are included
+	hasBlue := false
+	hasGreen := false
+	for _, dnsName := range dnsNames {
+		if strings.Contains(dnsName, "blue-rev") {
+			hasBlue = true
+		}
+		if strings.Contains(dnsName, "green-rev") {
+			hasGreen = true
+		}
+	}
+
+	if !hasBlue {
+		t.Error("Expected Blue revision DNS names not found")
+	}
+	if !hasGreen {
+		t.Error("Expected Green revision DNS names not found")
+	}
+}
+
+func TestComputeRequiredDNSSANs_EmptyRevisions(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueRevision:  "",
+				GreenRevision: "",
+			},
+		},
+	}
+
+	dnsNames := ComputeRequiredDNSSANs(cluster)
+	if len(dnsNames) != 0 {
+		t.Errorf("Expected no DNS names when revisions are empty, got %d", len(dnsNames))
+	}
+}
+
+func TestComputeRequiredDNSSANs_NilCluster(t *testing.T) {
+	dnsNames := ComputeRequiredDNSSANs(nil)
+	if dnsNames != nil {
+		t.Errorf("Expected nil for nil cluster, got %v", dnsNames)
+	}
+}


### PR DESCRIPTION
## Description
**Certificate Manager Coupled to Upgrade Strategy**: The certificate manager was directly inspecting `cluster.Status.BlueGreen` to compute DNS SANs for Blue/Green upgrades. This couples the cert manager to upgrade strategy implementation details.

**Changes Made:**

- **Move DNS SANS Computation to `internal/cluster` package** Centralize domain logic:
  - `sans.go`: Contains `ComputeRequiredDNSSANs()` which extracts upgrade-strategy-specific DNS SAN computation logic

- **Refactored Certificate Manager** (`internal/certs/manager.go`):
  - Removed direct inspection of `cluster.Status.BlueGreen`
  - `buildServerSANs()` now accepts `additionalDNSNames []string` parameter
  - `Reconcile()` method computes DNS SANs using `clusterpkg.ComputeRequiredDNSSANs()` and passes them to certificate building logic


- **Test Coverage:**
  - Updated tests `internal/cluster/sans_test.go`
  - All existing test cases preserved and updated to use new package structure

This refactoring improves separation of concerns, making the codebase more maintainable and allowing the certificate manager and provisioner to remain agnostic to upgrade strategies and domain-specific business logic.

## Related Issues


## Type of Change

- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.

## Verification Process

1. **Run unit tests:**
  ``` sh
   make test
   go test ./internal/cluster/... -v
   go test ./internal/certs/... -v
   go test ./internal/provisioner/... -v
  ```

2. **Run Upgrade e2e tests:***
   ```sh
   make test-e2e E2E_PARALLEL_NODES=2 E2E_LABEL_FILTER="upgrade"
   ```