### PR TITLE
refactor(architecture): harden shared controller boundary reporting

### DIFF
--- a/hack/architecture/report-internal-deps.sh
+++ b/hack/architecture/report-internal-deps.sh
@@ -14,6 +14,10 @@ mkdir -p "${OUT_DIR}"
 
 cd "${REPO_ROOT}"
 MODULE_PATH="$(go list -m)"
+root_controller_pkg_present="false"
+if go list ./... | grep -qx "${MODULE_PATH}/internal/controller"; then
+  root_controller_pkg_present="true"
+fi
 
 # Runtime scope only: api/v1alpha1, cmd/*, internal/*
 go list -f '{{.ImportPath}}|{{join .Imports ","}}' ./... \
@@ -88,8 +92,8 @@ awk -F'\t' -v mod="${MODULE_PATH}" '
   function is_service_pkg(p) {
     return p ~ /^internal\/(backup|restore|upgrade|upgrade\/bluegreen|upgrade\/rolling|infra|certs|init|provisioner)$/
   }
-  function is_controller_pkg(p) {
-    return p == "internal/controller" || p ~ /^internal\/controller\//
+  function is_controller_impl_pkg(p) {
+    return p ~ /^internal\/controller\//
   }
   function is_adapter_pkg(p) {
     return p ~ /^internal\/(kube|openbao|storage|auth|cluster|config|raft|security|storageenv|operationlock|revision|probe)$/
@@ -98,10 +102,10 @@ awk -F'\t' -v mod="${MODULE_PATH}" '
     src = rel($1)
     dep = rel($2)
 
-    if (is_service_pkg(src) && dep == "internal/controller") {
-      print "[service->controller] " src " -> " dep
+    if (dep == "internal/controller" && !is_controller_impl_pkg(src) && src != "internal/controller") {
+      print "[shared-controller-import] " src " -> " dep
     }
-    if (is_adapter_pkg(src) && is_controller_pkg(dep)) {
+    if (is_adapter_pkg(src) && is_controller_impl_pkg(dep)) {
       print "[adapter->controller] " src " -> " dep
     }
     if (is_adapter_pkg(src) && is_service_pkg(dep)) {
@@ -112,6 +116,10 @@ awk -F'\t' -v mod="${MODULE_PATH}" '
     }
   }
 ' "${EDGE_FILE}" | sort -u > "${WARNINGS_FILE}"
+
+if [ "${root_controller_pkg_present}" = "true" ]; then
+  printf '[shared-controller-package-present] internal/controller package exists; keep shared helpers in internal/predicates or internal/observability\n' >> "${WARNINGS_FILE}"
+fi
 
 constants_in="$(awk -F'\t' -v mod="${MODULE_PATH}" '$2 == mod "/internal/constants" {count++} END {print count + 0}' "${EDGE_FILE}")"
 openbaocluster_out="$(awk -F'\t' -v mod="${MODULE_PATH}" '$1 == mod "/internal/controller/openbaocluster" {count++} END {print count + 0}' "${EDGE_FILE}")"
@@ -242,6 +250,7 @@ GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   echo "- Nodes: ${node_count}"
   echo "- Edges: ${edge_count}"
   echo "- Cycle check: ${cycle_status}"
+  echo "- Shared controller package present: ${root_controller_pkg_present}"
   echo
   echo "## Artifacts"
   echo


### PR DESCRIPTION
## Description

Hardens local internal dependency boundary reporting around the controller layer.

- Detects whether the root `internal/controller` package exists.
- Flags imports of `internal/controller` from non-controller implementation packages as `[shared-controller-import]`.
- Keeps adapter boundary checks scoped to controller implementation packages (`internal/controller/*`).
- Emits a dedicated warning when a shared `internal/controller` package is present.
- Adds a summary field in the generated report: `Shared controller package present`.

This improves regression detection after predicate extraction by making boundary drift visible in local architecture reports.

## Related Issues

<!-- Closes #123 -->
N/A

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.

## Verification Process

<!-- How can the reviewer verify this change? -->
<!-- Example: Run `make test-e2e` or `kubectl apply -f examples/my-feature.yaml` -->
1. Run `bash -n hack/architecture/report-internal-deps.sh`
2. Run `make report-internal-deps`
3. Open `dist/architecture/internal-dependency-report.md` and confirm:
   - `Shared controller package present: false`
   - warning section contains no new false positives for removed shared controller helpers
