### PR TITLE
fix(openbao): stage safe raft scale-downs

### DIFF
--- a/internal/adapter/config/builder.go
+++ b/internal/adapter/config/builder.go
@@ -20,6 +20,8 @@ const (
 
 	jwtPolicyHealthStepDownAutopilot = `path "sys/health" { capabilities = ["read"] }
 path "sys/step-down" { capabilities = ["sudo", "update"] }
+path "sys/storage/raft/configuration" { capabilities = ["read"] }
+path "sys/storage/raft/remove-peer" { capabilities = ["update"] }
 path "sys/storage/raft/autopilot/configuration" { capabilities = ["read", "update"] }`
 
 	jwtPolicyUpgradeRolling = `path "sys/health" { capabilities = ["read"] }

--- a/internal/adapter/config/testdata/render_operator_bootstrap.hcl
+++ b/internal/adapter/config/testdata/render_operator_bootstrap.hcl
@@ -19,7 +19,7 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "sys/policies/acl/openbao-operator"
     data {
-      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
+      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/configuration\" { capabilities = [\"read\"] }\npath \"sys/storage/raft/remove-peer\" { capabilities = [\"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
     }
   }
   request "create-operator-role" {

--- a/internal/adapter/config/testdata/render_self_init_backup_upgrade_policies.hcl
+++ b/internal/adapter/config/testdata/render_self_init_backup_upgrade_policies.hcl
@@ -19,7 +19,7 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "sys/policies/acl/openbao-operator"
     data {
-      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
+      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/configuration\" { capabilities = [\"read\"] }\npath \"sys/storage/raft/remove-peer\" { capabilities = [\"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
     }
   }
   request "create-operator-role" {

--- a/internal/adapter/config/testdata/render_self_init_no_backup_upgrade.hcl
+++ b/internal/adapter/config/testdata/render_self_init_no_backup_upgrade.hcl
@@ -19,7 +19,7 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "sys/policies/acl/openbao-operator"
     data {
-      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
+      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/configuration\" { capabilities = [\"read\"] }\npath \"sys/storage/raft/remove-peer\" { capabilities = [\"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
     }
   }
   request "create-operator-role" {

--- a/internal/adapter/config/testdata/render_self_init_restore_policy.hcl
+++ b/internal/adapter/config/testdata/render_self_init_restore_policy.hcl
@@ -19,7 +19,7 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "sys/policies/acl/openbao-operator"
     data {
-      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
+      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/configuration\" { capabilities = [\"read\"] }\npath \"sys/storage/raft/remove-peer\" { capabilities = [\"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
     }
   }
   request "create-operator-role" {

--- a/internal/adapter/config/testdata/render_self_init_token_secret_ref.hcl
+++ b/internal/adapter/config/testdata/render_self_init_token_secret_ref.hcl
@@ -19,7 +19,7 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "sys/policies/acl/openbao-operator"
     data {
-      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
+      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/configuration\" { capabilities = [\"read\"] }\npath \"sys/storage/raft/remove-peer\" { capabilities = [\"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
     }
   }
   request "create-operator-role" {

--- a/internal/adapter/config/testdata/render_self_init_with_bootstrap.hcl
+++ b/internal/adapter/config/testdata/render_self_init_with_bootstrap.hcl
@@ -19,7 +19,7 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "sys/policies/acl/openbao-operator"
     data {
-      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
+      policy = "path \"sys/health\" { capabilities = [\"read\"] }\npath \"sys/step-down\" { capabilities = [\"sudo\", \"update\"] }\npath \"sys/storage/raft/configuration\" { capabilities = [\"read\"] }\npath \"sys/storage/raft/remove-peer\" { capabilities = [\"update\"] }\npath \"sys/storage/raft/autopilot/configuration\" { capabilities = [\"read\", \"update\"] }"
     }
   }
   request "create-operator-role" {

--- a/internal/adapter/raft/autopilot.go
+++ b/internal/adapter/raft/autopilot.go
@@ -15,6 +15,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -29,6 +30,9 @@ const (
 
 type Client interface {
 	portopenbao.AutopilotConfigurer
+	ReadRaftConfiguration(ctx context.Context) (*portopenbao.RaftConfigurationResponse, error)
+	RemoveRaftPeer(ctx context.Context, serverID string) error
+	StepDownLeader(ctx context.Context) error
 }
 
 type ClientFactory interface {
@@ -188,6 +192,7 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 	}
 
 	logger.Info("Reconciling Raft Autopilot configuration",
+		"cluster", cluster.Name,
 		"cleanup_dead_servers", desiredConfig.CleanupDeadServers,
 		"dead_server_last_contact_threshold", desiredConfig.DeadServerLastContactThreshold,
 		"min_quorum", desiredConfig.MinQuorum,
@@ -206,6 +211,75 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 	}
 
 	logger.V(1).Info("Raft Autopilot configuration reconciled successfully")
+	return nil
+}
+
+// PrepareScaleDown stages a single safe scale-down step by reconciling the
+// target autopilot configuration, stepping the victim leader down when needed,
+// and removing the departing Raft peer before the StatefulSet shrinks.
+func (m *Manager) PrepareScaleDown(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	statefulSetName string,
+	currentReplicas int32,
+	desiredReplicas int32,
+) error {
+	if currentReplicas <= desiredReplicas {
+		return nil
+	}
+	if cluster == nil {
+		return fmt.Errorf("cluster is required")
+	}
+	if strings.TrimSpace(statefulSetName) == "" {
+		return fmt.Errorf("statefulset name is required")
+	}
+
+	client, err := m.newScaleDownClient(ctx, logger, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to create authenticated OpenBao client for safe scale down: %w", err)
+	}
+
+	scaleStepCluster := cluster.DeepCopy()
+	scaleStepCluster.Spec.Replicas = desiredReplicas
+	if err := m.configureAutopilotWithClient(ctx, logger, client, scaleStepCluster); err != nil {
+		return err
+	}
+
+	configCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	raftConfig, err := client.ReadRaftConfiguration(configCtx)
+	if err != nil {
+		return m.wrapScaleDownPermissionError(
+			cluster,
+			fmt.Errorf("failed to read Raft configuration before scale down: %w", err),
+		)
+	}
+
+	victimPodName := fmt.Sprintf("%s-%d", statefulSetName, currentReplicas-1)
+	victimServer, found := findRaftServerForPod(raftConfig, victimPodName)
+	if !found {
+		logger.Info("Victim pod already absent from Raft configuration; continuing with scale down", "victim", victimPodName)
+		return nil
+	}
+
+	if victimServer.Leader {
+		logger.Info("Victim pod is current Raft leader; stepping down before scale down", "victim", victimPodName, "node_id", victimServer.NodeID)
+		if err := client.StepDownLeader(configCtx); err != nil {
+			return fmt.Errorf("failed to step down leader %s before scale down: %w", victimPodName, err)
+		}
+		return fmt.Errorf("waiting for leader step-down on %s to complete", victimPodName)
+	}
+
+	logger.Info("Removing Raft peer before scale down", "victim", victimPodName, "node_id", victimServer.NodeID)
+	if err := client.RemoveRaftPeer(configCtx, victimServer.NodeID); err != nil {
+		return m.wrapScaleDownPermissionError(
+			cluster,
+			fmt.Errorf("failed to remove Raft peer %q before scale down: %w", victimServer.NodeID, err),
+		)
+	}
+
 	return nil
 }
 
@@ -235,6 +309,38 @@ func (m *Manager) ConfigureAutopilot(ctx context.Context, logger logr.Logger, cl
 	}
 
 	logger.Info("Raft Autopilot configured successfully")
+	return nil
+}
+
+func (m *Manager) configureAutopilotWithClient(ctx context.Context, logger logr.Logger, client Client, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if client == nil {
+		return fmt.Errorf("OpenBao client is required")
+	}
+	if cluster == nil {
+		return fmt.Errorf("cluster is required")
+	}
+
+	desiredConfig := BuildAutopilotConfig(cluster)
+
+	logger.Info("Reconciling Raft Autopilot configuration",
+		"cluster", cluster.Name,
+		"cleanup_dead_servers", desiredConfig.CleanupDeadServers,
+		"dead_server_last_contact_threshold", desiredConfig.DeadServerLastContactThreshold,
+		"min_quorum", desiredConfig.MinQuorum,
+		"server_stabilization_time", desiredConfig.ServerStabilizationTime,
+	)
+
+	autopilotCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := client.ConfigureRaftAutopilot(autopilotCtx, desiredConfig); err != nil {
+		logger.Error(err, "Failed to update Raft Autopilot configuration; will retry on next reconcile")
+		return operatorerrors.WrapTransientConnection(
+			fmt.Errorf("failed to configure Raft Autopilot: %w", err),
+		)
+	}
+
+	logger.V(1).Info("Raft Autopilot configuration reconciled successfully")
 	return nil
 }
 
@@ -270,6 +376,34 @@ func (m *Manager) newOpenBaoClient(ctx context.Context, logger logr.Logger, clus
 	client, err := factory.NewWithJWT(ctx, baseURL, roleNameOperator, jwtToken)
 	if err != nil {
 		return nil, m.handleJWTAuthError(cluster, err)
+	}
+
+	return client, nil
+}
+
+func (m *Manager) newScaleDownClient(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (Client, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster is required")
+	}
+
+	if cluster.Spec.SelfInit != nil && cluster.Spec.SelfInit.Enabled {
+		return m.newOpenBaoClient(ctx, logger, cluster)
+	}
+
+	secretName := cluster.Name + suffixRootToken
+	secret, err := m.clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get root token Secret %s/%s: %w", cluster.Namespace, secretName, err)
+	}
+
+	rootToken, ok := secret.Data[rootTokenSecretKey]
+	if !ok || len(rootToken) == 0 {
+		return nil, fmt.Errorf("root token Secret %s/%s is missing token data", cluster.Namespace, secretName)
+	}
+
+	client, err := m.newOpenBaoClientWithToken(ctx, cluster, string(rootToken))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authenticated OpenBao client: %w", err)
 	}
 
 	return client, nil
@@ -337,6 +471,24 @@ func (m *Manager) handleJWTAuthError(cluster *openbaov1alpha1.OpenBaoCluster, er
 	return fmt.Errorf("failed to create authenticated OpenBao client: %w", err)
 }
 
+func (m *Manager) wrapScaleDownPermissionError(cluster *openbaov1alpha1.OpenBaoCluster, err error) error {
+	if cluster == nil || !portauth.OperatorJWTBootstrapEnabled(cluster) {
+		return err
+	}
+	if !portopenbao.IsStatus(err, http.StatusForbidden) {
+		return err
+	}
+
+	return operatorerrors.WrapPermanentPrerequisitesMissing(
+		fmt.Errorf(
+			"safe scale down requires the operator JWT policy in cluster %s/%s to allow Raft configuration reads and remove-peer updates: %w",
+			cluster.Namespace,
+			cluster.Name,
+			err,
+		),
+	)
+}
+
 // newOpenBaoClientWithToken creates an authenticated OpenBao client with the given token.
 func (m *Manager) newOpenBaoClientWithToken(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, token string) (Client, error) {
 	if strings.TrimSpace(cluster.Name) == "" || strings.TrimSpace(cluster.Namespace) == "" {
@@ -383,12 +535,44 @@ func (m *Manager) clientFactory(clusterKey string, caCert []byte) ClientFactory 
 	return m.clientFactoryProvider.FactoryFor(clusterKey, caCert)
 }
 
+func findRaftServerForPod(config *portopenbao.RaftConfigurationResponse, podName string) (portopenbao.RaftServer, bool) {
+	if config == nil || strings.TrimSpace(podName) == "" {
+		return portopenbao.RaftServer{}, false
+	}
+
+	for _, server := range config.Config.Servers {
+		if server.NodeID == podName || strings.Contains(server.Address, podName+".") {
+			return server, true
+		}
+	}
+
+	return portopenbao.RaftServer{}, false
+}
+
 // autopilotBaseURL returns a stable in-cluster address for performing Raft autopilot operations.
 //
 // We intentionally do not use Pod DNS names here because blue/green deployments use revisioned
 // StatefulSet pod names (e.g. "<cluster>-<revision>-0"), so "<cluster>-0" may not exist.
 func autopilotBaseURL(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	// Use the (clusterIP) public Service, which is stable across rolling and blue/green strategies.
-	// Service name: "<cluster>-public", DNS: "<service>.<namespace>.svc".
-	return fmt.Sprintf("https://%s-public.%s.svc:%d", cluster.Name, cluster.Namespace, portAPI)
+	serviceName := cluster.Name
+	if clusterNeedsExternalService(cluster) {
+		// When present, the external Service stays stable across rolling and blue/green strategies.
+		serviceName = cluster.Name + "-public"
+	}
+
+	return fmt.Sprintf("https://%s.%s.svc:%d", serviceName, cluster.Namespace, portAPI)
+}
+
+func clusterNeedsExternalService(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if cluster == nil {
+		return false
+	}
+
+	if cluster.Spec.Service != nil {
+		return true
+	}
+	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
+		return true
+	}
+	return cluster.Spec.Gateway != nil && cluster.Spec.Gateway.Enabled
 }

--- a/internal/adapter/raft/autopilot_runtime_test.go
+++ b/internal/adapter/raft/autopilot_runtime_test.go
@@ -27,9 +27,22 @@ func TestAutopilotBaseURL(t *testing.T) {
 	t.Parallel()
 	cluster := &openbaov1alpha1.OpenBaoCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "tenant-ns"},
+		Spec:       openbaov1alpha1.OpenBaoClusterSpec{Service: &openbaov1alpha1.ServiceConfig{}},
 	}
 	got := autopilotBaseURL(cluster)
 	want := "https://cluster-a-public.tenant-ns.svc:8200"
+	if got != want {
+		t.Fatalf("autopilotBaseURL()=%q, want %q", got, want)
+	}
+}
+
+func TestAutopilotBaseURL_UsesHeadlessServiceWithoutExternalService(t *testing.T) {
+	t.Parallel()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "tenant-ns"},
+	}
+	got := autopilotBaseURL(cluster)
+	want := "https://cluster-a.tenant-ns.svc:8200"
 	if got != want {
 		t.Fatalf("autopilotBaseURL()=%q, want %q", got, want)
 	}
@@ -231,4 +244,210 @@ func TestReconcileAutopilotConfig_EarlyBranches(t *testing.T) {
 			t.Fatalf("expected authenticated client creation error, got %v", err)
 		}
 	})
+}
+
+type fakeScaleDownClient struct {
+	configureCalls []portopenbao.AutopilotConfig
+	configureErr   error
+	raftConfig     *portopenbao.RaftConfigurationResponse
+	readErr        error
+	removeCalls    []string
+	removeErr      error
+	stepDownCalls  int
+	stepDownErr    error
+}
+
+func (c *fakeScaleDownClient) ConfigureRaftAutopilot(_ context.Context, config portopenbao.AutopilotConfig) error {
+	c.configureCalls = append(c.configureCalls, config)
+	return c.configureErr
+}
+
+func (c *fakeScaleDownClient) ReadRaftConfiguration(context.Context) (*portopenbao.RaftConfigurationResponse, error) {
+	if c.readErr != nil {
+		return nil, c.readErr
+	}
+	return c.raftConfig, nil
+}
+
+func (c *fakeScaleDownClient) RemoveRaftPeer(_ context.Context, serverID string) error {
+	c.removeCalls = append(c.removeCalls, serverID)
+	return c.removeErr
+}
+
+func (c *fakeScaleDownClient) StepDownLeader(context.Context) error {
+	c.stepDownCalls++
+	return c.stepDownErr
+}
+
+type fakeScaleDownFactory struct {
+	client       Client
+	newWithToken int
+}
+
+func (f *fakeScaleDownFactory) NewWithJWT(context.Context, string, string, string) (Client, error) {
+	return f.client, nil
+}
+
+func (f *fakeScaleDownFactory) NewWithToken(string, string) (Client, error) {
+	f.newWithToken++
+	return f.client, nil
+}
+
+type fakeScaleDownFactoryProvider struct {
+	factory    ClientFactory
+	clusterKey string
+	caCert     []byte
+}
+
+func (p *fakeScaleDownFactoryProvider) FactoryFor(clusterKey string, caCert []byte) ClientFactory {
+	p.clusterKey = clusterKey
+	p.caCert = append([]byte(nil), caCert...)
+	return p.factory
+}
+
+func TestPrepareScaleDown_RemovesFollowerAndUpdatesAutopilot(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile:  openbaov1alpha1.ProfileDevelopment,
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{Initialized: true},
+	}
+
+	client := &fakeScaleDownClient{
+		raftConfig: &portopenbao.RaftConfigurationResponse{
+			Config: portopenbao.RaftConfiguration{
+				Servers: []portopenbao.RaftServer{
+					{NodeID: "cluster-0", Address: "https://cluster-0.cluster.ns.svc:8200", Leader: true, Voter: true},
+					{NodeID: "cluster-1", Address: "https://cluster-1.cluster.ns.svc:8200", Voter: true},
+					{NodeID: "cluster-2", Address: "https://cluster-2.cluster.ns.svc:8200", Voter: true},
+				},
+			},
+		},
+	}
+	factory := &fakeScaleDownFactory{client: client}
+	provider := &fakeScaleDownFactoryProvider{factory: factory}
+
+	clientset := k8sfake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-root-token", Namespace: "ns"},
+			Data:       map[string][]byte{"token": []byte("root-token")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-tls-ca", Namespace: "ns"},
+			Data:       map[string][]byte{"ca.crt": []byte("pem-data")},
+		},
+	)
+
+	mgr := NewManager(clientset, provider)
+	err := mgr.PrepareScaleDown(context.Background(), logr.Discard(), cluster, "cluster", 3, 2)
+	if err != nil {
+		t.Fatalf("PrepareScaleDown() error = %v", err)
+	}
+
+	if len(client.configureCalls) != 1 {
+		t.Fatalf("expected one autopilot update, got %d", len(client.configureCalls))
+	}
+	if got := client.configureCalls[0].MinQuorum; got != 2 {
+		t.Fatalf("autopilot min_quorum = %d, want 2", got)
+	}
+	if client.configureCalls[0].CleanupDeadServers {
+		t.Fatalf("cleanup_dead_servers = true, want false for 2 replicas")
+	}
+	if len(client.removeCalls) != 1 || client.removeCalls[0] != "cluster-2" {
+		t.Fatalf("removeCalls = %v, want [cluster-2]", client.removeCalls)
+	}
+	if client.stepDownCalls != 0 {
+		t.Fatalf("stepDownCalls = %d, want 0", client.stepDownCalls)
+	}
+	if factory.newWithToken != 1 {
+		t.Fatalf("NewWithToken() calls = %d, want 1", factory.newWithToken)
+	}
+	if provider.clusterKey != "ns/cluster" {
+		t.Fatalf("clusterKey = %q, want ns/cluster", provider.clusterKey)
+	}
+	if string(provider.caCert) != "pem-data" {
+		t.Fatalf("caCert = %q, want pem-data", string(provider.caCert))
+	}
+}
+
+func TestPrepareScaleDown_StepsDownLeaderVictim(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile:  openbaov1alpha1.ProfileDevelopment,
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{Initialized: true},
+	}
+
+	client := &fakeScaleDownClient{
+		raftConfig: &portopenbao.RaftConfigurationResponse{
+			Config: portopenbao.RaftConfiguration{
+				Servers: []portopenbao.RaftServer{
+					{NodeID: "cluster-0", Address: "https://cluster-0.cluster.ns.svc:8200", Voter: true},
+					{NodeID: "cluster-1", Address: "https://cluster-1.cluster.ns.svc:8200", Voter: true},
+					{NodeID: "cluster-2", Address: "https://cluster-2.cluster.ns.svc:8200", Leader: true, Voter: true},
+				},
+			},
+		},
+	}
+
+	clientset := k8sfake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-root-token", Namespace: "ns"},
+			Data:       map[string][]byte{"token": []byte("root-token")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-tls-ca", Namespace: "ns"},
+			Data:       map[string][]byte{"ca.crt": []byte("pem-data")},
+		},
+	)
+
+	mgr := NewManager(clientset, &fakeScaleDownFactoryProvider{factory: &fakeScaleDownFactory{client: client}})
+	err := mgr.PrepareScaleDown(context.Background(), logr.Discard(), cluster, "cluster", 3, 2)
+	if err == nil || !strings.Contains(err.Error(), "waiting for leader step-down on cluster-2 to complete") {
+		t.Fatalf("expected step-down wait error, got %v", err)
+	}
+	if client.stepDownCalls != 1 {
+		t.Fatalf("stepDownCalls = %d, want 1", client.stepDownCalls)
+	}
+	if len(client.removeCalls) != 0 {
+		t.Fatalf("removeCalls = %v, want none", client.removeCalls)
+	}
+}
+
+func TestWrapScaleDownPermissionError_SelfInitClusterRequiresUpdatedPolicy(t *testing.T) {
+	t.Parallel()
+
+	mgr := &Manager{}
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+				OIDC:    &openbaov1alpha1.SelfInitOIDCConfig{Enabled: true},
+			},
+		},
+	}
+
+	err := mgr.wrapScaleDownPermissionError(cluster, fmt.Errorf("read raft config: %w", &portopenbao.APIError{
+		Operation:    "raft configuration request failed",
+		StatusCode:   http.StatusForbidden,
+		ResponseBody: `{"errors":["permission denied"]}`,
+	}))
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if !operatorerrors.IsPermanent(err) {
+		t.Fatalf("expected permanent classification, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "remove-peer") {
+		t.Fatalf("expected permission guidance, got %v", err)
+	}
 }

--- a/internal/adapter/raft/autopilot_test.go
+++ b/internal/adapter/raft/autopilot_test.go
@@ -7,6 +7,8 @@ import (
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
+const OpenBaoClusterNamespace = "openbaocluster-dev"
+
 func ptrToInt32(v int32) *int32 {
 	return &v
 }
@@ -366,13 +368,26 @@ func TestBuildAutopilotConfig(t *testing.T) {
 	}
 }
 
-func TestAutopilotBaseURL_UsesPublicService(t *testing.T) {
+func TestAutopilotBaseURL_UsesPublicServiceWhenRendered(t *testing.T) {
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
 	cluster.Name = "openbaocluster-dev"
-	cluster.Namespace = "openbaocluster-dev"
+	cluster.Namespace = OpenBaoClusterNamespace
+	cluster.Spec.Service = &openbaov1alpha1.ServiceConfig{}
 
 	got := autopilotBaseURL(cluster)
 	want := "https://openbaocluster-dev-public.openbaocluster-dev.svc:8200"
+	if got != want {
+		t.Fatalf("autopilotBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestAutopilotBaseURL_FallsBackToHeadlessService(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{}
+	cluster.Name = "openbaocluster-dev"
+	cluster.Namespace = OpenBaoClusterNamespace
+
+	got := autopilotBaseURL(cluster)
+	want := "https://openbaocluster-dev.openbaocluster-dev.svc:8200"
 	if got != want {
 		t.Fatalf("autopilotBaseURL() = %q, want %q", got, want)
 	}

--- a/internal/app/openbaocluster/infra.go
+++ b/internal/app/openbaocluster/infra.go
@@ -2,18 +2,22 @@ package openbaocluster
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
+	initmanagerport "github.com/dc-tec/openbao-operator/internal/port/initmanager"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
@@ -79,6 +83,12 @@ type InfraPodRuntime struct {
 	ClientForPodFunc ScaleDownPodClientFactory
 }
 
+// InfraScaleDownRuntime groups authenticated Raft membership operations used
+// to stage safe scale-downs.
+type InfraScaleDownRuntime struct {
+	Runtime initmanagerport.ScaleDownRuntime
+}
+
 // InfraDependencies provides external dependencies for infrastructure reconciliation.
 type InfraDependencies struct {
 	Kubernetes        InfraKubernetesRuntime
@@ -86,6 +96,7 @@ type InfraDependencies struct {
 	ImageVerification InfraImageVerificationRuntime
 	Events            InfraEventRuntime
 	Pods              InfraPodRuntime
+	ScaleDown         InfraScaleDownRuntime
 }
 
 type infraReconciler struct {
@@ -114,13 +125,34 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 	}
 
 	spec := r.computeStatefulSetSpec(logger, cluster, resolvedImages.mainImage, resolvedImages.initImage)
+	stagedScaleDown := false
 
 	currentSTS := &appsv1.StatefulSet{}
-	if err := r.deps.Kubernetes.Client.Get(ctx, client.ObjectKey{Name: spec.Name, Namespace: cluster.Namespace}, currentSTS); err == nil {
-		if err := r.handleScaleDownSafety(ctx, cluster, spec.Replicas, currentSTS); err != nil {
+	reader := r.deps.Kubernetes.APIReader
+	if reader == nil {
+		reader = r.deps.Kubernetes.Client
+	}
+
+	err = reader.Get(ctx, client.ObjectKey{Name: spec.Name, Namespace: cluster.Namespace}, currentSTS)
+	switch {
+	case err == nil:
+		appliedReplicas, err := r.handleScaleDownSafety(ctx, cluster, spec.Replicas, currentSTS)
+		if err != nil {
+			if operatorerrors.IsPermanent(err) && errors.Is(err, operatorerrors.ErrPermanentPrerequisitesMissing) {
+				logger.Info("Scale down safety check requires user intervention", "reason", err.Error())
+				return recon.Result{}, nil
+			}
 			logger.Info("Scale down safety check blocked reconciliation", "reason", err.Error())
 			return recon.Result{RequeueAfter: infraRequeueShort}, nil
 		}
+		spec.Replicas = appliedReplicas
+		stagedScaleDown = cluster.Status.Initialized && spec.Replicas > cluster.Spec.Replicas
+	case apierrors.IsNotFound(err):
+		// No StatefulSet exists yet; scale-down safety only applies once the workload is created.
+	default:
+		return recon.Result{}, operatorerrors.WrapTransientKubernetesAPI(
+			err,
+		)
 	}
 
 	effectiveOIDC, err := r.resolveOIDC(ctx, cluster)
@@ -131,6 +163,14 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 	manager := r.newInfraManager(effectiveOIDC)
 	if err := manager.Reconcile(ctx, logger, cluster, spec); err != nil {
 		return recon.Result{}, r.mapManagerReconcileError(err)
+	}
+	if stagedScaleDown {
+		logger.Info(
+			"Staged scale down step applied; requeueing to continue safe replica reduction",
+			"appliedStatefulSetReplicas", spec.Replicas,
+			"desiredReplicas", cluster.Spec.Replicas,
+		)
+		return recon.Result{RequeueAfter: infraRequeueShort}, nil
 	}
 
 	return recon.Result{}, nil

--- a/internal/app/openbaocluster/infra_scale_down.go
+++ b/internal/app/openbaocluster/infra_scale_down.go
@@ -10,48 +10,63 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
 
-func (r *infraReconciler) handleScaleDownSafety(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, desiredReplicas int32, currentSTS *appsv1.StatefulSet) error {
+func (r *infraReconciler) handleScaleDownSafety(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, desiredReplicas int32, currentSTS *appsv1.StatefulSet) (int32, error) {
 	if currentSTS.Spec.Replicas == nil {
-		return nil
+		return desiredReplicas, nil
 	}
 	currentReplicas := *currentSTS.Spec.Replicas
 	if desiredReplicas >= currentReplicas {
-		return nil
+		return desiredReplicas, nil
+	}
+	if !statefulSetSettledAtReplicas(currentSTS, currentReplicas) {
+		return currentReplicas, fmt.Errorf(
+			"waiting for StatefulSet %s/%s to settle at %d replicas before next scale-down step",
+			currentSTS.Namespace,
+			currentSTS.Name,
+			currentReplicas,
+		)
+	}
+
+	if r.deps.ScaleDown.Runtime == nil {
+		return currentReplicas, fmt.Errorf("scale-down runtime is not configured")
+	}
+
+	nextReplicas := currentReplicas - 1
+	if nextReplicas < desiredReplicas {
+		nextReplicas = desiredReplicas
 	}
 
 	victimOrdinal := currentReplicas - 1
 	victimPodName := fmt.Sprintf("%s-%d", currentSTS.Name, victimOrdinal)
 
-	logger := log.FromContext(ctx).WithValues("victim", victimPodName, "currentReplicas", currentReplicas, "desiredReplicas", desiredReplicas)
-	logger.Info("Detected scale down operation; checking victim leadership")
+	logger := log.FromContext(ctx).WithValues(
+		"victim", victimPodName,
+		"currentReplicas", currentReplicas,
+		"desiredReplicas", desiredReplicas,
+		"appliedReplicas", nextReplicas,
+	)
+	logger.Info("Detected scale down operation; preparing safe replica decrement")
 
-	victimClient, err := r.clientForPod(ctx, cluster, victimPodName)
-	if err != nil {
-		logger.Error(err, "Failed to create client for victim pod; assuming safe to remove")
-		return nil
+	if err := r.deps.ScaleDown.Runtime.PrepareScaleDown(ctx, logger, cluster, currentSTS.Name, currentReplicas, nextReplicas); err != nil {
+		return currentReplicas, err
 	}
 
-	isLeader, err := victimClient.IsLeader(ctx)
-	if err != nil {
-		logger.Error(err, "Failed to check leadership of victim pod; assuming safe to remove (pod might be down)")
-		return nil
-	}
-
-	if isLeader {
-		logger.Info("Victim pod is the Active Leader. Attempting graceful step-down.")
-		if err := victimClient.StepDownLeader(ctx); err != nil {
-			return fmt.Errorf("failed to step down leader %s: %w", victimPodName, err)
-		}
-		return fmt.Errorf("waiting for leader step-down on %s to complete", victimPodName)
-	}
-
-	logger.Info("Victim pod is a follower. Safe to scale down.")
-	return nil
+	logger.Info("Safe scale down step prepared")
+	return nextReplicas, nil
 }
 
-func (r *infraReconciler) clientForPod(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, podName string) (ScaleDownPodClient, error) {
-	if r.deps.Pods.ClientForPodFunc != nil {
-		return r.deps.Pods.ClientForPodFunc(ctx, cluster, podName)
+func statefulSetSettledAtReplicas(sts *appsv1.StatefulSet, replicas int32) bool {
+	if sts == nil {
+		return false
 	}
-	return nil, fmt.Errorf("OpenBao pod client factory is not configured")
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return false
+	}
+	if sts.Status.Replicas != replicas {
+		return false
+	}
+	if sts.Status.ReadyReplicas != replicas {
+		return false
+	}
+	return sts.Status.CurrentReplicas == replicas
 }

--- a/internal/app/openbaocluster/infra_test.go
+++ b/internal/app/openbaocluster/infra_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -21,21 +20,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	inframanager "github.com/dc-tec/openbao-operator/internal/service/infra"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
-func TestHandleScaleDownSafety(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = openbaov1alpha1.AddToScheme(scheme)
+type scaleDownRuntimeStub struct {
+	prepareFunc func(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, statefulSetName string, currentReplicas, desiredReplicas int32) error
+}
 
+func (s scaleDownRuntimeStub) PrepareScaleDown(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, statefulSetName string, currentReplicas, desiredReplicas int32) error {
+	if s.prepareFunc != nil {
+		return s.prepareFunc(ctx, logger, cluster, statefulSetName, currentReplicas, desiredReplicas)
+	}
+	return nil
+}
+
+func TestHandleScaleDownSafety(t *testing.T) {
 	clusterName := "test-cluster"
 	namespace := "default"
 
@@ -43,44 +47,87 @@ func TestHandleScaleDownSafety(t *testing.T) {
 		name            string
 		currentReplicas int32
 		desiredReplicas int32
-		victimLeader    bool
-		victimError     bool // simulate network error
+		statusReplicas  int32
+		readyReplicas   int32
+		currentStatus   int32
+		generation      int64
+		observedGen     int64
+		runtimeError    string
+		expectedApplied int32
 		expectedError   string
 	}{
 		{
-			name:            "No scale down",
+			name:            "no scale down",
 			currentReplicas: 3,
 			desiredReplicas: 3,
-			victimLeader:    false, // Irrelevant
+			statusReplicas:  3,
+			readyReplicas:   3,
+			currentStatus:   3,
+			generation:      1,
+			observedGen:     1,
+			expectedApplied: 3,
 			expectedError:   "",
 		},
 		{
-			name:            "Scale up",
+			name:            "scale up",
 			currentReplicas: 3,
 			desiredReplicas: 4,
-			victimLeader:    false, // Irrelevant
+			statusReplicas:  3,
+			readyReplicas:   3,
+			currentStatus:   3,
+			generation:      1,
+			observedGen:     1,
+			expectedApplied: 4,
 			expectedError:   "",
 		},
 		{
-			name:            "Scale down, victim is follower",
+			name:            "scale down uses one safe step",
 			currentReplicas: 3,
-			desiredReplicas: 2,
-			victimLeader:    false,
+			desiredReplicas: 1,
+			statusReplicas:  3,
+			readyReplicas:   3,
+			currentStatus:   3,
+			generation:      1,
+			observedGen:     1,
+			expectedApplied: 2,
 			expectedError:   "",
 		},
 		{
-			name:            "Scale down, victim is leader",
+			name:            "scale down waits for statefulset to settle between steps",
+			currentReplicas: 2,
+			desiredReplicas: 1,
+			statusReplicas:  2,
+			readyReplicas:   1,
+			currentStatus:   1,
+			generation:      2,
+			observedGen:     2,
+			expectedApplied: 2,
+			expectedError:   "waiting for StatefulSet default/test-cluster to settle at 2 replicas before next scale-down step",
+		},
+		{
+			name:            "scale down requeues when runtime blocks",
 			currentReplicas: 3,
 			desiredReplicas: 2,
-			victimLeader:    true,
+			statusReplicas:  3,
+			readyReplicas:   3,
+			currentStatus:   3,
+			generation:      1,
+			observedGen:     1,
+			runtimeError:    "waiting for leader step-down on test-cluster-2 to complete",
+			expectedApplied: 3,
 			expectedError:   "waiting for leader step-down on test-cluster-2 to complete",
 		},
 		{
-			name:            "Scale down, victim unreachable",
+			name:            "scale down blocks without runtime",
 			currentReplicas: 3,
 			desiredReplicas: 2,
-			victimError:     true,
-			expectedError:   "", // Should proceed (fail open)
+			statusReplicas:  3,
+			readyReplicas:   3,
+			currentStatus:   3,
+			generation:      1,
+			observedGen:     1,
+			expectedApplied: 3,
+			expectedError:   "scale-down runtime is not configured",
 		},
 	}
 
@@ -96,77 +143,49 @@ func TestHandleScaleDownSafety(t *testing.T) {
 				},
 			}
 
-			// Mock StatefulSet
 			sts := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: namespace,
+					Name:       clusterName,
+					Namespace:  namespace,
+					Generation: tt.generation,
 				},
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: &tt.currentReplicas,
 				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: tt.observedGen,
+					Replicas:           tt.statusReplicas,
+					ReadyReplicas:      tt.readyReplicas,
+					CurrentReplicas:    tt.currentStatus,
+				},
 			}
 
-			// Mock Client
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(cluster, sts).
-				Build()
-
-				// Mock OpenBao Client for victim pod
-			clientFunc := func(_ context.Context, c *openbaov1alpha1.OpenBaoCluster, podName string) (ScaleDownPodClient, error) {
-				if tt.victimError {
-					return nil, fmt.Errorf("network error")
+			r := &infraReconciler{}
+			if tt.name != "scale down blocks without runtime" {
+				r.deps.ScaleDown = InfraScaleDownRuntime{
+					Runtime: scaleDownRuntimeStub{
+						prepareFunc: func(_ context.Context, _ logr.Logger, gotCluster *openbaov1alpha1.OpenBaoCluster, statefulSetName string, currentReplicas, desiredReplicas int32) error {
+							assert.Same(t, cluster, gotCluster)
+							assert.Equal(t, clusterName, statefulSetName)
+							assert.Equal(t, tt.currentReplicas, currentReplicas)
+							if tt.currentReplicas > tt.desiredReplicas {
+								expectedDesired := tt.currentReplicas - 1
+								if expectedDesired < tt.desiredReplicas {
+									expectedDesired = tt.desiredReplicas
+								}
+								assert.Equal(t, expectedDesired, desiredReplicas)
+							}
+							if tt.runtimeError != "" {
+								return errors.New(tt.runtimeError)
+							}
+							return nil
+						},
+					},
 				}
-
-				// Mock server to handle health/step-down
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/v1/sys/health":
-						if tt.victimLeader {
-							// Active Leader: 200 OK, initialized=true, sealed=false, standby=false
-							w.WriteHeader(http.StatusOK)
-							_, _ = w.Write([]byte(`{"initialized": true, "sealed": false, "standby": false}`))
-						} else {
-							// Follower: 429, initialized=true, sealed=false, standby=true
-							w.WriteHeader(http.StatusTooManyRequests)
-							_, _ = w.Write([]byte(`{"initialized": true, "sealed": false, "standby": true}`))
-						}
-					case "/v1/sys/step-down":
-						if r.Method == http.MethodPut {
-							w.WriteHeader(http.StatusNoContent)
-						} else {
-							w.WriteHeader(http.StatusMethodNotAllowed)
-						}
-					default:
-						w.WriteHeader(http.StatusNotFound)
-					}
-				}))
-				// Note: server is not closed, leaking resources in test but acceptable for short unit test
-
-				// Important: Use server URL
-				clientConfig := portopenbao.ClientConfig{
-					BaseURL: server.URL,
-					Token:   "root", // required for step-down
-				}
-
-				return openbao.NewClient(clientConfig)
 			}
 
-			r := &infraReconciler{deps: InfraDependencies{
-				Kubernetes: InfraKubernetesRuntime{
-					Client: k8sClient,
-					Scheme: scheme,
-				},
-				Events: InfraEventRuntime{
-					Recorder: nil, // not needed for this test part
-				},
-				Pods: InfraPodRuntime{
-					ClientForPodFunc: clientFunc,
-				},
-			}}
-
-			err := r.handleScaleDownSafety(context.Background(), cluster, tt.desiredReplicas, sts)
+			appliedReplicas, err := r.handleScaleDownSafety(context.Background(), cluster, tt.desiredReplicas, sts)
+			assert.Equal(t, tt.expectedApplied, appliedReplicas)
 			if tt.expectedError == "" {
 				assert.NoError(t, err)
 			} else {
@@ -435,6 +454,75 @@ func TestInfraReconciler_Reconcile_MapsAPIServerNetworkConfigurationError(t *tes
 	if !strings.Contains(err.Error(), "spec.network.apiServerEndpointIPs") {
 		t.Fatalf("error %q does not mention apiServerEndpointIPs", err)
 	}
+}
+
+func TestInfraReconciler_Reconcile_DoesNotRequeuePermanentScaleDownPrerequisites(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = openbaov1alpha1.AddToScheme(scheme)
+
+	currentReplicas := int32(3)
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile:  openbaov1alpha1.ProfileDevelopment,
+			Version:  "2.5.0",
+			Image:    "openbao/openbao:2.5.0",
+			Replicas: 1,
+			InitContainer: &openbaov1alpha1.InitContainerConfig{
+				Image: "openbao-init:test",
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       cluster.Name,
+			Namespace:  cluster.Namespace,
+			Generation: 1,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           3,
+			ReadyReplicas:      3,
+			CurrentReplicas:    3,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, statefulSet).
+		Build()
+
+	r := &infraReconciler{
+		deps: InfraDependencies{
+			Kubernetes: InfraKubernetesRuntime{
+				Client: k8sClient,
+				Scheme: scheme,
+			},
+			ScaleDown: InfraScaleDownRuntime{
+				Runtime: scaleDownRuntimeStub{
+					prepareFunc: func(context.Context, logr.Logger, *openbaov1alpha1.OpenBaoCluster, string, int32, int32) error {
+						return operatorerrors.WrapPermanentPrerequisitesMissing(errors.New("missing raft permissions"))
+					},
+				},
+			},
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), logr.Discard(), cluster)
+	assert.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
 }
 
 func TestInfraReconciler_MapManagerReconcileError(t *testing.T) {

--- a/internal/app/openbaocluster/workload.go
+++ b/internal/app/openbaocluster/workload.go
@@ -3,10 +3,13 @@ package openbaocluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,6 +17,7 @@ import (
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	initmanagerport "github.com/dc-tec/openbao-operator/internal/port/initmanager"
+	inframanager "github.com/dc-tec/openbao-operator/internal/service/infra"
 )
 
 const eventReasonAutopilotConfigJWTPrerequisitesMissing = "AutopilotConfigJWTPrerequisitesMissing"
@@ -33,6 +37,7 @@ func AppendInitAndAutopilotReconcilers(
 	reconcilers []SubReconciler,
 	initMgr initmanagerport.Manager,
 	autopilotRuntime initmanagerport.AutopilotRuntime,
+	statefulSetReader client.Reader,
 	recorder events.EventRecorder,
 	requeueShort time.Duration,
 ) []SubReconciler {
@@ -45,8 +50,9 @@ func AppendInitAndAutopilotReconcilers(
 	// Add autopilot config reconciler for Day 2 operations when an autopilot runtime is available.
 	if autopilotRuntime != nil {
 		reconcilers = append(reconcilers, &autopilotConfigReconciler{
-			autopilotRuntime: autopilotRuntime,
-			recorder:         recorder,
+			autopilotRuntime:  autopilotRuntime,
+			statefulSetReader: statefulSetReader,
+			recorder:          recorder,
 			requeueShort: func() time.Duration {
 				if requeueShort > 0 {
 					return requeueShort
@@ -149,9 +155,10 @@ func workloadResultForError(
 // autopilotConfigReconciler reconciles Raft Autopilot configuration for initialized clusters.
 // This handles Day 2 operations like scaling replicas or changing autopilot settings.
 type autopilotConfigReconciler struct {
-	autopilotRuntime initmanagerport.AutopilotRuntime
-	recorder         events.EventRecorder
-	requeueShort     time.Duration
+	autopilotRuntime  initmanagerport.AutopilotRuntime
+	statefulSetReader client.Reader
+	recorder          events.EventRecorder
+	requeueShort      time.Duration
 }
 
 // Reconcile reconciles the Raft Autopilot configuration for an initialized cluster.
@@ -165,7 +172,18 @@ func (r *autopilotConfigReconciler) Reconcile(ctx context.Context, logger logr.L
 		return recon.Result{}, nil
 	}
 
-	if err := r.autopilotRuntime.ReconcileAutopilotConfig(ctx, logger, cluster); err != nil {
+	autopilotCluster, err := r.autopilotTargetCluster(ctx, logger, cluster)
+	if err != nil {
+		if operatorerrors.IsTransient(err) {
+			logger.V(1).Info("Transient error determining autopilot config target; will retry", "error", err)
+			return recon.Result{RequeueAfter: r.requeueShort}, nil
+		}
+
+		logger.Error(err, "Failed to determine autopilot config target (non-transient)")
+		return recon.Result{}, nil
+	}
+
+	if err := r.autopilotRuntime.ReconcileAutopilotConfig(ctx, logger, autopilotCluster); err != nil {
 		if operatorerrors.IsTransient(err) {
 			logger.V(1).Info("Transient error reconciling autopilot config; will retry", "error", err)
 			return recon.Result{RequeueAfter: r.requeueShort}, nil
@@ -203,6 +221,62 @@ func (r *autopilotConfigReconciler) Reconcile(ctx context.Context, logger logr.L
 	}
 
 	return recon.Result{}, nil
+}
+
+func (r *autopilotConfigReconciler) autopilotTargetCluster(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (*openbaov1alpha1.OpenBaoCluster, error) {
+	if cluster == nil || r.statefulSetReader == nil {
+		return cluster, nil
+	}
+
+	statefulSetName := cluster.Name
+	if stableRevision := inframanager.BlueGreenStableRevision(cluster); stableRevision != "" {
+		statefulSetName = fmt.Sprintf("%s-%s", cluster.Name, stableRevision)
+	}
+
+	currentStatefulSet := &appsv1.StatefulSet{}
+	err := r.statefulSetReader.Get(
+		ctx,
+		client.ObjectKey{Name: statefulSetName, Namespace: cluster.Namespace},
+		currentStatefulSet,
+	)
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		return cluster, nil
+	default:
+		return nil, operatorerrors.WrapTransientKubernetesAPI(
+			fmt.Errorf(
+				"failed to get StatefulSet %s/%s for autopilot reconciliation: %w",
+				cluster.Namespace,
+				statefulSetName,
+				err,
+			),
+		)
+	}
+
+	if currentStatefulSet.Spec.Replicas == nil {
+		return cluster, nil
+	}
+
+	appliedReplicas := *currentStatefulSet.Spec.Replicas
+	if cluster.Spec.Replicas >= appliedReplicas {
+		return cluster, nil
+	}
+
+	logger.V(1).Info(
+		"Using staged StatefulSet replica count for autopilot reconciliation during scale down",
+		"desiredReplicas", cluster.Spec.Replicas,
+		"appliedReplicas", appliedReplicas,
+		"statefulSet", fmt.Sprintf("%s/%s", currentStatefulSet.Namespace, currentStatefulSet.Name),
+	)
+
+	autopilotCluster := cluster.DeepCopy()
+	autopilotCluster.Spec.Replicas = appliedReplicas
+	return autopilotCluster, nil
 }
 
 func workloadRequeueShort(policy WorkloadResultPolicy) time.Duration {

--- a/internal/app/openbaocluster/workload_test.go
+++ b/internal/app/openbaocluster/workload_test.go
@@ -1,0 +1,184 @@
+package openbaocluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+type autopilotRuntimeStub struct {
+	reconcileFunc func(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error
+}
+
+func (s autopilotRuntimeStub) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if s.reconcileFunc != nil {
+		return s.reconcileFunc(ctx, logger, cluster)
+	}
+	return nil
+}
+
+type readerStub struct {
+	getFunc func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+}
+
+func (s readerStub) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if s.getFunc != nil {
+		return s.getFunc(ctx, key, obj, opts...)
+	}
+	return nil
+}
+
+func (s readerStub) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return nil
+}
+
+func TestAutopilotConfigReconciler_Reconcile_UsesStatefulSetReplicasDuringScaleDown(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, clientgoscheme.AddToScheme(scheme))
+	assert.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "openbaocluster-demo",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 1,
+		},
+	}
+	currentReplicas := int32(2)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+		},
+	}
+
+	k8sReader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(statefulSet).
+		Build()
+
+	var gotReplicas int32
+	reconciler := &autopilotConfigReconciler{
+		autopilotRuntime: autopilotRuntimeStub{
+			reconcileFunc: func(_ context.Context, _ logr.Logger, gotCluster *openbaov1alpha1.OpenBaoCluster) error {
+				gotReplicas = gotCluster.Spec.Replicas
+				return nil
+			},
+		},
+		statefulSetReader: k8sReader,
+		requeueShort:      5 * time.Second,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), logr.Discard(), cluster)
+	assert.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, int32(2), gotReplicas)
+	assert.Equal(t, int32(1), cluster.Spec.Replicas)
+}
+
+func TestAutopilotConfigReconciler_Reconcile_UsesRevisionedStatefulSetDuringScaleDown(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, clientgoscheme.AddToScheme(scheme))
+	assert.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "openbaocluster-demo",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 1,
+			Upgrade: &openbaov1alpha1.UpgradeConfig{
+				Strategy: openbaov1alpha1.UpdateStrategyBlueGreen,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueRevision: "blue-rev",
+			},
+		},
+	}
+	currentReplicas := int32(2)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-blue-rev",
+			Namespace: cluster.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &currentReplicas,
+		},
+	}
+
+	k8sReader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(statefulSet).
+		Build()
+
+	var gotReplicas int32
+	reconciler := &autopilotConfigReconciler{
+		autopilotRuntime: autopilotRuntimeStub{
+			reconcileFunc: func(_ context.Context, _ logr.Logger, gotCluster *openbaov1alpha1.OpenBaoCluster) error {
+				gotReplicas = gotCluster.Spec.Replicas
+				return nil
+			},
+		},
+		statefulSetReader: k8sReader,
+		requeueShort:      5 * time.Second,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), logr.Discard(), cluster)
+	assert.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, int32(2), gotReplicas)
+	assert.Equal(t, int32(1), cluster.Spec.Replicas)
+}
+
+func TestAutopilotConfigReconciler_Reconcile_RequeuesWhenStatefulSetReadFails(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "openbaocluster-demo",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 1,
+		},
+	}
+
+	runtimeCalled := false
+	reconciler := &autopilotConfigReconciler{
+		autopilotRuntime: autopilotRuntimeStub{
+			reconcileFunc: func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster) error {
+				runtimeCalled = true
+				return nil
+			},
+		},
+		statefulSetReader: readerStub{
+			getFunc: func(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return errors.New("boom")
+			},
+		},
+		requeueShort: 5 * time.Second,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), logr.Discard(), cluster)
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Second, result.RequeueAfter)
+	assert.False(t, runtimeCalled)
+}

--- a/internal/controller/openbaocluster/dependencies.go
+++ b/internal/controller/openbaocluster/dependencies.go
@@ -7,11 +7,17 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	initmanagerport "github.com/dc-tec/openbao-operator/internal/port/initmanager"
 	portsecurity "github.com/dc-tec/openbao-operator/internal/port/security"
 	"k8s.io/client-go/rest"
 )
 
 func (r *OpenBaoClusterReconciler) infraDependencies() appopenbaocluster.InfraDependencies {
+	var scaleDownRuntime initmanagerport.ScaleDownRuntime
+	if provider, ok := r.InitManager.(initmanagerport.ScaleDownProvider); ok {
+		scaleDownRuntime = provider.ScaleDownRuntime()
+	}
+
 	return appopenbaocluster.InfraDependencies{
 		Kubernetes: appopenbaocluster.InfraKubernetesRuntime{
 			Client:            r.Client,
@@ -45,6 +51,9 @@ func (r *OpenBaoClusterReconciler) infraDependencies() appopenbaocluster.InfraDe
 			ClientForPodFunc: func(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, podName string) (appopenbaocluster.ScaleDownPodClient, error) {
 				return r.clientForPod(ctx, cluster, podName)
 			},
+		},
+		ScaleDown: appopenbaocluster.InfraScaleDownRuntime{
+			Runtime: scaleDownRuntime,
 		},
 	}
 }

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -97,6 +97,10 @@ func (r *openBaoClusterWorkloadReconciler) reconcileCluster(
 	if provider, ok := r.parent.InitManager.(initmanagerport.AutopilotProvider); ok {
 		autopilotRuntime = provider.AutopilotRuntime()
 	}
+	statefulSetReader := r.parent.APIReader
+	if statefulSetReader == nil {
+		statefulSetReader = r.parent.Client
+	}
 
 	original := cluster.DeepCopy()
 	reconcilers := []appopenbaocluster.SubReconciler{
@@ -109,6 +113,7 @@ func (r *openBaoClusterWorkloadReconciler) reconcileCluster(
 		reconcilers,
 		r.parent.InitManager,
 		autopilotRuntime,
+		statefulSetReader,
 		r.parent.Recorder,
 		constants.RequeueShort,
 	)

--- a/internal/port/initmanager/initmanager.go
+++ b/internal/port/initmanager/initmanager.go
@@ -19,7 +19,18 @@ type AutopilotRuntime interface {
 	ReconcileAutopilotConfig(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error
 }
 
+// ScaleDownRuntime exposes authenticated Raft membership operations used to
+// stage safe cluster scale-downs one replica at a time.
+type ScaleDownRuntime interface {
+	PrepareScaleDown(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, statefulSetName string, currentReplicas, desiredReplicas int32) error
+}
+
 // AutopilotProvider allows init managers to optionally expose an autopilot runtime.
 type AutopilotProvider interface {
 	AutopilotRuntime() AutopilotRuntime
+}
+
+// ScaleDownProvider allows init managers to optionally expose a safe scale-down runtime.
+type ScaleDownProvider interface {
+	ScaleDownRuntime() ScaleDownRuntime
 }

--- a/internal/service/infra/manager.go
+++ b/internal/service/infra/manager.go
@@ -203,17 +203,37 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 		return nil
 	}
 
-	if err := m.EnsureStatefulSetWithRevision(ctx, logger, cluster, configContent, spec.Image, spec.InitContainerImage, spec.Revision, spec.DisableSelfInit); err != nil {
+	statefulSetCluster := clusterForStatefulSetSpec(cluster, spec)
+	if cluster != nil && statefulSetCluster != cluster {
+		logger.V(1).Info(
+			"Applying staged StatefulSet replica count",
+			"statefulset", spec.Name,
+			"clusterDesiredReplicas", cluster.Spec.Replicas,
+			"appliedStatefulSetReplicas", spec.Replicas,
+		)
+	}
+
+	if err := m.EnsureStatefulSetWithRevision(ctx, logger, statefulSetCluster, configContent, spec.Image, spec.InitContainerImage, spec.Revision, spec.DisableSelfInit); err != nil {
 		return err
 	}
 
 	// SECURITY: Create PodDisruptionBudget to prevent simultaneous pod evictions
 	// that could cause quorum loss during node drains or cluster upgrades
-	if err := m.ensurePodDisruptionBudget(ctx, logger, cluster); err != nil {
+	if err := m.ensurePodDisruptionBudget(ctx, logger, statefulSetCluster); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func clusterForStatefulSetSpec(cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSpec) *openbaov1alpha1.OpenBaoCluster {
+	if cluster == nil || spec.Replicas == cluster.Spec.Replicas {
+		return cluster
+	}
+
+	statefulSetCluster := cluster.DeepCopy()
+	statefulSetCluster.Spec.Replicas = spec.Replicas
+	return statefulSetCluster
 }
 
 func (m *Manager) reconcilePreStatefulSet(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, configContent string) error {

--- a/internal/service/infra/manager_stage_replicas_test.go
+++ b/internal/service/infra/manager_stage_replicas_test.go
@@ -1,0 +1,39 @@
+package infra
+
+import "testing"
+
+func TestClusterForStatefulSetSpec_UsesStagedReplicas(t *testing.T) {
+	cluster := newMinimalCluster("staged-scale-down", "default")
+	cluster.Spec.Replicas = 1
+
+	spec := StatefulSetSpec{
+		Name:     cluster.Name,
+		Replicas: 2,
+	}
+
+	got := clusterForStatefulSetSpec(cluster, spec)
+	if got == cluster {
+		t.Fatalf("expected staged cluster copy when replicas differ")
+	}
+	if got.Spec.Replicas != spec.Replicas {
+		t.Fatalf("staged cluster replicas = %d, want %d", got.Spec.Replicas, spec.Replicas)
+	}
+	if cluster.Spec.Replicas != 1 {
+		t.Fatalf("original cluster replicas mutated to %d, want 1", cluster.Spec.Replicas)
+	}
+}
+
+func TestClusterForStatefulSetSpec_ReusesClusterWhenReplicasMatch(t *testing.T) {
+	cluster := newMinimalCluster("steady-state", "default")
+	cluster.Spec.Replicas = 2
+
+	spec := StatefulSetSpec{
+		Name:     cluster.Name,
+		Replicas: 2,
+	}
+
+	got := clusterForStatefulSetSpec(cluster, spec)
+	if got != cluster {
+		t.Fatalf("expected original cluster when replicas already match")
+	}
+}

--- a/internal/service/init/manager.go
+++ b/internal/service/init/manager.go
@@ -109,6 +109,27 @@ func (a raftClientAdapter) ConfigureRaftAutopilot(ctx context.Context, config po
 	return a.client.ConfigureRaftAutopilot(ctx, config)
 }
 
+func (a raftClientAdapter) ReadRaftConfiguration(ctx context.Context) (*portopenbao.RaftConfigurationResponse, error) {
+	if a.client == nil {
+		return nil, fmt.Errorf("OpenBao client is required")
+	}
+	return a.client.ReadRaftConfiguration(ctx)
+}
+
+func (a raftClientAdapter) RemoveRaftPeer(ctx context.Context, serverID string) error {
+	if a.client == nil {
+		return fmt.Errorf("OpenBao client is required")
+	}
+	return a.client.RemoveRaftPeer(ctx, serverID)
+}
+
+func (a raftClientAdapter) StepDownLeader(ctx context.Context) error {
+	if a.client == nil {
+		return fmt.Errorf("OpenBao client is required")
+	}
+	return a.client.StepDownLeader(ctx)
+}
+
 // RaftManager returns the Raft Manager for autopilot configuration.
 func (m *Manager) RaftManager() *raft.Manager {
 	return m.raftManager
@@ -116,6 +137,11 @@ func (m *Manager) RaftManager() *raft.Manager {
 
 // AutopilotRuntime returns the optional day-2 autopilot runtime.
 func (m *Manager) AutopilotRuntime() initmanagerport.AutopilotRuntime {
+	return m.raftManager
+}
+
+// ScaleDownRuntime returns the optional day-2 scale-down runtime.
+func (m *Manager) ScaleDownRuntime() initmanagerport.ScaleDownRuntime {
 	return m.raftManager
 }
 

--- a/test/e2e/Cluster_Lifecycle_test.go
+++ b/test/e2e/Cluster_Lifecycle_test.go
@@ -334,8 +334,51 @@ var _ = Describe("Cluster Lifecycle", Label("lifecycle", "cluster"), Ordered, fu
 			_ = f.Cleanup(cleanupCtx)
 		})
 
+		verifyClusterServesJWTAuthenticatedKV := func(secretPath, expectedValue string) {
+			verifierLabels := map[string]string{"role": "test-verifier"}
+
+			Eventually(func(g Gomega) {
+				baoAddr, err := e2ehelpers.ResolveActiveOpenBaoAddress(ctx, c, f.Namespace, clusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(e2ehelpers.WriteSecretViaJWT(
+					ctx,
+					cfg,
+					c,
+					f.Namespace,
+					openBaoImage,
+					baoAddr,
+					"default",
+					"e2e-test",
+					secretPath,
+					verifierLabels,
+					map[string]string{"foo": expectedValue},
+				)).To(Succeed())
+
+				value, err := e2ehelpers.ReadSecretViaJWT(
+					ctx,
+					cfg,
+					c,
+					f.Namespace,
+					openBaoImage,
+					baoAddr,
+					"default",
+					"e2e-test",
+					secretPath,
+					verifierLabels,
+					"foo",
+				)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(value).To(Equal(expectedValue))
+			}, framework.DefaultLongWaitTimeout, 10*time.Second).Should(Succeed())
+		}
+
 		It("creates a cluster with 1 replica and verifies autopilot min_quorum=1", func() {
 			By(fmt.Sprintf("creating OpenBaoCluster %q with 1 replica", clusterName))
+			requests := append(
+				append([]openbaov1alpha1.SelfInitRequest{}, e2ehelpers.CreateAutopilotVerificationRequests(f.Namespace)...),
+				e2ehelpers.CreateE2ERequests(f.Namespace)...,
+			)
 			cluster := &openbaov1alpha1.OpenBaoCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
@@ -355,7 +398,7 @@ var _ = Describe("Cluster Lifecycle", Label("lifecycle", "cluster"), Ordered, fu
 						OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
 							Enabled: true,
 						},
-						Requests: e2ehelpers.CreateAutopilotVerificationRequests(f.Namespace),
+						Requests: requests,
 					},
 					TLS: openbaov1alpha1.TLSConfig{
 						Enabled:        true,
@@ -497,27 +540,30 @@ var _ = Describe("Cluster Lifecycle", Label("lifecycle", "cluster"), Ordered, fu
 			_, _ = fmt.Fprintf(GinkgoWriter, "✓ Raft Autopilot min_quorum=3 verified after scale up\n")
 		})
 
-		It("scales down to 2 replicas and verifies autopilot min_quorum=2", func() {
+		It("scales down to 1 replica, remains responsive, and verifies autopilot min_quorum=1", func() {
 
-			By("updating cluster to 2 replicas")
+			By("updating cluster to 1 replica")
 			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				cluster := &openbaov1alpha1.OpenBaoCluster{}
 				if err := c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: f.Namespace}, cluster); err != nil {
 					return err
 				}
-				cluster.Spec.Replicas = 2
+				cluster.Spec.Replicas = 1
 				return c.Update(ctx, cluster)
 			})).To(Succeed())
 
-			By("waiting for StatefulSet to scale down to 2 replicas")
-			f.WaitForStatefulSetReady(ctx, clusterName, 2, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval)
+			By("waiting for StatefulSet to scale down to 1 replica")
+			f.WaitForStatefulSetReady(ctx, clusterName, 1, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval)
 
-			By("waiting for pods to be ready")
+			By("waiting for the remaining pod to be ready")
 			Eventually(func(g Gomega) {
 				sts := &appsv1.StatefulSet{}
 				g.Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: f.Namespace}, sts)).To(Succeed())
-				g.Expect(sts.Status.ReadyReplicas).To(Equal(int32(2)))
+				g.Expect(sts.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+			By("waiting for Available condition after scale down")
+			f.WaitForCondition(clusterName, openbaov1alpha1.ConditionAvailable, metav1.ConditionTrue)
 
 			By("getting public service for autopilot verification")
 			svc := &corev1.Service{}
@@ -529,7 +575,7 @@ var _ = Describe("Cluster Lifecycle", Label("lifecycle", "cluster"), Ordered, fu
 			By("triggering reconcile after scale down so autopilot settings are refreshed promptly")
 			Expect(f.TriggerReconcile(ctx, clusterName)).To(Succeed())
 
-			By("verifying Raft Autopilot min_quorum=2 (Development profile with 2 replicas)")
+			By("verifying Raft Autopilot min_quorum=1 (Development profile with 1 replica)")
 			// Wait a bit for autopilot config to be reconciled after scaling
 			Eventually(func() error {
 				return e2ehelpers.VerifyRaftAutopilotMinQuorumViaJWT(
@@ -541,10 +587,16 @@ var _ = Describe("Cluster Lifecycle", Label("lifecycle", "cluster"), Ordered, fu
 					fmt.Sprintf("https://%s:8200", svc.Spec.ClusterIP),
 					"default",
 					map[string]string{"role": "test-verifier"},
-					2, // Expected min_quorum for Development profile with 2 replicas
+					1, // Expected min_quorum for Development profile with 1 replica
 				)
-			}, framework.DefaultLongWaitTimeout, 5*time.Second).Should(Succeed(), "Autopilot min_quorum should be updated to 2 after scale down")
-			_, _ = fmt.Fprintf(GinkgoWriter, "✓ Raft Autopilot min_quorum=2 verified after scale down\n")
+			}, framework.DefaultLongWaitTimeout, 5*time.Second).Should(Succeed(), "Autopilot min_quorum should be updated to 1 after scale down")
+			_, _ = fmt.Fprintf(GinkgoWriter, "✓ Raft Autopilot min_quorum=1 verified after scale down\n")
+
+			By("verifying the remaining cluster still serves JWT-authenticated KV traffic")
+			verifyClusterServesJWTAuthenticatedKV(
+				fmt.Sprintf("secret/%s-scaledown-smoke", clusterName),
+				"still-responsive-after-3-to-1",
+			)
 		})
 	})
 })

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,9 +12,9 @@ Notes:
 ## Summary
 
 - Files: `18`
-- Specs: `86`
-- Explicit case IDs: `16`
-- Coverage tags: `42`
+- Specs: `87`
+- Explicit case IDs: `17`
+- Coverage tags: `44`
 
 ## Suites
 
@@ -30,7 +30,7 @@ Notes:
 | [Manager Resilience](suites/Manager_Resilience_test.md) | 3 | 3 | 0 | `manager`, `cluster` | `test/e2e/Manager_Resilience_test.go` |
 | [Manager](suites/Operator_Manager_test.md) | 2 | 0 | 0 | `manager`, `critical`, `smoke` | `test/e2e/Operator_Manager_test.go` |
 | [OpenShift Platform](suites/Platform_OpenShift_test.md) | 2 | 0 | 0 | `openshift`, `platform` | `test/e2e/Platform_OpenShift_test.go` |
-| [Security Guardrails](suites/Security_Guardrails_test.md) | 20 | 0 | 0 | `security`, `critical`, `admission`, `config`, `pentest`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
+| [Security Guardrails](suites/Security_Guardrails_test.md) | 21 | 1 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
 | [Tenant Data Isolation](suites/Tenant_Data_Isolation_test.md) | 1 | 1 | 0 | `security`, `tenant`, `tenancy` | `test/e2e/Tenant_Data_Isolation_test.go` |
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow` | `test/e2e/Upgrade_Operation_Lock_test.go` |
@@ -47,6 +47,7 @@ Notes:
 | `anti-tamper` | 2 |
 | `pvc-cleanup` | 2 |
 | `recoverability-secret-cleanup` | 2 |
+| `admission-runtime-recheck` | 1 |
 | `backup-queueing` | 1 |
 | `bluegreen-drift` | 1 |
 | `cert-replacement` | 1 |
@@ -60,6 +61,7 @@ Notes:
 | `idempotent-reconcile` | 1 |
 | `ingress` | 1 |
 | `leader-election` | 1 |
+| `managed-resource-pause-on-policy-loss` | 1 |
 | `network-isolation` | 1 |
 | `observability-metrics` | 1 |
 | `operation-lock` | 1 |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -180,15 +180,15 @@
     "suiteTitle": ""
   },
   {
-    "id": "cluster-lifecycle-scales-down-to-2-replicas-and-08833c8b",
-    "generatedId": "cluster-lifecycle-scales-down-to-2-replicas-and-08833c8b",
+    "id": "cluster-lifecycle-scales-down-to-1-replica-remains-f03c312f",
+    "generatedId": "cluster-lifecycle-scales-down-to-1-replica-remains-f03c312f",
     "file": "test/e2e/Cluster_Lifecycle_test.go",
     "type": "It",
-    "name": "scales down to 2 replicas and verifies autopilot min_quorum=2",
+    "name": "scales down to 1 replica, remains responsive, and verifies autopilot min_quorum=1",
     "path": [
       "Cluster Lifecycle",
       "Development Profile: Scaling with Autopilot Reconciliation",
-      "scales down to 2 replicas and verifies autopilot min_quorum=2"
+      "scales down to 1 replica, remains responsive, and verifies autopilot min_quorum=1"
     ],
     "labels": [
       "lifecycle",
@@ -207,12 +207,14 @@
       "smoke"
     ],
     "steps": [
-      "updating cluster to 2 replicas",
-      "waiting for StatefulSet to scale down to 2 replicas",
-      "waiting for pods to be ready",
+      "updating cluster to 1 replica",
+      "waiting for StatefulSet to scale down to 1 replica",
+      "waiting for the remaining pod to be ready",
+      "waiting for Available condition after scale down",
       "getting public service for autopilot verification",
       "triggering reconcile after scale down so autopilot settings are refreshed promptly",
-      "verifying Raft Autopilot min_quorum=2 (Development profile with 2 replicas)"
+      "verifying Raft Autopilot min_quorum=1 (Development profile with 1 replica)",
+      "verifying the remaining cluster still serves JWT-authenticated KV traffic"
     ],
     "focused": false,
     "pending": false,
@@ -1067,6 +1069,49 @@
       "platform"
     ],
     "steps": null,
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
+    "id": "admission-runtime-binding-loss",
+    "generatedId": "security-guardrails-pauses-managed-resource-reconciliation-when-a-ee48afbc",
+    "caseLabel": "admission-runtime-binding-loss",
+    "coverage": [
+      "admission-runtime-recheck",
+      "managed-resource-pause-on-policy-loss"
+    ],
+    "file": "test/e2e/Security_Guardrails_test.go",
+    "type": "It",
+    "name": "pauses managed-resource reconciliation when a required admission binding disappears, then recovers when restored",
+    "path": [
+      "Security Guardrails",
+      "Admission Dependency Runtime Recheck",
+      "pauses managed-resource reconciliation when a required admission binding disappears, then recovers when restored"
+    ],
+    "labels": [
+      "security",
+      "critical",
+      "admission",
+      "pentest",
+      "case:admission-runtime-binding-loss",
+      "covers:admission-runtime-recheck",
+      "covers:managed-resource-pause-on-policy-loss"
+    ],
+    "domainLabels": [
+      "security",
+      "critical",
+      "admission",
+      "pentest"
+    ],
+    "steps": [
+      "removing a required admission binding after the cluster is healthy",
+      "waiting for live dependency checks to report the missing binding",
+      "requesting a scale-up that would normally mutate the managed StatefulSet",
+      "proving the controller fails closed and does not mutate the StatefulSet",
+      "restoring the admission binding and verifying recovery"
+    ],
     "focused": false,
     "pending": false,
     "suiteFile": "",

