### PR TITLE
fix(infra): fail closed on hostile OIDC bootstrap discovery

### DIFF
--- a/internal/app/openbaocluster/infra.go
+++ b/internal/app/openbaocluster/infra.go
@@ -2,6 +2,7 @@ package openbaocluster
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -244,6 +245,14 @@ func (r *infraReconciler) oidcDiscoveryError(err error) error {
 		}
 	}
 
+	if operatorerrors.IsTransientConnection(err) {
+		return operatorerrors.WrapTransientKubernetesAPI(operatorerrors.WrapTransientConnection(err))
+	}
+
+	if isOIDCDiscoveryContentError(err) {
+		return r.oidcBootstrapConfigurationError(err)
+	}
+
 	return operatorerrors.WrapTransientKubernetesAPI(operatorerrors.WrapTransientConnection(err))
 }
 
@@ -278,13 +287,47 @@ func (r *infraReconciler) resolveOIDC(ctx context.Context, cluster *openbaov1alp
 		return nil, r.oidcDiscoveryError(err)
 	}
 	if discovered == nil || strings.TrimSpace(discovered.IssuerURL) == "" {
-		return nil, operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("OIDC discovery returned empty issuer"))
+		return nil, r.oidcBootstrapConfigurationError(fmt.Errorf("OIDC discovery returned empty issuer"))
 	}
 	if strings.TrimSpace(discovered.OIDCDiscoveryURL) == "" && strings.TrimSpace(discovered.JWKSURL) == "" && len(discovered.JWKSKeys) == 0 {
-		return nil, operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("OIDC discovery returned no JWT validation material"))
+		return nil, r.oidcBootstrapConfigurationError(fmt.Errorf("OIDC discovery returned no JWT validation material"))
 	}
 
 	return discovered, nil
