### PR TITLE
fix(openbao): handle 403 forbidden gracefully

### DIFF
--- a/internal/openbao/client.go
+++ b/internal/openbao/client.go
@@ -269,9 +269,13 @@ func (c *Client) Health(ctx context.Context) (*HealthResponse, error) {
 		req.Header.Set("X-Vault-Token", c.token)
 	}
 
-	_, body, err := c.doAndReadAll(req, nil, "failed to query health endpoint")
+	resp, body, err := c.doAndReadAll(req, nil, "failed to query health endpoint")
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("health check forbidden (403): check operator permissions")
 	}
 
 	var health HealthResponse

--- a/internal/openbao/client_test.go
+++ b/internal/openbao/client_test.go
@@ -147,6 +147,19 @@ func TestClient_Health(t *testing.T) {
 			wantSealed:     false,
 			wantStandby:    false,
 		},
+		{
+			name:       "forbidden (safe mode)",
+			statusCode: http.StatusForbidden,
+			response:   HealthResponse{
+				// The body is usually an error struct, but here we just simulate
+				// that we don't get a valid health response.
+				// We expect an error, NOT a zero-value struct.
+			},
+			wantErr:        true,
+			wantInitalized: false,
+			wantSealed:     false, // correctly uninitialized/empty struct would have false here
+			wantStandby:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Fixes a bug where the Operator would panic when the `sys/health` endpoint returned a `403 Forbidden` response.

Previously, the `Health()` method continued execution after a 403 error, attempting to unmarshal the error body into a `HealthResponse` struct. This resulted in a zero-value struct (e.g., empty `Version` or `ClusterName`, causing downstream components (like the Upgrade Manager) to panic when accessing these fields.

This issue was triggered by "Safe Mode" tests which intentionally inject policies that deny assess to `sys/health`, causing collateral damage to other concurrent tests (like Azure Backup) because the shared Operator process crashed.

The fix explicitly checks for `http.StatusForbidden` in `Health()` and returns a typed error immediately.

## Related Issues

<!-- Closes #123 -->

## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

Run the new unit test case which simulates a 403 Forbidden response:

```bash
go test -v ./internal/openbao/... -run TestClient_Health/forbidden_\(safe_mode\)
```

Also run the full e2e test suite:

```bash
make test-e2e
```