### PR TITLE
fix(ci): always run perf weekly issue job after failed schedule check

### DIFF
--- a/.github/workflows/perf-weekly.yml
+++ b/.github/workflows/perf-weekly.yml
@@ -52,7 +52,8 @@ jobs:
     name: Open Weekly Regression Issue
     runs-on: ubuntu-24.04
     needs: verify-perf
-    if: ${{ github.event_name == 'schedule' && needs.verify-perf.result == 'failure' }}
+    # `always()` is required so this job still runs after the failed `needs` job.
+    if: ${{ always() && github.event_name == 'schedule' && needs.verify-perf.result == 'failure' }}
     steps:
       - name: Open or update issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.1


### PR DESCRIPTION
## Description

This ensures the scheduled perf issue job still runs when the upstream verification job fails.

GitHub Actions jobs that depend on a failed `needs` job are skipped unless the downstream job uses `always()`. Without that, the weekly workflow could miss opening or updating the regression issue precisely when the perf check failed.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `./bin/actionlint .github/workflows/perf-weekly.yml`
