### PR TITLE
ci(nightly): add artifact building job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,9 +72,36 @@ jobs:
       - name: Report operator-vs-upstream config schema drift (informational)
         run: go run ./hack/tools/openbao_operator_schema_drift --openbao-image-tag 2.4.4
 
+  build-artifacts:
+    name: Build Artifacts
+    runs-on: *runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+
+      - name: Build Linux Binaries
+        env:
+          GOFLAGS: -mod=readonly
+        run: make build-linux
+
+      - name: Upload Binaries
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: operator-binaries
+          path: bin/linux_amd64/
+          retention-days: 1
+
   e2e:
     name: E2E (kind ${{ matrix.k8s }})
     runs-on: *runner
+    needs: build-artifacts
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -104,6 +131,15 @@ jobs:
         with:
           path: bin/
           key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'go.sum') }}
+
+      - name: Download Binaries
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: operator-binaries
+          path: bin/linux_amd64
+
+      - name: Prepare Binaries
+        run: chmod +x bin/linux_amd64/*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0


### PR DESCRIPTION
## Description

This PR fixes a build failure in the Nightly workflow ([.github/workflows/nightly.yml](cci:7://file:///Users/roelc/projects/work/openbao-operator/.github/workflows/nightly.yml:0:0-0:0)). 

The "Build operator image" step in the `e2e` and `nightly` jobs was failing because the manager's Dockerfile expects a pre-compiled binary `bin/linux_amd64/manager`, but the nightly workflow was missing the compilation step.

**Changes:**
*   **Added `build-artifacts` Job**: Introduced a dedicated job to compile Linux binaries (`manager`, `init`, etc.) once.
*   **Updated `e2e` Job**: Modified the E2E matrix job to download these artifacts before running the Docker build. 

This brings the Nightly workflow structure in line with the main CI workflow and resolves the `COPY failed: ... /bin/linux_amd64/manager: not found` error.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

1.  **Nightly Workflow**: Trigger the `nightly` workflow via `workflow_dispatch` (or wait for the schedule).
2.  **Verify Build**: Confirm that the new `build-artifacts` job completes successfully.
3.  **Verify E2E**: Confirm that the `e2e` job successfully downloads the artifacts and builds the `openbao-operator:e2e` image without error.