### PR TITLE
refactor(cleanup): finish typed error cleanup

### DIFF
--- a/internal/adapter/probe/prober.go
+++ b/internal/adapter/probe/prober.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -173,13 +175,7 @@ func (p *HTTPProber) CheckReadiness(ctx context.Context) error {
 			break
 		}
 
-		// Check if this is a connection reset error that we should retry
-		errStr := err.Error()
-		isConnectionReset := strings.Contains(errStr, "connection reset") ||
-			strings.Contains(errStr, "EOF") ||
-			strings.Contains(errStr, "broken pipe")
-
-		if !isConnectionReset || attempt == maxRetries-1 {
+		if !shouldRetryReadinessProbeError(err) || attempt == maxRetries-1 {
 			// Not a connection reset error, or we've exhausted retries
 			break
 		}
@@ -206,6 +202,19 @@ func (p *HTTPProber) CheckReadiness(ctx context.Context) error {
 	default:
 		return fmt.Errorf("readiness check failed with status %d", resp.StatusCode)
 	}
+}
+
+func shouldRetryReadinessProbeError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EPIPE)
 }
 
 func newHTTPClient(

--- a/internal/adapter/probe/prober_test.go
+++ b/internal/adapter/probe/prober_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -232,6 +236,77 @@ func TestHTTPProber_CheckReadiness(t *testing.T) {
 	}
 }
 
+func TestHTTPProber_CheckReadiness_RetriesTypedTransientConnectionErrors(t *testing.T) {
+	t.Parallel()
+
+	prober, err := NewProber(ProberConfig{
+		Addr:          "https://localhost:8200",
+		Timeout:       4 * time.Second,
+		LivenessPath:  "/v1/sys/health",
+		ReadinessPath: "/v1/sys/health?standbyok=true",
+	})
+	if err != nil {
+		t.Fatalf("NewProber() error = %v", err)
+	}
+
+	attempts := 0
+	httpProber := prober.(*HTTPProber)
+	httpProber.client = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			attempts++
+			switch attempts {
+			case 1:
+				return nil, &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+			case 2:
+				return nil, io.ErrUnexpectedEOF
+			default:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       http.NoBody,
+				}, nil
+			}
+		}),
+	}
+
+	if err := prober.CheckReadiness(context.Background()); err != nil {
+		t.Fatalf("CheckReadiness() error = %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("CheckReadiness() attempts = %d, want 3", attempts)
+	}
+}
+
+func TestHTTPProber_CheckReadiness_DoesNotRetryNonTransientErrors(t *testing.T) {
+	t.Parallel()
+
+	prober, err := NewProber(ProberConfig{
+		Addr:          "https://localhost:8200",
+		Timeout:       4 * time.Second,
+		LivenessPath:  "/v1/sys/health",
+		ReadinessPath: "/v1/sys/health?standbyok=true",
+	})
+	if err != nil {
+		t.Fatalf("NewProber() error = %v", err)
+	}
+
+	attempts := 0
+	httpProber := prober.(*HTTPProber)
+	httpProber.client = &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			attempts++
+			return nil, errors.New("boom")
+		}),
+	}
+
+	err = prober.CheckReadiness(context.Background())
+	if err == nil {
+		t.Fatal("CheckReadiness() expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("CheckReadiness() attempts = %d, want 1", attempts)
+	}
+}
+
 func TestParseAddr(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -345,4 +420,10 @@ func TestVerifyLoopbackCertificate(t *testing.T) {
 	if err == nil {
 		t.Error("verifyLoopbackCertificate() expected error for empty certificates, got nil")
 	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/internal/service/infra/network_backend_tls_policy.go
+++ b/internal/service/infra/network_backend_tls_policy.go
@@ -179,7 +179,7 @@ func (m *Manager) ensureGatewayCAConfigMap(ctx context.Context, logger logr.Logg
 			logger.V(1).Info("CA Secret not found; skipping Gateway CA ConfigMap creation", "secret", caSecretName)
 			return nil
 		}
-		if apierrors.IsForbidden(err) || strings.Contains(strings.ToLower(err.Error()), "forbidden") {
+		if apierrors.IsForbidden(err) {
 			logger.V(1).Info("CA Secret access forbidden (likely waiting for RBAC); skipping Gateway CA ConfigMap creation", "secret", caSecretName)
 			return nil
 		}


### PR DESCRIPTION
## Description

This change finishes the remaining non-boundary string-based error classification from the Go idioms remediation work.

The readiness prober now retries on typed transient connection errors such as `io.EOF`, `io.ErrUnexpectedEOF`, `net.ErrClosed`, `ECONNRESET`, `ECONNABORTED`, and `EPIPE` instead of parsing error text. The Gateway CA ConfigMap path now relies on typed Kubernetes forbidden checks instead of a generic `"forbidden"` fallback.

This keeps the intentional opaque-boundary parsing in place where it still belongs, but closes out the last general runtime cleanup items from the audit plan.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Run `go test ./internal/adapter/probe ./internal/service/infra`
- Run `make lint-ast`
- Run `make lint`
