### PR TITLE
refactor(controller): reduce openbaocluster package fan-out

### DIFF
--- a/internal/app/openbaocluster/bridges.go
+++ b/internal/app/openbaocluster/bridges.go
@@ -1,0 +1,157 @@
+package openbaocluster
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/auth"
+	"github.com/dc-tec/openbao-operator/internal/logging"
+	"github.com/dc-tec/openbao-operator/internal/observability"
+	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
+	operatorpredicates "github.com/dc-tec/openbao-operator/internal/predicates"
+	"github.com/dc-tec/openbao-operator/internal/revision"
+	"github.com/dc-tec/openbao-operator/internal/security"
+	"github.com/dc-tec/openbao-operator/internal/upgrade"
+)
+
+// ReconcileMetrics records reconcile duration and categorized errors.
+type ReconcileMetrics interface {
+	ObserveDuration(durationSeconds float64)
+	IncrementError(reason string)
+}
+
+// ClusterMetrics records per-cluster readiness and phase gauges.
+type ClusterMetrics interface {
+	SetReadyReplicas(readyReplicas int32)
+	SetPhase(phase openbaov1alpha1.ClusterPhase)
+	Clear()
+}
+
+// NewReconcileMetrics returns a controller reconcile metrics recorder.
+func NewReconcileMetrics(namespace, name, controller string) ReconcileMetrics {
+	return observability.NewReconcileMetrics(namespace, name, controller)
+}
+
+// NewClusterMetrics returns per-cluster metrics helpers.
+func NewClusterMetrics(namespace, name string) ClusterMetrics {
+	return observability.NewClusterMetrics(namespace, name)
+}
+
+// LogRetentionSecretOrphaned emits a structured audit event for orphaned retention secrets.
+func LogRetentionSecretOrphaned(logger logr.Logger, clusterNamespace, clusterName, secretName, deletionPolicy string) {
+	logging.LogAuditEvent(logger, logging.EventRetentionSecretOrphaned, map[string]string{
+		"cluster_namespace": clusterNamespace,
+		"cluster_name":      clusterName,
+		"secret_name":       secretName,
+		"deletion_policy":   deletionPolicy,
+	})
+}
+
+// PredicateOptions configures OpenBaoCluster reconcile triggers.
+type PredicateOptions struct {
+	ReconcileOnUpgradeStatus   bool
+	ReconcileOnBackupStatus    bool
+	ReconcileOnBlueGreenStatus bool
+	ReconcileOnBreakGlass      bool
+	ReconcileOnWorkloadError   bool
+	ReconcileOnAdminOpsError   bool
+}
+
+// OpenBaoClusterPredicateWithOptions builds the canonical OpenBaoCluster update predicate.
+func OpenBaoClusterPredicateWithOptions(opts PredicateOptions) predicate.Predicate {
+	return operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		ReconcileOnUpgradeStatus:   opts.ReconcileOnUpgradeStatus,
+		ReconcileOnBackupStatus:    opts.ReconcileOnBackupStatus,
+		ReconcileOnBlueGreenStatus: opts.ReconcileOnBlueGreenStatus,
+		ReconcileOnBreakGlass:      opts.ReconcileOnBreakGlass,
+		ReconcileOnWorkloadError:   opts.ReconcileOnWorkloadError,
+		ReconcileOnAdminOpsError:   opts.ReconcileOnAdminOpsError,
+	})
+}
+
+// NewImageVerifier constructs the shared cluster image verifier.
+func NewImageVerifier(logger logr.Logger, k8sClient client.Client) imageverify.Verifier {
+	return security.NewImageVerifier(logger, k8sClient, nil)
+}
+
+// IsMainImageVerificationEnabled reports whether main workload image verification is enabled.
+func IsMainImageVerificationEnabled(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return security.IsMainImageVerificationEnabled(cluster)
+}
+
+// IsOperatorImageVerificationEnabled reports whether operator helper image verification is enabled.
+func IsOperatorImageVerificationEnabled(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return security.IsOperatorImageVerificationEnabled(cluster)
+}
+
+// VerifyImageForCluster verifies a primary OpenBao image according to cluster policy.
+func VerifyImageForCluster(
+	ctx context.Context,
+	logger logr.Logger,
+	verifier imageverify.Verifier,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	imageRef string,
+) (string, error) {
+	return security.VerifyImageForCluster(ctx, logger, verifier, cluster, imageRef)
+}
+
+// VerifyOperatorImageForCluster verifies an operator-managed helper image according to cluster policy.
+func VerifyOperatorImageForCluster(
+	ctx context.Context,
+	logger logr.Logger,
+	verifier imageverify.Verifier,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	imageRef string,
+) (string, error) {
+	return security.VerifyOperatorImageForCluster(ctx, logger, verifier, cluster, imageRef)
+}
+
+// OIDCConfig contains discovered issuer and key material for JWT bootstrap.
+type OIDCConfig struct {
+	IssuerURL string
+	JWKSKeys  []string
+}
+
+// DiscoverOIDCConfig resolves OIDC issuer metadata from the Kubernetes API.
+func DiscoverOIDCConfig(ctx context.Context, cfg *rest.Config) (*OIDCConfig, error) {
+	discovered, err := auth.DiscoverConfig(ctx, cfg, "")
+	if err != nil {
+		return nil, err
+	}
+	if discovered == nil {
+		return nil, nil
+	}
+	return &OIDCConfig{
+		IssuerURL: discovered.IssuerURL,
+		JWKSKeys:  discovered.JWKSKeys,
+	}, nil
+}
+
+// OIDCDiscoveryStatusCode extracts an HTTP status code from OIDC discovery errors.
+func OIDCDiscoveryStatusCode(err error) (int, bool) {
+	var statusErr *auth.HTTPStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode, true
+	}
+	return 0, false
+}
+
+// OpenBaoClusterRevision computes the deterministic revision used by blue/green status logic.
+func OpenBaoClusterRevision(version, image string, replicas int32) string {
+	return revision.OpenBaoClusterRevision(version, image, replicas)
+}
+
+// IsVersionDowngrade reports whether moving from one version to another is a downgrade.
+func IsVersionDowngrade(from, to string) (bool, error) {
+	change, err := upgrade.CompareVersions(from, to)
+	if err != nil {
+		return false, err
+	}
+	return change == upgrade.VersionChangeDowngrade, nil
+}

