### PR TITLE
fix(controller): refresh cluster status on standard cadence

### DIFF
--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -273,8 +273,18 @@ func (r *openBaoClusterStatusReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 
-	requeueAfter := safetyNetRequeueAfter(time.Now())
+	// In steady state, keep status fresh on a normal cadence. In multi-tenant mode
+	// we do not watch child resources directly, so relying only on the safety-net
+	// requeue can leave health conditions stale for many minutes after runtime drift.
+	requeueAfter := steadyStateStatusRefreshRequeueAfter(time.Now())
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func steadyStateStatusRefreshRequeueAfter(now time.Time) time.Duration {
+	if constants.RequeueStandard > 0 {
+		return constants.RequeueStandard
+	}
+	return safetyNetRequeueAfter(now)
 }
 
 func safetyNetRequeueAfter(now time.Time) time.Duration {

--- a/internal/controller/openbaocluster/status_requeue_test.go
+++ b/internal/controller/openbaocluster/status_requeue_test.go
@@ -114,3 +114,13 @@ func TestSafetyNetRequeueAfter(t *testing.T) {
 		}
 	}
 }
+
+func TestSteadyStateStatusRefreshRequeueAfter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1700000000, 123456789)
+	got := steadyStateStatusRefreshRequeueAfter(now)
+	if got != constants.RequeueStandard {
+		t.Fatalf("steadyStateStatusRefreshRequeueAfter(%v)=%v, want %v", now, got, constants.RequeueStandard)
+	}
+}


### PR DESCRIPTION
## Description

This fixes stale `OpenBaoCluster` health conditions after post-success runtime failures.

In multi-tenant mode, the status controller does not watch child resources directly. After a cluster reached steady state, status refreshes were falling back to the 20-25 minute safety-net requeue. That left `ConditionAvailable=True` stale for minutes after runtime drift, even when a pod was no longer healthy.

This change makes the status controller refresh steady-state cluster status on the normal `RequeueStandard` cadence instead of only relying on the long safety-net interval. Fast-path requeues for stale or partially ready workloads remain unchanged.

This PR also adds a unit test covering the new steady-state status refresh behavior.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test ./internal/controller/openbaocluster`
- `make test-e2e E2E_ENABLE_HARDENED_SIGNED_SUITE=true E2E_OPENBAO_IMAGE=ghcr.io/openbao/openbao:2.5.0 E2E_HARDENED_CONFIG_INIT_IMAGE=ghcr.io/dc-tec/openbao-init:edge E2E_FOCUS='Hardened profile.*(provisions tenant RBAC via OpenBaoTenant|creates a Hardened cluster that self-initializes and stays unsealed across restarts|fails closed when the transit CA bundle drifts after initial success)'`
