### PR TITLE
fix(auth): retry kubernetes jwks discovery via api service

### DIFF
--- a/docs/user-guide/operator/authn.md
+++ b/docs/user-guide/operator/authn.md
@@ -119,6 +119,10 @@ failed to create authenticated OpenBao client: ... permission denied
 
 If OIDC discovery or operator identity bootstrap is miswired, the cluster surfaces `OIDCBootstrapConfigurationInvalid`.
 
+On managed control planes, the discovery document may return a JWKS URL on a hostname that is not directly
+reachable from cluster Pods. The operator retries standard Kubernetes JWKS paths (`/openid/v1/jwks` and
+`/.well-known/jwks.json`) through the same Kubernetes API service endpoint used for discovery before failing.
+
 If the operator cannot recognize a human login path from `spec.selfInit.requests`, the cluster surfaces `UserAccessBootstrap=Unknown` with reason `UserAccessUnverified`. This is a warning signal, not a hard block.
 
 ### Manual Role Configuration

--- a/internal/adapter/auth/oidc.go
+++ b/internal/adapter/auth/oidc.go
@@ -12,11 +12,20 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"net/url"
 	"time"
 
 	"k8s.io/client-go/rest"
 
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
+)
+
+const (
+	defaultKubernetesOIDCDiscoveryBaseURL = "https://kubernetes.default.svc"
+	oidcWellKnownConfigurationPath        = "/.well-known/openid-configuration"
+	kubernetesOIDCJWKSPath                = "/openid/v1/jwks"
+	legacyOIDCJWKSPath                    = "/.well-known/jwks.json"
+	publicKeyPEMBlockType                 = "PUBLIC KEY"
 )
 
 // HTTPStatusError represents a non-200 response when calling an HTTP endpoint.