--- a/internal/controller/openbaocluster/deletion.go
+++ b/internal/controller/openbaocluster/deletion.go
@@ -12,10 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/constants"
 	inframanager "github.com/dc-tec/openbao-operator/internal/infra"
-	"github.com/dc-tec/openbao-operator/internal/logging"
-	observability "github.com/dc-tec/openbao-operator/internal/observability"
 )
 
 func (r *OpenBaoClusterReconciler) handleDeletion(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
@@ -36,7 +35,7 @@ func (r *OpenBaoClusterReconciler) handleDeletion(ctx context.Context, logger lo
 	}
 
 	// Clear per-cluster metrics to avoid leaving stale series after deletion.
-	clusterMetrics := observability.NewClusterMetrics(cluster.Namespace, cluster.Name)
+	clusterMetrics := appopenbaocluster.NewClusterMetrics(cluster.Namespace, cluster.Name)
 	clusterMetrics.Clear()
 
 	infraMgr := inframanager.NewManagerWithReader(r.Client, r.APIReader, r.Scheme, r.OperatorNamespace, r.OIDCIssuer, r.OIDCJWTKeys, r.Platform)
@@ -93,12 +92,13 @@ func (r *OpenBaoClusterReconciler) orphanRetentionSecrets(ctx context.Context, l
 			"secret", secretName,
 			"cluster_namespace", cluster.Namespace,
 			"cluster_name", cluster.Name)
-		logging.LogAuditEvent(logger, logging.EventRetentionSecretOrphaned, map[string]string{
-			"cluster_namespace": cluster.Namespace,
-			"cluster_name":      cluster.Name,
-			"secret_name":       secretName,
-			"deletion_policy":   string(cluster.Spec.DeletionPolicy),
-		})
+		appopenbaocluster.LogRetentionSecretOrphaned(
+			logger,
+			cluster.Namespace,
+			cluster.Name,
+			secretName,
+			string(cluster.Spec.DeletionPolicy),
+		)
 	}
 
 	return nil