+}
+
+func isOIDCDiscoveryContentError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return true
+	}
+
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	patterns := []string{
+		"oidc config missing issuer",
+		"oidc discovery returned empty issuer",
+		"oidc discovery returned no jwt validation material",
+		"failed to parse jwks document",
+		"failed to extract public keys from jwks",
+		"failed to fetch jwks keys",
+	}
+
+	for _, pattern := range patterns {
+		if strings.Contains(message, pattern) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func imageVerificationFailurePolicy(cluster *openbaov1alpha1.OpenBaoCluster) string {

--- a/internal/app/openbaocluster/infra_test.go
+++ b/internal/app/openbaocluster/infra_test.go
@@ -2,6 +2,7 @@ package openbaocluster
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -512,4 +513,160 @@ func TestInfraReconciler_ResolveOIDC_ForbiddenDiscoveryReturnsBootstrapReason(t 
 	if !ok || reason != "OIDCBootstrapConfigurationInvalid" {
 		t.Fatalf("reason = %q,%v want OIDCBootstrapConfigurationInvalid,true", reason, ok)
 	}
+}
+
+func TestInfraReconciler_ResolveOIDC_EmptyIssuerReturnsBootstrapReason(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+				OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	r := &infraReconciler{
+		deps: InfraDependencies{
+			OIDC: InfraOIDCRuntime{
+				RestConfig: &rest.Config{Host: "https://kubernetes.default.svc"},
+				DiscoverOIDCConfig: func(ctx context.Context, cfg *rest.Config) (*OIDCConfig, error) {
+					return &OIDCConfig{JWKSURL: "https://issuer.example/keys"}, nil
+				},
+			},
+		},
+		reasons: InfraReasonPolicy{
+			OIDCBootstrapConfiguration: "OIDCBootstrapConfigurationInvalid",
+		},
+	}
+
+	_, err := r.resolveOIDC(context.Background(), cluster)
+	assertOIDCBootstrapConfigurationError(t, err)
+}
+
+func TestInfraReconciler_ResolveOIDC_NoJWTValidationMaterialReturnsBootstrapReason(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+				OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	r := &infraReconciler{
+		deps: InfraDependencies{
+			OIDC: InfraOIDCRuntime{
+				RestConfig: &rest.Config{Host: "https://kubernetes.default.svc"},
+				DiscoverOIDCConfig: func(ctx context.Context, cfg *rest.Config) (*OIDCConfig, error) {
+					return &OIDCConfig{IssuerURL: "https://issuer.example"}, nil
+				},
+			},
+		},
+		reasons: InfraReasonPolicy{
+			OIDCBootstrapConfiguration: "OIDCBootstrapConfigurationInvalid",
+		},
+	}
+
+	_, err := r.resolveOIDC(context.Background(), cluster)
+	assertOIDCBootstrapConfigurationError(t, err)
+}
+
+func TestInfraReconciler_ResolveOIDC_MalformedJWKSReturnsBootstrapReason(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+				OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	r := &infraReconciler{
+		deps: InfraDependencies{
+			OIDC: InfraOIDCRuntime{
+				RestConfig: &rest.Config{Host: "https://kubernetes.default.svc"},
+				DiscoverOIDCConfig: func(ctx context.Context, cfg *rest.Config) (*OIDCConfig, error) {
+					return nil, fmt.Errorf("failed to fetch JWKS keys: failed to parse jwks document: %w", malformedJSONError())
+				},
+			},
+		},
+		reasons: InfraReasonPolicy{
+			OIDCBootstrapConfiguration: "OIDCBootstrapConfigurationInvalid",
+		},
+	}
+
+	_, err := r.resolveOIDC(context.Background(), cluster)
+	assertOIDCBootstrapConfigurationError(t, err)
+}
+
+func TestInfraReconciler_ResolveOIDC_TransientJWKSFetchFailureStaysTransient(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+				OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	r := &infraReconciler{
+		deps: InfraDependencies{
+			OIDC: InfraOIDCRuntime{
+				RestConfig: &rest.Config{Host: "https://kubernetes.default.svc"},
+				DiscoverOIDCConfig: func(ctx context.Context, cfg *rest.Config) (*OIDCConfig, error) {
+					return nil, fmt.Errorf("failed to fetch JWKS keys: failed to fetch jwks endpoint: %w", context.DeadlineExceeded)
+				},
+			},
+		},
+		reasons: InfraReasonPolicy{
+			OIDCBootstrapConfiguration: "OIDCBootstrapConfigurationInvalid",
+		},
+	}
+
+	_, err := r.resolveOIDC(context.Background(), cluster)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, operatorerrors.ErrPermanentConfig) {
+		t.Fatalf("expected transient error, got permanent config: %v", err)
+	}
+	if !operatorerrors.IsTransient(err) {
+		t.Fatalf("expected transient error, got %v", err)
+	}
+}
+
+func assertOIDCBootstrapConfigurationError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, operatorerrors.ErrPermanentConfig) {
+		t.Fatalf("expected permanent config error, got %v", err)
+	}
+	reason, ok := operatorerrors.Reason(err)
+	if !ok || reason != "OIDCBootstrapConfigurationInvalid" {
+		t.Fatalf("reason = %q,%v want OIDCBootstrapConfigurationInvalid,true", reason, ok)
+	}
+}
+
+func malformedJSONError() error {
+	var payload map[string]any
+	return json.Unmarshal([]byte("{"), &payload)
 }