--- a/test/e2e/catalog/suites/Cluster_Lifecycle_test.md
+++ b/test/e2e/catalog/suites/Cluster_Lifecycle_test.md
@@ -10,7 +10,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | --- | --- | --- | --- | --- |
 | `cluster-lifecycle-creates-a-cluster-with-self-init-19ac290f` | creates a cluster with self-init disabled and produces expected Secrets | active | _none_ | `lifecycle`, `cluster`, `profile-development` |
 | `cluster-lifecycle-creates-a-cluster-with-1-replica-9792a98c` | creates a cluster with 1 replica and verifies autopilot min_quorum=1 | active | _none_ | `lifecycle`, `cluster`, `profile-development`, `scaling`, `autopilot`, `smoke` |
-| `cluster-lifecycle-scales-down-to-2-replicas-and-08833c8b` | scales down to 2 replicas and verifies autopilot min_quorum=2 | active | _none_ | `lifecycle`, `cluster`, `profile-development`, `scaling`, `autopilot`, `smoke` |
+| `cluster-lifecycle-scales-down-to-1-replica-remains-f03c312f` | scales down to 1 replica, remains responsive, and verifies autopilot min_quorum=1 | active | _none_ | `lifecycle`, `cluster`, `profile-development`, `scaling`, `autopilot`, `smoke` |
 | `cluster-lifecycle-scales-up-to-3-replicas-and-9bd63a38` | scales up to 3 replicas and verifies autopilot min_quorum=3 | active | _none_ | `lifecycle`, `cluster`, `profile-development`, `scaling`, `autopilot`, `smoke` |
 | `cluster-lifecycle-creates-an-openbaocluster-and-converges-to-00cd448b` | creates an OpenBaoCluster and converges to Available | active | _none_ | `lifecycle`, `cluster`, `critical`, `tenant` |
 | `cluster-lifecycle-expands-storage-by-increasing-spec-storage-212f934d` | expands storage by increasing spec.storage.size (if supported) | active | _none_ | `lifecycle`, `cluster`, `critical`, `tenant` |
