### PR TITLE
ci(security): harden reproducibility workflow trust boundaries

### DIFF
--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: reproducibility-${{ github.event.workflow_run.head_branch || github.event.inputs.tag || github.run_id }}
+  group: reproducibility-${{ github.event.workflow_run.head_sha || github.event.inputs.tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -26,7 +26,8 @@ jobs:
       ${{
         github.event_name != 'workflow_run' ||
         (github.event.workflow_run.conclusion == 'success' &&
-         github.event.workflow_run.event == 'push')
+         github.event.workflow_run.event == 'push' &&
+         !github.event.workflow_run.repository.fork)
       }}
     permissions:
       contents: read
@@ -55,7 +56,18 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tag="${{ github.event.inputs.tag }}"
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            tag="${{ github.event.workflow_run.head_branch }}"
+            head_sha="${{ github.event.workflow_run.head_sha }}"
+            mapfile -t tags < <(git tag --points-at "${head_sha}" --sort=-v:refname)
+            for candidate in "${tags[@]}"; do
+              if [[ "${candidate}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
+                tag="${candidate}"
+                break
+              fi
+            done
+            if [[ -z "${tag}" ]]; then
+              echo "No SemVer tag found for workflow_run head sha ${head_sha}" >&2
+              exit 1
+            fi
           fi
 
           if ! [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
@@ -64,6 +76,14 @@ jobs:
           fi
 
           git checkout "refs/tags/${tag}" --detach
+          resolved_sha="$(git rev-parse HEAD)"
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            expected_sha="${{ github.event.workflow_run.head_sha }}"
+            if [[ "${resolved_sha}" != "${expected_sha}" ]]; then
+              echo "Resolved tag ${tag} to ${resolved_sha}, expected ${expected_sha}" >&2
+              exit 1
+            fi
+          fi
 
           chart_file="charts/openbao-operator/Chart.yaml"
           chart_version="$(sed -nE 's/^version:[[:space:]]*"?([^"#[:space:]]+)"?[[:space:]]*(#.*)?$/\1/p' "${chart_file}" | head -n1)"
@@ -75,7 +95,7 @@ jobs:
           source_date_epoch="$(git show -s --format=%ct HEAD)"
           owner="${GITHUB_REPOSITORY_OWNER}"
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
-          echo "ref=refs/tags/${tag}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${resolved_sha}" >> "${GITHUB_OUTPUT}"
           echo "chart_version=${chart_version}" >> "${GITHUB_OUTPUT}"
           echo "build_tag=repro-${tag}-${GITHUB_RUN_ID}" >> "${GITHUB_OUTPUT}"
           echo "source_date_epoch=${source_date_epoch}" >> "${GITHUB_OUTPUT}"
@@ -118,14 +138,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
-
-      - name: Cache Tools
-        id: cache-tools
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: bin/
-          key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'go.sum') }}
+          cache: false
 
       - name: Setup Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -9,8 +9,7 @@ on:
         type: string
       ref:
         description: "Git reference to checkout"
-        required: false
-        default: ${{ github.ref }}
+        required: true
         type: string
       source_date_epoch:
         description: "Unix timestamp used for deterministic build metadata"
@@ -65,6 +64,20 @@ jobs:
       backup_executor_digest: ${{ steps.set-output.outputs.backup_executor_digest }}
       upgrade_executor_digest: ${{ steps.set-output.outputs.upgrade_executor_digest }}
     steps:
+      - name: Validate checkout ref (immutable only)
+        env:
+          REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            exit 0
+          fi
+          if [[ "${REF}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
+            exit 0
+          fi
+          echo "inputs.ref must be an immutable commit SHA or semver tag ref; got: ${REF}" >&2
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Description

This PR hardens trusted GitHub Actions paths related to reproducibility builds:
- removes `workflow_run.head_branch` as a trust input in `.github/workflows/reproducibility.yml`
- derives SemVer tags from `workflow_run.head_sha` and verifies tag -> commit identity
- passes immutable SHA refs to downstream reusable build workflow
- disables cache usage in the privileged reproducibility compare job
- enforces immutable refs (full SHA or SemVer tag ref) in `.github/workflows/reusable-build.yml`

## Related Issues

- Code scanning alert: [#1](https://github.com/dc-tec/openbao-operator/security/code-scanning/1)
- Code scanning alert: [#2](https://github.com/dc-tec/openbao-operator/security/code-scanning/2)
- Code scanning alert: [#3](https://github.com/dc-tec/openbao-operator/security/code-scanning/3)
- Code scanning alert: [#4](https://github.com/dc-tec/openbao-operator/security/code-scanning/4)
- Code scanning alert: [#5](https://github.com/dc-tec/openbao-operator/security/code-scanning/5)
- Code scanning alert: [#6](https://github.com/dc-tec/openbao-operator/security/code-scanning/6)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `make lint-config`
- `make lint`
