### PR TITLE
fix(ci): stabilize nightly e2e image refs and matrix check naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
 
   e2e:
     needs: [changes, build-e2e-images]
-    if: (needs.changes.outputs.e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e'))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     name: E2E (${{ matrix.name }})
     runs-on: *runner
     timeout-minutes: 45
@@ -559,6 +559,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          TRIGGER_E2E="${{ needs.changes.outputs.e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}"
           FULL_E2E="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e') }}"
           PR_BACKUP="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'backup') }}"
           PR_UPGRADE="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'upgrades') }}"
@@ -566,6 +567,14 @@ jobs:
 
           FILTER="!slow && !nightly && !openshift && !pentest"
           SHOULD_RUN="true"
+
+          if [[ "${TRIGGER_E2E}" != "true" ]]; then
+            SHOULD_RUN="false"
+            echo "E2E_LABEL_FILTER=$FILTER" >> "${GITHUB_ENV}"
+            echo "SHOULD_RUN=$SHOULD_RUN" >> "${GITHUB_ENV}"
+            echo "::notice::Skipping ${{ matrix.name }} shard (no E2E-triggering changes/labels)"
+            exit 0
+          fi
 
           if [[ "${{ matrix.hardened_signed }}" == "true" ]]; then
             FILTER="!nightly && !openshift && !pentest"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -200,14 +200,14 @@ jobs:
           cache-from: type=gha,scope=openbao-upgrade
           cache-to: type=gha,mode=max,scope=openbao-upgrade
 
-      - name: Publish digest refs
+      - name: Publish image refs
         id: refs
         run: |
           set -euo pipefail
-          echo "manager_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-operator@${{ steps.build-manager.outputs.digest }}" >> "${GITHUB_OUTPUT}"
-          echo "config_init_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-init@${{ steps.build-init.outputs.digest }}" >> "${GITHUB_OUTPUT}"
-          echo "backup_executor_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-backup@${{ steps.build-backup.outputs.digest }}" >> "${GITHUB_OUTPUT}"
-          echo "upgrade_executor_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-upgrade@${{ steps.build-upgrade.outputs.digest }}" >> "${GITHUB_OUTPUT}"
+          echo "manager_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-operator:${{ steps.tag.outputs.value }}" >> "${GITHUB_OUTPUT}"
+          echo "config_init_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-init:${{ steps.tag.outputs.value }}" >> "${GITHUB_OUTPUT}"
+          echo "backup_executor_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-backup:${{ steps.tag.outputs.value }}" >> "${GITHUB_OUTPUT}"
+          echo "upgrade_executor_ref=ghcr.io/${GITHUB_REPOSITORY_OWNER}/openbao-upgrade:${{ steps.tag.outputs.value }}" >> "${GITHUB_OUTPUT}"
 
   e2e:
     name: E2E (kind ${{ matrix.k8s }})


### PR DESCRIPTION
## Description

This PR fixes two workflow issues discovered while investigating flaky nightly E2E runs:

1. In `nightly.yml`, publish E2E image refs using the computed run tag (same pattern as CI) instead of digest refs.
2. In `ci.yml`, keep the E2E matrix job instantiated and decide shard execution in the filter step, so skipped PRs do not produce unresolved check names like `CI / E2E (${{ matrix.name }})`.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- Run `make lint-config`
- Inspect workflow changes:
  - `.github/workflows/nightly.yml` (tag-based refs)
  - `.github/workflows/ci.yml` (matrix instantiation + shard-level skip)