--- a/internal/controller/openbaocluster/oidc_bootstrap_integration_test.go
+++ b/internal/controller/openbaocluster/oidc_bootstrap_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+// +build integration
+
+package openbaocluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	security "github.com/dc-tec/openbao-operator/internal/adapter/security"
+	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
+)
+
+var _ = Describe("OpenBaoCluster OIDC Bootstrap", func() {
+	Context("When hostile OIDC discovery blocks self-init bootstrap", func() {
+		ctx := context.Background()
+
+		newReconciler := func(discover portauth.DiscoverConfigFunc) *testCompositeReconciler {
+			parent := &OpenBaoClusterReconciler{
+				Client: k8sClient,
+				ControllerRuntime: ControllerRuntime{
+					APIReader:  k8sClient,
+					Scheme:     k8sClient.Scheme(),
+					RestConfig: cfg,
+				},
+				OIDCRuntime: OIDCRuntime{
+					DiscoverOIDCConfig: discover,
+					OIDCStatusCode:     portauth.DiscoveryStatusCode,
+				},
+				ImageVerificationRuntime: ImageVerificationRuntime{
+					ImageVerifier: security.NewImageVerifier(logr.Discard(), k8sClient, nil),
+				},
+			}
+			return &testCompositeReconciler{parent: parent}
+		}
+
+		createOIDCBootstrapCluster := func(name string) *openbaov1alpha1.OpenBaoCluster {
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+				},
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Version:  "2.4.4",
+					Image:    "openbao/openbao:2.4.4",
+					Replicas: 3,
+					Profile:  openbaov1alpha1.ProfileDevelopment,
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled:        true,
+						RotationPeriod: "720h",
+					},
+					Storage: openbaov1alpha1.StorageConfig{
+						Size: "10Gi",
+					},
+					InitContainer: &openbaov1alpha1.InitContainerConfig{
+						Image: "openbao/openbao-init:latest",
+					},
+					SelfInit: &openbaov1alpha1.SelfInitConfig{
+						Enabled: true,
+						OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+							Enabled: true,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			return cluster
+		}
+
+		assertFailClosedBootstrapError := func(cluster *openbaov1alpha1.OpenBaoCluster) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updated.Status.Workload).NotTo(BeNil())
+			Expect(updated.Status.Workload.LastError).NotTo(BeNil())
+			Expect(updated.Status.Workload.LastError.Reason).To(Equal(ReasonOIDCBootstrapConfigurationInvalid))
+
+			degraded := meta.FindStatusCondition(updated.Status.Conditions, string(openbaov1alpha1.ConditionDegraded))
+			Expect(degraded).NotTo(BeNil())
+			Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
+			Expect(degraded.Reason).To(Equal(ReasonOIDCBootstrapConfigurationInvalid))
+
+			sts := &appsv1.StatefulSet{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			}, sts)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected StatefulSet creation to stay blocked")
+		}
+
+		AfterEach(func() {
+			var clusterList openbaov1alpha1.OpenBaoClusterList
+			err := k8sClient.List(ctx, &clusterList)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range clusterList.Items {
+				_ = k8sClient.Delete(ctx, &clusterList.Items[i])
+			}
+		})
+
+		It("fails closed when discovery returns no issuer", func() {
+			cluster := createOIDCBootstrapCluster("test-oidc-discovery-empty-issuer")
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cluster.Name,
+					Namespace: cluster.Namespace,
+				},
+			}
+
+			reconciler := newReconciler(func(ctx context.Context, cfg *rest.Config, baseURL string) (*portauth.OIDCConfig, error) {
+				return &portauth.OIDCConfig{JWKSURL: "https://issuer.example/keys"}, nil
+			})
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			assertFailClosedBootstrapError(cluster)
+		})
+
+		It("fails closed when JWKS discovery content is malformed", func() {
+			cluster := createOIDCBootstrapCluster("test-oidc-malformed-jwks")
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cluster.Name,
+					Namespace: cluster.Namespace,
+				},
+			}
+
+			reconciler := newReconciler(func(ctx context.Context, cfg *rest.Config, baseURL string) (*portauth.OIDCConfig, error) {
+				return nil, fmt.Errorf("failed to fetch JWKS keys: failed to parse jwks document: %w", malformedOIDCDiscoveryJSON())
+			})
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			assertFailClosedBootstrapError(cluster)
+		})
+	})
+})
+
+func malformedOIDCDiscoveryJSON() error {
+	var payload map[string]any
+	return json.Unmarshal([]byte("{"), &payload)
+}


### PR DESCRIPTION
## Description

This hardens OIDC bootstrap discovery so malformed or content-free discovery data fails closed as a bootstrap configuration error instead of being treated as a transient Kubernetes API problem.

The infra reconciler now distinguishes transport failures from hostile or invalid discovery content, classifies empty issuer / missing JWT validation material / malformed JWKS content as `OIDCBootstrapConfigurationInvalid`, and leaves genuine transient fetch failures transient.

This PR adds direct infra tests for those cases and a controller integration test that proves the operator degrades with `OIDCBootstrapConfigurationInvalid` and blocks `StatefulSet` creation when OIDC discovery is hostile.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contributing/standards/index.html).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test ./internal/app/openbaocluster -run 'TestInfraReconciler_ResolveOIDC_'`
- `go test -tags=integration ./internal/controller/openbaocluster -run TestControllers -args -ginkgo.focus='OpenBaoCluster OIDC Bootstrap'`
- `go test ./internal/controller/openbaocluster`
