### PR TITLE
fix(ci): harden mainline publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
     name: Build E2E Images Once
     runs-on: *runner
     needs: [changes, build-artifacts]
-    if: (needs.changes.outputs.e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e'))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || ((needs.changes.outputs.e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e'))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository))
     permissions:
       contents: read
       packages: write
@@ -509,8 +509,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          TRIGGER_E2E="${{ needs.changes.outputs.e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}"
-          FULL_E2E="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e') }}"
+          IS_MAIN_PUSH="${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
+          TRIGGER_E2E="${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}"
+          FULL_E2E="${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}"
           PR_BACKUP="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'backup') }}"
           PR_UPGRADE="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'upgrades') }}"
           PR_HARDENED="${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller')) }}"
@@ -524,6 +525,10 @@ jobs:
             echo "SHOULD_RUN=$SHOULD_RUN" >> "${GITHUB_ENV}"
             echo "::notice::Skipping ${{ matrix.name }} shard (no E2E-triggering changes/labels)"
             exit 0
+          fi
+
+          if [[ "${IS_MAIN_PUSH}" == "true" ]]; then
+            FILTER="!openshift"
           fi
 
           if [[ "${{ matrix.hardened_signed }}" == "true" ]]; then
@@ -806,9 +811,21 @@ jobs:
           print(json.dumps(data, indent=2, sort_keys=True))
           PY
 
+      - name: Validate edge candidate bundle contents
+        run: |
+          set -euo pipefail
+          for path in \
+            dist/candidate/install.yaml \
+            dist/candidate/crds.yaml \
+            dist/candidate/checksums.txt \
+            dist/candidate/metadata.json; do
+            test -f "${path}" || { echo "missing required edge candidate file: ${path}" >&2; exit 1; }
+          done
+
       - name: Upload edge candidate bundle
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: edge-candidate-bundle
           path: dist/candidate/
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -467,9 +467,21 @@ jobs:
           print(json.dumps(data, indent=2, sort_keys=True))
           PY
 
+      - name: Validate nightly candidate bundle contents
+        run: |
+          set -euo pipefail
+          for path in \
+            dist/candidate/install.yaml \
+            dist/candidate/crds.yaml \
+            dist/candidate/checksums.txt \
+            dist/candidate/metadata.json; do
+            test -f "${path}" || { echo "missing required nightly candidate file: ${path}" >&2; exit 1; }
+          done
+
       - name: Upload nightly candidate bundle
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-candidate-bundle
           path: dist/candidate/
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -46,10 +46,26 @@ jobs:
       - name: Download edge candidate bundle from triggering run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
           mkdir -p dist/upstream dist/candidate
+          artifacts_json="$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/artifacts")"
+          ARTIFACTS_JSON="${artifacts_json}" ARTIFACT_NAME="edge-candidate-bundle" python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          data = json.loads(os.environ["ARTIFACTS_JSON"])
+          names = [artifact["name"] for artifact in data.get("artifacts", [])]
+          wanted = os.environ["ARTIFACT_NAME"]
+          if wanted in names:
+              sys.exit(0)
+          available = ", ".join(names) if names else "<none>"
+          print(f"expected upstream artifact '{wanted}' not found; available artifacts: {available}", file=sys.stderr)
+          sys.exit(1)
+          PY
           gh run download "${RUN_ID}" -n edge-candidate-bundle -D dist/upstream
           artifact_dir="$(dirname "$(find dist/upstream -type f -name metadata.json -print -quit)")"
           if [[ -z "${artifact_dir}" || ! -f "${artifact_dir}/metadata.json" ]]; then
@@ -93,6 +109,7 @@ jobs:
         with:
           name: edge-candidate-bundle
           path: dist/candidate/
+          if-no-files-found: error
           retention-days: 5
 
   promote:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -46,10 +46,26 @@ jobs:
       - name: Download nightly candidate bundle from triggering run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
           mkdir -p dist/upstream dist/candidate
