### PR TITLE
refactor(backup): categorize CLI exit errors

### DIFF
--- a/cmd/bao-backup/backup_flow.go
+++ b/cmd/bao-backup/backup_flow.go
@@ -18,33 +18,33 @@ func run(ctx context.Context) error {
 
 	cfg, err := backupconfig.LoadExecutorConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return categorizef(errConfigCategory, "failed to load configuration: %w", err)
 	}
 
 	leaderURL, err := findBackupLeader(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("failed to find leader: %w", err)
+		return categorizef(errLeaderCategory, "failed to find leader: %w", err)
 	}
 
 	token, err := authenticate(ctx, cfg, leaderURL)
 	if err != nil {
-		return fmt.Errorf("failed to authenticate: %w", err)
+		return categorizef(errAuthCategory, "failed to authenticate: %w", err)
 	}
 
 	baoClient, closeClient, err := openClusterClient(cfg, "backup", leaderURL, token)
 	if err != nil {
-		return err
+		return categorize(errConfigCategory, err)
 	}
 	defer closeClient()
 
 	backupKey, err := resolveBackupKey(cfg, time.Now().UTC())
 	if err != nil {
-		return fmt.Errorf("failed to generate backup key: %w", err)
+		return categorizef(errConfigCategory, "failed to generate backup key: %w", err)
 	}
 
 	storageClient, err := openStorageClient(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create storage client: %w", err)
+		return categorizef(errStorageCategory, "failed to create storage client: %w", err)
 	}
 	defer func() {
 		_ = storageClient.Close()
@@ -104,12 +104,12 @@ func uploadBackupSnapshot(
 	if err := storageClient.Upload(ctx, backupKey, pr); err != nil {
 		_ = pr.Close()
 		_ = pw.Close()
-		return fmt.Errorf("failed to upload backup: %w", err)
+		return categorizef(errStorageCategory, "failed to upload backup: %w", err)
 	}
 
 	_ = pr.Close()
 	if err := <-snapshotErrCh; err != nil {
-		return fmt.Errorf("failed to get snapshot: %w", err)
+		return categorizef(errSnapshotCategory, "failed to get snapshot: %w", err)
 	}
 
 	return nil
@@ -122,13 +122,19 @@ func verifyBackupUpload(
 ) (*blobstore.ObjectInfo, error) {
 	objInfo, err := storageClient.Head(ctx, backupKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify backup upload: %w", err)
+		return nil, categorizef(errVerificationCategory, "failed to verify backup upload: %w", err)
 	}
 	if objInfo == nil {
-		return nil, fmt.Errorf("backup verification failed: object not found after upload")
+		return nil, categorize(
+			errVerificationCategory,
+			fmt.Errorf("backup verification failed: object not found after upload"),
+		)
 	}
 	if objInfo.Size == 0 {
-		return nil, fmt.Errorf("backup verification failed: uploaded object has zero size")
+		return nil, categorize(
+			errVerificationCategory,
+			fmt.Errorf("backup verification failed: uploaded object has zero size"),
+		)
 	}
 
 	return objInfo, nil

--- a/cmd/bao-backup/errors.go
+++ b/cmd/bao-backup/errors.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errConfigCategory       = errors.New("backup configuration error")
+	errAuthCategory         = errors.New("backup authentication error")
+	errLeaderCategory       = errors.New("backup leader discovery error")
+	errSnapshotCategory     = errors.New("backup snapshot error")
+	errStorageCategory      = errors.New("backup storage error")
+	errVerificationCategory = errors.New("backup verification error")
+)
+
+type categorizedError struct {
+	category error
+	err      error
+}
+
+func (e *categorizedError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *categorizedError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	return []error{e.category, e.err}
+}
+
+func categorize(category error, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &categorizedError{
+		category: category,
+		err:      err,
+	}
+}
+
+func categorizef(category error, format string, args ...any) error {
+	return categorize(category, fmt.Errorf(format, args...))
+}

--- a/cmd/bao-backup/main.go
+++ b/cmd/bao-backup/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
-	"strings"
 )
 
 const (
@@ -52,22 +52,18 @@ func exitCodeForError(err error) int {
 		return exitSuccess
 	}
 
-	errStr := err.Error()
 	switch {
-	case strings.Contains(errStr, "failed to load configuration"):
+	case errors.Is(err, errConfigCategory):
 		return exitConfigError
-	case strings.Contains(errStr, "failed to authenticate"):
+	case errors.Is(err, errAuthCategory):
 		return exitAuthError
-	case strings.Contains(errStr, "failed to find leader"):
+	case errors.Is(err, errLeaderCategory):
 		return exitLeaderDiscovery
-	case strings.Contains(errStr, "failed to get snapshot") ||
-		strings.Contains(errStr, "failed to restore snapshot"):
+	case errors.Is(err, errSnapshotCategory):
 		return exitSnapshotError
-	case strings.Contains(errStr, "failed to upload backup") ||
-		strings.Contains(errStr, "failed to download snapshot") ||
-		strings.Contains(errStr, "failed to create storage client"):
+	case errors.Is(err, errStorageCategory):
 		return exitStorageError
-	case strings.Contains(errStr, "failed to verify"):
+	case errors.Is(err, errVerificationCategory):
 		return exitVerificationError
 	default:
 		return exitConfigError

--- a/cmd/bao-backup/main_test.go
+++ b/cmd/bao-backup/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -94,17 +95,65 @@ func TestExitCodeForError(t *testing.T) {
 		want int
 	}{
 		{name: "nil", err: nil, want: exitSuccess},
-		{name: "config", err: errors.New("config error"), want: exitConfigError},
-		{name: "load config text", err: wrapErr("failed to load configuration"), want: exitConfigError},
-		{name: "auth", err: wrapErr("failed to authenticate"), want: exitAuthError},
-		{name: "leader", err: wrapErr("failed to find leader"), want: exitLeaderDiscovery},
-		{name: "snapshot", err: wrapErr("failed to get snapshot"), want: exitSnapshotError},
-		{name: "restore snapshot", err: wrapErr("failed to restore snapshot"), want: exitSnapshotError},
-		{name: "upload", err: wrapErr("failed to upload backup"), want: exitStorageError},
-		{name: "download", err: wrapErr("failed to download snapshot"), want: exitStorageError},
-		{name: "storage client", err: wrapErr("failed to create storage client"), want: exitStorageError},
-		{name: "verify", err: wrapErr("failed to verify"), want: exitVerificationError},
-		{name: "fallback", err: wrapErr("unexpected"), want: exitConfigError},
+		{
+			name: "config category",
+			err: categorizef(
+				errConfigCategory,
+				"failed to generate backup key: %w",
+				errors.New("bad prefix"),
+			),
+			want: exitConfigError,
+		},
+		{
+			name: "auth category",
+			err: categorizef(
+				errAuthCategory,
+				"unexpected auth text: %w",
+				errors.New("denied"),
+			),
+			want: exitAuthError,
+		},
+		{
+			name: "leader category",
+			err:  categorizef(errLeaderCategory, "no leader found among replicas"),
+			want: exitLeaderDiscovery,
+		},
+		{
+			name: "snapshot category",
+			err: categorizef(
+				errSnapshotCategory,
+				"failed to restore snapshot: %w",
+				errors.New("restore failed"),
+			),
+			want: exitSnapshotError,
+		},
+		{
+			name: "storage category",
+			err: categorizef(
+				errStorageCategory,
+				"failed to create storage client: %w",
+				errors.New("s3 unavailable"),
+			),
+			want: exitStorageError,
+		},
+		{
+			name: "verification category",
+			err: categorizef(
+				errVerificationCategory,
+				"snapshot not found: %s",
+				"demo.snap",
+			),
+			want: exitVerificationError,
+		},
+		{
+			name: "nested category",
+			err: fmt.Errorf(
+				"outer context: %w",
+				categorizef(errAuthCategory, "jwt login failed"),
+			),
+			want: exitAuthError,
+		},
+		{name: "fallback", err: errors.New("unexpected"), want: exitConfigError},
 	}
 
 	for _, tt := range tests {
@@ -268,8 +317,4 @@ func TestBuildStorageConfig(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "unknown storage provider"))
 	})
-}
-
-func wrapErr(msg string) error {
-	return errors.New(msg)
 }

