### PR TITLE
refactor(controller): tighten internal sub-reconciler surface

### DIFF
--- a/internal/controller/openbaocluster/infra_reconciler.go
+++ b/internal/controller/openbaocluster/infra_reconciler.go
@@ -29,7 +29,7 @@ import (
 	security "github.com/dc-tec/openbao-operator/internal/security"
 )
 
-// infraReconciler wraps InfraManager to implement SubReconciler interface.
+// infraReconciler wraps InfraManager to implement the controller's sub-reconciler contract.
 // It handles image verification and injects the verified digest into InfraManager.
 type infraReconciler struct {
 	client                  client.Client
@@ -332,7 +332,7 @@ func (r *infraReconciler) resolveTargetMainImage(ctx context.Context, logger log
 	return targetImage
 }
 
-// Reconcile implements SubReconciler for infrastructure reconciliation.
+// Reconcile implements the controller's sub-reconciler contract for infrastructure reconciliation.
 // TODO: split this function into smaller functions
 // nolint:gocyclo
 func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -291,7 +291,7 @@ func (r *openBaoClusterWorkloadReconciler) reconcileCluster(
 		cluster.Status.Workload = &openbaov1alpha1.WorkloadControllerStatus{}
 	}
 
-	reconcilers := []SubReconciler{
+	reconcilers := []subReconciler{
 		certmanager.NewManagerWithReloader(r.parent.Client, r.parent.Scheme, r.parent.TLSReload),
 		&infraReconciler{
 			client:                r.parent.Client,
@@ -353,7 +353,7 @@ func (r *openBaoClusterWorkloadReconciler) runWorkloadReconcilers(
 	ctx context.Context,
 	logger logr.Logger,
 	original, cluster *openbaov1alpha1.OpenBaoCluster,
-	reconcilers []SubReconciler,
+	reconcilers []subReconciler,
 	recordError func(error),
 ) (ctrl.Result, error) {
 	for _, rec := range reconcilers {
@@ -453,7 +453,7 @@ func (r *openBaoClusterAdminOpsReconciler) Reconcile(ctx context.Context, req ct
 		cluster.Status.AdminOps = &openbaov1alpha1.AdminOpsControllerStatus{}
 	}
 
-	var reconcilers []SubReconciler
+	var reconcilers []subReconciler
 	infraMgr := inframanager.NewManagerWithReader(r.parent.Client, r.parent.APIReader, r.parent.Scheme, r.parent.OperatorNamespace, r.parent.OIDCIssuer, r.parent.OIDCJWTKeys, r.parent.Platform)
 	// Blue/green upgrade strategy
 	reconcilers = append(reconcilers, bluegreen.NewManager(r.parent.Client, r.parent.Scheme, infraMgr, r.parent.SmartClientConfig, r.parent.ImageVerifier, r.parent.OperatorImageVerifier, r.parent.Platform))

--- a/internal/controller/openbaocluster/subreconcilers.go
+++ b/internal/controller/openbaocluster/subreconcilers.go
@@ -9,11 +9,11 @@ import (
 	recon "github.com/dc-tec/openbao-operator/internal/reconcile"
 )
 
-// SubReconciler is a standardized interface for sub-reconcilers that handle
+// subReconciler is a standardized interface for sub-reconcilers that handle
 // specific aspects of OpenBaoCluster reconciliation.
 // Implementations should return a Result that indicates whether (and when) the
 // reconciliation should be requeued.
-type SubReconciler interface {
+type subReconciler interface {
 	// Reconcile performs reconciliation for the given cluster.
 	Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error)
 }

--- a/internal/upgrade/bluegreen/manager.go
+++ b/internal/upgrade/bluegreen/manager.go
@@ -89,7 +89,7 @@ func requeueAfter(duration time.Duration) recon.Result {
 }
 
 // Reconcile manages the blue/green upgrade state machine.
-// This implements the SubReconciler interface.
+// This implements the controller workload sub-reconciler contract.
 // Returns (result, error) where result indicates whether (and when) reconciliation should be requeued.
 //
 // Note: Image verification for the Blue StatefulSet is handled by the infra reconciler which runs before this.


### PR DESCRIPTION
## Description

Implements the remaining code-level PR-04 boundary cleanup in `internal/controller` by reducing unnecessary exported controller utility surface.

Changes:
- Renames `openbaocluster.SubReconciler` to unexported `openbaocluster.subReconciler`.
- Updates all internal references in openbaocluster split reconcilers.
- Aligns related comments in infra reconciler and blue/green manager.

Why:
- Keeps controller orchestration contracts internal to the controller package.
- Reduces accidental reuse of controller internals as cross-layer utility APIs.
- Preserves behavior and wiring; this is a structural visibility refinement only.

## Related Issues

<!-- Closes #123 -->
N/A

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

<!-- How can the reviewer verify this change? -->
<!-- Example: Run `make test-e2e` or `kubectl apply -f examples/my-feature.yaml` -->
1. Run:
   - `go test ./internal/controller/openbaocluster ./internal/controller/openbaorestore ./internal/controller/provisioner ./internal/upgrade/bluegreen`
2. Run:
   - `make report-internal-deps`
3. Verify no behavior changes are introduced (symbol visibility only) and dependency report generation remains successful.
