### PR TITLE
test(e2e): align lifecycle and gateway coverage

### DIFF
--- a/test/e2e/Cluster_Profile_Hardened_test.go
+++ b/test/e2e/Cluster_Profile_Hardened_test.go
@@ -65,44 +65,23 @@ var _ = Describe("Hardened profile (External TLS + Transit auto-unseal + SelfIni
 
 	ensureTransitTokenSecret := func() {
 		By("creating transit token secret with CA certificate for TLS verification")
-		infraBaoCASecret := &corev1.Secret{}
-		Expect(c.Get(ctx, types.NamespacedName{Name: infraBaoName + "-tls-ca", Namespace: f.Namespace}, infraBaoCASecret)).To(Succeed())
-		infraBaoCACert := infraBaoCASecret.Data["ca.crt"]
-		Expect(infraBaoCACert).NotTo(BeEmpty(), "Infra-bao CA certificate should exist")
+		infraBaoCACert, err := e2ehelpers.ReadInfraBaoTLSCACert(ctx, c, f.Namespace, infraBaoName)
+		Expect(err).NotTo(HaveOccurred())
 
-		tokenValue := strings.TrimSpace(infraBaoRootToken)
-		secretKey := types.NamespacedName{Name: infraBaoTokenSecretName, Namespace: f.Namespace}
-		existing := &corev1.Secret{}
-		err := c.Get(ctx, secretKey, existing)
-		switch {
-		case apierrors.IsNotFound(err):
-			tokenSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      infraBaoTokenSecretName,
-					Namespace: f.Namespace,
-				},
-				Type: corev1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					"token":  []byte(tokenValue),
-					"ca.crt": infraBaoCACert,
-				},
-			}
-			Expect(c.Create(ctx, tokenSecret)).To(Succeed())
-		default:
-			Expect(err).NotTo(HaveOccurred())
-			original := existing.DeepCopy()
-			if existing.Data == nil {
-				existing.Data = map[string][]byte{}
-			}
-			existing.Data["token"] = []byte(tokenValue)
-			existing.Data["ca.crt"] = infraBaoCACert
-			Expect(c.Patch(ctx, existing, client.MergeFrom(original))).To(Succeed())
-		}
+		Expect(e2ehelpers.EnsureInfraBaoSealCredentialsSecret(
+			ctx,
+			c,
+			f.Namespace,
+			infraBaoTokenSecretName,
+			infraBaoRootToken,
+			infraBaoCACert,
+			nil,
+		)).To(Succeed())
 
 		Eventually(func(g Gomega) {
 			created := &corev1.Secret{}
-			g.Expect(c.Get(ctx, secretKey, created)).To(Succeed())
-			g.Expect(strings.TrimSpace(string(created.Data["token"]))).To(Equal(tokenValue))
+			g.Expect(c.Get(ctx, types.NamespacedName{Name: infraBaoTokenSecretName, Namespace: f.Namespace}, created)).To(Succeed())
+			g.Expect(strings.TrimSpace(string(created.Data["token"]))).To(Equal(strings.TrimSpace(infraBaoRootToken)))
 			g.Expect(created.Data["ca.crt"]).To(Equal(infraBaoCACert))
 		}, 10*time.Second, 1*time.Second).Should(Succeed())
 		_, _ = fmt.Fprintf(GinkgoWriter, "Verified transit token secret %q\n", infraBaoTokenSecretName)
@@ -133,26 +112,18 @@ var _ = Describe("Hardened profile (External TLS + Transit auto-unseal + SelfIni
 			Namespace: f.Namespace,
 			Name:      infraBaoName,
 			Image:     openBaoImage,
-			// Placeholder; actual root token is captured from init secret below.
-			RootToken: "placeholder",
 		}
 		Expect(e2ehelpers.EnsureInfraBao(ctx, cfg, c, infraCfg)).To(Succeed())
 		_, _ = fmt.Fprintf(GinkgoWriter, "Infra-bao instance %q is running\n", infraBaoName)
 
-		// Fetch the actual infra-bao root token captured during initialization.
-		infraBaoRootSecret := &corev1.Secret{}
-		Expect(c.Get(ctx, types.NamespacedName{
-			Name:      infraBaoName + "-root-token",
-			Namespace: f.Namespace,
-		}, infraBaoRootSecret)).To(Succeed())
-		tokenBytes := infraBaoRootSecret.Data["token"]
-		Expect(tokenBytes).NotTo(BeEmpty(), "infra-bao root token should be present")
-		infraBaoRootToken = strings.TrimSpace(string(tokenBytes))
+		var errRead error
+		infraBaoRootToken, errRead = e2ehelpers.ReadInfraBaoRootToken(ctx, c, f.Namespace, infraBaoName)
+		Expect(errRead).NotTo(HaveOccurred())
 
 		By("configuring transit secrets engine on infra-bao")
 		// Infra-bao always runs with TLS in production mode
 		infraAddr := fmt.Sprintf("https://%s.%s.svc:8200", infraBaoName, f.Namespace)
-		result, err := e2ehelpers.ConfigureInfraBaoTransit(ctx, cfg, c, f.Namespace, openBaoImage, infraAddr, infraBaoRootToken, infraBaoKeyName)
+		result, err := e2ehelpers.ConfigureInfraBaoTransit(ctx, cfg, c, f.Namespace, infraBaoName, openBaoImage, infraAddr, infraBaoKeyName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Phase).To(Equal(corev1.PodSucceeded), "infra-bao transit setup failed, logs:\n%s", result.Logs)
 		_, _ = fmt.Fprintf(GinkgoWriter, "Transit secrets engine configured with key %q\n", infraBaoKeyName)
