### PR TITLE
refactor(provisioner): remove app reconcile bridge

### DIFF
--- a/.ast-grep/policy/architecture-boundaries.yml
+++ b/.ast-grep/policy/architecture-boundaries.yml
@@ -205,7 +205,6 @@ globalImportBoundaries:
     ignores:
       - "**/*_test.go"
       # Transitional bridge points pending decomposition away from ctrl.Result/ctrl.Request.
-      - internal/app/provisioner/tenant_reconcile.go
       - internal/app/openbaocluster/adminops.go
       - internal/app/openbaocluster/adminops/reconcile.go
       - internal/app/openbaocluster/workload.go

--- a/.ast-grep/rules/generated/architecture-boundary/no-controller-runtime-reconcile-apis-in-app-layer.yml
+++ b/.ast-grep/rules/generated/architecture-boundary/no-controller-runtime-reconcile-apis-in-app-layer.yml
@@ -9,7 +9,6 @@ files:
     - internal/app/**/*.go
 ignores:
     - '**/*_test.go'
-    - internal/app/provisioner/tenant_reconcile.go
     - internal/app/openbaocluster/adminops.go
     - internal/app/openbaocluster/adminops/reconcile.go
     - internal/app/openbaocluster/workload.go

--- a/internal/app/provisioner/tenant_reconcile.go
+++ b/internal/app/provisioner/tenant_reconcile.go
@@ -11,13 +11,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/admission"
 	"github.com/dc-tec/openbao-operator/internal/logging"
 	provisionermanager "github.com/dc-tec/openbao-operator/internal/provisioner"
+	recon "github.com/dc-tec/openbao-operator/internal/reconcile"
 )
 
 const (
@@ -39,21 +39,21 @@ type TenantRuntime struct {
 }
 
 // ReconcileOpenBaoTenant runs the business flow for namespace provisioning.
-func ReconcileOpenBaoTenant(ctx context.Context, req ctrl.Request, logger logr.Logger, runtime TenantRuntime) (ctrl.Result, error) {
+func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logger logr.Logger, runtime TenantRuntime) (recon.Result, error) {
 	if runtime.Client == nil {
-		return ctrl.Result{}, fmt.Errorf("client is required")
+		return recon.Result{}, fmt.Errorf("client is required")
 	}
 	if runtime.Provisioner == nil {
-		return ctrl.Result{}, fmt.Errorf("provisioner manager is required")
+		return recon.Result{}, fmt.Errorf("provisioner manager is required")
 	}
 
 	tenant := &openbaov1alpha1.OpenBaoTenant{}
-	if err := runtime.Client.Get(ctx, req.NamespacedName, tenant); err != nil {
+	if err := runtime.Client.Get(ctx, key, tenant); err != nil {
 		if apierrors.IsNotFound(err) {
 			// OpenBaoTenant deleted - nothing to do.
-			return ctrl.Result{}, nil
+			return recon.Result{}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("failed to get OpenBaoTenant %s: %w", req.NamespacedName, err)
+		return recon.Result{}, fmt.Errorf("failed to get OpenBaoTenant %s: %w", key, err)
 	}
 
 	targetNS := tenant.Spec.TargetNamespace
@@ -83,24 +83,24 @@ func ReconcileOpenBaoTenant(ctx context.Context, req ctrl.Request, logger logr.L
 			Message:            err.Error(),
 		})
 		if patchErr := patchStatus(ctx, runtime.Client, tenant, original); patchErr != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to patch status for security violation: %w", patchErr)
+			return recon.Result{}, fmt.Errorf("failed to patch status for security violation: %w", patchErr)
 		}
 
 		// Do not requeue. User must fix the CR.
-		return ctrl.Result{}, nil
+		return recon.Result{}, nil
 	}
 
 	if !tenant.DeletionTimestamp.IsZero() {
-		return reconcileDeletion(ctx, logger, runtime, tenant, targetNS, req)
+		return reconcileDeletion(ctx, logger, runtime, tenant, targetNS, key)
 	}
 
 	if !containsFinalizer(tenant.Finalizers, openbaov1alpha1.OpenBaoTenantFinalizer) {
 		tenant.Finalizers = append(tenant.Finalizers, openbaov1alpha1.OpenBaoTenantFinalizer)
 		if err := runtime.Client.Update(ctx, tenant); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to OpenBaoTenant %s: %w", req.NamespacedName, err)
+			return recon.Result{}, fmt.Errorf("failed to add finalizer to OpenBaoTenant %s: %w", key, err)
 		}
 		// Requeue to observe the resource with the finalizer attached.
-		return ctrl.Result{RequeueAfter: resolveRequeueShort(runtime)}, nil
+		return recon.Result{RequeueAfter: resolveRequeueShort(runtime)}, nil
 	}
 
 	ns := &corev1.Namespace{}