--- a/cmd/bao-backup/restore_flow.go
+++ b/cmd/bao-backup/restore_flow.go
@@ -30,33 +30,33 @@ func runRestore(ctx context.Context) error {
 
 	cfg, err := backupconfig.LoadExecutorConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return categorizef(errConfigCategory, "failed to load configuration: %w", err)
 	}
 	fmt.Printf("Configuration loaded - cluster=%s, namespace=%s, replicas=%d\n",
 		cfg.ClusterName, cfg.ClusterNamespace, cfg.ClusterReplicas)
 
 	settings, err := resolveRestoreSettings(cfg)
 	if err != nil {
-		return err
+		return categorize(errConfigCategory, err)
 	}
 	fmt.Printf("Restore key: %s\n", settings.key)
 
 	leaderURL, err := findRestoreLeader(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("failed to find leader: %w", err)
+		return categorizef(errLeaderCategory, "failed to find leader: %w", err)
 	}
 	fmt.Printf("Found leader at: %s\n", leaderURL)
 
 	fmt.Printf("Authenticating to leader (method=%s)...\n", cfg.AuthMethod)
 	token, err := authenticate(ctx, cfg, leaderURL)
 	if err != nil {
-		return fmt.Errorf("failed to authenticate: %w", err)
+		return categorizef(errAuthCategory, "failed to authenticate: %w", err)
 	}
 	fmt.Println("Authentication successful")
 
 	baoClient, closeClient, err := openClusterClient(cfg, "restore", leaderURL, token)
 	if err != nil {
-		return err
+		return categorize(errConfigCategory, err)
 	}
 	defer closeClient()
 
