### PR TITLE
fix(infra): delete scaled-down raft PVCs

### DIFF
--- a/internal/service/infra/statefulset_builder.go
+++ b/internal/service/infra/statefulset_builder.go
@@ -64,6 +64,10 @@ func buildStatefulSetWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, confi
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: headlessServiceName(cluster),
 			Replicas:    int32Ptr(replicas),
+			// Scale-down removes the departing Raft peer before shrinking the StatefulSet.
+			// Reusing that ordinal's old data directory on a later scale-up resurrects
+			// stale Raft membership, so scaled-down PVCs must be deleted.
+			PersistentVolumeClaimRetentionPolicy: buildStatefulSetPVCRetentionPolicy(),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -103,6 +107,13 @@ func buildStatefulSetWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, confi
 	security.AddManagedWorkloadSecurityLabels(statefulSet.Labels, cluster)
 
 	return statefulSet, nil
+}
+
+func buildStatefulSetPVCRetentionPolicy() *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy {
+	return &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+		WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+	}
 }
 
 func buildStatefulSetAffinity(cluster *openbaov1alpha1.OpenBaoCluster) *corev1.Affinity {

--- a/internal/service/infra/statefulset_builder_test.go
+++ b/internal/service/infra/statefulset_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -134,6 +135,26 @@ func TestBuildStatefulSet_MaintenanceAnnotations(t *testing.T) {
 
 	if got := statefulSet.Spec.Template.Annotations[constants.AnnotationRestartAt]; got != "2026-01-19T00:00:00Z" {
 		t.Fatalf("expected Pod template annotation %q to be set, got %q", constants.AnnotationRestartAt, got)
+	}
+}
+
+func TestBuildStatefulSet_DeletesPVCsOnlyWhenScaledDown(t *testing.T) {
+	cluster := newMinimalCluster("scaledown-pvc-cluster", "default")
+
+	statefulSet, err := buildStatefulSetWithRevision(cluster, "test-config", true, "", "", "", false, constants.PlatformKubernetes)
+	if err != nil {
+		t.Fatalf("buildStatefulSetWithRevision() error = %v", err)
+	}
+
+	retentionPolicy := statefulSet.Spec.PersistentVolumeClaimRetentionPolicy
+	if retentionPolicy == nil {
+		t.Fatal("expected StatefulSet PVC retention policy")
+	}
+	if got := retentionPolicy.WhenScaled; got != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
+		t.Fatalf("WhenScaled = %q, want %q", got, appsv1.DeletePersistentVolumeClaimRetentionPolicyType)
+	}
+	if got := retentionPolicy.WhenDeleted; got != appsv1.RetainPersistentVolumeClaimRetentionPolicyType {
+		t.Fatalf("WhenDeleted = %q, want %q", got, appsv1.RetainPersistentVolumeClaimRetentionPolicyType)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR changes the generated OpenBao StatefulSet PVC retention policy so PVCs are deleted when replicas are scaled down, while retaining PVCs when the StatefulSet itself is deleted. This prevents removed Raft peers from being resurrected with stale local Raft state when the same ordinal is later scaled back up.

The issue was observed after scaling down and back up: pods for previously removed ordinals became Kubernetes-ready but reported stale Raft peer membership, while the active leader had a different current voter set. Deleting scaled-down ordinal PVCs ensures future scale-ups create fresh peers that join the active Raft cluster cleanly.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `make test-ci`
- Verified on locally running cluster, that OpenBao remains stable during up and downscales