--- a/internal/controller/openbaocluster/image_verification.go
+++ b/internal/controller/openbaocluster/image_verification.go
@@ -6,15 +6,15 @@ import (
 	"github.com/go-logr/logr"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/security"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 )
 
 // verifyImageRef verifies the signature for the given image reference and returns a digest pin.
 // This must verify the same image ref that the infra layer will apply, otherwise we can pin the
 // wrong digest (e.g., verifying Green while reconciling Blue during blue/green upgrades).
 func (r *OpenBaoClusterReconciler) verifyImageRef(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, imageRef string) (string, error) {
-	if !security.IsMainImageVerificationEnabled(cluster) {
+	if !appopenbaocluster.IsMainImageVerificationEnabled(cluster) {
 		return "", nil
 	}
-	return security.VerifyImageForCluster(ctx, logger, r.ImageVerifier, cluster, imageRef)
+	return appopenbaocluster.VerifyImageForCluster(ctx, logger, r.ImageVerifier, cluster, imageRef)
 }

--- a/internal/controller/openbaocluster/infra_reconciler.go
+++ b/internal/controller/openbaocluster/infra_reconciler.go
@@ -19,14 +19,13 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/admission"
-	"github.com/dc-tec/openbao-operator/internal/auth"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/errors"
 	inframanager "github.com/dc-tec/openbao-operator/internal/infra"
 	openbao "github.com/dc-tec/openbao-operator/internal/openbao"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	recon "github.com/dc-tec/openbao-operator/internal/reconcile"
-	security "github.com/dc-tec/openbao-operator/internal/security"
 )
 
 // infraReconciler wraps InfraManager to implement the controller's sub-reconciler contract.
@@ -47,7 +46,7 @@ type infraReconciler struct {
 	platform                string
 	smartClientConfig       openbao.ClientConfig
 	clientForPodFunc        func(cluster *openbaov1alpha1.OpenBaoCluster, podName string) (*openbao.Client, error)
-	discoverOIDCConfigFunc  func(ctx context.Context, cfg *rest.Config) (*auth.OIDCConfig, error)
+	discoverOIDCConfigFunc  func(ctx context.Context, cfg *rest.Config) (*appopenbaocluster.OIDCConfig, error)
 }
 
 func shouldBootstrapJWTAuth(cluster *openbaov1alpha1.OpenBaoCluster) bool {
@@ -62,13 +61,12 @@ func oidcDiscoveryError(err error) error {
 		return nil
 	}
 
-	var statusErr *auth.HTTPStatusError
-	if errors.As(err, &statusErr) {
-		switch statusErr.StatusCode {
+	if statusCode, ok := appopenbaocluster.OIDCDiscoveryStatusCode(err); ok {
+		switch statusCode {
 		case http.StatusUnauthorized, http.StatusForbidden:
 			return operatorerrors.WrapPermanentConfig(fmt.Errorf(
 				"OIDC discovery blocked by Kubernetes API RBAC (%d). Ensure the operator ServiceAccount can GET %q and %q on the Kubernetes API server (nonResourceURLs RBAC): %w",
-				statusErr.StatusCode,
+				statusCode,
 				"/.well-known/openid-configuration",
 				"/openid/v1/jwks",
 				err,
@@ -79,7 +77,7 @@ func oidcDiscoveryError(err error) error {
 				err,
 			))
 		default:
-			if statusErr.StatusCode == http.StatusTooManyRequests || statusErr.StatusCode >= 500 {
+			if statusCode == http.StatusTooManyRequests || statusCode >= 500 {
 				return operatorerrors.WrapTransientKubernetesAPI(err)
 			}
 			return operatorerrors.WrapPermanentConfig(err)
@@ -103,10 +101,7 @@ func (r *infraReconciler) resolveOIDC(ctx context.Context, cluster *openbaov1alp
 
 	discover := r.discoverOIDCConfigFunc
 	if discover == nil {
-		discover = func(ctx context.Context, cfg *rest.Config) (*auth.OIDCConfig, error) {
-			// Security: never use any CR-provided URL as the discovery target.
-			return auth.DiscoverConfig(ctx, cfg, "")
-		}
+		discover = appopenbaocluster.DiscoverOIDCConfig
 	}
 
 	discoveryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -200,7 +195,7 @@ func (r *infraReconciler) verifyImageDigestWithPolicy(
 
 func (r *infraReconciler) verifyMainImageDigest(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, imageRef string) (string, error) {
 	opts := imageVerificationOptions{
-		enabled:              security.IsMainImageVerificationEnabled(cluster),
+		enabled:              appopenbaocluster.IsMainImageVerificationEnabled(cluster),
 		imageRef:             imageRef,
 		failurePolicy:        imageVerificationFailurePolicy(cluster),
 		failureReason:        constants.ReasonImageVerificationFailed,
@@ -219,7 +214,7 @@ func (r *infraReconciler) verifyMainImageDigest(ctx context.Context, logger logr
 
 func (r *infraReconciler) verifyOperatorImageDigest(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, imageRef string, failureReason string, failureMessagePrefix string) (string, error) {
 	// Use OperatorImageVerification only - no fallback to ImageVerification
-	if !security.IsOperatorImageVerificationEnabled(cluster) {
+	if !appopenbaocluster.IsOperatorImageVerificationEnabled(cluster) {
 		return "", nil
 	}
 
@@ -235,7 +230,7 @@ func (r *infraReconciler) verifyOperatorImageDigest(ctx context.Context, logger 
 
 	verifyFunc := r.verifyOperatorImageFunc
 	if verifyFunc == nil {
-		verifyFunc = security.VerifyOperatorImageForCluster
+		verifyFunc = appopenbaocluster.VerifyOperatorImageForCluster
 	}
 
 	return r.verifyImageDigestWithPolicy(ctx, logger, cluster, opts, func(ctx context.Context) (string, error) {

--- a/internal/controller/openbaocluster/infra_reconciler_test.go
+++ b/internal/controller/openbaocluster/infra_reconciler_test.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/auth"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/constants"
 	"github.com/dc-tec/openbao-operator/internal/openbao"
 )
@@ -180,9 +180,9 @@ func TestInfraReconciler_ResolveOIDC_LazyDiscoveryForSelfInit(t *testing.T) {
 		restConfig:  &rest.Config{Host: "https://kubernetes.default.svc"},
 		oidcIssuer:  "",
 		oidcJWTKeys: nil,
-		discoverOIDCConfigFunc: func(ctx context.Context, cfg *rest.Config) (*auth.OIDCConfig, error) {
+		discoverOIDCConfigFunc: func(ctx context.Context, cfg *rest.Config) (*appopenbaocluster.OIDCConfig, error) {
 			called++
-			return &auth.OIDCConfig{
+			return &appopenbaocluster.OIDCConfig{
 				IssuerURL: "https://issuer.example",
 				JWKSKeys:  []string{"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw==\n-----END PUBLIC KEY-----\n"},
 			}, nil

--- a/internal/controller/openbaocluster/setup.go
+++ b/internal/controller/openbaocluster/setup.go
@@ -12,9 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/constants"
-	operatorpredicates "github.com/dc-tec/openbao-operator/internal/predicates"
-	"github.com/dc-tec/openbao-operator/internal/security"
 )
 
 // SetupWithManager sets up the OpenBaoCluster controllers with the Manager.
@@ -27,18 +26,16 @@ import (
 func (r *OpenBaoClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Initialize ImageVerifier with embedded trusted root (nil config)
 	// This ensures we reuse the same verifier (and its internal caches) across reconciliations.
-	r.ImageVerifier = security.NewImageVerifier(
+	r.ImageVerifier = appopenbaocluster.NewImageVerifier(
 		mgr.GetLogger().WithName("image-verifier"),
 		r.Client,
-		nil, // trustedRootConfig
 	)
 
 	// Initialize OperatorImageVerifier with embedded trusted root (nil config)
 	// This ensures we reuse the same verifier (and its internal caches) across reconciliations.
-	r.OperatorImageVerifier = security.NewImageVerifier(
+	r.OperatorImageVerifier = appopenbaocluster.NewImageVerifier(
 		mgr.GetLogger().WithName("operator-image-verifier"),
 		r.Client,
-		nil, // trustedRootConfig
 	)
 
 	if r.SingleTenantMode {
@@ -69,7 +66,7 @@ func (r *OpenBaoClusterReconciler) setupSingleTenantMode(mgr ctrl.Manager) error
 		Owns(&corev1.Secret{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.ServiceAccount{}).
-		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		WithEventFilter(appopenbaocluster.OpenBaoClusterPredicateWithOptions(appopenbaocluster.PredicateOptions{
 			ReconcileOnBlueGreenStatus: true,
 		})).
 		WithOptions(controller.Options{
@@ -84,7 +81,7 @@ func (r *OpenBaoClusterReconciler) setupSingleTenantMode(mgr ctrl.Manager) error
 	// AdminOps controller for upgrades/backups
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
-		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		WithEventFilter(appopenbaocluster.OpenBaoClusterPredicateWithOptions(appopenbaocluster.PredicateOptions{
 			ReconcileOnUpgradeStatus: true,
 			ReconcileOnBackupStatus:  true,
 		})).
@@ -101,7 +98,7 @@ func (r *OpenBaoClusterReconciler) setupSingleTenantMode(mgr ctrl.Manager) error
 	// Status controller for finalizer and condition aggregation
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
-		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		WithEventFilter(appopenbaocluster.OpenBaoClusterPredicateWithOptions(appopenbaocluster.PredicateOptions{
 			ReconcileOnUpgradeStatus:   true,
 			ReconcileOnBackupStatus:    true,
 			ReconcileOnBlueGreenStatus: true,
@@ -142,7 +139,7 @@ func (r *OpenBaoClusterReconciler) setupMultiTenantMode(mgr ctrl.Manager) error 
 	// to clean up temporary services after upgrades.
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
-		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		WithEventFilter(appopenbaocluster.OpenBaoClusterPredicateWithOptions(appopenbaocluster.PredicateOptions{
 			ReconcileOnBlueGreenStatus: true,
 		})).
 		WithOptions(controller.Options{
@@ -157,7 +154,7 @@ func (r *OpenBaoClusterReconciler) setupMultiTenantMode(mgr ctrl.Manager) error 
 	// AdminOps controller: runs upgrades and backups.
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
-		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		WithEventFilter(appopenbaocluster.OpenBaoClusterPredicateWithOptions(appopenbaocluster.PredicateOptions{
 			ReconcileOnUpgradeStatus: true,
 			ReconcileOnBackupStatus:  true,
 		})).
@@ -173,7 +170,7 @@ func (r *OpenBaoClusterReconciler) setupMultiTenantMode(mgr ctrl.Manager) error 
 	// Status controller: owns finalizer and condition/status aggregation.
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
-		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
+		WithEventFilter(appopenbaocluster.OpenBaoClusterPredicateWithOptions(appopenbaocluster.PredicateOptions{
 			ReconcileOnUpgradeStatus:   true,
 			ReconcileOnBackupStatus:    true,
 			ReconcileOnBlueGreenStatus: true,

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -14,7 +14,6 @@ import (
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	certmanager "github.com/dc-tec/openbao-operator/internal/certs"
 	"github.com/dc-tec/openbao-operator/internal/constants"
-	observability "github.com/dc-tec/openbao-operator/internal/observability"
 )
 
 type openBaoClusterWorkloadReconciler struct {
@@ -41,7 +40,7 @@ func (r *OpenBaoClusterReconciler) loggerFor(ctx context.Context, _ ctrl.Request
 
 func (r *openBaoClusterWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	start := time.Now()
-	reconcileMetrics := observability.NewReconcileMetrics(req.Namespace, req.Name, constants.ControllerNameOpenBaoClusterWorkload)
+	reconcileMetrics := appopenbaocluster.NewReconcileMetrics(req.Namespace, req.Name, constants.ControllerNameOpenBaoClusterWorkload)
 	recordedError := false
 	recordError := func(e error) {
 		if e == nil {
@@ -149,7 +148,7 @@ func (r *openBaoClusterWorkloadReconciler) reconcileCluster(
 
 func (r *openBaoClusterAdminOpsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	start := time.Now()
-	reconcileMetrics := observability.NewReconcileMetrics(req.Namespace, req.Name, constants.ControllerNameOpenBaoClusterAdminOps)
+	reconcileMetrics := appopenbaocluster.NewReconcileMetrics(req.Namespace, req.Name, constants.ControllerNameOpenBaoClusterAdminOps)
 	recordedError := false
 	recordError := func(e error) {
 		if e == nil {
@@ -198,7 +197,7 @@ func (r *openBaoClusterAdminOpsReconciler) Reconcile(ctx context.Context, req ct
 
 func (r *openBaoClusterStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	start := time.Now()
-	reconcileMetrics := observability.NewReconcileMetrics(req.Namespace, req.Name, constants.ControllerNameOpenBaoClusterStatus)
+	reconcileMetrics := appopenbaocluster.NewReconcileMetrics(req.Namespace, req.Name, constants.ControllerNameOpenBaoClusterStatus)
 	recordedError := false
 	recordError := func(e error) {
 		if e == nil {

--- a/internal/controller/openbaocluster/status.go
+++ b/internal/controller/openbaocluster/status.go
@@ -15,12 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/constants"
 	"github.com/dc-tec/openbao-operator/internal/kube"
-	observability "github.com/dc-tec/openbao-operator/internal/observability"
 	openbaolabels "github.com/dc-tec/openbao-operator/internal/openbao"
-	"github.com/dc-tec/openbao-operator/internal/revision"
-	"github.com/dc-tec/openbao-operator/internal/upgrade"
 )
 
 // patchStatusSSA updates the cluster status using Server-Side Apply.
@@ -183,7 +181,7 @@ func (r *OpenBaoClusterReconciler) updateStatus(ctx context.Context, logger logr
 	// otherwise it can race with in-progress partitioned rollouts.
 
 	// Update per-cluster metrics
-	clusterMetrics := observability.NewClusterMetrics(cluster.Namespace, cluster.Name)
+	clusterMetrics := appopenbaocluster.NewClusterMetrics(cluster.Namespace, cluster.Name)
 	clusterMetrics.SetReadyReplicas(state.ReadyReplicas)
 	clusterMetrics.SetPhase(cluster.Status.Phase)
 
@@ -233,7 +231,7 @@ func (r *OpenBaoClusterReconciler) reconcileCurrentVersion(logger logr.Logger, c
 		return
 	}
 
-	change, err := upgrade.CompareVersions(cluster.Status.CurrentVersion, observedVersion)
+	isDowngrade, err := appopenbaocluster.IsVersionDowngrade(cluster.Status.CurrentVersion, observedVersion)
 	if err != nil {
 		logger.V(1).Info("Skipping CurrentVersion correction due to unparsable version",
 			"currentVersion", cluster.Status.CurrentVersion,
@@ -241,7 +239,7 @@ func (r *OpenBaoClusterReconciler) reconcileCurrentVersion(logger logr.Logger, c
 			"error", err)
 		return
 	}
-	if change == upgrade.VersionChangeDowngrade {
+	if isDowngrade {
 		logger.V(1).Info("Ignoring CurrentVersion regression from pod labels",
 			"currentVersion", cluster.Status.CurrentVersion,
 			"observedVersion", observedVersion)
@@ -272,7 +270,7 @@ func (r *OpenBaoClusterReconciler) maybeAdvanceCurrentVersionForBlueGreen(logger
 	// CRITICAL CHECK: Verify that the upgrade actually happened.
 	// PhaseIdle can mean "Before Upgrade" OR "After Upgrade".
 	// We distinguish them by checking if the active BlueRevision matches the current Spec.
-	currentSpecRevision := revision.OpenBaoClusterRevision(cluster.Spec.Version, cluster.Spec.Image, cluster.Spec.Replicas)
+	currentSpecRevision := appopenbaocluster.OpenBaoClusterRevision(cluster.Spec.Version, cluster.Spec.Image, cluster.Spec.Replicas)
 	if cluster.Status.BlueGreen.BlueRevision != currentSpecRevision {
 		return
 	}


### PR DESCRIPTION
## Description

This stacked PR reduces direct package coupling in `internal/controller/openbaocluster` by routing cross-cutting integrations through `internal/app/openbaocluster` bridge helpers.

Changes include:
- Add app-layer bridge helpers for:
  - metrics (`observability`)
  - security/image verification
  - OIDC discovery/status code extraction
  - predicate construction
  - audit event emission
  - revision/version comparison helpers
- Update openbaocluster controller files to consume bridge helpers instead of importing these packages directly.

Outcome from local dependency report:
- `internal/controller/openbaocluster` fan-out reduced to `12` (target `<= 12`).
- Dependency policy warnings are now `None`.

## Related Issues

<!-- Closes #123 -->

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- `make lint-config lint`
- `go test ./...`
- `make report-internal-deps`
