### PR TITLE
fix(controller): remove force ownership of status

### DIFF
--- a/internal/backup/manager.go
+++ b/internal/backup/manager.go
@@ -247,7 +247,6 @@ func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.O
 
 	return m.client.Status().Patch(ctx, applyCluster, client.Apply,
 		client.FieldOwner("openbao-backup-controller"),
-		client.ForceOwnership,
 	)
 }
 

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -66,7 +66,7 @@ func patchStatusIfChanged(ctx context.Context, c client.Client, logger logr.Logg
 		Status: cluster.Status,
 	}
 
-	if err := c.Status().Patch(ctx, applyCluster, client.Apply, client.FieldOwner("openbao-cluster-controller"), client.ForceOwnership); err != nil {
+	if err := c.Status().Patch(ctx, applyCluster, client.Apply, client.FieldOwner("openbao-cluster-controller")); err != nil {
 		return fmt.Errorf("failed to patch status (%s) for OpenBaoCluster %s/%s: %w", reason, cluster.Namespace, cluster.Name, err)
 	}
 	logger.V(1).Info("Patched OpenBaoCluster status (SSA)", "reason", reason)

--- a/internal/controller/openbaocluster/status.go
+++ b/internal/controller/openbaocluster/status.go
@@ -37,7 +37,6 @@ func (r *OpenBaoClusterReconciler) patchStatusSSA(ctx context.Context, cluster *
 
 	return r.Status().Patch(ctx, applyCluster, client.Apply,
 		client.FieldOwner("openbao-cluster-controller"),
-		client.ForceOwnership,
 	)
 }
 

--- a/internal/upgrade/rolling/status_patch.go
+++ b/internal/upgrade/rolling/status_patch.go
@@ -30,6 +30,5 @@ func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.O
 
 	return m.client.Status().Patch(ctx, applyCluster, client.Apply,
 		client.FieldOwner(ssaFieldOwner),
-		client.ForceOwnership,
 	)
 }


### PR DESCRIPTION
## Description

This PR fixes a race condition in status patching that was causing the rolling upgrade e2e test to fail. The root cause was multiple controllers using Server-Side Apply (SSA) with `client.ForceOwnership` when patching the `OpenBaoCluster` status, which caused field ownership conflicts.

**The Problem:**
- Multiple controllers (workload, adminops/upgrade, backup, status) were all patching the entire `Status` object using SSA with `ForceOwnership`
- When a controller patched status without including fields owned by other controllers (e.g., `Status.Workload`), SSA with `ForceOwnership` would set those fields to `null`
- This triggered CRD validation errors: `status.workload: Invalid value: "null": workload in body must be of type object: "null"`
- The workload controller reconciliation failures blocked the upgrade manager from initializing upgrades, causing the test to timeout waiting for `status.upgrade` to be set

**The Solution:**
Removed `client.ForceOwnership` from all status patch operations. Without `ForceOwnership`, SSA merges fields from different field owners instead of overwriting them, allowing controllers to coexist without conflicts.

**Files Changed:**
- `internal/controller/openbaocluster/split_reconcilers.go`: Removed `ForceOwnership` from `patchStatusIfChanged`
- `internal/upgrade/rolling/status_patch.go`: Removed `ForceOwnership` from rolling upgrade status patches
- `internal/backup/manager.go`: Removed `ForceOwnership` from backup status patches
- `internal/controller/openbaocluster/status.go`: Removed `ForceOwnership` from status controller patches

**Why This Works:**
SSA field ownership allows each controller to manage only the fields it owns (e.g., `openbao-cluster-controller` owns `Status.Workload`, `openbao-upgrade-manager` owns `Status.Upgrade`). Without `ForceOwnership`, the API server merges fields from all owners, preventing one controller from accidentally nullifying another's fields.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

1. **Run the full upgrade e2e test suite**:
```sh
make test-e2e E2E_PARALLEL_NODES=2 E2E_LABEL_FILTER="upgrade"
```
   