### PR TITLE
refactor(oidc): type discovery content errors

### DIFF
--- a/internal/adapter/auth/oidc_discovery.go
+++ b/internal/adapter/auth/oidc_discovery.go
@@ -37,7 +37,7 @@ func DiscoverConfig(ctx context.Context, cfg *rest.Config, baseURL string) (*por
 		return nil, err
 	}
 	if oidcConfig.Issuer == "" {
-		return nil, fmt.Errorf("OIDC config missing issuer")
+		return nil, fmt.Errorf("%w: OIDC config missing issuer", portauth.ErrDiscoveryContentInvalid)
 	}
 
 	return buildDiscoveredOIDCConfig(ctx, cfg, baseURL, oidcConfig)
@@ -138,7 +138,7 @@ func fetchOIDCWellKnown(ctx context.Context, httpClient *http.Client, wellKnownU
 
 	var oidcConfig oidcWellKnownDocument
 	if err := json.NewDecoder(resp.Body).Decode(&oidcConfig); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: failed to parse OIDC discovery document: %w", portauth.ErrDiscoveryContentInvalid, err)
 	}
 
 	return &oidcConfig, nil

--- a/internal/adapter/auth/oidc_jwks.go
+++ b/internal/adapter/auth/oidc_jwks.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 
 	"k8s.io/client-go/rest"
+
+	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
 
 type jwksDocument struct {
@@ -75,12 +77,12 @@ func fetchJWKSKeysWithClient(ctx context.Context, httpClient *http.Client, jwksU
 
 	var jwks jwksDocument
 	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-		return nil, fmt.Errorf("failed to parse jwks document: %w", err)
+		return nil, fmt.Errorf("%w: failed to parse jwks document: %w", portauth.ErrDiscoveryContentInvalid, err)
 	}
 
 	keys, err := pemPublicKeysFromJWKS(jwks)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract public keys from jwks: %w", err)
+		return nil, fmt.Errorf("%w: failed to extract public keys from jwks: %w", portauth.ErrDiscoveryContentInvalid, err)
 	}
 
 	return keys, nil

