### PR TITLE
fix(admission): allow hardened image verification defaults

### DIFF
--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -186,36 +186,10 @@ spec:
     - expression: >-
         !has(object.spec.profile) ||
         object.spec.profile != "Hardened" ||
-        !has(object.spec.imageVerification) ||
-        object.spec.imageVerification.enabled != true ||
-        (
-          (has(object.spec.imageVerification.publicKey) && object.spec.imageVerification.publicKey != "") ||
-          ((has(object.spec.imageVerification.issuer) && object.spec.imageVerification.issuer != "") &&
-            (has(object.spec.imageVerification.subject) && object.spec.imageVerification.subject != "")) ||
-          ((has(object.spec.imageVerification.issuerRegExp) && object.spec.imageVerification.issuerRegExp != "") &&
-            (has(object.spec.imageVerification.subjectRegExp) && object.spec.imageVerification.subjectRegExp != ""))
-        )
-      message: When enabled in Hardened profile, spec.imageVerification must provide publicKey, issuer+subject, or issuerRegExp+subjectRegExp.
-    - expression: >-
-        !has(object.spec.profile) ||
-        object.spec.profile != "Hardened" ||
         !has(object.spec.operatorImageVerification) ||
         !has(object.spec.operatorImageVerification.failurePolicy) ||
         object.spec.operatorImageVerification.failurePolicy != "Warn"
       message: Hardened profile does not allow spec.operatorImageVerification.failurePolicy=Warn.
-    - expression: >-
-        !has(object.spec.profile) ||
-        object.spec.profile != "Hardened" ||
-        !has(object.spec.operatorImageVerification) ||
-        object.spec.operatorImageVerification.enabled != true ||
-        (
-          (has(object.spec.operatorImageVerification.publicKey) && object.spec.operatorImageVerification.publicKey != "") ||
-          ((has(object.spec.operatorImageVerification.issuer) && object.spec.operatorImageVerification.issuer != "") &&
-            (has(object.spec.operatorImageVerification.subject) && object.spec.operatorImageVerification.subject != "")) ||
-          ((has(object.spec.operatorImageVerification.issuerRegExp) && object.spec.operatorImageVerification.issuerRegExp != "") &&
-            (has(object.spec.operatorImageVerification.subjectRegExp) && object.spec.operatorImageVerification.subjectRegExp != ""))
-        )
-      message: When enabled in Hardened profile, spec.operatorImageVerification must provide publicKey, issuer+subject, or issuerRegExp+subjectRegExp.
     - expression: >-
         !has(object.spec.initContainer) ||
         object.spec.initContainer.enabled == true

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -183,36 +183,10 @@ spec:
     - expression: >-
         !has(object.spec.profile) ||
         object.spec.profile != "Hardened" ||
-        !has(object.spec.imageVerification) ||
-        object.spec.imageVerification.enabled != true ||
-        (
-          (has(object.spec.imageVerification.publicKey) && object.spec.imageVerification.publicKey != "") ||
-          ((has(object.spec.imageVerification.issuer) && object.spec.imageVerification.issuer != "") &&
-            (has(object.spec.imageVerification.subject) && object.spec.imageVerification.subject != "")) ||
-          ((has(object.spec.imageVerification.issuerRegExp) && object.spec.imageVerification.issuerRegExp != "") &&
-            (has(object.spec.imageVerification.subjectRegExp) && object.spec.imageVerification.subjectRegExp != ""))
-        )
-      message: When enabled in Hardened profile, spec.imageVerification must provide publicKey, issuer+subject, or issuerRegExp+subjectRegExp.
-    - expression: >-
-        !has(object.spec.profile) ||
-        object.spec.profile != "Hardened" ||
         !has(object.spec.operatorImageVerification) ||
         !has(object.spec.operatorImageVerification.failurePolicy) ||
         object.spec.operatorImageVerification.failurePolicy != "Warn"
       message: Hardened profile does not allow spec.operatorImageVerification.failurePolicy=Warn.