@@ -50,9 +50,9 @@ Recorded checkpoints:
 - verifying Raft Autopilot min_quorum=1 (Development profile with 1 replica)
 
 
-## `cluster-lifecycle-scales-down-to-2-replicas-and-08833c8b`
+## `cluster-lifecycle-scales-down-to-1-replica-remains-f03c312f`
 
-Path: `Cluster Lifecycle > Development Profile: Scaling with Autopilot Reconciliation > scales down to 2 replicas and verifies autopilot min_quorum=2`
+Path: `Cluster Lifecycle > Development Profile: Scaling with Autopilot Reconciliation > scales down to 1 replica, remains responsive, and verifies autopilot min_quorum=1`
 
 State: `active`
 
@@ -61,12 +61,14 @@ Covers: _none_
 Labels: `lifecycle`, `cluster`, `profile-development`, `scaling`, `autopilot`, `smoke`
 
 Recorded checkpoints:
-- updating cluster to 2 replicas
-- waiting for StatefulSet to scale down to 2 replicas
-- waiting for pods to be ready
+- updating cluster to 1 replica
+- waiting for StatefulSet to scale down to 1 replica
+- waiting for the remaining pod to be ready
+- waiting for Available condition after scale down
 - getting public service for autopilot verification
 - triggering reconcile after scale down so autopilot settings are refreshed promptly
