### PR TITLE
fix(build): stabilize byte reproducibility gates for checksums and sbom outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -541,13 +541,37 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize SBOM JSON (deterministic)
+        env:
+          SOURCE_DATE_EPOCH: ${{ needs.prepare.outputs.source_date_epoch }}
+        run: |
+          set -euo pipefail
+          bash hack/ci/normalize-spdx-json.sh \
+            dist/primary/sbom-openbao-operator.spdx.json \
+            dist/primary/sbom-openbao-init.spdx.json \
+            dist/primary/sbom-openbao-backup.spdx.json \
+            dist/primary/sbom-openbao-upgrade.spdx.json \
+            dist/rebuild/sbom-openbao-operator.spdx.json \
+            dist/rebuild/sbom-openbao-init.spdx.json \
+            dist/rebuild/sbom-openbao-backup.spdx.json \
+            dist/rebuild/sbom-openbao-upgrade.spdx.json
+
       - name: Generate deterministic checksums
         run: |
           set -euo pipefail
           generate_checksums() {
             local dir="$1"
+            local -a sboms=()
+            local sbom_names=()
+            local sbom_path
             mapfile -t sboms < <(find "${dir}" -maxdepth 1 -type f -name 'sbom-*.spdx.json' | LC_ALL=C sort)
-            sha256sum "${dir}/install.yaml" "${dir}/crds.yaml" "${sboms[@]}" > "${dir}/checksums.txt"
+            for sbom_path in "${sboms[@]}"; do
+              sbom_names+=("$(basename "${sbom_path}")")
+            done
+            (
+              cd "${dir}"
+              sha256sum install.yaml crds.yaml "${sbom_names[@]}" > checksums.txt
+            )
           }
           generate_checksums dist/primary
           generate_checksums dist/rebuild

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -298,13 +298,32 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize SBOM JSON (deterministic)
+        env:
+          SOURCE_DATE_EPOCH: ${{ needs.prepare.outputs.source_date_epoch }}
+        run: |
+          set -euo pipefail
+          bash hack/ci/normalize-spdx-json.sh \
+            dist/release/sbom-openbao-operator.spdx.json \
+            dist/release/sbom-openbao-init.spdx.json \
+            dist/release/sbom-openbao-backup.spdx.json \
+            dist/release/sbom-openbao-upgrade.spdx.json \
+            dist/rebuild/sbom-openbao-operator.spdx.json \
+            dist/rebuild/sbom-openbao-init.spdx.json \
+            dist/rebuild/sbom-openbao-backup.spdx.json \
+            dist/rebuild/sbom-openbao-upgrade.spdx.json
+
       - name: Generate deterministic checksums
         run: |
           set -euo pipefail
-          mapfile -t release_sboms < <(find dist/release -maxdepth 1 -type f -name 'sbom-*.spdx.json' | LC_ALL=C sort)
-          mapfile -t rebuild_sboms < <(find dist/rebuild -maxdepth 1 -type f -name 'sbom-*.spdx.json' | LC_ALL=C sort)
-          sha256sum dist/release/install.yaml dist/release/crds.yaml "${release_sboms[@]}" > dist/release/checksums.txt
-          sha256sum dist/rebuild/install.yaml dist/rebuild/crds.yaml "${rebuild_sboms[@]}" > dist/rebuild/checksums.txt
+          for dir in dist/release dist/rebuild; do
+            (
+              cd "${dir}"
+              mapfile -t sboms < <(find . -maxdepth 1 -type f -name 'sbom-*.spdx.json' -print | LC_ALL=C sort)
+              mapfile -t sbom_names < <(printf '%s\n' "${sboms[@]}" | sed 's#^\./##')
+              sha256sum install.yaml crds.yaml "${sbom_names[@]}" > checksums.txt
+            )
+          done
 
       - name: Compare reproducibility (report-only)
         env:

--- a/.github/workflows/reusable-channel-hardening.yml
+++ b/.github/workflows/reusable-channel-hardening.yml
@@ -325,11 +325,32 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize SBOM JSON (deterministic)
+        env:
+          SOURCE_DATE_EPOCH: ${{ inputs.source_date_epoch }}
+        run: |
+          set -euo pipefail
+          bash hack/ci/normalize-spdx-json.sh \
+            dist/primary/sbom-openbao-operator.spdx.json \
+            dist/primary/sbom-openbao-init.spdx.json \
+            dist/primary/sbom-openbao-backup.spdx.json \
+            dist/primary/sbom-openbao-upgrade.spdx.json \
+            dist/rebuild/sbom-openbao-operator.spdx.json \
+            dist/rebuild/sbom-openbao-init.spdx.json \
+            dist/rebuild/sbom-openbao-backup.spdx.json \
+            dist/rebuild/sbom-openbao-upgrade.spdx.json
+
       - name: Generate deterministic checksums
         run: |
           set -euo pipefail