@@ -110,12 +110,12 @@ func ReconcileOpenBaoTenant(ctx context.Context, req ctrl.Request, logger logr.L
 			tenant.Status.Provisioned = false
 			tenant.Status.LastError = fmt.Sprintf("target namespace %s not found", targetNS)
 			if patchErr := patchStatus(ctx, runtime.Client, tenant, original); patchErr != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", patchErr)
+				return recon.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", patchErr)
 			}
 			logger.Info("Target namespace not found; will retry", "target_namespace", targetNS)
-			return ctrl.Result{RequeueAfter: resolveRequeueStandard(runtime)}, nil
+			return recon.Result{RequeueAfter: resolveRequeueStandard(runtime)}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("failed to get namespace %s: %w", targetNS, err)
+		return recon.Result{}, fmt.Errorf("failed to get namespace %s: %w", targetNS, err)
 	}
 
 	ready, result := ensureAdmissionDependenciesReady(ctx, logger, runtime, tenant)
@@ -129,16 +129,16 @@ func ReconcileOpenBaoTenant(ctx context.Context, req ctrl.Request, logger logr.L
 		tenant.Status.Provisioned = false
 		tenant.Status.LastError = err.Error()
 		if statusErr := patchStatus(ctx, runtime.Client, tenant, original); statusErr != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w (original error: %w)", statusErr, err)
+			return recon.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w (original error: %w)", statusErr, err)
 		}
-		return ctrl.Result{}, fmt.Errorf("failed to ensure tenant RBAC for namespace %s: %w", targetNS, err)
+		return recon.Result{}, fmt.Errorf("failed to ensure tenant RBAC for namespace %s: %w", targetNS, err)
 	}
 
 	original := tenant.DeepCopy()
 	tenant.Status.Provisioned = true
 	tenant.Status.LastError = ""
 	if err := patchStatus(ctx, runtime.Client, tenant, original); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", err)
+		return recon.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", err)
 	}
 
 	logger.Info("Successfully provisioned tenant RBAC", "target_namespace", targetNS)
@@ -147,7 +147,7 @@ func ReconcileOpenBaoTenant(ctx context.Context, req ctrl.Request, logger logr.L
 		"tenant_name":      tenant.Name,
 		"target_namespace": targetNS,
 	})
