### PR TITLE
chore(ast-grep): add error string classification rule

### DIFF
--- a/.ast-grep/rules/runtime-safety/no-error-string-classification.yml
+++ b/.ast-grep/rules/runtime-safety/no-error-string-classification.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-error-string-classification
+message: Do not classify errors by matching err.Error(); prefer typed sentinels, status helpers, or explicit adapter-boundary translation.
+severity: warning
+language: Go
+files:
+  - internal/**/*.go
+  - cmd/**/*.go
+ignores:
+  - '**/*_test.go'
+  - 'internal/platform/admission/canary.go'
+  - 'internal/adapter/security/image_verifier_verify.go'
+rule:
+  any:
+    - pattern: strings.Contains($ERR.Error(), $MSG)
+    - pattern: strings.Contains(strings.ToLower($ERR.Error()), $MSG)
+    - pattern: strings.EqualFold($ERR.Error(), $MSG)
+    - pattern: strings.HasPrefix($ERR.Error(), $MSG)
+    - pattern: strings.HasPrefix(strings.ToLower($ERR.Error()), $MSG)
+    - pattern: strings.HasSuffix($ERR.Error(), $MSG)
+    - pattern: strings.HasSuffix(strings.ToLower($ERR.Error()), $MSG)
+note: Keep string parsing at explicit opaque boundaries only; elsewhere preserve error chains and branch on typed errors or status values.

--- a/.ast-grep/tests/__snapshots__/no-error-string-classification-snapshot.yml
+++ b/.ast-grep/tests/__snapshots__/no-error-string-classification-snapshot.yml
@@ -1,0 +1,35 @@
+id: no-error-string-classification
+snapshots:
+  ? |
+    package p
+    import "strings"
+    func f(err error) bool {
+      return strings.Contains(err.Error(), "forbidden")
+    }
+  : labels:
+    - source: 'strings.Contains(err.Error(), "forbidden")'
+      style: primary
+      start: 61
+      end: 103
+  ? |
+    package p
+    import "strings"
+    func f(err error) bool {
+      return strings.Contains(strings.ToLower(err.Error()), "forbidden")
+    }
+  : labels:
+    - source: 'strings.Contains(strings.ToLower(err.Error()), "forbidden")'
+      style: primary
+      start: 61
+      end: 120
+  ? |
+    package p
+    import "strings"
+    func f(err error) bool {
+      return strings.EqualFold(err.Error(), "already initialized")
+    }
+  : labels:
+    - source: 'strings.EqualFold(err.Error(), "already initialized")'
+      style: primary
+      start: 61
+      end: 114

--- a/.ast-grep/tests/runtime-safety/no-error-string-classification-test.yml
+++ b/.ast-grep/tests/runtime-safety/no-error-string-classification-test.yml
@@ -1,0 +1,38 @@
+id: no-error-string-classification
+valid:
+  - |
+    package p
+    import "errors"
+    func f(err error, sentinel error) bool {
+      return errors.Is(err, sentinel)
+    }
+  - |
+    package p
+    import "strings"
+    func f(message string) bool {
+      return strings.Contains(message, "forbidden")
+    }
+  - |
+    package p
+    func f(err error) string {
+      return err.Error()
+    }
+invalid:
+  - |
+    package p
+    import "strings"
+    func f(err error) bool {
+      return strings.Contains(err.Error(), "forbidden")
+    }
+  - |
+    package p
+    import "strings"
+    func f(err error) bool {
+      return strings.Contains(strings.ToLower(err.Error()), "forbidden")
+    }
+  - |
+    package p
+    import "strings"
+    func f(err error) bool {
+      return strings.EqualFold(err.Error(), "already initialized")
+    }


### PR DESCRIPTION
## Description

Add a new ast-grep runtime-safety rule that flags error classification via `err.Error()` string matching.

The rule is intended to push callers toward typed sentinels, status helpers, or explicit adapter-boundary translation instead of parsing error strings in internal runtime code. The PR includes the rule, a focused test fixture, and the matching snapshot.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Run `./.github/tools/node_modules/.bin/ast-grep test -c .ast-grep/sgconfig.yml`
- Run `./.github/tools/node_modules/.bin/ast-grep scan -c .ast-grep/sgconfig.yml --report-style=medium --error .`
- Confirm the new rule fixture passes under `no-error-string-classification`