-          sha256sum dist/primary/install.yaml dist/primary/crds.yaml > dist/primary/checksums.txt
-          sha256sum dist/rebuild/install.yaml dist/rebuild/crds.yaml > dist/rebuild/checksums.txt
+          (
+            cd dist/primary
+            sha256sum install.yaml crds.yaml > checksums.txt
+          )
+          (
+            cd dist/rebuild
+            sha256sum install.yaml crds.yaml > checksums.txt
+          )
 
       - name: Verify byte reproducibility
         env:

--- a/hack/ci/normalize-spdx-json.sh
+++ b/hack/ci/normalize-spdx-json.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${SOURCE_DATE_EPOCH:?SOURCE_DATE_EPOCH is required}"
+
+if [[ "$#" -lt 1 ]]; then
+  echo "usage: $0 <sbom.spdx.json> [more sbom files...]" >&2
+  exit 1
+fi
+
+python3 - "${SOURCE_DATE_EPOCH}" "$@" <<'PY'
+import copy
+import datetime
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+def sort_list(entries, keys):
+    if not isinstance(entries, list):
+        return entries
+
+    def key_fn(item):
+        if not isinstance(item, dict):
+            return (str(item),)
+        return tuple(str(item.get(k, "")) for k in keys)
+
+    return sorted(entries, key=key_fn)
+
+
+def canonicalize(node):
+    if isinstance(node, dict):
+        out = {k: canonicalize(v) for k, v in node.items()}
+        out["packages"] = sort_list(out.get("packages"), ("SPDXID", "name", "versionInfo"))
+        out["relationships"] = sort_list(
+            out.get("relationships"),
+            ("spdxElementId", "relationshipType", "relatedSpdxElement", "comment"),
+        )
+        out["files"] = sort_list(out.get("files"), ("SPDXID", "fileName"))
+        out["annotations"] = sort_list(out.get("annotations"), ("SPDXID", "annotationDate", "comment"))
+        out["hasExtractedLicensingInfos"] = sort_list(
+            out.get("hasExtractedLicensingInfos"),
+            ("licenseId", "name", "comment"),
+        )
+        return out
+    if isinstance(node, list):
+        return [canonicalize(v) for v in node]
+    return node
+
+
+def canonical_json(obj):
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def normalize_document(doc, created):
+    doc = canonicalize(doc)
+    creation_info = doc.setdefault("creationInfo", {})
+    if isinstance(creation_info, dict):
+        creation_info["created"] = created
+
+    namespace_seed = copy.deepcopy(doc)
+    namespace_seed.pop("documentNamespace", None)
+    seed_creation = namespace_seed.get("creationInfo")
+    if isinstance(seed_creation, dict):
+        seed_creation.pop("created", None)
+    namespace_seed = canonicalize(namespace_seed)
+
+    seed_hash = hashlib.sha256(canonical_json(namespace_seed).encode("utf-8")).hexdigest()
+    doc["documentNamespace"] = f"https://openbao-operator.dev/sbom/{seed_hash}"
+
+    return canonicalize(doc)
+
+
+source_date_epoch = int(sys.argv[1])
+created = datetime.datetime.fromtimestamp(
+    source_date_epoch, datetime.timezone.utc
+).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+for sbom_path in sys.argv[2:]:
+    path = Path(sbom_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    normalized = normalize_document(data, created)
+    path.write_text(canonical_json(normalized) + "\n", encoding="utf-8")
+PY


### PR DESCRIPTION
## Description

This PR fixes remaining byte-reproducibility failures in release/build hardening workflows after image digest reproducibility was resolved.

Root cause:
- Image digests matched, but byte checks still failed due to:
  - nondeterministic SPDX SBOM fields (`documentNamespace`, `creationInfo.created`, and ordering)
  - checksum file path variance (directory-prefixed paths in some workflows)

Changes:
- Added deterministic SPDX normalization script:
  - `hack/ci/normalize-spdx-json.sh`
- Applied SBOM normalization in:
  - `.github/workflows/reusable-channel-hardening.yml`
  - `.github/workflows/release.yml`
  - `.github/workflows/reproducibility.yml`
- Updated checksum generation to run from inside artifact directories so entries are stable (`install.yaml`, `crds.yaml`, `sbom-*.spdx.json`) instead of path-prefixed variants.
- This hardens both edge/nightly channel parity and stable release behavior.

## Related Issues

N/A (fixes current pipeline reproducibility gate failures)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Reproduced failing pattern from latest edge publish run (`Publish Edge`, run `22543007411`):
  - image digests matched
  - `checksums.txt` and `sbom-*.spdx.json` mismatched
- Verified SBOM nondeterminism locally (same image, different raw SPDX bytes).
- Verified normalization determinism locally (normalized SPDX bytes match).
- Verified config/docs checks:
  - `make lint-config`
  - `make docs-build`
- Workflow-level validation pending on next GitHub Actions run (edge/nightly/release paths).