-	return ctrl.Result{}, nil
+	return recon.Result{}, nil
 }
 
 func reconcileDeletion(
@@ -156,10 +156,10 @@ func reconcileDeletion(
 	runtime TenantRuntime,
 	tenant *openbaov1alpha1.OpenBaoTenant,
 	targetNS string,
-	req ctrl.Request,
-) (ctrl.Result, error) {
+	key types.NamespacedName,
+) (recon.Result, error) {
 	if !containsFinalizer(tenant.Finalizers, openbaov1alpha1.OpenBaoTenantFinalizer) {
-		return ctrl.Result{}, nil
+		return recon.Result{}, nil
 	}
 
 	logger.Info("OpenBaoTenant is being deleted", "target_namespace", targetNS)
@@ -167,18 +167,18 @@ func reconcileDeletion(
 	// Keep tenant RBAC while OpenBaoCluster finalizers may still need it.
 	clusterList := &openbaov1alpha1.OpenBaoClusterList{}
 	if err := runtime.Client.List(ctx, clusterList, client.InNamespace(targetNS)); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list keys in namespace %s: %w", targetNS, err)
+		return recon.Result{}, fmt.Errorf("failed to list keys in namespace %s: %w", targetNS, err)
 	}
 	if len(clusterList.Items) > 0 {
 		logger.Info("Waiting for OpenBaoClusters to be deleted before cleaning up RBAC",
 			"target_namespace", targetNS,
 			"cluster_count", len(clusterList.Items))
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		return recon.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	logger.Info("No OpenBaoClusters found; cleaning up tenant RBAC", "target_namespace", targetNS)
 	if err := runtime.Provisioner.CleanupTenantRBAC(ctx, targetNS); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to cleanup tenant RBAC for namespace %s: %w", targetNS, err)
+		return recon.Result{}, fmt.Errorf("failed to cleanup tenant RBAC for namespace %s: %w", targetNS, err)
 	}
 	logging.LogAuditEvent(logger, logging.EventTenantRBACCleaned, map[string]string{
 		"tenant_namespace": tenant.Namespace,
@@ -188,10 +188,10 @@ func reconcileDeletion(
 
 	tenant.Finalizers = removeFinalizer(tenant.Finalizers, openbaov1alpha1.OpenBaoTenantFinalizer)
 	if err := runtime.Client.Update(ctx, tenant); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from OpenBaoTenant %s: %w", req.NamespacedName, err)
+		return recon.Result{}, fmt.Errorf("failed to remove finalizer from OpenBaoTenant %s: %w", key, err)
 	}
 
-	return ctrl.Result{}, nil
+	return recon.Result{}, nil
 }
 
 func ensureAdmissionDependenciesReady(
@@ -199,14 +199,14 @@ func ensureAdmissionDependenciesReady(
 	logger logr.Logger,
 	runtime TenantRuntime,
 	tenant *openbaov1alpha1.OpenBaoTenant,
-) (bool, ctrl.Result) {
+) (bool, recon.Result) {
 	// Fail-closed privileged actions when admission policies are not ready.
 	if admission.UnsafeAdmissionDisabled() {
 		admission.SetAdmissionDependenciesReady(true)
-		return true, ctrl.Result{}
+		return true, recon.Result{}
 	}
 	if admission.AdmissionDependenciesReady() {
-		return true, ctrl.Result{}
+		return true, recon.Result{}
 	}
 
 	reader := runtime.APIReader
@@ -225,12 +225,12 @@ func ensureAdmissionDependenciesReady(
 	if err != nil {
 		admission.SetAdmissionDependenciesReady(false)
 		logger.Info("Admission policy dependencies not ready; delaying tenant provisioning", "error", err)
-		return false, ctrl.Result{RequeueAfter: admissionDependencyRequeueAfter}
+		return false, recon.Result{RequeueAfter: admissionDependencyRequeueAfter}
 	}
 
 	admission.SetAdmissionDependenciesReady(status.OverallReady)
 	if status.OverallReady {
-		return true, ctrl.Result{}
+		return true, recon.Result{}
 	}
 
 	original := tenant.DeepCopy()
@@ -240,7 +240,7 @@ func ensureAdmissionDependenciesReady(
 	_ = patchStatus(ctx, runtime.Client, tenant, original)
 
 	logger.Info("Admission policy dependencies not ready; delaying tenant provisioning", "summary", status.SummaryMessage())
-	return false, ctrl.Result{RequeueAfter: admissionDependencyRequeueAfter}
+	return false, recon.Result{RequeueAfter: admissionDependencyRequeueAfter}
 }
 
 func patchStatus(ctx context.Context, c client.Client, tenant *openbaov1alpha1.OpenBaoTenant, original *openbaov1alpha1.OpenBaoTenant) error {

--- a/internal/app/provisioner/tenant_reconcile_test.go
+++ b/internal/app/provisioner/tenant_reconcile_test.go
@@ -14,13 +14,13 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/admission"
 	provisionermanager "github.com/dc-tec/openbao-operator/internal/provisioner"
+	recon "github.com/dc-tec/openbao-operator/internal/reconcile"
 )
 
 func newTenantScheme(t *testing.T) *k8sruntime.Scheme {
@@ -65,7 +65,7 @@ func setAdmissionReady(t *testing.T, ready bool) {
 }
 
 func TestReconcileOpenBaoTenant_Validation(t *testing.T) {
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "ns"}}
+	req := types.NamespacedName{Name: "tenant", Namespace: "ns"}
 	if _, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), TenantRuntime{}); err == nil || !strings.Contains(err.Error(), "client is required") {
 		t.Fatalf("expected client required error, got %v", err)
 	}
@@ -83,11 +83,11 @@ func TestReconcileOpenBaoTenant_SecurityViolation(t *testing.T) {
 	}
 	runtime := newTenantRuntime(t, tenant)
 
-	result, err := ReconcileOpenBaoTenant(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "team-a"}}, logr.Discard(), runtime)
+	result, err := ReconcileOpenBaoTenant(context.Background(), types.NamespacedName{Name: "tenant", Namespace: "team-a"}, logr.Discard(), runtime)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != (ctrl.Result{}) {
+	if result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
 	}
 
@@ -112,7 +112,7 @@ func TestReconcileOpenBaoTenant_FinalizerAndProvisioning(t *testing.T) {
 	}
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns"}}
 	runtime := newTenantRuntime(t, tenant, ns)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}}
+	req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
 
 	result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
 	if err != nil {
@@ -126,12 +126,12 @@ func TestReconcileOpenBaoTenant_FinalizerAndProvisioning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile 2: %v", err)
 	}
-	if result != (ctrl.Result{}) {
+	if result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
 	}
 
 	updated := &openbaov1alpha1.OpenBaoTenant{}
-	if getErr := runtime.Client.Get(context.Background(), req.NamespacedName, updated); getErr != nil {
+	if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
 		t.Fatalf("get updated tenant: %v", getErr)
 	}
 	if !containsFinalizer(updated.Finalizers, openbaov1alpha1.OpenBaoTenantFinalizer) {
@@ -163,7 +163,7 @@ func TestReconcileOpenBaoTenant_TargetNamespaceMissing(t *testing.T) {
 		Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "missing-ns"},
 	}
 	runtime := newTenantRuntime(t, tenant)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}}
