### PR TITLE
ci(docs): fix documentation deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages-${{ github.ref }}
@@ -26,7 +24,6 @@ jobs:
     runs-on: ubuntu-24.04
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,15 +62,3 @@ jobs:
           else
             mike deploy --push --update-aliases "${VERSION}" latest
           fi
-
-      - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
-        with:
-          path: site
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Description
Fixes the GitHub Pages deployment workflow that was using conflicting deployment methods. The workflow was mixing mike's branch-based deployment with GitHub Actions artifact deployment, causing the Pages site to not work correctly.
The mike plugin manages versioned documentation by pushing directly to the `gh-pages` branch, while the artifact-based deployment method was attempting to deploy from a non-existent `site/` directory. This fix removes the conflicting artifact deployment steps and keeps only the mike-based deployment.

## Related Issues

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist
- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process
1. After merging this PR:
2. The Pages workflow should run successfully
3. Verify at https://dc-tec.github.io/openbao-operator/latest/ that documentation is accessible
4. Check that the README links work correctly
5. Ensure repository Settings → Pages is configured to deploy from the `gh-pages` branch (not GitHub Actions)