@@ -551,6 +522,9 @@ var _ = Describe("Hardened profile (External TLS + Transit auto-unseal + SelfIni
 		Expect(f.TriggerReconcile(ctx, clusterName)).To(Succeed())
 		_, _ = fmt.Fprintf(GinkgoWriter, "Triggered reconcile for cluster %q\n", clusterName)
 		_, _ = fmt.Fprintf(GinkgoWriter, "Cluster %q is initialized via self-init\n", clusterName)
+
+		By("verifying the documented hardened production readiness condition")
+		f.WaitForConditionReason(clusterName, openbaov1alpha1.ConditionProductionReady, metav1.ConditionTrue, "ProductionReady")
 
 		By("asserting root token and static unseal secrets do NOT exist")
 		Consistently(func() bool {

--- a/test/e2e/Cluster_TLS_ACME_test.go
+++ b/test/e2e/Cluster_TLS_ACME_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -51,7 +52,7 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 
 	var (
 		infraBaoRootToken string
-		infraBaoCASecret  *corev1.Secret
+		infraBaoTLSCACert []byte
 		infraBaoPKICA     []byte
 	)
 
@@ -80,49 +81,36 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 			Namespace: f.Namespace,
 			Name:      infraBaoName,
 			Image:     openBaoImage,
-			// Placeholder; actual root token is captured from init secret below.
-			RootToken: "placeholder",
 		}
 		Expect(e2ehelpers.EnsureInfraBao(ctx, cfg, c, infraCfg)).To(Succeed())
 		_, _ = fmt.Fprintf(GinkgoWriter, "Infra-bao instance %q is running in production mode with TLS\n", infraBaoName)
 
-		// Fetch the actual root token captured during infra-bao initialization.
-		rootTokenSecret := &corev1.Secret{}
-		Expect(c.Get(ctx, types.NamespacedName{
-			Name:      infraBaoName + "-root-token",
-			Namespace: f.Namespace,
-		}, rootTokenSecret)).To(Succeed())
-		tokenBytes := rootTokenSecret.Data["token"]
-		Expect(tokenBytes).NotTo(BeEmpty(), "infra-bao root token should be present")
-		infraBaoRootToken = strings.TrimSpace(string(tokenBytes))
+		var errRead error
+		infraBaoRootToken, errRead = e2ehelpers.ReadInfraBaoRootToken(ctx, c, f.Namespace, infraBaoName)
+		Expect(errRead).NotTo(HaveOccurred())
 
-		// Fetch infra-bao CA certificate for TLS verification when using transit seal.
-		infraBaoCASecret = &corev1.Secret{}
-		Expect(c.Get(ctx, types.NamespacedName{
-			Name:      infraBaoName + "-tls-ca",
-			Namespace: f.Namespace,
-		}, infraBaoCASecret)).To(Succeed())
-		_, _ = fmt.Fprintf(GinkgoWriter, "Fetched infra-bao CA secret %q\n", infraBaoName+"-tls-ca")
-		Expect(infraBaoCASecret.Data["ca.crt"]).NotTo(BeEmpty(), "infra-bao CA certificate should exist")
+		infraBaoTLSCACert, errRead = e2ehelpers.ReadInfraBaoTLSCACert(ctx, c, f.Namespace, infraBaoName)
+		Expect(errRead).NotTo(HaveOccurred())
+		_, _ = fmt.Fprintf(GinkgoWriter, "Fetched infra-bao CA bundle for %q\n", infraBaoName)
 
 		By("configuring PKI secrets engine with ACME support on infra-bao")
 		// Use HTTPS since infra-bao is configured with TLS for ACME tests
 		infraAddr := fmt.Sprintf("https://%s.%s.svc:8200", infraBaoName, f.Namespace)
 		clusterPath := infraAddr + "/v1/pki"
 
-		result, err := e2ehelpers.ConfigureInfraBaoPKIACME(ctx, cfg, c, f.Namespace, openBaoImage, infraAddr, infraBaoRootToken, clusterPath)
+		result, err := e2ehelpers.ConfigureInfraBaoPKIACME(ctx, cfg, c, f.Namespace, infraBaoName, openBaoImage, infraAddr, clusterPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Phase).To(Equal(corev1.PodSucceeded), "infra-bao pki/acme setup failed, logs:\n%s", result.Logs)
 		_, _ = fmt.Fprintf(GinkgoWriter, "PKI secrets engine configured with ACME support at path %q\n", clusterPath)
 
 		By("configuring transit secrets engine on infra-bao")
-		result, err = e2ehelpers.ConfigureInfraBaoTransit(ctx, cfg, c, f.Namespace, openBaoImage, infraAddr, infraBaoRootToken, infraBaoKeyName)
+		result, err = e2ehelpers.ConfigureInfraBaoTransit(ctx, cfg, c, f.Namespace, infraBaoName, openBaoImage, infraAddr, infraBaoKeyName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Phase).To(Equal(corev1.PodSucceeded), "infra-bao transit setup failed, logs:\n%s", result.Logs)
 		_, _ = fmt.Fprintf(GinkgoWriter, "Transit secrets engine configured with key %q\n", infraBaoKeyName)
 
 		By("fetching PKI CA certificate from infra-bao for ACME certificate verification")
-		infraBaoPKICA, err = e2ehelpers.FetchInfraBaoPKICA(ctx, cfg, c, f.Namespace, openBaoImage, infraAddr)
+		infraBaoPKICA, err = e2ehelpers.FetchInfraBaoPKICA(ctx, cfg, c, f.Namespace, infraBaoName, openBaoImage, infraAddr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(infraBaoPKICA).NotTo(BeEmpty(), "PKI CA certificate should not be empty")
 		_, _ = fmt.Fprintf(GinkgoWriter, "Fetched PKI CA certificate from infra-bao (length: %d bytes)\n", len(infraBaoPKICA))
@@ -167,22 +155,16 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 		_, _ = fmt.Fprintf(GinkgoWriter, "ACME directory URL: %q, domain: %q\n", acmeDirectoryURL, acmeDomain)
 
 		By("creating transit token secret for auto-unseal (include TLS CA for transit and PKI CA for ACME)")
-		tokenSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      infraBaoTokenSecretName,
-				Namespace: f.Namespace,
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				"token":      []byte(infraBaoRootToken),
-				"ca.crt":     infraBaoCASecret.Data["ca.crt"], // TLS CA for transit seal
-				"pki-ca.crt": infraBaoPKICA,                   // PKI CA for ACME certificate verification
-			},
-		}
-		err = c.Create(ctx, tokenSecret)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		err = e2ehelpers.EnsureInfraBaoSealCredentialsSecret(
+			ctx,
+			c,
+			f.Namespace,
+			infraBaoTokenSecretName,
+			infraBaoRootToken,
+			infraBaoTLSCACert,
+			infraBaoPKICA,
+		)
+		Expect(err).NotTo(HaveOccurred())
 		_, _ = fmt.Fprintf(GinkgoWriter, "Created transit token secret %q\n", infraBaoTokenSecretName)
 
 		// Verify the token in the secret works with infra-bao before the cluster tries to use it
@@ -237,6 +219,10 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 		_ = e2ehelpers.DeletePodBestEffort(ctx, c, f.Namespace, verifyTokenPod.Name)
 
 		By(fmt.Sprintf("creating OpenBaoCluster %q with ACME TLS mode", clusterName))
+		var acmeCacheStorageClass *string
+		if sc := strings.TrimSpace(os.Getenv("E2E_STORAGE_CLASS")); sc != "" {
+			acmeCacheStorageClass = &sc
+		}
 		cluster := &openbaov1alpha1.OpenBaoCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
@@ -286,6 +272,11 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 					ACME: &openbaov1alpha1.ACMEConfig{
 						DirectoryURL: acmeDirectoryURL,
 						Email:        "e2e@example.invalid",
+						SharedCache: &openbaov1alpha1.ACMESharedCacheConfig{
+							Mode:             openbaov1alpha1.ACMESharedCacheModeManagedPVC,
+							Size:             "1Gi",
+							StorageClassName: acmeCacheStorageClass,
+						},
 					},
 				},
 				Configuration: &openbaov1alpha1.OpenBaoConfiguration{
@@ -455,6 +446,22 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 		}, 10*time.Minute, 5*time.Second).Should(Succeed())
 		_, _ = fmt.Fprintf(GinkgoWriter, "StatefulSet %q pods are Ready\n", clusterName)
 
