### PR TITLE
refactor(openbao): preserve typed OpenBao API status errors

### DIFF
--- a/internal/adapter/openbao/client_bootstrap.go
+++ b/internal/adapter/openbao/client_bootstrap.go
@@ -64,13 +64,11 @@ func (c *Client) Snapshot(ctx context.Context, writer io.Writer) error {
 		if c.state != nil {
 			if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
 				c.state.after(req, false)
-				return operatorerrors.WrapTransientRemoteOverloaded(
-					fmt.Errorf("snapshot request failed due to remote overload (status %d): %s", resp.StatusCode, string(body)),
-				)
+				return operatorerrors.WrapTransientRemoteOverloaded(portopenbao.NewAPIError("snapshot request failed", resp.StatusCode, body))
 			}
 			c.state.after(req, true)
 		}
-		return fmt.Errorf("snapshot request failed with status %d: %s", resp.StatusCode, string(body))
+		return portopenbao.NewAPIError("snapshot request failed", resp.StatusCode, body)
 	}
 
 	if _, err := io.Copy(writer, resp.Body); err != nil {
@@ -112,7 +110,7 @@ func (c *Client) Restore(ctx context.Context, reader io.Reader) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("restore request failed with status %d: %s", resp.StatusCode, string(body))
+		return portopenbao.NewAPIError("restore request failed", resp.StatusCode, body)
 	}
 
 	return nil
@@ -136,7 +134,7 @@ func (c *Client) Init(ctx context.Context, req InitRequest) (*InitResponse, erro
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("init request failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, portopenbao.NewAPIError("init request failed", resp.StatusCode, respBody)
 	}
 
 	var initResp InitResponse
@@ -182,7 +180,7 @@ func (c *Client) LoginJWT(ctx context.Context, role, jwtToken string) (string, i
 		return "", 0, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", 0, fmt.Errorf("JWT auth request failed with status %d: %s", resp.StatusCode, string(respBody))
+		return "", 0, portopenbao.NewAPIError("JWT auth request failed", resp.StatusCode, respBody)
 	}
 
 	var authResp JWTAuthLoginResponse

--- a/internal/adapter/openbao/client_health.go
+++ b/internal/adapter/openbao/client_health.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 // LeaderStatusResponse represents the response from GET /v1/sys/leader.
@@ -31,7 +33,9 @@ func (c *Client) Health(ctx context.Context) (*HealthResponse, error) {
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, fmt.Errorf("health check forbidden (403): check operator permissions")
+		return nil, fmt.Errorf("health check forbidden: check operator permissions: %w",
+			portopenbao.NewAPIError("health check request failed", resp.StatusCode, body),
+		)
 	}
 
 	var health HealthResponse
@@ -68,7 +72,7 @@ func (c *Client) StepDown(ctx context.Context) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("step-down request failed with status %d: %s", resp.StatusCode, string(body))
+		return portopenbao.NewAPIError("step-down request failed", resp.StatusCode, body)
 	}
 
 	return nil

--- a/internal/adapter/openbao/client_raft.go
+++ b/internal/adapter/openbao/client_raft.go
@@ -87,7 +87,7 @@ func (c *Client) JoinRaftCluster(ctx context.Context, leaderAPIAddr string, retr
 		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("raft join request failed with status %d: %s", resp.StatusCode, string(body))
+		return portopenbao.NewAPIError("raft join request failed", resp.StatusCode, body)
 	}
 
 	var joinResp JoinRaftClusterResponse