@@ -54,9 +63,9 @@ func (e *HTTPStatusError) HTTPStatusCode() int {
 // profile clusters without OIDC, but Hardened profile requires OIDC.
 func DiscoverConfig(ctx context.Context, cfg *rest.Config, baseURL string) (*portauth.OIDCConfig, error) {
 	if baseURL == "" {
-		baseURL = "https://kubernetes.default.svc"
+		baseURL = defaultKubernetesOIDCDiscoveryBaseURL
 	}
-	wellKnownURL := baseURL + "/.well-known/openid-configuration"
+	wellKnownURL := baseURL + oidcWellKnownConfigurationPath
 
 	transport, err := rest.TransportFor(cfg)
 	if err != nil {
@@ -101,6 +110,11 @@ func DiscoverConfig(ctx context.Context, cfg *rest.Config, baseURL string) (*por
 	var jwksKeys []string
 	if oidcConfig.JWKSURI != "" {
 		keys, err := FetchJWKSKeys(ctx, cfg, oidcConfig.JWKSURI)
+		if err != nil {
+			if fallbackURL, ok := kubernetesJWKSFallbackURL(baseURL, oidcConfig.JWKSURI); ok {
+				keys, err = FetchJWKSKeys(ctx, cfg, fallbackURL)
+			}
+		}
 		if err != nil {
 			// Log but don't fail - JWKS keys are optional for some configurations
 			return &portauth.OIDCConfig{
@@ -178,6 +192,37 @@ func FetchJWKSKeys(ctx context.Context, cfg *rest.Config, jwksURL string) ([]str
 	return keys, nil
 }
 
+func kubernetesJWKSFallbackURL(baseURL, jwksURL string) (string, bool) {
+	if baseURL == "" || jwksURL == "" {
+		return "", false
+	}
+
+	base, err := url.Parse(baseURL)
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return "", false
+	}
+
+	jwks, err := url.Parse(jwksURL)
+	if err != nil || jwks.Scheme == "" || jwks.Host == "" {
+		return "", false
+	}
+
+	if jwks.Host == base.Host && jwks.Scheme == base.Scheme {
+		return "", false
+	}
+
+	switch jwks.Path {
+	case kubernetesOIDCJWKSPath, legacyOIDCJWKSPath:
+	default:
+		return "", false
+	}
+
+	return base.ResolveReference(&url.URL{
+		Path:     jwks.Path,
+		RawQuery: jwks.RawQuery,
+	}).String(), true
+}
+
 func pemPublicKeysFromJWKS(jwks jwksDocument) ([]string, error) {
 	var pemKeys []string
 	seen := make(map[string]struct{}, len(jwks.Keys))
@@ -199,7 +244,7 @@ func pemPublicKeysFromJWKS(jwks jwksDocument) ([]string, error) {
 				return nil, fmt.Errorf("failed to marshal jwk x5c public key: %w", err)
 			}
 
-			pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+			pemKey := string(pem.EncodeToMemory(&pem.Block{Type: publicKeyPEMBlockType, Bytes: pubDER}))
 			if _, ok := seen[pemKey]; ok {
 				continue
 			}
@@ -237,7 +282,7 @@ func pemPublicKeysFromJWKS(jwks jwksDocument) ([]string, error) {
 				return nil, fmt.Errorf("failed to marshal rsa public key: %w", err)
 			}
 
-			pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+			pemKey := string(pem.EncodeToMemory(&pem.Block{Type: publicKeyPEMBlockType, Bytes: pubDER}))
 			if _, ok := seen[pemKey]; ok {
 				continue
 			}
@@ -276,7 +321,7 @@ func pemPublicKeysFromJWKS(jwks jwksDocument) ([]string, error) {
 				return nil, fmt.Errorf("failed to marshal ec public key: %w", err)
 			}
 
-			pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+			pemKey := string(pem.EncodeToMemory(&pem.Block{Type: publicKeyPEMBlockType, Bytes: pubDER}))
 			if _, ok := seen[pemKey]; ok {
 				continue
 			}

--- a/internal/adapter/auth/oidc_test.go
+++ b/internal/adapter/auth/oidc_test.go
@@ -83,7 +83,7 @@ func TestFetchJWKSKeys(t *testing.T) {
 
 	// Create a test server that returns JWKS
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/.well-known/jwks.json" {
+		if r.URL.Path != legacyOIDCJWKSPath {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -109,7 +109,7 @@ func TestFetchJWKSKeys(t *testing.T) {
 		Host: server.URL,
 	}
 
-	keys, err := FetchJWKSKeys(context.Background(), cfg, server.URL+"/.well-known/jwks.json")
+	keys, err := FetchJWKSKeys(context.Background(), cfg, server.URL+legacyOIDCJWKSPath)
 	if err != nil {
 		t.Fatalf("FetchJWKSKeys() error = %v", err)
 	}
@@ -191,7 +191,7 @@ func TestDiscoverConfig(t *testing.T) {
 				}
 
 				jwksServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path != "/.well-known/jwks.json" {
+					if r.URL.Path != legacyOIDCJWKSPath {
 						w.WriteHeader(http.StatusNotFound)
 						return
 					}
@@ -213,7 +213,7 @@ func TestDiscoverConfig(t *testing.T) {
 
 			// Create a test server for OIDC discovery
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/.well-known/openid-configuration" {
+				if r.URL.Path != oidcWellKnownConfigurationPath {
 					w.WriteHeader(http.StatusNotFound)
 					return
 				}
@@ -225,7 +225,7 @@ func TestDiscoverConfig(t *testing.T) {
 
 				jwksURI := tt.jwksURI
 				if jwksURI == "" && tt.wantJWKS && jwksServer != nil {
-					jwksURI = jwksServer.URL + "/.well-known/jwks.json"
+					jwksURI = jwksServer.URL + legacyOIDCJWKSPath
 				}
 
 				config := map[string]interface{}{
@@ -271,6 +271,102 @@ func TestDiscoverConfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDiscoverConfig_FallsBackToDiscoveryBaseForStandardJWKSPath(t *testing.T) {
+	t.Helper()
+
+	cert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate rsa key: %v", err)
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcWellKnownConfigurationPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":   "https://issuer.example.internal",
+				"jwks_uri": "https://unreachable.example.internal/openid/v1/jwks",
+			})
+		case kubernetesOIDCJWKSPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(jwksDocument{
+				Keys: []jwkKey{
+					{
+						Kty: "RSA",
+						X5c: []string{base64.StdEncoding.EncodeToString(certDER)},
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &rest.Config{Host: server.URL}
+	config, err := DiscoverConfig(context.Background(), cfg, server.URL)
+	if err != nil {
+		t.Fatalf("DiscoverConfig() error = %v, want nil", err)
+	}
+	if config == nil {
+		t.Fatal("DiscoverConfig() returned nil config")
+	}
+	if config.IssuerURL != "https://issuer.example.internal" {
+		t.Fatalf("DiscoverConfig() IssuerURL = %q, want %q", config.IssuerURL, "https://issuer.example.internal")
+	}
+	if len(config.JWKSKeys) == 0 {
+		t.Fatal("DiscoverConfig() expected JWKS keys from fallback path, got none")
+	}
+}
+
+func TestDiscoverConfig_DoesNotRewriteCustomJWKSPath(t *testing.T) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case oidcWellKnownConfigurationPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":   "https://issuer.example.internal",
+				"jwks_uri": "https://unreachable.example.internal/custom/jwks",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &rest.Config{Host: server.URL}
+	config, err := DiscoverConfig(context.Background(), cfg, server.URL)
+	if err == nil {
+		t.Fatal("DiscoverConfig() expected error for unreachable custom jwks_uri, got nil")
+	}
+	if config == nil {
+		t.Fatal("DiscoverConfig() expected partial config on JWKS fetch error, got nil")
+	}
+	if config.IssuerURL != "https://issuer.example.internal" {
+		t.Fatalf("DiscoverConfig() IssuerURL = %q, want %q", config.IssuerURL, "https://issuer.example.internal")
+	}
+	if len(config.JWKSKeys) != 0 {
+		t.Fatalf("DiscoverConfig() JWKSKeys = %d, want 0", len(config.JWKSKeys))
+	}
+	if !strings.Contains(err.Error(), "failed to fetch JWKS keys") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Description

This change fixes OIDC discovery for managed Kubernetes control planes where the Kubernetes discovery document is reachable through the in-cluster API service, but the advertised `jwks_uri` hostname is not directly reachable from Pods.

The operator now keeps the existing discovery flow through the Kubernetes API service and retries JWKS retrieval through the same discovery base URL when the discovered `jwks_uri` points to one of the standard Kubernetes JWKS paths:

- `/openid/v1/jwks`
- `/.well-known/jwks.json`

This keeps the behavior cloud-agnostic while avoiding provider-specific hostname assumptions. Arbitrary custom JWKS URLs are not rewritten.

The change also adds focused adapter tests for the fallback behavior and documents the managed-control-plane troubleshooting note in the operator authn guide.

## Related Issues

- N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test ./internal/adapter/auth`
- `go test ./internal/app/openbaocluster ./internal/service/infra`
- `make docs-build`
- `make test-ci`
- `make lint-ci`