-    - expression: >-
-        !has(object.spec.profile) ||
-        object.spec.profile != "Hardened" ||
-        !has(object.spec.operatorImageVerification) ||
-        object.spec.operatorImageVerification.enabled != true ||
-        (
-          (has(object.spec.operatorImageVerification.publicKey) && object.spec.operatorImageVerification.publicKey != "") ||
-          ((has(object.spec.operatorImageVerification.issuer) && object.spec.operatorImageVerification.issuer != "") &&
-            (has(object.spec.operatorImageVerification.subject) && object.spec.operatorImageVerification.subject != "")) ||
-          ((has(object.spec.operatorImageVerification.issuerRegExp) && object.spec.operatorImageVerification.issuerRegExp != "") &&
-            (has(object.spec.operatorImageVerification.subjectRegExp) && object.spec.operatorImageVerification.subjectRegExp != ""))
-        )
-      message: When enabled in Hardened profile, spec.operatorImageVerification must provide publicKey, issuer+subject, or issuerRegExp+subjectRegExp.
     - expression: >-
         !has(object.spec.initContainer) ||
         object.spec.initContainer.enabled == true

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -6437,32 +6437,10 @@ spec:
       !has(object.spec.imageVerification) || !has(object.spec.imageVerification.failurePolicy)
       || object.spec.imageVerification.failurePolicy != "Warn"'
     message: Hardened profile does not allow spec.imageVerification.failurePolicy=Warn.
-  - expression: |-
-      !has(object.spec.profile) || object.spec.profile != "Hardened" || !has(object.spec.imageVerification) || object.spec.imageVerification.enabled != true || (
-
-        (has(object.spec.imageVerification.publicKey) && object.spec.imageVerification.publicKey != "") ||
-        ((has(object.spec.imageVerification.issuer) && object.spec.imageVerification.issuer != "") &&
-          (has(object.spec.imageVerification.subject) && object.spec.imageVerification.subject != "")) ||
-        ((has(object.spec.imageVerification.issuerRegExp) && object.spec.imageVerification.issuerRegExp != "") &&
-          (has(object.spec.imageVerification.subjectRegExp) && object.spec.imageVerification.subjectRegExp != ""))
-      )
-    message: When enabled in Hardened profile, spec.imageVerification must provide
-      publicKey, issuer+subject, or issuerRegExp+subjectRegExp.
   - expression: '!has(object.spec.profile) || object.spec.profile != "Hardened" ||
       !has(object.spec.operatorImageVerification) || !has(object.spec.operatorImageVerification.failurePolicy)
       || object.spec.operatorImageVerification.failurePolicy != "Warn"'
     message: Hardened profile does not allow spec.operatorImageVerification.failurePolicy=Warn.
-  - expression: |-
-      !has(object.spec.profile) || object.spec.profile != "Hardened" || !has(object.spec.operatorImageVerification) || object.spec.operatorImageVerification.enabled != true || (
-
-        (has(object.spec.operatorImageVerification.publicKey) && object.spec.operatorImageVerification.publicKey != "") ||
-        ((has(object.spec.operatorImageVerification.issuer) && object.spec.operatorImageVerification.issuer != "") &&
-          (has(object.spec.operatorImageVerification.subject) && object.spec.operatorImageVerification.subject != "")) ||
-        ((has(object.spec.operatorImageVerification.issuerRegExp) && object.spec.operatorImageVerification.issuerRegExp != "") &&
-          (has(object.spec.operatorImageVerification.subjectRegExp) && object.spec.operatorImageVerification.subjectRegExp != ""))
-      )
-    message: When enabled in Hardened profile, spec.operatorImageVerification must
-      provide publicKey, issuer+subject, or issuerRegExp+subjectRegExp.
   - expression: '!has(object.spec.initContainer) || object.spec.initContainer.enabled
       == true'
     message: spec.initContainer is optional; when set, spec.initContainer.enabled

--- a/docs/security/workload/supply-chain.md
+++ b/docs/security/workload/supply-chain.md
@@ -56,7 +56,8 @@ flowchart LR
 
     !!! tip "Keyless Defaults for Official Images"
         When verification is enabled and no `publicKey`/keyless identity fields are provided
-        (`issuer`/`subject` or `issuerRegExp`/`subjectRegExp`),
+        (`issuer`/`subject` or `issuerRegExp`/`subjectRegExp`), including when the verification block is
+        present with `enabled: true` but otherwise empty,
         the operator auto-fills keyless identity defaults for official release images:
 
         - `openbao/openbao:<tag>`, `ghcr.io/openbao/openbao:<tag>`, `quay.io/openbao/openbao:<tag>` -> OpenBao release workflow identity