+		By("waiting for the ACME shared cache PVC to become Bound")
+		Eventually(func(g Gomega) {
+			pvc := &corev1.PersistentVolumeClaim{}
+			g.Expect(c.Get(ctx, types.NamespacedName{Name: clusterName + "-acme-cache", Namespace: f.Namespace}, pvc)).To(Succeed())
+			_, _ = fmt.Fprintf(GinkgoWriter, "ACME cache PVC %q phase=%s accessModes=%v\n", pvc.Name, pvc.Status.Phase, pvc.Spec.AccessModes)
+			g.Expect(pvc.Spec.AccessModes).To(ContainElement(corev1.ReadWriteMany))
+			g.Expect(pvc.Status.Phase).To(Equal(corev1.ClaimBound))
+		}, 5*time.Minute, 5*time.Second).Should(Succeed())
+		_, _ = fmt.Fprintf(GinkgoWriter, "Managed ACME shared cache PVC is Bound\n")
+
+		By("verifying documented ACME readiness conditions")
+		f.WaitForCondition(clusterName, openbaov1alpha1.ConditionAvailable, metav1.ConditionTrue)
+		f.WaitForConditionReason(clusterName, openbaov1alpha1.ConditionACMEIntegrationReady, metav1.ConditionTrue, "ACMEIntegrationReady")
+		f.WaitForConditionReason(clusterName, openbaov1alpha1.ConditionACMECacheReady, metav1.ConditionTrue, "ACMECacheReady")
+		f.WaitForConditionReason(clusterName, openbaov1alpha1.ConditionProductionReady, metav1.ConditionTrue, "ProductionReady")
+
 		By("validating that the config contains ACME parameters")
 		// Validate that the config rendered by the operator contains the ACME parameters.
 		// We run a short-lived pod that queries the OpenBao pod's config via the API server
@@ -469,8 +476,10 @@ var _ = Describe("ACME TLS (OpenBao native ACME client)", Label("tls", "security
 			g.Expect(cfgText).To(ContainSubstring(acmeDirectoryURL))
 			g.Expect(cfgText).To(ContainSubstring("tls_acme_domains"))
 			g.Expect(cfgText).To(ContainSubstring(acmeDomain))
+			g.Expect(cfgText).To(ContainSubstring("tls_acme_cache_path"))
+			g.Expect(cfgText).To(ContainSubstring("/bao/acme-cache/certmagic"))
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
-		_, _ = fmt.Fprintf(GinkgoWriter, "ConfigMap contains ACME parameters (tls_acme_ca_directory, tls_acme_domains)\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "ConfigMap contains ACME parameters (tls_acme_ca_directory, tls_acme_domains, tls_acme_cache_path)\n")
 
 		By("verifying the ACME-issued certificate is trusted by the PKI CA")
 		verifyACMECertPod := &corev1.Pod{

--- a/test/e2e/GitOps_Contract_test.go
+++ b/test/e2e/GitOps_Contract_test.go
@@ -6,14 +6,12 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -73,22 +71,16 @@ var _ = Describe("GitOps contract (Argo-like apply)", Label("gitops", "contract"
 			Namespace: f.Namespace,
 			Name:      infraBaoName,
 			Image:     openBaoImage,
-			RootToken: "placeholder",
 		}
 		Expect(e2ehelpers.EnsureInfraBao(ctx, cfg, c, infraCfg)).To(Succeed())
 
-		infraBaoRootSecret := &corev1.Secret{}
-		Expect(c.Get(ctx, types.NamespacedName{
-			Name:      infraBaoName + "-root-token",
-			Namespace: f.Namespace,
-		}, infraBaoRootSecret)).To(Succeed())
-		tokenBytes := infraBaoRootSecret.Data["token"]
-		Expect(tokenBytes).NotTo(BeEmpty(), "infra-bao root token should be present")
-		infraBaoRootToken = strings.TrimSpace(string(tokenBytes))
+		var errRead error
+		infraBaoRootToken, errRead = e2ehelpers.ReadInfraBaoRootToken(ctx, c, f.Namespace, infraBaoName)
+		Expect(errRead).NotTo(HaveOccurred())
 
 		By("configuring transit secrets engine on infra-bao")
 		infraAddr := fmt.Sprintf("https://%s.%s.svc:8200", infraBaoName, f.Namespace)
-		result, err := e2ehelpers.ConfigureInfraBaoTransit(ctx, cfg, c, f.Namespace, openBaoImage, infraAddr, infraBaoRootToken, infraBaoKeyName)
+		result, err := e2ehelpers.ConfigureInfraBaoTransit(ctx, cfg, c, f.Namespace, infraBaoName, openBaoImage, infraAddr, infraBaoKeyName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Phase).To(Equal(corev1.PodSucceeded), "infra-bao transit setup failed, logs:\n%s", result.Logs)
 
@@ -96,27 +88,18 @@ var _ = Describe("GitOps contract (Argo-like apply)", Label("gitops", "contract"
 		Expect(e2ehelpers.EnsureExternalTLSSecrets(ctx, c, f.Namespace, clusterName, 1)).To(Succeed())
 
 		By("creating transit credentials secret for the cluster (token + CA cert)")
-		infraBaoCASecret := &corev1.Secret{}
-		Expect(c.Get(ctx, types.NamespacedName{Name: infraBaoName + "-tls-ca", Namespace: f.Namespace}, infraBaoCASecret)).To(Succeed())
-		infraBaoCACert := infraBaoCASecret.Data["ca.crt"]
-		Expect(infraBaoCACert).NotTo(BeEmpty(), "infra-bao CA certificate should exist")
+		infraBaoCACert, errRead := e2ehelpers.ReadInfraBaoTLSCACert(ctx, c, f.Namespace, infraBaoName)
+		Expect(errRead).NotTo(HaveOccurred())
 
-		tokenValue := strings.TrimSpace(infraBaoRootToken)
-		tokenSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      infraBaoTokenSecretName,
-				Namespace: f.Namespace,
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				"token":  []byte(tokenValue),
-				"ca.crt": infraBaoCACert,
-			},
-		}
-		err = c.Create(ctx, tokenSecret)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(e2ehelpers.EnsureInfraBaoSealCredentialsSecret(
+			ctx,
+			c,
+			f.Namespace,
+			infraBaoTokenSecretName,
+			infraBaoRootToken,
+			infraBaoCACert,
+			nil,
+		)).To(Succeed())
 	})
 
 	It("repeatedly applies the same manifest without spec/metadata drift", func() {

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -18,6 +18,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -27,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/auth"
@@ -3224,6 +3226,163 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 					}
 				}
 			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+		})
+	})
+
+	Context("Gateway TLS Passthrough", Label("gateway", "requires-gateway-api", "tls-passthrough"), func() {
+		var (
+			tenantNamespace     string
+			tenantFW            *framework.Framework
+			admin               client.Client
+			passthroughCluster  *openbaov1alpha1.OpenBaoCluster
+			passthroughHostname = "bao-passthrough.example.local"
+			passthroughListener = "tls-passthrough"
+			passthroughGateway  = "tenant-gateway-passthrough"
+		)
+
+		BeforeAll(func() {
+			var err error
+
+			tenantFW, err = framework.NewSetup(ctx, "tenant-gateway-tls", operatorNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			tenantNamespace = tenantFW.Namespace
+			admin = tenantFW.Client
+
+			cleanup, err := tenantFW.RequireGatewayAPI()
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(cleanup)
+
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      passthroughGateway,
+					Namespace: tenantNamespace,
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "traefik",
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     gatewayv1.SectionName(passthroughListener),
+							Port:     443,
+							Protocol: gatewayv1.TLSProtocolType,
+							Hostname: ptrTo(gatewayv1.Hostname(passthroughHostname)),
+							TLS: &gatewayv1.ListenerTLSConfig{
+								Mode: ptrTo(gatewayv1.TLSModePassthrough),
+							},
+						},
+					},
+				},
+			}
+			Expect(admin.Create(ctx, gw)).To(Succeed())
+
+			passthroughCluster = &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-passthrough-cluster",
+					Namespace: tenantNamespace,
+				},
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Profile:  openbaov1alpha1.ProfileDevelopment,
+					Version:  openBaoVersion,
+					Image:    openBaoImage,
+					Replicas: 1,
+					InitContainer: &openbaov1alpha1.InitContainerConfig{
+						Enabled: true,
+						Image:   configInitImage,
+					},
+					SelfInit: &openbaov1alpha1.SelfInitConfig{
+						Enabled: true,
+						OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+							Enabled: true,
+						},
+						Requests: e2ehelpers.CreateE2ERequests(tenantNamespace),
+					},
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled:        true,
+						Mode:           openbaov1alpha1.TLSModeOperatorManaged,
+						RotationPeriod: "720h",
+					},
+					Storage: openbaov1alpha1.StorageConfig{
+						Size: "1Gi",
+					},
+					Network: &openbaov1alpha1.NetworkConfig{
+						APIServerCIDR: apiServerCIDR,
+					},
+					Gateway: &openbaov1alpha1.GatewayConfig{
+						Enabled:        true,
+						TLSPassthrough: true,
+						ListenerName:   passthroughListener,
+						Hostname:       passthroughHostname,
+						GatewayRef: openbaov1alpha1.GatewayReference{
+							Name: passthroughGateway,
+						},
+					},
+					DeletionPolicy: openbaov1alpha1.DeletionPolicyDeleteAll,
+				},
+			}
+			Expect(admin.Create(ctx, passthroughCluster)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: passthroughCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
+				g.Expect(updated.Status.Initialized).To(BeTrue())
+				available := meta.FindStatusCondition(updated.Status.Conditions, string(openbaov1alpha1.ConditionAvailable))
+				g.Expect(available).NotTo(BeNil())
+				g.Expect(available.Status).To(Equal(metav1.ConditionTrue))
+			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			if tenantFW != nil {
+				_ = tenantFW.Cleanup(ctx)
+			}
+		})
+
+		It("creates a TLSRoute and reports healthy passthrough integration", func() {
+			By("waiting for passthrough Gateway integration status")
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: passthroughCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
+
+				cond := meta.FindStatusCondition(updated.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).NotTo(Equal(metav1.ConditionFalse))
+				switch cond.Status {
+				case metav1.ConditionTrue:
+					g.Expect(cond.Reason).To(Equal("GatewayIntegrationReady"))
+				case metav1.ConditionUnknown:
+					g.Expect(cond.Reason).To(Equal("GatewayCapabilitiesUnknown"))
+				default:
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				}
+			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+			By("verifying a TLSRoute is created for passthrough access")
+			Eventually(func(g Gomega) {
+				tlsRoute := &gatewayv1alpha2.TLSRoute{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      fmt.Sprintf("%s-tlsroute", passthroughCluster.Name),
+					Namespace: tenantNamespace,
+				}, tlsRoute)).To(Succeed())
+
+				g.Expect(tlsRoute.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(tlsRoute.Spec.ParentRefs[0].Name).To(Equal(gatewayv1alpha2.ObjectName(passthroughGateway)))
+				g.Expect(tlsRoute.Spec.ParentRefs[0].SectionName).NotTo(BeNil())
+				g.Expect(*tlsRoute.Spec.ParentRefs[0].SectionName).To(Equal(gatewayv1alpha2.SectionName(passthroughListener)))
+				g.Expect(tlsRoute.Spec.Hostnames).To(Equal([]gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(passthroughHostname)}))
+				g.Expect(tlsRoute.Spec.Rules).To(HaveLen(1))
+				g.Expect(tlsRoute.Spec.Rules[0].BackendRefs).To(HaveLen(1))
+				g.Expect(tlsRoute.Spec.Rules[0].BackendRefs[0].Name).To(Equal(gatewayv1alpha2.ObjectName(fmt.Sprintf("%s-public", passthroughCluster.Name))))
+				g.Expect(tlsRoute.Spec.Rules[0].BackendRefs[0].Port).NotTo(BeNil())
+				g.Expect(*tlsRoute.Spec.Rules[0].BackendRefs[0].Port).To(Equal(gatewayv1alpha2.PortNumber(constants.PortAPI)))
+			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+			By("verifying BackendTLSPolicy is not created for passthrough mode")
+			Consistently(func() bool {
+				err := admin.Get(ctx, types.NamespacedName{
+					Name:      fmt.Sprintf("%s-backend-tls", passthroughCluster.Name),
+					Namespace: tenantNamespace,
+				}, &gatewayv1.BackendTLSPolicy{})
+				return apierrors.IsNotFound(err)
+			}, 30*time.Second, framework.DefaultPollInterval).Should(BeTrue())
 		})
 	})
 })

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -27,6 +27,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	restoresvc "github.com/dc-tec/openbao-operator/internal/service/restore"
 	"github.com/dc-tec/openbao-operator/test/e2e/framework"
 	e2ehelpers "github.com/dc-tec/openbao-operator/test/e2e/helpers"
 )