+	req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
 
 	result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
 	if err != nil {
@@ -174,7 +174,7 @@ func TestReconcileOpenBaoTenant_TargetNamespaceMissing(t *testing.T) {
 	}
 
 	updated := &openbaov1alpha1.OpenBaoTenant{}
-	if getErr := runtime.Client.Get(context.Background(), req.NamespacedName, updated); getErr != nil {
+	if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
 		t.Fatalf("get updated tenant: %v", getErr)
 	}
 	if updated.Status.Provisioned {
@@ -198,7 +198,7 @@ func TestReconcileOpenBaoTenant_AdmissionNotReadyRequeues(t *testing.T) {
 	}
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns"}}
 	runtime := newTenantRuntime(t, tenant, ns)
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}}
+	req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
 
 	result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
 	if err != nil {
@@ -209,7 +209,7 @@ func TestReconcileOpenBaoTenant_AdmissionNotReadyRequeues(t *testing.T) {
 	}
 
 	updated := &openbaov1alpha1.OpenBaoTenant{}
-	if getErr := runtime.Client.Get(context.Background(), req.NamespacedName, updated); getErr != nil {
+	if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
 		t.Fatalf("get updated tenant: %v", getErr)
 	}
 	if updated.Status.Provisioned {
@@ -238,7 +238,7 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "tenant-ns"}}
 		runtime := newTenantRuntime(t, tenant, ns, cluster)
 
-		result, err := ReconcileOpenBaoTenant(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}}, logr.Discard(), runtime)
+		result, err := ReconcileOpenBaoTenant(context.Background(), types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}, logr.Discard(), runtime)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -260,18 +260,18 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		}
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns"}}
 		runtime := newTenantRuntime(t, tenant, ns)
-		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}}
+		req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
 
 		result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if result != (ctrl.Result{}) {
+		if result != (recon.Result{}) {
 			t.Fatalf("result=%v, want zero", result)
 		}
 
 		updated := &openbaov1alpha1.OpenBaoTenant{}
-		if getErr := runtime.Client.Get(context.Background(), req.NamespacedName, updated); getErr != nil {
+		if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
 			if !apierrors.IsNotFound(getErr) {
 				t.Fatalf("get updated tenant: %v", getErr)
 			}

--- a/internal/controller/provisioner/controller.go
+++ b/internal/controller/provisioner/controller.go
@@ -34,6 +34,7 @@ import (
 	observability "github.com/dc-tec/openbao-operator/internal/observability"
 	operatorpredicates "github.com/dc-tec/openbao-operator/internal/predicates"
 	"github.com/dc-tec/openbao-operator/internal/provisioner"
+	recon "github.com/dc-tec/openbao-operator/internal/reconcile"
 )
 
 // NamespaceProvisionerReconciler reconciles OpenBaoTenant objects to provision
@@ -86,7 +87,7 @@ func (r *NamespaceProvisionerReconciler) Reconcile(ctx context.Context, req ctrl
 		"tenant", req.NamespacedName,
 	)
 
-	result, err = appprovisioner.ReconcileOpenBaoTenant(ctx, req, logger, appprovisioner.TenantRuntime{
+	appResult, appErr := appprovisioner.ReconcileOpenBaoTenant(ctx, req.NamespacedName, logger, appprovisioner.TenantRuntime{
 		Client:                   r.Client,
 		APIReader:                r.APIReader,
 		Provisioner:              r.Provisioner,
@@ -95,11 +96,17 @@ func (r *NamespaceProvisionerReconciler) Reconcile(ctx context.Context, req ctrl
 		RequeueShort:             constants.RequeueShort,
 		RequeueStandard:          constants.RequeueStandard,
 	})
+	result = controllerResult(appResult)
+	err = appErr
 	if err != nil {
 		recordError(err)
 	}
 
 	return result, err
+}
+
+func controllerResult(result recon.Result) ctrl.Result {
+	return ctrl.Result{RequeueAfter: result.RequeueAfter}
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
## Description

This change removes the remaining provisioner app reconcile bridge to controller-runtime types.

- switches the app reconcile entrypoint to app-domain request/result types
- keeps `ctrl.Request` and `ctrl.Result` adaptation in the controller layer
- removes the corresponding transitional architecture-policy ignore

This is needed to keep reconcile API ownership in the controller layer and keep the provisioner app layer free of controller-runtime coupling.

## Related Issues

<!-- Closes #123 -->

N/A

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Verification Process

- `go test ./internal/app/provisioner ./internal/controller/provisioner`
- `make test-ast`
- `make lint`
