### PR TITLE
fix(security): wrap bundle fallback verification error

### DIFF
--- a/internal/security/image_verifier.go
+++ b/internal/security/image_verifier.go
@@ -251,7 +251,7 @@ func (v *ImageVerifier) verifyImageSignature(ctx context.Context, digestRef stri
 	}
 
 	if err := v.verifyImageSignatureWithBundles(ctx, ref, digestRef, config, remoteOpts); err != nil {
-		return fmt.Errorf("image signature verification failed (legacy+bundle): legacy=%v; bundle=%v", legacyErr, err)
+		return fmt.Errorf("image signature verification failed (legacy+bundle): legacy=%v; bundle=%w", legacyErr, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Replace `%v` with `%w` when returning the bundle fallback verification error in `ImageVerifier`, preserving the wrapped error chain for downstream `errors.Is/errors.As` checks and aligning with runtime-safety error-wrapping guardrails.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process
- `go test ./internal/security/...`