-- verifying Raft Autopilot min_quorum=2 (Development profile with 2 replicas)
+- verifying Raft Autopilot min_quorum=1 (Development profile with 1 replica)
+- verifying the remaining cluster still serves JWT-authenticated KV traffic
 
 
 ## `cluster-lifecycle-scales-up-to-3-replicas-and-9bd63a38`

--- a/test/e2e/catalog/suites/Security_Guardrails_test.md
+++ b/test/e2e/catalog/suites/Security_Guardrails_test.md
@@ -8,6 +8,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 
 | Case ID | Spec | State | Covers | Labels |
 | --- | --- | --- | --- | --- |
+| `admission-runtime-binding-loss` | pauses managed-resource reconciliation when a required admission binding disappears, then recovers when restored | active | `admission-runtime-recheck`, `managed-resource-pause-on-policy-loss` | `security`, `critical`, `admission`, `pentest` |
 | `security-guardrails-accepts-structured-configuration-protected-stanzas-cannot-2a18b9bd` | accepts structured configuration (protected stanzas cannot be overridden) | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-blocks-cross-namespace-tenant-targeting-self-6a21b1fd` | blocks cross-namespace tenant targeting (self-service mode) | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-blocks-decimal-ip-encoding-in-backup-d19bda3d` | blocks decimal IP encoding in backup endpoint (SSRF protection) | active | _none_ | `security`, `critical`, `admission` |
