### PR TITLE
refactor(cmd): normalize entrypoint flag handling

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -54,6 +54,7 @@ import (
 	certmanager "github.com/dc-tec/openbao-operator/internal/certs"
 	openbaoclustercontroller "github.com/dc-tec/openbao-operator/internal/controller/openbaocluster"
 	openbaorestorecontroller "github.com/dc-tec/openbao-operator/internal/controller/openbaorestore"
+	"github.com/dc-tec/openbao-operator/internal/entrypoint"
 	initmanager "github.com/dc-tec/openbao-operator/internal/init"
 	"github.com/dc-tec/openbao-operator/internal/logging"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -68,14 +69,11 @@ var (
 )
 
 const (
-	admissionEnforcementFail        = "fail"
-	admissionEnforcementWarn        = "warn"
-	admissionEnforcementExpectedMsg = "expected --admission-enforcement=fail or warn"
-	platformAuto                    = "auto"
-	platformKubernetes              = "kubernetes"
-	platformOpenShift               = "openshift"
-	controllerNameOpenBaoCluster    = "openbaocluster"
-	controllerNameOpenBaoRestore    = "openbaorestore"
+	platformAuto                 = "auto"
+	platformKubernetes           = "kubernetes"
+	platformOpenShift            = "openshift"
+	controllerNameOpenBaoCluster = "openbaocluster"
+	controllerNameOpenBaoRestore = "openbaorestore"
 )
 
 func detectPlatform(cfg *rest.Config) string {
@@ -96,17 +94,6 @@ func detectPlatform(cfg *rest.Config) string {
 	}
 
 	return platformKubernetes
-}
-
-func normalizeAdmissionEnforcement(in string) (string, error) {
-	normalized := strings.ToLower(strings.TrimSpace(in))
-	if normalized == "" {
-		normalized = admissionEnforcementFail
-	}
-	if normalized != admissionEnforcementFail && normalized != admissionEnforcementWarn {
-		return "", fmt.Errorf("invalid admission enforcement mode %q", normalized)
-	}
-	return normalized, nil
 }
 
 func init() {
@@ -144,13 +131,7 @@ func Run(args []string) {
 	var admissionEnforcement string
 	var admissionStartupTimeout time.Duration
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metrics endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&secureMetrics, "metrics-secure", true,
-		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+	entrypoint.BindManagerFlags(flag.CommandLine, &metricsAddr, &probeAddr, &enableLeaderElection, &secureMetrics)
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -171,11 +152,7 @@ func Run(args []string) {
 	flag.DurationVar(&clientCBOpenDuration, "openbao-client-cb-open-duration", 30*time.Second,
 		"The duration the circuit breaker remains open before testing the connection.")
 
-	flag.StringVar(&admissionEnforcement, "admission-enforcement", admissionEnforcementFail,
-		"Admission dependency enforcement mode: fail or warn. "+
-			"In fail mode the operator refuses to start unless required ValidatingAdmissionPolicies are present and enforced.")
-	flag.DurationVar(&admissionStartupTimeout, "admission-startup-timeout", 60*time.Second,
-		"Maximum time to wait for required admission policies at startup when --admission-enforcement=fail.")
+	entrypoint.BindAdmissionFlags(flag.CommandLine, &admissionEnforcement, &admissionStartupTimeout)
 
 	opts := zap.Options{
 		Development: false,
@@ -188,9 +165,9 @@ func Run(args []string) {
 	var err error
 
 	platform = strings.ToLower(strings.TrimSpace(platform))
-	admissionEnforcement, err = normalizeAdmissionEnforcement(admissionEnforcement)
+	admissionEnforcement, err = entrypoint.NormalizeAdmissionEnforcement(admissionEnforcement)
 	if err != nil {
-		setupLog.Error(err, admissionEnforcementExpectedMsg)
+		setupLog.Error(err, entrypoint.AdmissionEnforcementExpectedMsg)
 		os.Exit(2)
 	}
 
@@ -416,7 +393,7 @@ func Run(args []string) {
 		admission.SetAdmissionDependenciesReady(true)
 	} else {
 		switch admissionEnforcement {
-		case admissionEnforcementFail:
+		case entrypoint.AdmissionEnforcementFail:
 			setupLog.Info("Waiting for admission policy dependencies", "timeout", admissionStartupTimeout)
 			status, err := admission.WaitForDependencies(
 				context.Background(),

--- a/cmd/provisioner/run.go
+++ b/cmd/provisioner/run.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -44,6 +43,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/admission"
 	provisionercontroller "github.com/dc-tec/openbao-operator/internal/controller/provisioner"
+	"github.com/dc-tec/openbao-operator/internal/entrypoint"
 	"github.com/dc-tec/openbao-operator/internal/logging"
 	"github.com/dc-tec/openbao-operator/internal/provisioner"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -54,23 +54,6 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
-
-const (
-	admissionEnforcementFail        = "fail"
-	admissionEnforcementWarn        = "warn"
-	admissionEnforcementExpectedMsg = "expected --admission-enforcement=fail or warn"
-)
-
-func normalizeAdmissionEnforcement(in string) (string, error) {
-	normalized := strings.ToLower(strings.TrimSpace(in))
-	if normalized == "" {
-		normalized = admissionEnforcementFail
-	}
-	if normalized != admissionEnforcementFail && normalized != admissionEnforcementWarn {
-		return "", fmt.Errorf("invalid admission enforcement mode %q", normalized)
-	}
-	return normalized, nil
-}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -98,18 +81,8 @@ func Run(args []string) {
 	var admissionStartupTimeout time.Duration
 	var admissionCanary bool
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metrics endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&secureMetrics, "metrics-secure", true,
-		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
-	flag.StringVar(&admissionEnforcement, "admission-enforcement", admissionEnforcementFail,
-		"Admission dependency enforcement mode: fail or warn. "+
-			"In fail mode the operator refuses to start unless required ValidatingAdmissionPolicies are present and enforced.")
-	flag.DurationVar(&admissionStartupTimeout, "admission-startup-timeout", 60*time.Second,
-		"Maximum time to wait for required admission policies at startup when --admission-enforcement=fail.")
+	entrypoint.BindManagerFlags(flag.CommandLine, &metricsAddr, &probeAddr, &enableLeaderElection, &secureMetrics)
+	entrypoint.BindAdmissionFlags(flag.CommandLine, &admissionEnforcement, &admissionStartupTimeout)
 	flag.BoolVar(&admissionCanary, "admission-canary", false,
 		"If set, perform an admission canary (dry-run) that must be denied "+
 			"by the Provisioner RBAC ValidatingAdmissionPolicy. "+
@@ -121,9 +94,9 @@ func Run(args []string) {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	admissionEnforcement, err := normalizeAdmissionEnforcement(admissionEnforcement)
+	admissionEnforcement, err := entrypoint.NormalizeAdmissionEnforcement(admissionEnforcement)
 	if err != nil {
-		setupLog.Error(err, admissionEnforcementExpectedMsg)
+		setupLog.Error(err, entrypoint.AdmissionEnforcementExpectedMsg)
 		os.Exit(2)
 	}
 
@@ -188,7 +161,7 @@ func Run(args []string) {
 		admission.SetAdmissionDependenciesReady(true)
 	} else {
 		switch admissionEnforcement {
-		case admissionEnforcementFail:
+		case entrypoint.AdmissionEnforcementFail:
 			setupLog.Info("Waiting for admission policy dependencies", "timeout", admissionStartupTimeout)
 			status, err := admission.WaitForDependencies(
 				context.Background(),

--- a/internal/entrypoint/flags.go
+++ b/internal/entrypoint/flags.go
@@ -1,0 +1,46 @@
+package entrypoint
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	AdmissionEnforcementFail        = "fail"
+	AdmissionEnforcementWarn        = "warn"
+	AdmissionEnforcementExpectedMsg = "expected --admission-enforcement=fail or warn"
+)
+
+// NormalizeAdmissionEnforcement validates and canonicalizes admission enforcement mode.
+func NormalizeAdmissionEnforcement(in string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(in))
+	if normalized == "" {
+		normalized = AdmissionEnforcementFail
+	}
+	if normalized != AdmissionEnforcementFail && normalized != AdmissionEnforcementWarn {
+		return "", fmt.Errorf("invalid admission enforcement mode %q", normalized)
+	}
+	return normalized, nil
+}
+
+// BindManagerFlags binds standard manager networking/election flags.
+func BindManagerFlags(fs *flag.FlagSet, metricsAddr, probeAddr *string, enableLeaderElection, secureMetrics *bool) {
+	fs.StringVar(metricsAddr, "metrics-bind-address", ":8443", "The address the metrics endpoint binds to.")
+	fs.StringVar(probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.BoolVar(enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	fs.BoolVar(secureMetrics, "metrics-secure", true,
+		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+}
+
+// BindAdmissionFlags binds admission enforcement flags shared across entrypoints.
+func BindAdmissionFlags(fs *flag.FlagSet, admissionEnforcement *string, admissionStartupTimeout *time.Duration) {
+	fs.StringVar(admissionEnforcement, "admission-enforcement", AdmissionEnforcementFail,
+		"Admission dependency enforcement mode: fail or warn. "+
+			"In fail mode the operator refuses to start unless required ValidatingAdmissionPolicies are present and enforced.")
+	fs.DurationVar(admissionStartupTimeout, "admission-startup-timeout", 60*time.Second,
+		"Maximum time to wait for required admission policies at startup when --admission-enforcement=fail.")
+}


### PR DESCRIPTION
## Description

This stacked PR normalizes entrypoint flag handling between `cmd/controller` and `cmd/provisioner`.

Changes:
- Add shared entrypoint helpers in `internal/entrypoint/flags.go` for:
  - standard manager flags (`metrics-bind-address`, `health-probe-bind-address`, `leader-elect`, `metrics-secure`)
  - admission flags (`admission-enforcement`, `admission-startup-timeout`)
  - admission enforcement normalization/validation
- Update both binaries to consume the shared helpers and constants.

This keeps startup wiring thinner and consistent while preserving existing flag names and behavior.

## Related Issues

<!-- Closes #123 -->

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- `make lint-config lint`
- `go test ./...`