@@ -118,7 +118,7 @@ func (c *Client) ReadRaftConfiguration(ctx context.Context) (*portopenbao.RaftCo
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("raft configuration request failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, portopenbao.NewAPIError("raft configuration request failed", resp.StatusCode, body)
 	}
 
 	type raftConfigEnvelope struct {
@@ -153,10 +153,10 @@ func (c *Client) ReadRaftAutopilotState(ctx context.Context) (*RaftAutopilotStat
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrAutopilotNotAvailable
+		return nil, fmt.Errorf("%w: %w", ErrAutopilotNotAvailable, portopenbao.NewAPIError("raft autopilot state request failed", resp.StatusCode, body))
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("raft autopilot state request failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, portopenbao.NewAPIError("raft autopilot state request failed", resp.StatusCode, body)
 	}
 
 	type raftAutopilotEnvelope struct {
@@ -197,7 +197,7 @@ func (c *Client) ConfigureRaftAutopilot(ctx context.Context, config portopenbao.
 		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("autopilot config request failed with status %d: %s", resp.StatusCode, string(body))
+		return portopenbao.NewAPIError("autopilot config request failed", resp.StatusCode, body)
 	}
 
 	return nil
@@ -228,7 +228,7 @@ func (c *Client) executeRaftPeerAction(ctx context.Context, serverID string, pat
 		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("raft %s request failed with status %d: %s", action, resp.StatusCode, string(body))
+		return portopenbao.NewAPIError(fmt.Sprintf("raft %s request failed", action), resp.StatusCode, body)
 	}
 
 	return nil
@@ -276,7 +276,7 @@ func (c *Client) UpdateRaftConfiguration(ctx context.Context, servers []portopen
 		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("raft configuration update request failed with status %d: %s", resp.StatusCode, string(body))
+		return portopenbao.NewAPIError("raft configuration update request failed", resp.StatusCode, body)
 	}
 
 	return nil

--- a/internal/adapter/openbao/client_test.go
+++ b/internal/adapter/openbao/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	"k8s.io/utils/ptr"
 )
 
@@ -321,6 +322,7 @@ func TestClient_StepDown(t *testing.T) {
 		token      string
 		statusCode int
 		wantErr    bool
+		wantStatus int
 	}{
 		{
 			name:       "successful step-down with 204",
@@ -345,12 +347,14 @@ func TestClient_StepDown(t *testing.T) {
 			token:      "s.invalid-token",
 			statusCode: http.StatusForbidden,
 			wantErr:    true,
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name:       "internal error",
 			token:      "s.valid-token",
 			statusCode: http.StatusInternalServerError,
 			wantErr:    true,
+			wantStatus: http.StatusInternalServerError,
 		},
 	}
 
@@ -385,6 +389,10 @@ func TestClient_StepDown(t *testing.T) {
 			err = client.StepDown(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StepDown() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantStatus != 0 {
+				assertStatusCode(t, err, tt.wantStatus)
 			}
 		})
 	}
@@ -482,6 +490,7 @@ func TestClient_Init(t *testing.T) {
 		wantShares     int
 		wantThreshold  int
 		wantErrMessage string
+		wantStatusCode int
 	}{
 		{
 			name: "successful init",
@@ -509,6 +518,7 @@ func TestClient_Init(t *testing.T) {
 			responseBody:   map[string]string{"error": "already initialized"},
 			wantErr:        true,
 			wantErrMessage: "already initialized",
+			wantStatusCode: http.StatusBadRequest,
 		},
 		{
 			name: "invalid shares",
@@ -579,8 +589,11 @@ func TestClient_Init(t *testing.T) {
 			}
 
 			if tt.wantErr {
-				if tt.wantErrMessage != "" && !errors.Is(err, nil) && !containsError(err, tt.wantErrMessage) {
+				if tt.wantErrMessage != "" && !containsError(err, tt.wantErrMessage) {
 					t.Fatalf("Init() error = %v, want message containing %q", err, tt.wantErrMessage)
+				}
+				if tt.wantStatusCode != 0 {
+					assertStatusCode(t, err, tt.wantStatusCode)
 				}
 				return
 			}
@@ -650,6 +663,18 @@ func containsError(err error, substr string) bool {
 	return strings.Contains(err.Error(), substr)
 }
 
+func assertStatusCode(t *testing.T, err error, want int) {
+	t.Helper()
+
+	got, ok := portopenbao.StatusCode(err)
+	if !ok {
+		t.Fatalf("expected API status %d, got non-API error %v", want, err)
+	}
+	if got != want {
+		t.Fatalf("status code = %d, want %d (err=%v)", got, want, err)
+	}
+}
+
 func TestClient_LoginJWT(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -660,6 +685,7 @@ func TestClient_LoginJWT(t *testing.T) {
 		wantErr        bool
 		wantToken      string
 		wantErrMessage string
+		wantStatusCode int
 	}{
 		{
 			name:       "successful authentication",
@@ -706,6 +732,7 @@ func TestClient_LoginJWT(t *testing.T) {
 			},
 			wantErr:        true,
 			wantErrMessage: "status 403",
+			wantStatusCode: http.StatusForbidden,
 		},
 		{
 			name:       "authentication failed - invalid token",
@@ -717,6 +744,7 @@ func TestClient_LoginJWT(t *testing.T) {
 			},
 			wantErr:        true,
 			wantErrMessage: "status 400",
+			wantStatusCode: http.StatusBadRequest,
 		},
 		{
 			name:       "missing client_token in response",
@@ -795,6 +823,9 @@ func TestClient_LoginJWT(t *testing.T) {
 				if tt.wantErrMessage != "" && !containsError(err, tt.wantErrMessage) {
 					t.Errorf("LoginJWT() error = %v, want message containing %q", err, tt.wantErrMessage)
 				}
+				if tt.wantStatusCode != 0 {
+					assertStatusCode(t, err, tt.wantStatusCode)
+				}
 				return
 			}
 
@@ -803,4 +834,32 @@ func TestClient_LoginJWT(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_ReadRaftAutopilotState_NotFoundPreservesStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != constants.APIPathRaftAutopilotState {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":["autopilot not enabled"]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL: server.URL,
+		Token:   "s.test-token",
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = client.ReadRaftAutopilotState(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrAutopilotNotAvailable) {
+		t.Fatalf("expected ErrAutopilotNotAvailable, got %v", err)
+	}
+	assertStatusCode(t, err, http.StatusNotFound)
 }

--- a/internal/adapter/openbao/errors.go
+++ b/internal/adapter/openbao/errors.go
@@ -1,6 +1,8 @@
 package openbao
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrAutopilotNotAvailable indicates the Raft Autopilot state endpoint is not available.

--- a/internal/adapter/openbao/transport.go
+++ b/internal/adapter/openbao/transport.go
@@ -265,9 +265,7 @@ func (c *Client) doAndReadAll(req *http.Request, httpClient *http.Client, op str
 			if c.state != nil {
 				c.state.after(req, false)
 			}
-			return nil, nil, operatorerrors.WrapTransientRemoteOverloaded(
-				fmt.Errorf("%s: OpenBao API overloaded (status %d): %s", op, resp.StatusCode, string(body)),
-			)
+			return nil, nil, operatorerrors.WrapTransientRemoteOverloaded(portopenbao.NewAPIError(op, resp.StatusCode, body))
 		}
 	}
 

--- a/internal/adapter/raft/autopilot.go
+++ b/internal/adapter/raft/autopilot.go
@@ -3,6 +3,7 @@ package raft
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -313,7 +314,7 @@ func (m *Manager) getJWTToken(logger logr.Logger) (string, error) {
 
 // handleJWTAuthError provides helpful error messages for common JWT auth failures.
 func (m *Manager) handleJWTAuthError(cluster *openbaov1alpha1.OpenBaoCluster, err error) error {
-	if strings.Contains(err.Error(), "status 404") {
+	if portopenbao.IsStatus(err, http.StatusNotFound) {
 		guidance := "Enable JWT auth via spec.selfInit.oidc.enabled: true or configure JWT via self-init requests"
 		if cluster.Status.Initialized {
 			guidance = "Manually configure JWT authentication via OpenBao API/CLI"
@@ -323,7 +324,7 @@ func (m *Manager) handleJWTAuthError(cluster *openbaov1alpha1.OpenBaoCluster, er
 				cluster.Namespace, cluster.Name, guidance),
 		)
 	}
-	if strings.Contains(err.Error(), "status 400") {
+	if portopenbao.IsStatus(err, http.StatusBadRequest) {
 		guidance := fmt.Sprintf("Ensure JWT role '%s' is configured", roleNameOperator)
 		if cluster.Status.Initialized {
 			guidance = "Manually configure JWT role via OpenBao API/CLI"

--- a/internal/adapter/raft/autopilot_runtime_test.go
+++ b/internal/adapter/raft/autopilot_runtime_test.go
@@ -3,6 +3,8 @@ package raft
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -18,6 +20,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 func TestAutopilotBaseURL(t *testing.T) {
@@ -48,23 +51,35 @@ func TestHandleJWTAuthError(t *testing.T) {
 		{
 			name:        "404 maps to prerequisite missing guidance",
 			initialized: false,
-			err:         errors.New("login failed: status 404"),
-			wantPerm:    true,
-			wantText:    "Enable JWT auth",
+			err: fmt.Errorf("failed to authenticate using JWT Auth: %w", &portopenbao.APIError{
+				Operation:    "JWT auth request failed",
+				StatusCode:   http.StatusNotFound,
+				ResponseBody: `{"errors":["no handler for route"]}`,
+			}),
+			wantPerm: true,
+			wantText: "Enable JWT auth",
 		},
 		{
 			name:        "400 maps to role guidance",
 			initialized: false,
-			err:         errors.New("login failed: status 400"),
-			wantPerm:    true,
-			wantText:    "Ensure JWT role",
+			err: fmt.Errorf("failed to authenticate using JWT Auth: %w", &portopenbao.APIError{
+				Operation:    "JWT auth request failed",
+				StatusCode:   http.StatusBadRequest,
+				ResponseBody: `{"errors":["invalid JWT token"]}`,
+			}),
+			wantPerm: true,
+			wantText: "Ensure JWT role",
 		},
 		{
 			name:        "initialized cluster uses manual guidance",
 			initialized: true,
-			err:         errors.New("login failed: status 400"),
-			wantPerm:    true,
-			wantText:    "Manually configure JWT role",
+			err: fmt.Errorf("failed to authenticate using JWT Auth: %w", &portopenbao.APIError{
+				Operation:    "JWT auth request failed",
+				StatusCode:   http.StatusBadRequest,
+				ResponseBody: `{"errors":["invalid JWT token"]}`,
+			}),
+			wantPerm: true,
+			wantText: "Manually configure JWT role",
 		},
 		{
 			name:        "other error remains generic",

--- a/internal/port/openbao/errors.go
+++ b/internal/port/openbao/errors.go
@@ -1,0 +1,82 @@
+package openbao
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const apiErrorBodyLimit = 2048
+
+// APIError captures an OpenBao API failure with a machine-readable HTTP status.
+type APIError struct {
+	Operation    string
+	StatusCode   int
+	ResponseBody string
+}
+
+// Error returns a stable text form while preserving typed access to the HTTP status.
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	operation := strings.TrimSpace(e.Operation)
+	if operation == "" {
+		operation = "OpenBao API request failed"
+	}
+
+	if strings.TrimSpace(e.ResponseBody) == "" {
+		return fmt.Sprintf("%s with status %d", operation, e.StatusCode)
+	}
+
+	return fmt.Sprintf("%s with status %d: %s", operation, e.StatusCode, e.ResponseBody)
+}
+
+// HTTPStatusCode returns the underlying OpenBao API response status code.
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}
+
+// NewAPIError constructs a typed OpenBao API error and normalizes the response body.
+func NewAPIError(operation string, statusCode int, responseBody []byte) *APIError {
+	return &APIError{
+		Operation:    strings.TrimSpace(operation),
+		StatusCode:   statusCode,
+		ResponseBody: normalizeAPIErrorBody(responseBody),
+	}
+}
+
+func normalizeAPIErrorBody(responseBody []byte) string {
+	body := strings.TrimSpace(string(responseBody))
+	if body == "" {
+		return ""
+	}
+	if len(body) > apiErrorBodyLimit {
+		return body[:apiErrorBodyLimit] + "..."
+	}
+	return body
+}
+
+type httpStatusCoder interface {
+	error
+	HTTPStatusCode() int
+}
+
+// StatusCode extracts the OpenBao HTTP status code from an error chain when present.
+func StatusCode(err error) (int, bool) {
+	var statusErr httpStatusCoder
+	if errors.As(err, &statusErr) {
+		return statusErr.HTTPStatusCode(), true
+	}
+	return 0, false
+}
+
+// IsStatus reports whether an error chain contains an OpenBao API error with the given status code.
+func IsStatus(err error, statusCode int) bool {
+	got, ok := StatusCode(err)
+	return ok && got == statusCode
+}


### PR DESCRIPTION
## Description

This change introduces a typed `openbao.APIError` at the OpenBao adapter boundary so HTTP status information is preserved in the error chain instead of being flattened into free-form strings.

The adapter now returns structured API errors for unexpected OpenBao HTTP responses in the bootstrap, raft, health, and transport paths. The first downstream migration is included as well: the raft autopilot JWT handling now classifies 400/404 responses by typed status instead of parsing `"status 400"` / `"status 404"` from error text.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Run `make lint`
- Run `go test ./internal/adapter/openbao`
- Run `go test ./internal/adapter/raft ./internal/service/init ./internal/service/upgrade/raftops`