@@ -28,6 +29,26 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `security-guardrails-prevents-sidecar-injection-via-statefulset-updates-145c71ee` | prevents sidecar injection via StatefulSet updates | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-unauthorized-deletion-of-the-tls-9e011135` | prevents unauthorized deletion of the TLS CA secret | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-unauthorized-deletion-of-the-unseal-2ea235de` | prevents unauthorized deletion of the unseal Secret | active | _none_ | `security`, `critical`, `tamper` |
+
+## `admission-runtime-binding-loss`
+
+Path: `Security Guardrails > Admission Dependency Runtime Recheck > pauses managed-resource reconciliation when a required admission binding disappears, then recovers when restored`
+
+State: `active`
+
+Generated fallback ID: `security-guardrails-pauses-managed-resource-reconciliation-when-a-ee48afbc`
+
+Covers: `admission-runtime-recheck`, `managed-resource-pause-on-policy-loss`
+
+Labels: `security`, `critical`, `admission`, `pentest`
+
+Recorded checkpoints:
+- removing a required admission binding after the cluster is healthy
+- waiting for live dependency checks to report the missing binding
+- requesting a scale-up that would normally mutate the managed StatefulSet
+- proving the controller fails closed and does not mutate the StatefulSet
+- restoring the admission binding and verifying recovery
+
 
 ## `security-guardrails-accepts-structured-configuration-protected-stanzas-cannot-2a18b9bd`
 


### PR DESCRIPTION
## Description

This PR makes cluster scale-downs stage one replica at a time so Raft autopilot quorum and membership are updated before the StatefulSet shrinks. It also keeps autopilot reconciliation aligned with the currently applied StatefulSet replica count, supports safe scale-downs when the cluster has no external Service, and stops hot-looping when JWT bootstrap policies are missing the new Raft permissions.

The lifecycle E2E now exercises the real `3 -> 1` downscale path and verifies that the remaining cluster still serves JWT-authenticated KV traffic after the downscale. Generated E2E catalog output was refreshed to match the updated lifecycle coverage.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test ./internal/app/openbaocluster ./internal/service/infra ./internal/controller/openbaocluster`
- `go test -tags=e2e ./test/e2e/... -run '^$'`
- `make test-e2e-existing E2E_LABEL_FILTER='lifecycle && scaling && autopilot'`