--- a/internal/adapter/auth/oidc_test.go
+++ b/internal/adapter/auth/oidc_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,8 @@ import (
 	"time"
 
 	"k8s.io/client-go/rest"
+
+	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
 
 func TestPemPublicKeysFromJWKS_UsesX5C(t *testing.T) {
@@ -133,6 +136,7 @@ func TestDiscoverConfig(t *testing.T) {
 		wantJWKS   bool
 		baseURL    string
 		statusCode int
+		wantErrIs  error
 	}{
 		{
 			name:       "successful discovery with JWKS",
@@ -165,6 +169,7 @@ func TestDiscoverConfig(t *testing.T) {
 			wantErr:    true,
 			wantJWKS:   false,
 			statusCode: http.StatusOK,
+			wantErrIs:  portauth.ErrDiscoveryContentInvalid,
 		},
 	}
 
@@ -256,6 +261,9 @@ func TestDiscoverConfig(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("DiscoverConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+				t.Fatalf("DiscoverConfig() error = %v, want errors.Is(..., %v)", err, tt.wantErrIs)
+			}
 
 			if !tt.wantErr {
 				if config == nil {
@@ -272,6 +280,27 @@ func TestDiscoverConfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFetchJWKSKeys_InvalidDocumentReturnsContentError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != legacyOIDCJWKSPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[`))
+	}))
+	defer server.Close()
+
+	cfg := &rest.Config{Host: server.URL}
+	_, err := FetchJWKSKeys(context.Background(), cfg, server.URL+legacyOIDCJWKSPath)
+	if err == nil {
+		t.Fatal("FetchJWKSKeys() expected error, got nil")
+	}
+	if !errors.Is(err, portauth.ErrDiscoveryContentInvalid) {
+		t.Fatalf("FetchJWKSKeys() error = %v, want ErrDiscoveryContentInvalid", err)
 	}
 }
 

--- a/internal/adapter/security/cluster_image_verification.go
+++ b/internal/adapter/security/cluster_image_verification.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultGitHubOIDCIssuerRegExp = "^https://token\\.actions\\.githubusercontent\\.com$"
 	openBaoReleaseSubjectRegExp   = "^https://github\\.com/openbao/openbao/\\.github/workflows/release\\.yml@refs/tags/v?[0-9A-Za-z][0-9A-Za-z._+-]*$"
-	operatorSubjectRegExp         = "^https://github\\.com/dc-tec/openbao-operator/\\.github/workflows/(release\\.yml@refs/tags/.+|publish-edge\\.yml@refs/heads/main|publish-nightly\\.yml@refs/heads/main)$"
+	operatorSubjectRegExp         = "^https://github\\.com/dc-tec/openbao-operator/\\.github/workflows/(release\\.yml@refs/tags/.+|publish-edge\\.yml@refs/heads/main|publish-nightly\\.yml@refs/heads/main|reusable-build\\.yml@refs/heads/main)$"
 )
 
 func VerifyImageForCluster(ctx context.Context, logger logr.Logger, verifier imageverify.Verifier, cluster *openbaov1alpha1.OpenBaoCluster, imageRef string) (string, error) {

--- a/internal/adapter/security/cluster_image_verification_test.go
+++ b/internal/adapter/security/cluster_image_verification_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -127,6 +128,35 @@ func TestVerifyOperatorImageForCluster_AppliesDefaultsForEdgeTag(t *testing.T) {
 	}
 	if got := verifier.config.SubjectRegExp; got != operatorSubjectRegExp {
 		t.Fatalf("subjectRegExp = %q, want %q", got, operatorSubjectRegExp)
+	}
+}
+
+func TestOperatorSubjectRegExp_TrustedWorkflowIdentities(t *testing.T) {
+	t.Parallel()
+
+	re := regexp.MustCompile(operatorSubjectRegExp)
+
+	trusted := []string{
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/release.yml@refs/tags/v1.2.3",
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/publish-edge.yml@refs/heads/main",
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/publish-nightly.yml@refs/heads/main",
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/reusable-build.yml@refs/heads/main",
+	}
+	for _, subject := range trusted {
+		if !re.MatchString(subject) {
+			t.Fatalf("trusted subject %q did not match %q", subject, operatorSubjectRegExp)
+		}
+	}
+
+	untrusted := []string{
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/reusable-build.yml@refs/heads/feature",
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/ci.yml@refs/heads/main",
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/release.yml@refs/heads/main",
+	}
+	for _, subject := range untrusted {
+		if re.MatchString(subject) {
+			t.Fatalf("untrusted subject %q unexpectedly matched %q", subject, operatorSubjectRegExp)
+		}
 	}
 }
 

--- a/internal/app/openbaocluster/infra_oidc.go
+++ b/internal/app/openbaocluster/infra_oidc.go
@@ -2,7 +2,6 @@ package openbaocluster
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -78,7 +77,7 @@ func (r *infraReconciler) oidcDiscoveryError(err error) error {
 		return operatorerrors.WrapTransientKubernetesAPI(operatorerrors.WrapTransientConnection(err))
 	}
 
-	if isOIDCDiscoveryContentError(err) {
+	if errors.Is(err, portauth.ErrDiscoveryContentInvalid) {
 		return r.oidcBootstrapConfigurationError(err)
 	}
 
@@ -123,38 +122,4 @@ func (r *infraReconciler) resolveOIDC(ctx context.Context, cluster *openbaov1alp
 	}
 
 	return discovered, nil
-}
-
-func isOIDCDiscoveryContentError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
-		return true
-	}
-
-	var typeErr *json.UnmarshalTypeError
-	if errors.As(err, &typeErr) {
-		return true
-	}
-
-	message := strings.ToLower(err.Error())
-	patterns := []string{
-		"oidc config missing issuer",
-		"oidc discovery returned empty issuer",
-		"oidc discovery returned no jwt validation material",
-		"failed to parse jwks document",
-		"failed to extract public keys from jwks",
-		"failed to fetch jwks keys",
-	}
-
-	for _, pattern := range patterns {
-		if strings.Contains(message, pattern) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/app/openbaocluster/infra_test.go
+++ b/internal/app/openbaocluster/infra_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	inframanager "github.com/dc-tec/openbao-operator/internal/service/infra"
@@ -625,7 +626,7 @@ func TestInfraReconciler_ResolveOIDC_MalformedJWKSReturnsBootstrapReason(t *test
 			OIDC: InfraOIDCRuntime{
 				RestConfig: &rest.Config{Host: "https://kubernetes.default.svc"},
 				DiscoverOIDCConfig: func(ctx context.Context, cfg *rest.Config) (*OIDCConfig, error) {
-					return nil, fmt.Errorf("failed to fetch JWKS keys: failed to parse jwks document: %w", malformedJSONError())
+					return nil, fmt.Errorf("%w: failed to parse jwks document: %w", portauth.ErrDiscoveryContentInvalid, malformedJSONError())
 				},
 			},
 		},

--- a/internal/controller/openbaocluster/oidc_bootstrap_integration_test.go
+++ b/internal/controller/openbaocluster/oidc_bootstrap_integration_test.go
@@ -145,7 +145,10 @@ var _ = Describe("OpenBaoCluster OIDC Bootstrap", func() {
 			}
 
 			reconciler := newReconciler(func(ctx context.Context, cfg *rest.Config, baseURL string) (*portauth.OIDCConfig, error) {
-				return nil, fmt.Errorf("failed to fetch JWKS keys: failed to parse jwks document: %w", malformedOIDCDiscoveryJSON())
+				return nil, fmt.Errorf(
+					"failed to fetch JWKS keys: %w",
+					fmt.Errorf("%w: failed to parse jwks document: %w", portauth.ErrDiscoveryContentInvalid, malformedOIDCDiscoveryJSON()),
+				)
 			})
 
 			_, err := reconciler.Reconcile(ctx, req)

--- a/internal/port/auth/oidc.go
+++ b/internal/port/auth/oidc.go
@@ -7,6 +7,12 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+var (
+	// ErrDiscoveryContentInvalid indicates OIDC discovery or JWKS content was syntactically valid enough to fetch
+	// but semantically unusable for JWT bootstrap.
+	ErrDiscoveryContentInvalid = errors.New("OIDC discovery content invalid")
+)
+
 // OIDCConfig contains discovered issuer and JWT validation material for
 // operator bootstrap. OIDCDiscoveryURL is preferred for dynamic verification
 // and key rotation; JWKSURL and JWKSKeys are retained as compatibility

--- a/internal/port/security/image_verification.go
+++ b/internal/port/security/image_verification.go
@@ -16,7 +16,7 @@ const (
 	defaultGitHubOIDCIssuerRegExp = "^https://token\\.actions\\.githubusercontent\\.com$"
 
 	openBaoReleaseSubjectRegExp = "^https://github\\.com/openbao/openbao/\\.github/workflows/release\\.yml@refs/tags/v?[0-9A-Za-z][0-9A-Za-z._+-]*$"
-	operatorSubjectRegExp       = "^https://github\\.com/dc-tec/openbao-operator/\\.github/workflows/(release\\.yml@refs/tags/.+|publish-edge\\.yml@refs/heads/main|publish-nightly\\.yml@refs/heads/main)$"
+	operatorSubjectRegExp       = "^https://github\\.com/dc-tec/openbao-operator/\\.github/workflows/(release\\.yml@refs/tags/.+|publish-edge\\.yml@refs/heads/main|publish-nightly\\.yml@refs/heads/main|reusable-build\\.yml@refs/heads/main)$"
 
 	operatorInitOfficialRepository    = "ghcr.io/dc-tec/openbao-init"
 	operatorBackupOfficialRepository  = "ghcr.io/dc-tec/openbao-backup"


### PR DESCRIPTION
## Description

This change removes string-based content-error classification from the OIDC bootstrap path.

The auth layer now exposes a typed `portauth.ErrDiscoveryContentInvalid` sentinel for invalid OIDC discovery and JWKS content. The OIDC adapter wraps malformed discovery documents, missing issuer data, and invalid JWKS content with that sentinel, and the infra reconciler now uses `errors.Is` against the typed contract instead of parsing error messages.

This keeps transient fetch/network failures transient, while routing invalid discovery/JWKS content into the permanent bootstrap-configuration path without depending on wording.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Run `go test ./internal/adapter/auth ./internal/app/openbaocluster`
- Run `make lint`
- Run `make lint-ast`