@@ -65,7 +65,7 @@ func runRestore(ctx context.Context) error {
 	fmt.Println("Creating storage client...")
 	storageClient, err := openStorageClient(ctx, &restoreCfg)
 	if err != nil {
-		return fmt.Errorf("failed to create storage client: %w", err)
+		return categorizef(errStorageCategory, "failed to create storage client: %w", err)
 	}
 	defer func() {
 		_ = storageClient.Close()
@@ -84,7 +84,7 @@ func runRestore(ctx context.Context) error {
 	fmt.Println("Snapshot downloaded successfully")
 	fmt.Println("Restoring snapshot to cluster...")
 	if err := baoClient.Restore(ctx, reader); err != nil {
-		return fmt.Errorf("failed to restore snapshot: %w", err)
+		return categorizef(errSnapshotCategory, "failed to restore snapshot: %w", err)
 	}
 
 	_, _ = fmt.Fprintf(os.Stdout, "Restore completed successfully from: %s\n", settings.key)
@@ -135,16 +135,16 @@ func downloadRestoreSnapshot(
 	fmt.Printf("Verifying snapshot exists: %s\n", key)
 	objInfo, err := storageClient.Head(ctx, key)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to verify snapshot exists: %w", err)
+		return nil, nil, categorizef(errVerificationCategory, "failed to verify snapshot exists: %w", err)
 	}
 	if objInfo == nil {
-		return nil, nil, fmt.Errorf("snapshot not found: %s", key)
+		return nil, nil, categorize(errVerificationCategory, fmt.Errorf("snapshot not found: %s", key))
 	}
 
 	fmt.Println("Downloading snapshot from storage...")
 	reader, err := storageClient.Download(ctx, key)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to download snapshot: %w", err)
+		return nil, nil, categorizef(errStorageCategory, "failed to download snapshot: %w", err)
 	}
 
 	return reader, objInfo, nil


### PR DESCRIPTION
## Description

This change removes string-based exit-code classification from the `bao-backup` CLI.

The backup and restore flows now wrap failures in explicit error categories for configuration, authentication, leader discovery, snapshot, storage, and verification paths. `exitCodeForError` now uses `errors.Is` against those categories instead of parsing message substrings.

This keeps the existing user-facing error messages, but makes exit-code behavior stable even if message wording changes.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Run `go test ./cmd/bao-backup`
- Run `make lint-ast`
- Run `make lint`