@@ -121,7 +122,8 @@ By default, the Operator verifies signatures against the [Sigstore Rekor](https:
 
 !!! warning "Hardened Profile Guardrails"
     Hardened profile rejects explicit `enabled=false` and `failurePolicy=Warn` for image verification blocks.
-    Omitted verification blocks are still allowed, and are implicitly treated as enabled in Hardened.
+    Omitted verification blocks, or enabled blocks without explicit trust material for official images, are still
+    allowed and are implicitly treated as enabled in Hardened.
 
 ## Verified Workloads
 

--- a/docs/user-guide/openbaocluster/configuration/security-profiles.md
+++ b/docs/user-guide/openbaocluster/configuration/security-profiles.md
@@ -86,9 +86,10 @@ flowchart LR
     - :material-check: **Secure Network**: If backups are enabled, explicit egress rules are required (fail-closed networking).
     - :material-check: **Supply Chain Guardrails**: `spec.imageVerification` and `spec.operatorImageVerification` cannot be disabled and cannot use `failurePolicy: Warn`.
 
-    If verification blocks are omitted in Hardened, verification is still applied. For official release image
-    repositories/tags, default GitHub keyless identity values are used. For mirrored/private registries, provide
-    explicit `publicKey` or keyless identity fields in the verification config.
+    If verification blocks are omitted in Hardened, or are present with `enabled: true` but no explicit trust
+    material, verification is still applied. For official release image repositories/tags, default GitHub keyless
+    identity values are used. For mirrored/private registries, provide explicit `publicKey` or keyless identity
+    fields in the verification config.
 
     ### Benefits
 

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -380,6 +380,44 @@ func TestVAP_OpenBaoCluster_RejectsTransitClientCertWithoutKey(t *testing.T) {
 	}
 }
 
+func TestVAP_OpenBaoCluster_AllowsHardenedOfficialImageVerificationDefaults(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	cluster := newMinimalClusterObj(namespace, "cluster-hardened-image-verification-defaults")
+	cluster.Spec.Profile = openbaov1alpha1.ProfileHardened
+	cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeExternal
+	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
+		Enabled: true,
+		Requests: []openbaov1alpha1.SelfInitRequest{
+			{
+				Name:      "health-check",
+				Operation: openbaov1alpha1.SelfInitOperationRead,
+				Path:      "sys/health",
+			},
+		},
+	}
+	cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+		Type: "awskms",
+		AWSKMS: &openbaov1alpha1.AWSKMSSealConfig{
+			Region:   "eu-central-1",
+			KMSKeyID: "alias/openbao-unseal",
+		},
+	}
+	cluster.Spec.ImageVerification = &openbaov1alpha1.ImageVerificationConfig{
+		Enabled:       true,
+		FailurePolicy: "Block",
+	}
+	cluster.Spec.OperatorImageVerification = &openbaov1alpha1.ImageVerificationConfig{
+		Enabled:       true,
+		FailurePolicy: "Block",
+	}
+
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("expected Hardened OpenBaoCluster with enabled official image verification defaults to succeed, got: %v", err)
+	}
+}
+
 func TestVAP_OpenBaoCluster_RejectsDisabledInitContainerOverride(t *testing.T) {
 	ensureDefaultAdmissionPoliciesApplied(t)
 	namespace := newTestNamespace(t)


### PR DESCRIPTION
## Description

This change fixes a contract mismatch between admission and runtime image verification in the Hardened profile.

The operator already auto-fills keyless verification defaults for official OpenBao and operator-managed helper images at runtime. However, the `openbao-validate-openbaocluster` admission policy still rejected `spec.imageVerification` and `spec.operatorImageVerification` when they were explicitly enabled without inline trust material.

This change aligns the admission policy with the actual runtime behavior by allowing Hardened clusters to rely on official-image defaults, while still keeping the existing guardrails that disallow `enabled=false` and `failurePolicy=Warn`.

The change also updates the related docs and adds integration coverage for the intended Hardened path.

## Related Issues

- N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test -tags=integration ./test/integration -run 'TestVAP_OpenBaoCluster_AllowsHardenedOfficialImageVerificationDefaults$'`
- `make verify-generated`
- `make docs-build`