+          artifacts_json="$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/artifacts")"
+          ARTIFACTS_JSON="${artifacts_json}" ARTIFACT_NAME="nightly-candidate-bundle" python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          data = json.loads(os.environ["ARTIFACTS_JSON"])
+          names = [artifact["name"] for artifact in data.get("artifacts", [])]
+          wanted = os.environ["ARTIFACT_NAME"]
+          if wanted in names:
+              sys.exit(0)
+          available = ", ".join(names) if names else "<none>"
+          print(f"expected upstream artifact '{wanted}' not found; available artifacts: {available}", file=sys.stderr)
+          sys.exit(1)
+          PY
           gh run download "${RUN_ID}" -n nightly-candidate-bundle -D dist/upstream
           artifact_dir="$(dirname "$(find dist/upstream -type f -name metadata.json -print -quit)")"
           if [[ -z "${artifact_dir}" || ! -f "${artifact_dir}/metadata.json" ]]; then
@@ -94,6 +110,7 @@ jobs:
         with:
           name: nightly-candidate-bundle
           path: dist/candidate/
+          if-no-files-found: error
           retention-days: 7
 
   promote:

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -89,10 +89,26 @@ jobs:
       - name: Download reproducibility report artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ needs.resolve-run.outputs.run_id }}
         run: |
           set -euo pipefail
           mkdir -p dist/upstream dist/report
+          artifacts_json="$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/artifacts")"
+          ARTIFACTS_JSON="${artifacts_json}" ARTIFACT_NAME="release-reproducibility-report" python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          data = json.loads(os.environ["ARTIFACTS_JSON"])
+          names = [artifact["name"] for artifact in data.get("artifacts", [])]
+          wanted = os.environ["ARTIFACT_NAME"]
+          if wanted in names:
+              sys.exit(0)
+          available = ", ".join(names) if names else "<none>"
+          print(f"expected upstream artifact '{wanted}' not found; available artifacts: {available}", file=sys.stderr)
+          sys.exit(1)
+          PY
           gh run download "${RUN_ID}" -n release-reproducibility-report -D dist/upstream
           artifact_dir="$(dirname "$(find dist/upstream -type f -name 'reproducibility-report.md' -print -quit)")"
           if [[ -z "${artifact_dir}" || ! -f "${artifact_dir}/reproducibility-report.md" ]]; then
@@ -109,4 +125,5 @@ jobs:
         with:
           name: reproducibility-report
           path: dist/report/reproducibility-report.md
+          if-no-files-found: error
           retention-days: 30


### PR DESCRIPTION
## Description

This PR hardens the `main` -> `edge` / `nightly` publish path and fixes the mismatch between successful source workflows and downstream publish expectations.

It makes three concrete changes:

- `ci.yml` now always runs the edge-candidate prerequisites on pushes to `main`
  - `Build E2E Images Once` is no longer skipped on `main`
  - the E2E shard planner treats `main` pushes as full-E2E runs, while keeping PR optimization intact
- `publish-edge.yml`, `publish-nightly.yml`, and `reproducibility.yml` now set explicit GitHub CLI repo context
  - `gh run download` no longer depends on an implicit local checkout or git repo state
- candidate/report artifact handoffs now fail earlier and more clearly
  - upstream candidate bundles are validated before upload
  - artifact uploads use `if-no-files-found: error`
  - downstream consumers preflight the expected upstream artifact name and report what artifacts were actually available

This fixes the recent situation where:
- `CI` on `main` could go green without producing `edge-candidate-bundle`
- `publish-edge` then failed later while trying to consume a missing or unreachable artifact

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

Run:
- `actionlint .github/workflows/*.yml`
- `git diff --check`

Additional validation:
- inspected successful `CI` run `22850916742` on `main`
- inspected failed `publish-edge` run `22851108453`
- confirmed `publish-edge` was failing in `gh run download` without repo context
- confirmed `CI` on `main` had not produced `edge-candidate-bundle` because the candidate path was still optimized away
- verified the workflow changes now make `main` produce the candidate path deterministically and harden artifact handoff failures