@@ -441,6 +442,7 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 
 			Expect(tenantFW.TriggerReconcile(ctx, drCluster.Name)).To(Succeed())
+			tenantFW.WaitForConditionReason(drCluster.Name, openbaov1alpha1.ConditionBackupConfigurationReady, metav1.ConditionTrue, "Ready")
 		})
 
 		AfterAll(func() {
@@ -561,6 +563,18 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 
 			_, _ = fmt.Fprintf(GinkgoWriter, "Creating OpenBaoRestore CR: %s\n", restore.Name)
 			Expect(admin.Create(ctx, restore)).To(Succeed())
+
+			By("verifying restore configuration is accepted before execution")
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoRestore{}
+				err := admin.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: tenantNamespace}, updated)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				configuration := meta.FindStatusCondition(updated.Status.Conditions, restoresvc.RestoreConfigurationConditionType)
+				g.Expect(configuration).NotTo(BeNil())
+				g.Expect(configuration.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(configuration.Reason).To(Equal("Ready"))
+			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				updated := &openbaov1alpha1.OpenBaoRestore{}

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,7 +12,7 @@ Notes:
 ## Summary
 
 - Files: `18`
-- Specs: `85`
+- Specs: `86`
 - Explicit case IDs: `16`
 - Coverage tags: `42`
 
@@ -34,7 +34,7 @@ Notes:
 | [Tenant Data Isolation](suites/Tenant_Data_Isolation_test.md) | 1 | 1 | 0 | `security`, `tenant`, `tenancy` | `test/e2e/Tenant_Data_Isolation_test.go` |
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow` | `test/e2e/Upgrade_Operation_Lock_test.go` |
-| [Upgrade Strategies](suites/Upgrade_Strategies_test.md) | 13 | 0 | 0 | `upgrade`, `upgrades`, `cluster`, `slow`, `bluegreen`, `verification`, `failure`, `gateway`, `requires-gateway-api`, `rollback`, `rolling`, `recovery`, `snapshot`, `chaos`, `guardrails`, `validation` | `test/e2e/Upgrade_Strategies_test.go` |
+| [Upgrade Strategies](suites/Upgrade_Strategies_test.md) | 14 | 0 | 0 | `upgrade`, `upgrades`, `cluster`, `slow`, `bluegreen`, `verification`, `failure`, `gateway`, `requires-gateway-api`, `tls-passthrough`, `rollback`, `rolling`, `recovery`, `snapshot`, `chaos`, `guardrails`, `validation` | `test/e2e/Upgrade_Strategies_test.go` |
 | [Upgrade Strategies: Blue/Green Drift](suites/Upgrade_Target_Drift_test.md) | 1 | 1 | 0 | `upgrade`, `bluegreen`, `slow` | `test/e2e/Upgrade_Target_Drift_test.go` |
 | [Security: Anti-Tamper Policy](suites/anti_tamper_policy_test.md) | 2 | 2 | 0 | `security`, `tamper`, `cluster`, `slow` | `test/e2e/anti_tamper_policy_test.go` |
 | [DR: Storage Providers Backup & Restore](suites/backup_restore_test.md) | 11 | 0 | 0 | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `failure-injection` | `test/e2e/backup_restore_test.go` |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -211,6 +211,7 @@
       "waiting for StatefulSet to scale down to 2 replicas",
       "waiting for pods to be ready",
       "getting public service for autopilot verification",
+      "triggering reconcile after scale down so autopilot settings are refreshed promptly",
       "verifying Raft Autopilot min_quorum=2 (Development profile with 2 replicas)"
     ],
     "focused": false,
@@ -250,6 +251,7 @@
       "waiting for StatefulSet to scale to 3 replicas",
       "waiting for all pods to be ready",
       "getting public service for autopilot verification",
+      "triggering reconcile after scale up so autopilot settings are refreshed promptly",
       "verifying Raft Autopilot min_quorum=3 (Development profile with 3 replicas)"
     ],
     "focused": false,
@@ -475,6 +477,7 @@
       "waiting for the StatefulSet pod to become Ready (proves auto-unseal worked)",
       "waiting for status.initialized=true (self-init, no operator init)",
       "triggering reconcile to ensure status is updated",
+      "verifying the documented hardened production readiness condition",
       "asserting root token and static unseal secrets do NOT exist",
       "deleting pods to verify auto-unseal works after restart (maintenance mode)"
     ],
@@ -722,6 +725,8 @@
       "checking for prerequisite resources (ConfigMap)",
       "waiting for StatefulSet to be created",
       "waiting for StatefulSet pods to become Ready",
+      "waiting for the ACME shared cache PVC to become Bound",
+      "verifying documented ACME readiness conditions",
       "validating that the config contains ACME parameters",
       "verifying the ACME-issued certificate is trusted by the PKI CA"
     ],
@@ -2140,6 +2145,45 @@
     "suiteTitle": ""
   },
   {
+    "id": "upgrade-strategies-creates-a-tlsroute-and-reports-healthy-0fb8639d",
+    "generatedId": "upgrade-strategies-creates-a-tlsroute-and-reports-healthy-0fb8639d",
+    "file": "test/e2e/Upgrade_Strategies_test.go",
+    "type": "It",
+    "name": "creates a TLSRoute and reports healthy passthrough integration",
+    "path": [
+      "Upgrade Strategies",
+      "Gateway TLS Passthrough",
+      "creates a TLSRoute and reports healthy passthrough integration"
+    ],
+    "labels": [
+      "upgrade",
+      "upgrades",
+      "cluster",
+      "slow",
+      "gateway",
+      "requires-gateway-api",
+      "tls-passthrough"
+    ],
+    "domainLabels": [
+      "upgrade",
+      "upgrades",
+      "cluster",
+      "slow",
+      "gateway",
+      "requires-gateway-api",
+      "tls-passthrough"
+    ],
+    "steps": [
+      "waiting for passthrough Gateway integration status",
+      "verifying a TLSRoute is created for passthrough access",
+      "verifying BackendTLSPolicy is not created for passthrough mode"
+    ],
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "upgrade-strategies-triggers-late-phase-rollback-after-promotion-c44db935",
     "generatedId": "upgrade-strategies-triggers-late-phase-rollback-after-promotion-c44db935",
     "file": "test/e2e/Upgrade_Strategies_test.go",
@@ -2940,6 +2984,7 @@
       "slow"
     ],
     "steps": [
+      "verifying restore configuration is accepted before execution",
       "Verifying secret persists after restore",
       "Verifying restore metrics are emitted"
     ],

--- a/test/e2e/catalog/suites/Cluster_Lifecycle_test.md
+++ b/test/e2e/catalog/suites/Cluster_Lifecycle_test.md
@@ -65,6 +65,7 @@ Recorded checkpoints:
 - waiting for StatefulSet to scale down to 2 replicas
 - waiting for pods to be ready
 - getting public service for autopilot verification
+- triggering reconcile after scale down so autopilot settings are refreshed promptly
 - verifying Raft Autopilot min_quorum=2 (Development profile with 2 replicas)
 
 
@@ -83,6 +84,7 @@ Recorded checkpoints:
 - waiting for StatefulSet to scale to 3 replicas
 - waiting for all pods to be ready
 - getting public service for autopilot verification
+- triggering reconcile after scale up so autopilot settings are refreshed promptly
 - verifying Raft Autopilot min_quorum=3 (Development profile with 3 replicas)
 
 

--- a/test/e2e/catalog/suites/Cluster_Profile_Hardened_test.md
+++ b/test/e2e/catalog/suites/Cluster_Profile_Hardened_test.md
@@ -78,6 +78,7 @@ Recorded checkpoints:
 - waiting for the StatefulSet pod to become Ready (proves auto-unseal worked)
 - waiting for status.initialized=true (self-init, no operator init)
 - triggering reconcile to ensure status is updated
+- verifying the documented hardened production readiness condition
 - asserting root token and static unseal secrets do NOT exist
 - deleting pods to verify auto-unseal works after restart (maintenance mode)
 

--- a/test/e2e/catalog/suites/Cluster_TLS_ACME_test.md
+++ b/test/e2e/catalog/suites/Cluster_TLS_ACME_test.md
@@ -30,6 +30,8 @@ Recorded checkpoints:
 - checking for prerequisite resources (ConfigMap)
 - waiting for StatefulSet to be created
 - waiting for StatefulSet pods to become Ready
+- waiting for the ACME shared cache PVC to become Bound
+- verifying documented ACME readiness conditions
 - validating that the config contains ACME parameters
 - verifying the ACME-issued certificate is trusted by the PKI CA
 

--- a/test/e2e/catalog/suites/Upgrade_Strategies_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Strategies_test.md
@@ -13,6 +13,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `upgrade-strategies-aborts-before-promotion-when-the-pre-230729f6` | aborts before promotion when the pre-promotion hook fails | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `bluegreen`, `verification`, `failure` |
 | `upgrade-strategies-induces-executor-failure-and-validates-retry-f587a124` | induces executor failure and validates retry plus auto-abort behavior | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `failure`, `bluegreen` |
 | `upgrade-strategies-keeps-httproute-stable-and-switches-external-94f5ef4e` | keeps HTTPRoute stable and switches external Service selector at cutover | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `gateway`, `requires-gateway-api`, `bluegreen` |
+| `upgrade-strategies-creates-a-tlsroute-and-reports-healthy-0fb8639d` | creates a TLSRoute and reports healthy passthrough integration | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `gateway`, `requires-gateway-api`, `tls-passthrough` |
 | `upgrade-strategies-triggers-late-phase-rollback-after-promotion-c44db935` | triggers late-phase rollback after promotion failures and recovers when auth is restored | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `failure`, `bluegreen`, `rollback` |
 | `upgrade-strategies-recovers-a-failed-rolling-upgrade-after-5a3c4b87` | recovers a failed rolling upgrade after a retry request clears stale state | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `recovery` |
 | `upgrade-strategies-retries-a-failed-rolling-pre-upgrade-fade7ad8` | retries a failed rolling pre-upgrade snapshot before starting rollout | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `snapshot`, `recovery` |
@@ -120,6 +121,22 @@ Recorded checkpoints:
 - Waiting for Blue/Green upgrade to complete
 - Verifying legacy blue/green Services do not exist
 - Verifying HTTPRoute remains stable throughout upgrade
+
+
+## `upgrade-strategies-creates-a-tlsroute-and-reports-healthy-0fb8639d`
+
+Path: `Upgrade Strategies > Gateway TLS Passthrough > creates a TLSRoute and reports healthy passthrough integration`
+
+State: `active`
+
+Covers: _none_
+
+Labels: `upgrade`, `upgrades`, `cluster`, `slow`, `gateway`, `requires-gateway-api`, `tls-passthrough`
+
+Recorded checkpoints:
+- waiting for passthrough Gateway integration status
+- verifying a TLSRoute is created for passthrough access
+- verifying BackendTLSPolicy is not created for passthrough mode
 
 
 ## `upgrade-strategies-triggers-late-phase-rollback-after-promotion-c44db935`

--- a/test/e2e/catalog/suites/backup_restore_test.md
+++ b/test/e2e/catalog/suites/backup_restore_test.md
@@ -171,6 +171,7 @@ Covers: _none_
 Labels: `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`
 
 Recorded checkpoints:
+- verifying restore configuration is accepted before execution
 - Verifying secret persists after restore
 - Verifying restore metrics are emitted
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/test/utils"
@@ -190,6 +191,9 @@ func NewSetup(ctx context.Context, baseName string, operatorNamespace string) (*
 	if err := gatewayv1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("failed to add gateway scheme: %w", err)
 	}
+	if err := gatewayv1alpha2.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add gateway alpha2 scheme: %w", err)
+	}
 
 	c, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
@@ -227,6 +231,7 @@ func (f *Framework) InstallGatewayAPI() error {
 	cmd = exec.Command("kubectl", "wait", "--for", "condition=Established",
 		"crd/gateways.gateway.networking.k8s.io",
 		"crd/httproutes.gateway.networking.k8s.io",
+		"crd/tlsroutes.gateway.networking.k8s.io",
 		"--timeout", "5m")
 	if _, err := utils.Run(cmd); err != nil {
 		return fmt.Errorf("failed to wait for Gateway API CRDs: %w", err)
@@ -265,6 +270,31 @@ func (f *Framework) WaitForCondition(clusterName string, conditionType openbaov1
 		g.Expect(cond).NotTo(BeNil())
 		g.Expect(cond.Status).To(Equal(status))
 	}, DefaultWaitTimeout, DefaultPollInterval).Should(Succeed(), "Cluster failed to reach condition %s=%s", conditionType, status)
+}
+
+// WaitForConditionReason waits for the specified condition to have the expected status and reason.
+func (f *Framework) WaitForConditionReason(
+	clusterName string,
+	conditionType openbaov1alpha1.ConditionType,
+	status metav1.ConditionStatus,
+	reason string,
+) {
+	Eventually(func(g Gomega) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{}
+		err := f.Client.Get(f.Ctx, types.NamespacedName{Name: clusterName, Namespace: f.Namespace}, cluster)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, string(conditionType))
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(status))
+		g.Expect(cond.Reason).To(Equal(reason))
+	}, DefaultWaitTimeout, DefaultPollInterval).Should(
+		Succeed(),
+		"Cluster failed to reach condition %s=%s reason=%s",
+		conditionType,
+		status,
+		reason,
+	)
 }
 
 // Cleanup deletes the tenant namespace and OpenBaoTenant, ignoring NotFound.

--- a/test/e2e/helpers/bao_infra.go
+++ b/test/e2e/helpers/bao_infra.go
@@ -31,8 +31,9 @@ type InfraBaoConfig struct {
 	Namespace string
 	Name      string
 	Image     string
-	RootToken string
 }
+
+const infraBaoCAMountPath = "/etc/bao/infra-ca"
 
 // EnsureInfraBao creates (or reuses) a production-mode OpenBao pod + service with TLS.
 // The service is reachable at https://<name>.<namespace>.svc:8200.
@@ -54,9 +55,6 @@ func EnsureInfraBao(ctx context.Context, restCfg *rest.Config, c client.Client, 
 	}
 	if cfg.Image == "" {
 		return fmt.Errorf("image is required")
-	}
-	if cfg.RootToken == "" {
-		return fmt.Errorf("root token is required")
 	}
 
 	// Always generate TLS certificates and configure production mode (never dev mode)
@@ -341,6 +339,183 @@ listener "tcp" {
 	return nil
 }
 
+func infraBaoRootTokenSecretName(name string) string {
+	return name + "-root-token"
+}
+
+func infraBaoTLSCASecretName(name string) string {
+	return name + "-tls-ca"
+}
+
+func readSecretData(ctx context.Context, c client.Client, namespace, name, key string) ([]byte, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
+		return nil, err
+	}
+
+	value, ok := secret.Data[key]
+	if !ok || len(strings.TrimSpace(string(value))) == 0 {
+		return nil, fmt.Errorf("secret %s/%s missing non-empty key %q", namespace, name, key)
+	}
+	return value, nil
+}
+
+// ReadInfraBaoRootToken returns the initialized infra-bao root token captured by EnsureInfraBao.
+func ReadInfraBaoRootToken(ctx context.Context, c client.Client, namespace, name string) (string, error) {
+	data, err := readSecretData(ctx, c, namespace, infraBaoRootTokenSecretName(name), "token")
+	if err != nil {
+		return "", fmt.Errorf("failed to read infra-bao root token: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// ReadInfraBaoTLSCACert returns the infra-bao TLS CA bundle used to trust the helper service.
+func ReadInfraBaoTLSCACert(ctx context.Context, c client.Client, namespace, name string) ([]byte, error) {
+	data, err := readSecretData(ctx, c, namespace, infraBaoTLSCASecretName(name), "ca.crt")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read infra-bao CA bundle: %w", err)
+	}
+	return data, nil
+}
+
+func buildInfraBaoSealCredentialsData(rootToken string, tlsCACert, pkiCACert []byte) map[string][]byte {
+	data := map[string][]byte{
+		"token":  []byte(strings.TrimSpace(rootToken)),
+		"ca.crt": tlsCACert,
+	}
+	if len(pkiCACert) > 0 {
+		data["pki-ca.crt"] = pkiCACert
+	}
+	return data
+}
+
+// EnsureInfraBaoSealCredentialsSecret upserts a Secret matching the transit/private-ACME
+// seal credential contract used by the E2E suites.
+func EnsureInfraBaoSealCredentialsSecret(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	secretName string,
+	rootToken string,
+	tlsCACert []byte,
+	pkiCACert []byte,
+) error {
+	if c == nil {
+		return fmt.Errorf("kubernetes client is required")
+	}
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if secretName == "" {
+		return fmt.Errorf("secret name is required")
+	}
+	if strings.TrimSpace(rootToken) == "" {
+		return fmt.Errorf("root token is required")
+	}
+	if len(tlsCACert) == 0 {
+		return fmt.Errorf("tls CA certificate is required")
+	}
+
+	desiredData := buildInfraBaoSealCredentialsData(rootToken, tlsCACert, pkiCACert)
+	key := types.NamespacedName{Name: secretName, Namespace: namespace}
+	existing := &corev1.Secret{}
+	err := c.Get(ctx, key, existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		return c.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: desiredData,
+		})
+	case err != nil:
+		return err
+	default:
+		original := existing.DeepCopy()
+		existing.Type = corev1.SecretTypeOpaque
+		existing.Data = desiredData
+		return c.Patch(ctx, existing, client.MergeFrom(original))
+	}
+}
+
+func newInfraBaoClientPod(
+	namespace string,
+	podName string,
+	image string,
+	infraBaoName string,
+	infraBaoAddress string,
+	token string,
+	script string,
+) *corev1.Pod {
+	env := []corev1.EnvVar{
+		{Name: "BAO_ADDR", Value: infraBaoAddress},
+		{Name: "BAO_CACERT", Value: infraBaoCAMountPath + "/ca.crt"},
+	}
+	if strings.TrimSpace(token) != "" {
+		env = append(env, corev1.EnvVar{Name: "BAO_TOKEN", Value: strings.TrimSpace(token)})
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(true),
+				RunAsUser:    ptr.To(int64(100)),
+				RunAsGroup:   ptr.To(int64(1000)),
+				FSGroup:      ptr.To(int64(1000)),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "bao",
+					Image:   image,
+					Env:     env,
+					Command: []string{"/bin/sh", "-ec"},
+					Args:    []string{script},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "infra-ca",
+							MountPath: infraBaoCAMountPath,
+							ReadOnly:  true,
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: ptr.To(true),
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "infra-ca",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: infraBaoTLSCASecretName(infraBaoName),
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "ca.crt",
+									Path: "ca.crt",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // CleanupInfraBao best-effort deletes the infra-bao resources created by EnsureInfraBao.
 // It is safe to call even if resources were partially created or already removed.
 func CleanupInfraBao(ctx context.Context, c client.Client, cfg InfraBaoConfig) {
@@ -362,7 +537,7 @@ func CleanupInfraBao(ctx context.Context, c client.Client, cfg InfraBaoConfig) {
 	})
 	_ = c.Delete(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfg.Name + "-root-token",
+			Name:      infraBaoRootTokenSecretName(cfg.Name),
 			Namespace: cfg.Namespace,
 		},
 	})
@@ -380,7 +555,7 @@ func CleanupInfraBao(ctx context.Context, c client.Client, cfg InfraBaoConfig) {
 // It uses the static auto-unseal configuration, so no secret_shares or secret_threshold
 // are needed. The root token is stored in a Secret for later use.
 func initializeInfraBao(ctx context.Context, restCfg *rest.Config, c client.Client, cfg InfraBaoConfig) error {
-	secretName := cfg.Name + "-root-token"
+	secretName := infraBaoRootTokenSecretName(cfg.Name)
 	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: cfg.Namespace}, &corev1.Secret{}); err == nil {
 		return nil
 	} else if !apierrors.IsNotFound(err) {
@@ -388,32 +563,7 @@ func initializeInfraBao(ctx context.Context, restCfg *rest.Config, c client.Clie
 	}
 
 	infraAddr := fmt.Sprintf("https://%s.%s.svc:8200", cfg.Name, cfg.Namespace)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfg.Name + "-operator-init",
-			Namespace: cfg.Namespace,
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(int64(100)),
-				RunAsGroup:   ptr.To(int64(1000)),
-				FSGroup:      ptr.To(int64(1000)),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  "bao",
-					Image: cfg.Image,
-					Env: []corev1.EnvVar{
-						{Name: "BAO_ADDR", Value: infraAddr},
-						{Name: "BAO_SKIP_VERIFY", Value: "true"},
-					},
-					Command: []string{"/bin/sh", "-c"},
-					Args: []string{`
+	pod := newInfraBaoClientPod(cfg.Namespace, cfg.Name+"-operator-init", cfg.Image, cfg.Name, infraAddr, "", `
 set -u
 
 wait_for_api() {
@@ -437,18 +587,7 @@ wait_for_api || exit 1
 
 # For static seal, we don't need to pass secret_shares or secret_threshold.
 bao operator init -format=json
-`},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-						RunAsNonRoot: ptr.To(true),
-					},
-				},
-			},
-		},
-	}
+`)
 
 	result, err := RunPodUntilCompletion(ctx, restCfg, c, pod, 2*time.Minute)
 	if err != nil {
@@ -500,60 +639,34 @@ func ConfigureInfraBaoTransit(
 	restCfg *rest.Config,
 	c client.Client,
 	namespace string,
+	infraBaoName string,
 	clientImage string,
 	infraBaoAddress string,
-	rootToken string,
 	keyName string,
 ) (*PodResult, error) {
 	if infraBaoAddress == "" {
 		return nil, fmt.Errorf("infra-bao address is required")
 	}
+	if infraBaoName == "" {
+		return nil, fmt.Errorf("infra-bao name is required")
+	}
 	if keyName == "" {
 		return nil, fmt.Errorf("key name is required")
 	}
 
-	// Always use the root token captured during initialization
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, types.NamespacedName{
-		Name:      "infra-bao-root-token",
-		Namespace: namespace,
-	}, secret); err != nil {
-		return nil, fmt.Errorf("failed to read infra-bao root token Secret: %w", err)
+	tokenToUse, err := ReadInfraBaoRootToken(ctx, c, namespace, infraBaoName)
+	if err != nil {
+		return nil, err
 	}
-	tokenBytes, ok := secret.Data["token"]
-	if !ok || len(tokenBytes) == 0 {
-		return nil, fmt.Errorf("infra-bao root token Secret missing token data")
-	}
-	tokenToUse := strings.TrimSpace(string(tokenBytes))
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "infra-bao-configure-transit",
-			Namespace: namespace,
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(int64(100)),
-				RunAsGroup:   ptr.To(int64(1000)),
-				FSGroup:      ptr.To(int64(1000)),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  "bao",
-					Image: clientImage,
-					Env: []corev1.EnvVar{
-						{Name: "BAO_ADDR", Value: infraBaoAddress},
-						{Name: "BAO_TOKEN", Value: tokenToUse},
-						// Skip TLS verification for self-signed certificates in test environment
-						{Name: "BAO_SKIP_VERIFY", Value: "true"},
-					},
-					Command: []string{"/bin/sh", "-ec"},
-					Args: []string{`
+	pod := newInfraBaoClientPod(
+		namespace,
+		"infra-bao-configure-transit",
+		clientImage,
+		infraBaoName,
+		infraBaoAddress,
+		tokenToUse,
+		`
 wait_for_unsealed() {
   # Ensure the server is reachable and unsealed. OpenBao CLI returns exit code 2
   # when sealed/uninitialized; treat that as "not ready yet" and keep polling.
@@ -585,23 +698,13 @@ if ! out="$(bao secrets enable transit 2>&1)"; then
 fi
 
 # Ensure the transit key exists.
-if ! bao read -format=json transit/keys/` + keyName + ` >/dev/null 2>&1; then
-  bao write -f transit/keys/` + keyName + ` type=aes256-gcm96 >/dev/null
+if ! bao read -format=json transit/keys/`+keyName+` >/dev/null 2>&1; then
+  bao write -f transit/keys/`+keyName+` type=aes256-gcm96 >/dev/null
 fi
 
 echo "ok"
-`},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-						RunAsNonRoot: ptr.To(true),
-					},
-				},
-			},
-		},
-	}
+`,
+	)
 
 	result, err := RunPodUntilCompletion(ctx, restCfg, c, pod, 2*time.Minute)
 	if err != nil {
@@ -619,60 +722,34 @@ func ConfigureInfraBaoPKIACME(
 	restCfg *rest.Config,
 	c client.Client,
 	namespace string,
+	infraBaoName string,
 	clientImage string,
 	infraBaoAddress string,
-	rootToken string,
 	clusterPath string,
 ) (*PodResult, error) {
 	if infraBaoAddress == "" {
 		return nil, fmt.Errorf("infra-bao address is required")
 	}
+	if infraBaoName == "" {
+		return nil, fmt.Errorf("infra-bao name is required")
+	}
 	if clusterPath == "" {
 		return nil, fmt.Errorf("cluster path is required")
 	}
 
-	// Always use the root token captured during initialization
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, types.NamespacedName{
-		Name:      "infra-bao-root-token",
-		Namespace: namespace,
-	}, secret); err != nil {
-		return nil, fmt.Errorf("failed to read infra-bao root token Secret: %w", err)
+	tokenToUse, err := ReadInfraBaoRootToken(ctx, c, namespace, infraBaoName)
+	if err != nil {
+		return nil, err
 	}
-	tokenBytes, ok := secret.Data["token"]
-	if !ok || len(tokenBytes) == 0 {
-		return nil, fmt.Errorf("infra-bao root token Secret missing token data")
-	}
-	tokenToUse := strings.TrimSpace(string(tokenBytes))
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "infra-bao-configure-pki-acme",
-			Namespace: namespace,
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(int64(100)),
-				RunAsGroup:   ptr.To(int64(1000)),
-				FSGroup:      ptr.To(int64(1000)),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  "bao",
-					Image: clientImage,
-					Env: []corev1.EnvVar{
-						{Name: "BAO_ADDR", Value: infraBaoAddress},
-						{Name: "BAO_TOKEN", Value: tokenToUse},
-						// Skip TLS verification for self-signed certificates in test environment
-						{Name: "BAO_SKIP_VERIFY", Value: "true"},
-					},
-					Command: []string{"/bin/sh", "-ec"},
-					Args: []string{`
+	pod := newInfraBaoClientPod(
+		namespace,
+		"infra-bao-configure-pki-acme",
+		clientImage,
+		infraBaoName,
+		infraBaoAddress,
+		tokenToUse,
+		`
 wait_for_unsealed() {
   i=0
   while [ "$i" -lt 60 ]; do
@@ -701,32 +778,22 @@ if ! out="$(bao secrets enable pki 2>&1)"; then
   esac
 fi
 
-bao secrets tune -tls-skip-verify \
+bao secrets tune \
   -allowed-response-headers=Location \
   -allowed-response-headers=Replay-Nonce \
   -allowed-response-headers=Link \
   pki/ >/dev/null
 
-if ! bao read -format=json -tls-skip-verify pki/cert/ca >/dev/null 2>&1; then
-  bao write -format=json -tls-skip-verify pki/root/generate/internal \
+if ! bao read -format=json pki/cert/ca >/dev/null 2>&1; then
+  bao write -format=json pki/root/generate/internal \
     common_name="E2E ACME Root CA" ttl=87600h >/dev/null
 fi
 
-bao write -tls-skip-verify pki/config/cluster path="` + clusterPath + `" >/dev/null
-bao write -tls-skip-verify pki/config/acme enabled=true >/dev/null
+bao write pki/config/cluster path="`+clusterPath+`" >/dev/null
+bao write pki/config/acme enabled=true >/dev/null
 echo "ok"
-`},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-						RunAsNonRoot: ptr.To(true),
-					},
-				},
-			},
-		},
-	}
+`,
+	)
 
 	result, err := RunPodUntilCompletion(ctx, restCfg, c, pod, 2*time.Minute)
 	if err != nil {
@@ -744,67 +811,31 @@ func FetchInfraBaoPKICA(
 	restCfg *rest.Config,
 	c client.Client,
 	namespace string,
+	infraBaoName string,
 	clientImage string,
 	infraBaoAddress string,
 ) ([]byte, error) {
 	if infraBaoAddress == "" {
 		return nil, fmt.Errorf("infra-bao address is required")
 	}
+	if infraBaoName == "" {
+		return nil, fmt.Errorf("infra-bao name is required")
+	}
 
-	// Get the root token
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, types.NamespacedName{
-		Name:      "infra-bao-root-token",
-		Namespace: namespace,
-	}, secret); err != nil {
-		return nil, fmt.Errorf("failed to read infra-bao root token Secret: %w", err)
+	tokenToUse, err := ReadInfraBaoRootToken(ctx, c, namespace, infraBaoName)
+	if err != nil {
+		return nil, err
 	}
-	tokenBytes, ok := secret.Data["token"]
-	if !ok || len(tokenBytes) == 0 {
-		return nil, fmt.Errorf("infra-bao root token Secret missing token data")
-	}
-	tokenToUse := strings.TrimSpace(string(tokenBytes))
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "infra-bao-fetch-pki-ca",
-			Namespace: namespace,
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(int64(100)),
-				RunAsGroup:   ptr.To(int64(1000)),
-				FSGroup:      ptr.To(int64(1000)),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  "bao",
-					Image: clientImage,
-					Env: []corev1.EnvVar{
-						{Name: "BAO_ADDR", Value: infraBaoAddress},
-						{Name: "BAO_TOKEN", Value: tokenToUse},
-						{Name: "BAO_SKIP_VERIFY", Value: "true"},
-					},
-					Command: []string{"/bin/sh", "-ec"},
-					Args: []string{
-						`bao read -format=json pki/cert/ca`,
-					},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-						RunAsNonRoot: ptr.To(true),
-					},
-				},
-			},
-		},
-	}
+	pod := newInfraBaoClientPod(
+		namespace,
+		"infra-bao-fetch-pki-ca",
+		clientImage,
+		infraBaoName,
+		infraBaoAddress,
+		tokenToUse,
+		`bao read -format=json pki/cert/ca`,
+	)
 
 	result, err := RunPodUntilCompletion(ctx, restCfg, c, pod, 2*time.Minute)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR updates the E2E helper flows and targeted coverage to match the current lifecycle and exposure paths. It adds explicit assertions for documented readiness conditions, includes Gateway TLS passthrough coverage, and refreshes the generated E2E catalog output.

This PR builds on #235.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test -tags=e2e ./test/e2e -run TestNope`
- `make e2e-catalog`
- `make lint-ci`
- targeted live `make test-e2e` runs for hardened, ACME, GitOps, backup or restore, Gateway integration, Gateway TLS passthrough, and admission policy coverage
