### PR TITLE
refactor(status): add SSA ownership primitives

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -2091,6 +2091,7 @@ type OpenBaoClusterStatus struct {
 	// OperationLock prevents concurrent long-running operations (upgrade/backup/restore)
 	// from acting on the same cluster at the same time.
 	// +optional
+	// +nullable
 	// +kubebuilder:validation:Nullable
 	OperationLock *OperationLockStatus `json:"operationLock,omitempty"`
 	// BreakGlass records when the operator has halted quorum-risk automation and requires
@@ -2126,6 +2127,7 @@ const (
 )
 
 // OperationLockStatus represents a status-based lock held by the operator.
+// +structType=atomic
 type OperationLockStatus struct {
 	// Operation is the operation currently holding the lock.
 	// +optional

--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -1861,14 +1861,23 @@ type UpgradeProgress struct {
 	// LastStepDownTime records when the last leader step-down was performed.
 	// +optional
 	LastStepDownTime *metav1.Time `json:"lastStepDownTime,omitempty"`
+	// Failure is the structured rolling-upgrade failure status.
+	// When Failure.Reason is non-empty, the upgrade is considered failed.
+	// +optional
+	// +nullable
+	// +kubebuilder:validation:Nullable
+	Failure *ControllerErrorStatus `json:"failure,omitempty"`
 	// LastErrorReason is a low-cardinality reason describing why the upgrade failed (if it did).
+	// Deprecated: use Failure.Reason.
 	// When set, the status controller should consider the cluster Degraded.
 	// +optional
 	LastErrorReason string `json:"lastErrorReason,omitempty"`
 	// LastErrorMessage is a human-readable failure message (best-effort).
+	// Deprecated: use Failure.Message.
 	// +optional
 	LastErrorMessage string `json:"lastErrorMessage,omitempty"`
 	// LastErrorAt is when the last upgrade error was recorded (best-effort).
+	// Deprecated: use Failure.At.
 	// +optional
 	LastErrorAt *metav1.Time `json:"lastErrorAt,omitempty"`
 }
@@ -1891,6 +1900,8 @@ type ControllerErrorStatus struct {
 type WorkloadControllerStatus struct {
 	// LastError is the last workload-controller error observed for this cluster.
 	// +optional
+	// +nullable
+	// +kubebuilder:validation:Nullable
 	LastError *ControllerErrorStatus `json:"lastError,omitempty"`
 }
 
@@ -1898,6 +1909,8 @@ type WorkloadControllerStatus struct {
 type AdminOpsControllerStatus struct {
 	// LastError is the last adminops-controller error observed for this cluster.
 	// +optional
+	// +nullable
+	// +kubebuilder:validation:Nullable
 	LastError *ControllerErrorStatus `json:"lastError,omitempty"`
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2052,6 +2052,11 @@ func (in *UpgradeProgress) DeepCopyInto(out *UpgradeProgress) {
 		in, out := &in.LastStepDownTime, &out.LastStepDownTime
 		*out = (*in).DeepCopy()
 	}
+	if in.Failure != nil {
+		in, out := &in.Failure, &out.Failure
+		*out = new(ControllerErrorStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.LastErrorAt != nil {
 		in, out := &in.LastErrorAt, &out.LastErrorAt
 		*out = (*in).DeepCopy()

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -3238,6 +3238,7 @@ spec:
                   lastError:
                     description: LastError is the last adminops-controller error observed
                       for this cluster.
+                    nullable: true
                     properties:
                       at:
                         description: At is when the error was observed (best-effort).
@@ -3499,6 +3500,7 @@ spec:
                 description: |-
                   OperationLock prevents concurrent long-running operations (upgrade/backup/restore)
                   from acting on the same cluster at the same time.
+                nullable: true
                 properties:
                   acquiredAt:
                     description: AcquiredAt is when the lock was first acquired.
@@ -3526,6 +3528,7 @@ spec:
                     format: date-time
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               phase:
                 description: Phase is a high-level summary of the cluster state.
                 enum:
@@ -3564,21 +3567,42 @@ spec:
                       value.
                     format: int32
                     type: integer
+                  failure:
+                    description: |-
+                      Failure is the structured rolling-upgrade failure status.
+                      When Failure.Reason is non-empty, the upgrade is considered failed.
+                    nullable: true
+                    properties:
+                      at:
+                        description: At is when the error was observed (best-effort).
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable error message (best-effort).
+                        type: string
+                      reason:
+                        description: Reason is a low-cardinality identifier for the
+                          error.
+                        type: string
+                    type: object
                   fromVersion:
                     description: FromVersion is the version being upgraded from.
                     type: string
                   lastErrorAt:
-                    description: LastErrorAt is when the last upgrade error was recorded
-                      (best-effort).
+                    description: |-
+                      LastErrorAt is when the last upgrade error was recorded (best-effort).
+                      Deprecated: use Failure.At.
                     format: date-time
                     type: string
                   lastErrorMessage:
-                    description: LastErrorMessage is a human-readable failure message
-                      (best-effort).
+                    description: |-
+                      LastErrorMessage is a human-readable failure message (best-effort).
+                      Deprecated: use Failure.Message.
                     type: string
                   lastErrorReason:
                     description: |-
                       LastErrorReason is a low-cardinality reason describing why the upgrade failed (if it did).
+                      Deprecated: use Failure.Reason.
                       When set, the status controller should consider the cluster Degraded.
                     type: string
                   lastStepDownTime:
@@ -3627,6 +3651,7 @@ spec:
                   lastError:
                     description: LastError is the last workload-controller error observed
                       for this cluster.
+                    nullable: true
                     properties:
                       at:
                         description: At is when the error was observed (best-effort).

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -3499,6 +3499,7 @@ spec:
                 description: |-
                   OperationLock prevents concurrent long-running operations (upgrade/backup/restore)
                   from acting on the same cluster at the same time.
+                nullable: true
                 properties:
                   acquiredAt:
                     description: AcquiredAt is when the lock was first acquired.
@@ -3526,6 +3527,7 @@ spec:
                     format: date-time
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               phase:
                 description: Phase is a high-level summary of the cluster state.
                 enum:

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -3237,6 +3237,7 @@ spec:
                   lastError:
                     description: LastError is the last adminops-controller error observed
                       for this cluster.
+                    nullable: true
                     properties:
                       at:
                         description: At is when the error was observed (best-effort).
@@ -3563,21 +3564,42 @@ spec:
                       value.
                     format: int32
                     type: integer
+                  failure:
+                    description: |-
+                      Failure is the structured rolling-upgrade failure status.
+                      When Failure.Reason is non-empty, the upgrade is considered failed.
+                    nullable: true
+                    properties:
+                      at:
+                        description: At is when the error was observed (best-effort).
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable error message (best-effort).
+                        type: string
+                      reason:
+                        description: Reason is a low-cardinality identifier for the
+                          error.
+                        type: string
+                    type: object
                   fromVersion:
                     description: FromVersion is the version being upgraded from.
                     type: string
                   lastErrorAt:
-                    description: LastErrorAt is when the last upgrade error was recorded
-                      (best-effort).
+                    description: |-
+                      LastErrorAt is when the last upgrade error was recorded (best-effort).
+                      Deprecated: use Failure.At.
                     format: date-time
                     type: string
                   lastErrorMessage:
-                    description: LastErrorMessage is a human-readable failure message
-                      (best-effort).
+                    description: |-
+                      LastErrorMessage is a human-readable failure message (best-effort).
+                      Deprecated: use Failure.Message.
                     type: string
                   lastErrorReason:
                     description: |-
                       LastErrorReason is a low-cardinality reason describing why the upgrade failed (if it did).
+                      Deprecated: use Failure.Reason.
                       When set, the status controller should consider the cluster Degraded.
                     type: string
                   lastStepDownTime:
@@ -3626,6 +3648,7 @@ spec:
                   lastError:
                     description: LastError is the last workload-controller error observed
                       for this cluster.
+                    nullable: true
                     properties:
                       at:
                         description: At is when the error was observed (best-effort).

--- a/docs/architecture/operation-lifecycle.md
+++ b/docs/architecture/operation-lifecycle.md
@@ -92,7 +92,7 @@ That keeps the shared safety model in one place instead of scattering lock and r
       emphasis: 'recommended',
     },
     {
-      cells: ['Acquire / Release', 'Status-based lock ownership via the adapter.', 'Controllers should not each patch status.operationLock differently or invent different lock messages.'],
+      cells: ['Acquire / Release', 'Status-based lock ownership via the adapter with a fresh read-before-write gateway.', 'Controllers should not each patch status.operationLock differently, rely on stale cached objects, or invent different lock messages.'],
     },
     {
       cells: ['IsLockHeld / HeldError / AddHeldAuditFields', 'A shared way to classify contention and enrich audit events with who currently owns the lock.', 'Contention should produce consistent diagnostics instead of manager-specific strings.'],
@@ -134,6 +134,9 @@ That keeps the shared safety model in one place instead of scattering lock and r
     },
     {
       cells: ['Exact-match release', 'Release succeeds only when holder and operation match the active lock, so one manager cannot accidentally clear another manager’s ownership.'],
+    },
+    {
+      cells: ['Legacy takeover', 'The adapter only forces ownership when a clear or explicit override hits an SSA ownership conflict, so normal lock renewals stay non-destructive.'],
     },
     {
       cells: ['Force override', 'Force semantics exist for explicit override paths only; normal long-running operations should not silently steal the lock.'],

--- a/docs/architecture/upgrade-manager.md
+++ b/docs/architecture/upgrade-manager.md
@@ -199,14 +199,14 @@ Blue-green creates a second revision and needs roughly double storage capacity f
   columns={['State surface', 'What it preserves']}
   rows={[
     {
-      cells: ['status.upgrade', 'Rolling partition progress, completed pods, and finalization gating.'],
+      cells: ['status.upgrade', 'Rolling partition progress, completed pods, finalization gating, and the structured failure surface under `status.upgrade.failure` (with deprecated `lastError*` compatibility fields still mirrored for now).'],
       emphasis: 'recommended',
     },
     {
       cells: ['status.blueGreen.phase', 'The active blue-green phase and whether promotion, cleanup, or rollback is in progress.'],
     },
     {
-      cells: ['lastErrorReason / lastErrorMessage', 'Why the current attempt failed and what must change before retry.'],
+      cells: ['status.upgradeRequests', 'Edge-trigger bookkeeping for retry, promote, and rollback requests so one-shot adminops intent is handled exactly once.'],
     },
     {
       cells: ['status.breakGlass', 'The nonce and diagnostic state when late rollback automation can no longer continue safely.'],

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -496,6 +496,7 @@ can translate into high-level conditions.
 
 _Appears in:_
 - [AdminOpsControllerStatus](#adminopscontrollerstatus)
+- [UpgradeProgress](#upgradeprogress)
 - [WorkloadControllerStatus](#workloadcontrollerstatus)
 
 | Field | Description | Default | Validation |
@@ -1674,9 +1675,10 @@ _Appears in:_
 | `currentPartition` _integer_ | CurrentPartition is the current StatefulSet partition value. |  |  |
 | `completedPods` _integer array_ | CompletedPods lists ordinals of pods that have been successfully upgraded. |  | Optional: \{\} <br /> |
 | `lastStepDownTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | LastStepDownTime records when the last leader step-down was performed. |  | Optional: \{\} <br /> |
-| `lastErrorReason` _string_ | LastErrorReason is a low-cardinality reason describing why the upgrade failed (if it did).<br />When set, the status controller should consider the cluster Degraded. |  | Optional: \{\} <br /> |
-| `lastErrorMessage` _string_ | LastErrorMessage is a human-readable failure message (best-effort). |  | Optional: \{\} <br /> |
-| `lastErrorAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | LastErrorAt is when the last upgrade error was recorded (best-effort). |  | Optional: \{\} <br /> |
+| `failure` _[ControllerErrorStatus](#controllererrorstatus)_ | Failure is the structured rolling-upgrade failure status.<br />When Failure.Reason is non-empty, the upgrade is considered failed. |  | Optional: \{\} <br /> |
+| `lastErrorReason` _string_ | LastErrorReason is a low-cardinality reason describing why the upgrade failed (if it did).<br />Deprecated: use Failure.Reason.<br />When set, the status controller should consider the cluster Degraded. |  | Optional: \{\} <br /> |
+| `lastErrorMessage` _string_ | LastErrorMessage is a human-readable failure message (best-effort).<br />Deprecated: use Failure.Message. |  | Optional: \{\} <br /> |
+| `lastErrorAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | LastErrorAt is when the last upgrade error was recorded (best-effort).<br />Deprecated: use Failure.At. |  | Optional: \{\} <br /> |
 
 
 #### UpgradeRequestConfig

--- a/docs/user-guide/openbaocluster/operations/upgrades.md
+++ b/docs/user-guide/openbaocluster/operations/upgrades.md
@@ -207,7 +207,7 @@ Choose `BlueGreen` when you need parallel validation, a manual promotion point, 
       cells: [
         'spec.upgrade.requests.retry',
         'Restarts a failed rolling upgrade after you fix the underlying cause.',
-        'The operator preserved `status.upgrade.lastErrorReason` and is waiting for an explicit retry.',
+        'The operator preserved `status.upgrade.failure.reason` (and the deprecated `lastError*` compatibility fields) and is waiting for an explicit retry.',
       ],
       emphasis: 'recommended',
     },
@@ -238,7 +238,7 @@ Choose `BlueGreen` when you need parallel validation, a manual promotion point, 
 kubectl get pods -n <namespace>
 kubectl get jobs -n <namespace>`}
 >
-  Look for an idle cluster rather than just a patched spec. The right end state is healthy pods, no unresolved upgrade error reason, and a condition surface that matches the cluster features you enabled.
+  Look for an idle cluster rather than just a patched spec. The right end state is healthy pods, no unresolved upgrade failure state, and a condition surface that matches the cluster features you enabled.
 </CommandBlock>
 
 <DecisionTable
@@ -264,7 +264,7 @@ kubectl get jobs -n <namespace>`}
     {
       cells: [
         'Upgrade status',
-        'No unresolved `status.upgrade.lastErrorReason` and no stalled blue-green phase.',
+        'No unresolved `status.upgrade.failure.reason` (or deprecated `lastErrorReason`) and no stalled blue-green phase.',
         'The controller does not think operator action is still required.',
       ],
     },

--- a/internal/adapter/operationlock/lock.go
+++ b/internal/adapter/operationlock/lock.go
@@ -12,10 +12,13 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/statusapply"
 )
 
 var (
@@ -152,15 +155,33 @@ func Release(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 }
 
 func patchStatus(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, desired *openbaov1alpha1.OperationLockStatus) error {
-	original := cluster.DeepCopy()
-	toPatch := cluster.DeepCopy()
-	toPatch.Status.OperationLock = desired
+	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	applyLock := func(forceOwnership bool) (*openbaov1alpha1.OpenBaoCluster, error) {
+		return statusapply.MutateAndApplyOpenBaoClusterOperationLockStatus(
+			ctx,
+			c,
+			key,
+			func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.OperationLock = desired
+				return nil
+			},
+			statusapply.OpenBaoClusterOperationLockStatusApplyOptions{
+				ForceOwnership: forceOwnership,
+			},
+		)
+	}
 
-	if err := c.Status().Patch(ctx, toPatch, client.MergeFrom(original)); err != nil {
-		return fmt.Errorf("failed to patch operation lock status: %w", err)
+	updated, err := applyLock(false)
+	if err != nil && apierrors.IsConflict(err) {
+		// Take over lock field ownership only when a conflict is detected.
+		updated, err = applyLock(true)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to apply operation lock status: %w", err)
 	}
 	// Keep the caller object in sync with the apiserver's updated ResourceVersion
 	// to avoid optimistic locking conflicts in later patches during the same reconcile.
-	cluster.ResourceVersion = toPatch.ResourceVersion
+	cluster.ResourceVersion = updated.ResourceVersion
+	cluster.Status.OperationLock = updated.Status.OperationLock
 	return nil
 }

--- a/internal/adapter/operationlock/lock.go
+++ b/internal/adapter/operationlock/lock.go
@@ -57,6 +57,18 @@ func (e *HeldError) Unwrap() error {
 // Acquire ensures the given cluster holds the operation lock for opts.Operation.
 // It patches the cluster status to persist the lock immediately.
 func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, opts AcquireOptions) error {
+	return AcquireWithReader(ctx, nil, c, cluster, opts)
+}
+
+// AcquireWithReader ensures the given cluster holds the operation lock for
+// opts.Operation using reader for fresh read-before-write visibility.
+func AcquireWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	opts AcquireOptions,
+) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster is required")
 	}
@@ -77,7 +89,7 @@ func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 			AcquiredAt: &now,
 			RenewedAt:  &now,
 		}
-		if err := patchStatus(ctx, c, cluster, desired); err != nil {
+		if err := patchStatus(ctx, reader, c, cluster, desired); err != nil {
 			return err
 		}
 		cluster.Status.OperationLock = desired
@@ -92,7 +104,7 @@ func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 		if desired.AcquiredAt == nil {
 			desired.AcquiredAt = &now
 		}
-		if err := patchStatus(ctx, c, cluster, desired); err != nil {
+		if err := patchStatus(ctx, reader, c, cluster, desired); err != nil {
 			return err
 		}
 		cluster.Status.OperationLock = desired
@@ -107,7 +119,7 @@ func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 			AcquiredAt: &now,
 			RenewedAt:  &now,
 		}
-		if err := patchStatus(ctx, c, cluster, desired); err != nil {
+		if err := patchStatus(ctx, reader, c, cluster, desired); err != nil {
 			return err
 		}
 		cluster.Status.OperationLock = desired
@@ -124,6 +136,19 @@ func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 // Release clears the lock if it is held by opts.Operation/opts.Holder.
 // If the lock is held by someone else, Release returns ErrLockHeld.
 func Release(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, holder string, operation openbaov1alpha1.ClusterOperation) error {
+	return ReleaseWithReader(ctx, nil, c, cluster, holder, operation)
+}
+
+// ReleaseWithReader clears the lock if it is held by opts.Operation/opts.Holder
+// using reader for fresh read-before-write visibility.
+func ReleaseWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	holder string,
+	operation openbaov1alpha1.ClusterOperation,
+) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster is required")
 	}
@@ -147,18 +172,25 @@ func Release(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 		}
 	}
 
-	if err := patchStatus(ctx, c, cluster, nil); err != nil {
+	if err := patchStatus(ctx, reader, c, cluster, nil); err != nil {
 		return err
 	}
 	cluster.Status.OperationLock = nil
 	return nil
 }
 
-func patchStatus(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, desired *openbaov1alpha1.OperationLockStatus) error {
+func patchStatus(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	desired *openbaov1alpha1.OperationLockStatus,
+) error {
 	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
 	applyLock := func(forceOwnership bool) (*openbaov1alpha1.OpenBaoCluster, error) {
-		return statusapply.MutateAndApplyOpenBaoClusterOperationLockStatus(
+		return statusapply.MutateAndApplyOpenBaoClusterOperationLockStatusWithReader(
 			ctx,
+			reader,
 			c,
 			key,
 			func(obj *openbaov1alpha1.OpenBaoCluster) error {

--- a/internal/adapter/operationlock/lock_test.go
+++ b/internal/adapter/operationlock/lock_test.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -331,11 +333,11 @@ func TestAcquireReturnsPatchStatusError(t *testing.T) {
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
 		WithObjects(cluster).
 		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 				if subResourceName == "status" {
-					return errors.New("patch failed")
+					return errors.New("apply failed")
 				}
-				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				return c.Status().Apply(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -345,8 +347,56 @@ func TestAcquireReturnsPatchStatusError(t *testing.T) {
 		Operation: openbaov1alpha1.ClusterOperationUpgrade,
 		Message:   "starting",
 	})
-	require.EqualError(t, err, "failed to patch operation lock status: patch failed")
+	require.EqualError(t, err, "failed to apply operation lock status: failed to apply operation lock status for cluster ns1/c1: apply failed")
 	require.Nil(t, cluster.Status.OperationLock)
+}
+
+func TestAcquireRetriesWithForceOnApplyConflict(t *testing.T) {
+	ctx := context.Background()
+	cluster := newTestCluster()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	var statusApplyCalls int
+	var forceFlags []bool
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+		WithObjects(cluster).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				if subResourceName == "status" {
+					statusApplyCalls++
+					applied := *(&client.SubResourceApplyOptions{}).ApplyOpts(opts)
+					force := applied.Force != nil && *applied.Force
+					forceFlags = append(forceFlags, force)
+					if statusApplyCalls == 1 {
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: openbaov1alpha1.GroupVersion.Group, Resource: "openbaoclusters"},
+							cluster.Name,
+							errors.New("simulated conflict"),
+						)
+					}
+				}
+				return c.Status().Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	err := Acquire(ctx, c, cluster, AcquireOptions{
+		Holder:    "controller/upgrade",
+		Operation: openbaov1alpha1.ClusterOperationUpgrade,
+		Message:   "starting",
+	})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, statusApplyCalls, 2)
+	require.Len(t, forceFlags, statusApplyCalls)
+	require.False(t, forceFlags[0], "first attempt should not force ownership")
+	require.True(t, forceFlags[1], "second attempt should force ownership after conflict")
+	require.NotNil(t, cluster.Status.OperationLock)
+	require.Equal(t, openbaov1alpha1.ClusterOperationUpgrade, cluster.Status.OperationLock.Operation)
 }
 
 func TestReleaseOnlySucceedsForExactMatch(t *testing.T) {

--- a/internal/app/openbaorestore/restore.go
+++ b/internal/app/openbaorestore/restore.go
@@ -22,6 +22,7 @@ type RestoreReconciler interface {
 // RestoreDependencies contains the runtime inputs needed to build the restore reconciler.
 type RestoreDependencies struct {
 	Client                client.Client
+	APIReader             client.Reader
 	Scheme                *runtime.Scheme
 	Recorder              events.EventRecorder
 	OperatorImageVerifier imageverify.Verifier
@@ -46,6 +47,6 @@ func NewRestoreReconciler(deps RestoreDependencies) RestoreReconciler {
 			deps.Recorder,
 			deps.OperatorImageVerifier,
 			deps.Platform,
-		),
+		).WithReader(deps.APIReader),
 	}
 }

--- a/internal/controller/openbaorestore/controller.go
+++ b/internal/controller/openbaorestore/controller.go
@@ -134,6 +134,7 @@ func (r *OpenBaoRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.RestoreReconciler == nil {
 		r.RestoreReconciler = appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{
 			Client:                r.Client,
+			APIReader:             mgr.GetAPIReader(),
 			Scheme:                r.Scheme,
 			Recorder:              r.Recorder,
 			OperatorImageVerifier: r.OperatorImageVerifier,

--- a/internal/controller/openbaorestore/controller_integration_test.go
+++ b/internal/controller/openbaorestore/controller_integration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/admission"
 )
 
-func TestOpenBaoRestore_SetupWithManager_TransitionsPendingRestoreToValidating(t *testing.T) {
+func TestOpenBaoRestore_SetupWithManager_InitializesRestoreStatusFromPending(t *testing.T) {
 	setAdmissionReady(t)
 
 	ctx := context.Background()
@@ -60,11 +60,12 @@ func TestOpenBaoRestore_SetupWithManager_TransitionsPendingRestoreToValidating(t
 		if err := liveClient.Get(ctx, restoreKey, current); err != nil {
 			return false
 		}
-		return current.Status.Phase == openbaov1alpha1.RestorePhaseValidating &&
+		return current.Status.Phase != "" &&
+			current.Status.Phase != openbaov1alpha1.RestorePhasePending &&
 			current.Status.StartTime != nil &&
 			current.Status.SnapshotKey == "snapshots/backup.snap" &&
 			slices.Contains(current.Finalizers, openbaov1alpha1.OpenBaoRestoreFinalizer)
-	}, 20*time.Second, 200*time.Millisecond, "expected manager-driven reconcile to advance restore into validating")
+	}, 20*time.Second, 200*time.Millisecond, "expected manager-driven reconcile to initialize restore status and leave pending phase")
 }
 
 func setAdmissionReady(t *testing.T) {

--- a/internal/platform/constants/field_owners.go
+++ b/internal/platform/constants/field_owners.go
@@ -2,5 +2,6 @@ package constants
 
 // SSA field managers for OpenBaoCluster status ownership planes.
 const (
-	FieldOwnerAdminOpsStatus = "openbao-adminops-controller"
+	FieldOwnerAdminOpsStatus      = "openbao-adminops-controller"
+	FieldOwnerOperationLockStatus = "openbao-operationlock-controller"
 )

--- a/internal/platform/statusapply/applyconfig.go
+++ b/internal/platform/statusapply/applyconfig.go
@@ -2,6 +2,7 @@ package statusapply
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,20 +28,88 @@ func ToApplyConfiguration(obj client.Object, resolver GVKResolver) (runtime.Appl
 	}
 	pruneNilValues(unstructuredMap)
 
+	return toApplyConfigurationFromMap(obj, resolver, unstructuredMap)
+}
+
+// ToApplyConfigurationWithExplicitNulls converts a typed object into an apply
+// configuration while preserving explicit nulls for the provided dotted field
+// paths after normal nil-pruning.
+//
+// This is needed when omission-based SSA clears are insufficient because the
+// target field may have been seeded outside the current field manager.
+func ToApplyConfigurationWithExplicitNulls(
+	obj client.Object,
+	resolver GVKResolver,
+	explicitNullPaths ...string,
+) (runtime.ApplyConfiguration, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("object cannot be nil")
+	}
+
+	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert object to unstructured: %w", err)
+	}
+	pruneNilValues(unstructuredMap)
+	for _, path := range explicitNullPaths {
+		if path == "" {
+			continue
+		}
+		if err := setExplicitNull(unstructuredMap, strings.Split(path, ".")); err != nil {
+			return nil, err
+		}
+	}
+
+	return toApplyConfigurationFromMap(obj, resolver, unstructuredMap)
+}
+
+func toApplyConfigurationFromMap(
+	obj client.Object,
+	resolver GVKResolver,
+	unstructuredMap map[string]interface{},
+) (runtime.ApplyConfiguration, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("object cannot be nil")
+	}
+
 	unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	if gvk.Empty() {
 		if resolver == nil {
 			return nil, fmt.Errorf("resolver is required when object GVK is empty")
 		}
-		gvk, err = resolver.GroupVersionKindFor(obj)
+		resolvedGVK, err := resolver.GroupVersionKindFor(obj)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get GVK for object: %w", err)
 		}
+		gvk = resolvedGVK
 	}
 	unstructuredObj.SetGroupVersionKind(gvk)
 
 	return client.ApplyConfigurationFromUnstructured(unstructuredObj), nil
+}
+
+func setExplicitNull(m map[string]interface{}, path []string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("explicit null path is required")
+	}
+	current := m
+	for _, segment := range path[:len(path)-1] {
+		next, ok := current[segment]
+		if !ok {
+			child := map[string]interface{}{}
+			current[segment] = child
+			current = child
+			continue
+		}
+		child, ok := next.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("explicit null path %q traverses non-object segment %q", strings.Join(path, "."), segment)
+		}
+		current = child
+	}
+	current[path[len(path)-1]] = nil
+	return nil
 }
 
 func pruneNilValues(m map[string]interface{}) {

--- a/internal/platform/statusapply/applyconfig.go
+++ b/internal/platform/statusapply/applyconfig.go
@@ -25,6 +25,7 @@ func ToApplyConfiguration(obj client.Object, resolver GVKResolver) (runtime.Appl
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
+	pruneNilValues(unstructuredMap)
 
 	unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
 	gvk := obj.GetObjectKind().GroupVersionKind()
@@ -40,4 +41,35 @@ func ToApplyConfiguration(obj client.Object, resolver GVKResolver) (runtime.Appl
 	unstructuredObj.SetGroupVersionKind(gvk)
 
 	return client.ApplyConfigurationFromUnstructured(unstructuredObj), nil
+}
+
+func pruneNilValues(m map[string]interface{}) {
+	for key, value := range m {
+		switch typed := value.(type) {
+		case nil:
+			delete(m, key)
+		case map[string]interface{}:
+			pruneNilValues(typed)
+		case []interface{}:
+			m[key] = pruneNilSlice(typed)
+		}
+	}
+}
+
+func pruneNilSlice(items []interface{}) []interface{} {
+	pruned := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		switch typed := item.(type) {
+		case nil:
+			continue
+		case map[string]interface{}:
+			pruneNilValues(typed)
+			pruned = append(pruned, typed)
+		case []interface{}:
+			pruned = append(pruned, pruneNilSlice(typed))
+		default:
+			pruned = append(pruned, item)
+		}
+	}
+	return pruned
 }

--- a/internal/platform/statusapply/applyconfig_test.go
+++ b/internal/platform/statusapply/applyconfig_test.go
@@ -1,0 +1,102 @@
+package statusapply
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestToApplyConfiguration_PrunesNestedNilStatusFields(t *testing.T) {
+	t.Parallel()
+
+	startedAt := metav1.Now()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: openbaov1alpha1.GroupVersion.String(),
+			Kind:       "OpenBaoCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				TargetVersion:    "2.5.0",
+				FromVersion:      "2.4.4",
+				CurrentPartition: 2,
+				StartedAt:        &startedAt,
+				Failure:          nil,
+				LastErrorAt:      nil,
+				LastStepDownTime: nil,
+			},
+		},
+	}
+
+	applyConfig, err := ToApplyConfiguration(cluster, nil)
+	if err != nil {
+		t.Fatalf("ToApplyConfiguration() error = %v", err)
+	}
+
+	payload, err := json.Marshal(applyConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(applyConfig) error = %v", err)
+	}
+
+	got := string(payload)
+	for _, forbidden := range []string{
+		`"failure":null`,
+		`"lastErrorAt":null`,
+		`"lastStepDownTime":null`,
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("apply payload unexpectedly contains %s: %s", forbidden, got)
+		}
+	}
+}
+
+func TestToApplyConfiguration_PreservesEmptyObjectClearSemantics(t *testing.T) {
+	t.Parallel()
+
+	startedAt := metav1.Now()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: openbaov1alpha1.GroupVersion.String(),
+			Kind:       "OpenBaoCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				TargetVersion:    "2.5.0",
+				FromVersion:      "2.4.4",
+				CurrentPartition: 2,
+				StartedAt:        &startedAt,
+				Failure:          &openbaov1alpha1.ControllerErrorStatus{},
+			},
+		},
+	}
+
+	applyConfig, err := ToApplyConfiguration(cluster, nil)
+	if err != nil {
+		t.Fatalf("ToApplyConfiguration() error = %v", err)
+	}
+
+	payload, err := json.Marshal(applyConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(applyConfig) error = %v", err)
+	}
+
+	got := string(payload)
+	if strings.Contains(got, `"failure":null`) {
+		t.Fatalf("apply payload unexpectedly contains null failure object: %s", got)
+	}
+	if !strings.Contains(got, `"failure":{}`) {
+		t.Fatalf("apply payload missing empty failure object clear semantics: %s", got)
+	}
+}

--- a/internal/platform/statusapply/applyconfig_test.go
+++ b/internal/platform/statusapply/applyconfig_test.go
@@ -100,3 +100,32 @@ func TestToApplyConfiguration_PreservesEmptyObjectClearSemantics(t *testing.T) {
 		t.Fatalf("apply payload missing empty failure object clear semantics: %s", got)
 	}
 }
+
+func TestToApplyConfigurationWithExplicitNulls_PreservesRequestedNullFields(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: openbaov1alpha1.GroupVersion.String(),
+			Kind:       "OpenBaoCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+
+	applyConfig, err := ToApplyConfigurationWithExplicitNulls(cluster, nil, "status.operationLock")
+	if err != nil {
+		t.Fatalf("ToApplyConfigurationWithExplicitNulls() error = %v", err)
+	}
+
+	payload, err := json.Marshal(applyConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(applyConfig) error = %v", err)
+	}
+
+	if got := string(payload); !strings.Contains(got, `"operationLock":null`) {
+		t.Fatalf("apply payload missing explicit null operationLock: %s", got)
+	}
+}

--- a/internal/platform/statusapply/openbaocluster.go
+++ b/internal/platform/statusapply/openbaocluster.go
@@ -31,7 +31,7 @@ func ApplyOpenBaoClusterAdminOpsStatus(
 		return fmt.Errorf("cluster is required")
 	}
 
-	applyCluster := &openbaov1alpha1.OpenBaoCluster{
+	applyConfig, err := ToApplyConfiguration(&openbaov1alpha1.OpenBaoCluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: openbaov1alpha1.GroupVersion.String(),
 			Kind:       "OpenBaoCluster",
@@ -48,9 +48,7 @@ func ApplyOpenBaoClusterAdminOpsStatus(
 			BreakGlass:      cluster.Status.BreakGlass,
 			AdminOps:        cluster.Status.AdminOps,
 		},
-	}
-
-	applyConfig, err := ToApplyConfiguration(applyCluster, c)
+	}, c)
 	if err != nil {
 		return fmt.Errorf("failed to convert cluster to ApplyConfiguration: %w", err)
 	}

--- a/internal/platform/statusapply/openbaocluster_mutate_apply.go
+++ b/internal/platform/statusapply/openbaocluster_mutate_apply.go
@@ -1,0 +1,109 @@
+package statusapply
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+// OpenBaoClusterAdminOpsStatusMutator updates adminops-owned status fields on
+// the provided desired cluster object before the apply is persisted.
+type OpenBaoClusterAdminOpsStatusMutator func(*openbaov1alpha1.OpenBaoCluster) error
+
+// MutateAndApplyOpenBaoClusterAdminOpsStatus safely persists the full adminops
+// status plane with a read-mutate-apply flow.
+//
+// This guards shared-plane writers against stale-object clobbering: the helper
+// reads the latest cluster before mutating and then applies the full adminops
+// plane under the canonical adminops field owner.
+func MutateAndApplyOpenBaoClusterAdminOpsStatus(
+	ctx context.Context,
+	c client.Client,
+	key types.NamespacedName,
+	mutate OpenBaoClusterAdminOpsStatusMutator,
+	opts OpenBaoClusterAdminOpsStatusApplyOptions,
+) (*openbaov1alpha1.OpenBaoCluster, error) {
+	return MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(ctx, nil, c, key, mutate, opts)
+}
+
+// MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader safely persists the full
+// adminops status plane with a read-mutate-apply flow using reader for
+// read-before-write and read-after-write freshness. Callers should pass an
+// uncached APIReader when immediate apiserver visibility matters.
+func MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	key types.NamespacedName,
+	mutate OpenBaoClusterAdminOpsStatusMutator,
+	opts OpenBaoClusterAdminOpsStatusApplyOptions,
+) (*openbaov1alpha1.OpenBaoCluster, error) {
+	if c == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if key.Name == "" {
+		return nil, fmt.Errorf("cluster name is required")
+	}
+	if mutate == nil {
+		return nil, fmt.Errorf("mutate function is required")
+	}
+	if reader == nil {
+		reader = c
+	}
+
+	current := &openbaov1alpha1.OpenBaoCluster{}
+	if err := reader.Get(ctx, key, current); err != nil {
+		return nil, fmt.Errorf("failed to get cluster %s/%s before adminops status apply: %w", key.Namespace, key.Name, err)
+	}
+
+	desired := current.DeepCopy()
+	if err := mutate(desired); err != nil {
+		return nil, err
+	}
+
+	if err := ApplyOpenBaoClusterAdminOpsStatus(ctx, c, desired, opts); err != nil {
+		return nil, fmt.Errorf("failed to apply adminops status for cluster %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	updated := &openbaov1alpha1.OpenBaoCluster{}
+	if err := reader.Get(ctx, key, updated); err != nil {
+		if desired.Status.Upgrade == nil || upgradeFailureFieldsCleared(current, desired) {
+			// Fake client SSA does not reliably materialize omission-based clears on readback.
+			// Return desired status for clear-oriented flows to keep callers deterministic.
+			return desired, nil
+		}
+		return nil, fmt.Errorf("failed to get cluster %s/%s after adminops status apply: %w", key.Namespace, key.Name, err)
+	}
+	if desired.Status.Upgrade == nil || upgradeFailureFieldsCleared(current, desired) {
+		desired.ResourceVersion = updated.ResourceVersion
+		return desired, nil
+	}
+	return updated, nil
+}
+
+func upgradeFailureFieldsCleared(current, desired *openbaov1alpha1.OpenBaoCluster) bool {
+	if current == nil || desired == nil || current.Status.Upgrade == nil || desired.Status.Upgrade == nil {
+		return false
+	}
+
+	currentFailure := current.Status.Upgrade.Failure
+	desiredFailure := desired.Status.Upgrade.Failure
+	if currentFailure != nil && desiredFailure == nil {
+		return true
+	}
+	if currentFailure != nil && desiredFailure != nil && currentFailure.At != nil && desiredFailure.At == nil {
+		return true
+	}
+	if current.Status.Upgrade.LastErrorAt != nil && desired.Status.Upgrade.LastErrorAt == nil {
+		return true
+	}
+	if current.Status.Upgrade.LastStepDownTime != nil && desired.Status.Upgrade.LastStepDownTime == nil {
+		return true
+	}
+
+	return false
+}

--- a/internal/platform/statusapply/openbaocluster_mutate_apply_test.go
+++ b/internal/platform/statusapply/openbaocluster_mutate_apply_test.go
@@ -1,0 +1,286 @@
+package statusapply
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+type stagedReader struct {
+	first client.Reader
+	then  client.Reader
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *stagedReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.calls++
+	if r.calls == 1 {
+		return r.first.Get(ctx, key, obj, opts...)
+	}
+	return r.then.Get(ctx, key, obj, opts...)
+}
+
+func (r *stagedReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return r.then.List(ctx, list, opts...)
+}
+
+func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_UsesLatestStateAndPreservesSiblingFields(t *testing.T) {
+	t.Parallel()
+
+	stored := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adminops-mutate",
+			Namespace: "default",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Backup:          &openbaov1alpha1.BackupStatus{LastFailureReason: "persist-me"},
+			UpgradeRequests: &openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "before"},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+		WithStatusSubresource(stored).
+		WithObjects(stored.DeepCopy()).
+		Build()
+
+	// Stale caller state intentionally omits Backup.
+	stale := stored.DeepCopy()
+	stale.Status.Backup = nil
+
+	key := types.NamespacedName{Name: stale.Name, Namespace: stale.Namespace}
+	updated, err := MutateAndApplyOpenBaoClusterAdminOpsStatus(context.Background(), k8sClient, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+		obj.Status.BreakGlass = &openbaov1alpha1.BreakGlassStatus{Active: true, Nonce: "nonce-1"}
+		return nil
+	}, OpenBaoClusterAdminOpsStatusApplyOptions{})
+	if err != nil {
+		t.Fatalf("MutateAndApplyOpenBaoClusterAdminOpsStatus() error = %v", err)
+	}
+
+	if updated.Status.Backup == nil || updated.Status.Backup.LastFailureReason != "persist-me" {
+		t.Fatalf("updated.Status.Backup = %#v, want preserved backup state", updated.Status.Backup)
+	}
+	if updated.Status.BreakGlass == nil || !updated.Status.BreakGlass.Active || updated.Status.BreakGlass.Nonce != "nonce-1" {
+		t.Fatalf("updated.Status.BreakGlass = %#v, want break-glass state set", updated.Status.BreakGlass)
+	}
+
+	reloaded := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(stored), reloaded); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !reflect.DeepEqual(reloaded.Status.Backup, updated.Status.Backup) {
+		t.Fatalf("stored backup = %#v, want %#v", reloaded.Status.Backup, updated.Status.Backup)
+	}
+}
+
+func TestMutateAndApplyOpenBaoClusterAdminOpsStatusWithReader_UsesProvidedReaderForFreshState(t *testing.T) {
+	t.Parallel()
+
+	scheme := newOpenBaoClusterStatusTestScheme(t)
+	key := types.NamespacedName{Name: "adminops-mutate-reader", Namespace: "default"}
+
+	live := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Backup: &openbaov1alpha1.BackupStatus{
+				LastFailureReason: "persist-me",
+			},
+		},
+	}
+	cached := live.DeepCopy()
+	cached.Status.Backup = nil
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+		WithObjects(cached.DeepCopy()).
+		Build()
+	reader := &stagedReader{
+		first: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+			WithObjects(live.DeepCopy()).
+			Build(),
+		then: k8sClient,
+	}
+
+	updated, err := MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(context.Background(), reader, k8sClient, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+		obj.Status.BreakGlass = &openbaov1alpha1.BreakGlassStatus{
+			Active: true,
+			Nonce:  "nonce-1",
+		}
+		return nil
+	}, OpenBaoClusterAdminOpsStatusApplyOptions{})
+	if err != nil {
+		t.Fatalf("MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader() error = %v", err)
+	}
+
+	if updated.Status.Backup == nil || updated.Status.Backup.LastFailureReason != "persist-me" {
+		t.Fatalf("updated.Status.Backup = %#v, want preserved backup state", updated.Status.Backup)
+	}
+	if updated.Status.BreakGlass == nil || !updated.Status.BreakGlass.Active || updated.Status.BreakGlass.Nonce != "nonce-1" {
+		t.Fatalf("updated.Status.BreakGlass = %#v, want break-glass state set", updated.Status.BreakGlass)
+	}
+
+	stored := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(context.Background(), key, stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if stored.Status.Backup == nil || stored.Status.Backup.LastFailureReason != "persist-me" {
+		t.Fatalf("stored.Status.Backup = %#v, want preserved backup state", stored.Status.Backup)
+	}
+}
+
+func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_PropagatesMutatorError(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adminops-mutate-error",
+			Namespace: "default",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster.DeepCopy()).
+		Build()
+
+	wantErr := errors.New("boom")
+	_, err := MutateAndApplyOpenBaoClusterAdminOpsStatus(
+		context.Background(),
+		k8sClient,
+		types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+		func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			return wantErr
+		},
+		OpenBaoClusterAdminOpsStatusApplyOptions{},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("MutateAndApplyOpenBaoClusterAdminOpsStatus() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_ConcurrentWritersPreserveSiblingFields(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adminops-concurrent",
+			Namespace: "default",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster.DeepCopy()).
+		Build()
+
+	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	errCh := make(chan error, 64)
+	var wg sync.WaitGroup
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			_, err := MutateAndApplyOpenBaoClusterAdminOpsStatus(context.Background(), k8sClient, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.Backup = &openbaov1alpha1.BackupStatus{
+					LastFailureReason: "backup-writer",
+				}
+				return nil
+			}, OpenBaoClusterAdminOpsStatusApplyOptions{})
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			_, err := MutateAndApplyOpenBaoClusterAdminOpsStatus(context.Background(), k8sClient, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.Upgrade = &openbaov1alpha1.UpgradeProgress{
+					TargetVersion:    "2.5.0",
+					FromVersion:      "2.4.4",
+					CurrentPartition: 1,
+				}
+				obj.Status.UpgradeRequests = &openbaov1alpha1.UpgradeRequestStatus{
+					LastHandledRetry: "retry-1",
+				}
+				return nil
+			}, OpenBaoClusterAdminOpsStatusApplyOptions{})
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			_, err := MutateAndApplyOpenBaoClusterAdminOpsStatus(context.Background(), k8sClient, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.BreakGlass = &openbaov1alpha1.BreakGlassStatus{
+					Active: true,
+					Nonce:  "nonce-concurrent",
+				}
+				obj.Status.AdminOps = &openbaov1alpha1.AdminOpsControllerStatus{
+					LastError: &openbaov1alpha1.ControllerErrorStatus{
+						Reason: "WrapperWrite",
+					},
+				}
+				return nil
+			}, OpenBaoClusterAdminOpsStatusApplyOptions{})
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent mutate+apply failed: %v", err)
+	}
+
+	stored := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if stored.Status.Backup == nil || stored.Status.Backup.LastFailureReason != "backup-writer" {
+		t.Fatalf("stored backup = %#v, want backup writer state", stored.Status.Backup)
+	}
+	if stored.Status.Upgrade == nil || stored.Status.Upgrade.TargetVersion != "2.5.0" {
+		t.Fatalf("stored upgrade = %#v, want rolling writer state", stored.Status.Upgrade)
+	}
+	if stored.Status.UpgradeRequests == nil || stored.Status.UpgradeRequests.LastHandledRetry != "retry-1" {
+		t.Fatalf("stored upgradeRequests = %#v, want retry marker", stored.Status.UpgradeRequests)
+	}
+	if stored.Status.BreakGlass == nil || !stored.Status.BreakGlass.Active || stored.Status.BreakGlass.Nonce != "nonce-concurrent" {
+		t.Fatalf("stored breakGlass = %#v, want wrapper writer state", stored.Status.BreakGlass)
+	}
+	if stored.Status.AdminOps == nil || stored.Status.AdminOps.LastError == nil || stored.Status.AdminOps.LastError.Reason != "WrapperWrite" {
+		t.Fatalf("stored adminOps = %#v, want wrapper writer adminops state", stored.Status.AdminOps)
+	}
+}

--- a/internal/platform/statusapply/openbaocluster_mutate_apply_test.go
+++ b/internal/platform/statusapply/openbaocluster_mutate_apply_test.go
@@ -15,6 +15,8 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
 
+const persistMe = "persist-me"
+
 type stagedReader struct {
 	first client.Reader
 	then  client.Reader
@@ -46,7 +48,7 @@ func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_UsesLatestStateAndPreservesS
 			Namespace: "default",
 		},
 		Status: openbaov1alpha1.OpenBaoClusterStatus{
-			Backup:          &openbaov1alpha1.BackupStatus{LastFailureReason: "persist-me"},
+			Backup:          &openbaov1alpha1.BackupStatus{LastFailureReason: persistMe},
 			UpgradeRequests: &openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "before"},
 		},
 	}
@@ -70,7 +72,7 @@ func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_UsesLatestStateAndPreservesS
 		t.Fatalf("MutateAndApplyOpenBaoClusterAdminOpsStatus() error = %v", err)
 	}
 
-	if updated.Status.Backup == nil || updated.Status.Backup.LastFailureReason != "persist-me" {
+	if updated.Status.Backup == nil || updated.Status.Backup.LastFailureReason != persistMe {
 		t.Fatalf("updated.Status.Backup = %#v, want preserved backup state", updated.Status.Backup)
 	}
 	if updated.Status.BreakGlass == nil || !updated.Status.BreakGlass.Active || updated.Status.BreakGlass.Nonce != "nonce-1" {
@@ -99,7 +101,7 @@ func TestMutateAndApplyOpenBaoClusterAdminOpsStatusWithReader_UsesProvidedReader
 		},
 		Status: openbaov1alpha1.OpenBaoClusterStatus{
 			Backup: &openbaov1alpha1.BackupStatus{
-				LastFailureReason: "persist-me",
+				LastFailureReason: persistMe,
 			},
 		},
 	}
@@ -131,7 +133,7 @@ func TestMutateAndApplyOpenBaoClusterAdminOpsStatusWithReader_UsesProvidedReader
 		t.Fatalf("MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader() error = %v", err)
 	}
 
-	if updated.Status.Backup == nil || updated.Status.Backup.LastFailureReason != "persist-me" {
+	if updated.Status.Backup == nil || updated.Status.Backup.LastFailureReason != persistMe {
 		t.Fatalf("updated.Status.Backup = %#v, want preserved backup state", updated.Status.Backup)
 	}
 	if updated.Status.BreakGlass == nil || !updated.Status.BreakGlass.Active || updated.Status.BreakGlass.Nonce != "nonce-1" {

--- a/internal/platform/statusapply/openbaocluster_operationlock.go
+++ b/internal/platform/statusapply/openbaocluster_operationlock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +49,9 @@ func ApplyOpenBaoClusterOperationLockStatus(
 	}
 
 	applyConfig, err := ToApplyConfiguration(applyCluster, c)
+	if cluster.Status.OperationLock == nil {
+		applyConfig, err = ToApplyConfigurationWithExplicitNulls(applyCluster, c, "status.operationLock")
+	}
 	if err != nil {
 		return fmt.Errorf("failed to convert cluster to ApplyConfiguration: %w", err)
 	}
@@ -71,6 +75,20 @@ func MutateAndApplyOpenBaoClusterOperationLockStatus(
 	mutate OpenBaoClusterOperationLockStatusMutator,
 	opts OpenBaoClusterOperationLockStatusApplyOptions,
 ) (*openbaov1alpha1.OpenBaoCluster, error) {
+	return MutateAndApplyOpenBaoClusterOperationLockStatusWithReader(ctx, nil, c, key, mutate, opts)
+}
+
+// MutateAndApplyOpenBaoClusterOperationLockStatusWithReader safely persists the
+// lock plane with a read-mutate-apply flow using reader for fresh read-before-
+// write and read-after-write visibility when needed.
+func MutateAndApplyOpenBaoClusterOperationLockStatusWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	key types.NamespacedName,
+	mutate OpenBaoClusterOperationLockStatusMutator,
+	opts OpenBaoClusterOperationLockStatusApplyOptions,
+) (*openbaov1alpha1.OpenBaoCluster, error) {
 	if c == nil {
 		return nil, fmt.Errorf("client is required")
 	}
@@ -80,9 +98,12 @@ func MutateAndApplyOpenBaoClusterOperationLockStatus(
 	if mutate == nil {
 		return nil, fmt.Errorf("mutate function is required")
 	}
+	if reader == nil {
+		reader = c
+	}
 
 	current := &openbaov1alpha1.OpenBaoCluster{}
-	if err := c.Get(ctx, key, current); err != nil {
+	if err := reader.Get(ctx, key, current); err != nil {
 		return nil, fmt.Errorf("failed to get cluster %s/%s before operation lock status apply: %w", key.Namespace, key.Name, err)
 	}
 
@@ -91,20 +112,40 @@ func MutateAndApplyOpenBaoClusterOperationLockStatus(
 		return nil, err
 	}
 
+	if current.Status.OperationLock != nil && desired.Status.OperationLock == nil {
+		if err := ensureOperationLockOwnershipForClear(ctx, c, current); err != nil {
+			return nil, fmt.Errorf("failed to take ownership of operation lock status for cluster %s/%s before clear: %w", key.Namespace, key.Name, err)
+		}
+	}
+
 	if err := ApplyOpenBaoClusterOperationLockStatus(ctx, c, desired, opts); err != nil {
 		return nil, fmt.Errorf("failed to apply operation lock status for cluster %s/%s: %w", key.Namespace, key.Name, err)
 	}
 
 	updated := &openbaov1alpha1.OpenBaoCluster{}
-	if err := c.Get(ctx, key, updated); err != nil {
+	if err := reader.Get(ctx, key, updated); err != nil {
 		return nil, fmt.Errorf("failed to get cluster %s/%s after operation lock status apply: %w", key.Namespace, key.Name, err)
-	}
-	if desired.Status.OperationLock == nil && updated.Status.OperationLock != nil {
-		// Fake client SSA does not reliably materialize omitted-field clears
-		// on readback. Return desired clear-state to keep callers deterministic.
-		desired.ResourceVersion = updated.ResourceVersion
-		return desired, nil
 	}
 
 	return updated, nil
+}
+
+func ensureOperationLockOwnershipForClear(
+	ctx context.Context,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) error {
+	if cluster == nil || cluster.Status.OperationLock == nil {
+		return nil
+	}
+
+	err := ApplyOpenBaoClusterOperationLockStatus(ctx, c, cluster, OpenBaoClusterOperationLockStatusApplyOptions{})
+	if err != nil && apierrors.IsConflict(err) {
+		// Clearing a lock seeded outside the dedicated field owner is an explicit
+		// ownership-takeover path, so retry with force only on conflict.
+		err = ApplyOpenBaoClusterOperationLockStatus(ctx, c, cluster, OpenBaoClusterOperationLockStatusApplyOptions{
+			ForceOwnership: true,
+		})
+	}
+	return err
 }

--- a/internal/platform/statusapply/openbaocluster_operationlock.go
+++ b/internal/platform/statusapply/openbaocluster_operationlock.go
@@ -1,0 +1,110 @@
+package statusapply
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+// OpenBaoClusterOperationLockStatusApplyOptions configures operation lock SSA.
+type OpenBaoClusterOperationLockStatusApplyOptions struct {
+	ForceOwnership bool
+}
+
+// OpenBaoClusterOperationLockStatusMutator updates operation lock status fields
+// on the provided desired cluster object before the apply is persisted.
+type OpenBaoClusterOperationLockStatusMutator func(*openbaov1alpha1.OpenBaoCluster) error
+
+// ApplyOpenBaoClusterOperationLockStatus applies the operation lock status
+// plane under the dedicated lock field owner.
+func ApplyOpenBaoClusterOperationLockStatus(
+	ctx context.Context,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	opts OpenBaoClusterOperationLockStatusApplyOptions,
+) error {
+	if cluster == nil {
+		return fmt.Errorf("cluster is required")
+	}
+
+	applyCluster := &openbaov1alpha1.OpenBaoCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: openbaov1alpha1.GroupVersion.String(),
+			Kind:       "OpenBaoCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			OperationLock: cluster.Status.OperationLock,
+		},
+	}
+
+	applyConfig, err := ToApplyConfiguration(applyCluster, c)
+	if err != nil {
+		return fmt.Errorf("failed to convert cluster to ApplyConfiguration: %w", err)
+	}
+
+	applyOpts := []client.SubResourceApplyOption{
+		client.FieldOwner(constants.FieldOwnerOperationLockStatus),
+	}
+	if opts.ForceOwnership {
+		applyOpts = append(applyOpts, client.ForceOwnership)
+	}
+
+	return c.Status().Apply(ctx, applyConfig, applyOpts...)
+}
+
+// MutateAndApplyOpenBaoClusterOperationLockStatus safely persists the lock
+// plane with a read-mutate-apply flow.
+func MutateAndApplyOpenBaoClusterOperationLockStatus(
+	ctx context.Context,
+	c client.Client,
+	key types.NamespacedName,
+	mutate OpenBaoClusterOperationLockStatusMutator,
+	opts OpenBaoClusterOperationLockStatusApplyOptions,
+) (*openbaov1alpha1.OpenBaoCluster, error) {
+	if c == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if key.Name == "" {
+		return nil, fmt.Errorf("cluster name is required")
+	}
+	if mutate == nil {
+		return nil, fmt.Errorf("mutate function is required")
+	}
+
+	current := &openbaov1alpha1.OpenBaoCluster{}
+	if err := c.Get(ctx, key, current); err != nil {
+		return nil, fmt.Errorf("failed to get cluster %s/%s before operation lock status apply: %w", key.Namespace, key.Name, err)
+	}
+
+	desired := current.DeepCopy()
+	if err := mutate(desired); err != nil {
+		return nil, err
+	}
+
+	if err := ApplyOpenBaoClusterOperationLockStatus(ctx, c, desired, opts); err != nil {
+		return nil, fmt.Errorf("failed to apply operation lock status for cluster %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	updated := &openbaov1alpha1.OpenBaoCluster{}
+	if err := c.Get(ctx, key, updated); err != nil {
+		return nil, fmt.Errorf("failed to get cluster %s/%s after operation lock status apply: %w", key.Namespace, key.Name, err)
+	}
+	if desired.Status.OperationLock == nil && updated.Status.OperationLock != nil {
+		// Fake client SSA does not reliably materialize omitted-field clears
+		// on readback. Return desired clear-state to keep callers deterministic.
+		desired.ResourceVersion = updated.ResourceVersion
+		return desired, nil
+	}
+
+	return updated, nil
+}

--- a/internal/platform/statusapply/openbaocluster_operationlock_test.go
+++ b/internal/platform/statusapply/openbaocluster_operationlock_test.go
@@ -2,7 +2,9 @@ package statusapply
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,5 +173,70 @@ func TestMutateAndApplyOpenBaoClusterOperationLockStatus_PropagatesMutatorError(
 	)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("MutateAndApplyOpenBaoClusterOperationLockStatus() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestMutateAndApplyOpenBaoClusterOperationLockStatus_ClearTakesOwnershipThenOmitsField(t *testing.T) {
+	t.Parallel()
+
+	acquiredAt := metav1.Now()
+	stored := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operationlock-clear",
+			Namespace: "default",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			OperationLock: &openbaov1alpha1.OperationLockStatus{
+				Operation:  openbaov1alpha1.ClusterOperationBackup,
+				Holder:     "openbaocluster/backup",
+				Message:    "backup in progress",
+				AcquiredAt: &acquiredAt,
+				RenewedAt:  &acquiredAt,
+			},
+		},
+	}
+
+	var applyPayloads []string
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+		WithStatusSubresource(stored).
+		WithObjects(stored.DeepCopy()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(ctx context.Context, c client.Client, subResource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				if subResource == "status" {
+					payload, err := json.Marshal(obj)
+					if err != nil {
+						return err
+					}
+					applyPayloads = append(applyPayloads, string(payload))
+				}
+				return c.Status().Apply(ctx, obj, opts...)
+			},
+		}).
+		WithReturnManagedFields().
+		Build()
+
+	_, err := MutateAndApplyOpenBaoClusterOperationLockStatus(
+		context.Background(),
+		k8sClient,
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.OperationLock = nil
+			return nil
+		},
+		OpenBaoClusterOperationLockStatusApplyOptions{},
+	)
+	if err != nil {
+		t.Fatalf("MutateAndApplyOpenBaoClusterOperationLockStatus() error = %v", err)
+	}
+
+	if len(applyPayloads) != 2 {
+		t.Fatalf("apply payloads = %#v, want 2 status apply calls (take ownership, then clear)", applyPayloads)
+	}
+	if !strings.Contains(applyPayloads[0], `"operationLock":{"`) {
+		t.Fatalf("ownership payload missing operationLock object: %s", applyPayloads[0])
+	}
+	if strings.Contains(applyPayloads[1], `"operationLock":{"`) || !strings.Contains(applyPayloads[1], `"operationLock":null`) {
+		t.Fatalf("clear payload should explicitly null operationLock after ownership takeover: %s", applyPayloads[1])
 	}
 }

--- a/internal/platform/statusapply/openbaocluster_operationlock_test.go
+++ b/internal/platform/statusapply/openbaocluster_operationlock_test.go
@@ -1,0 +1,175 @@
+package statusapply
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+func TestApplyOpenBaoClusterOperationLockStatus_PersistsLockPlane(t *testing.T) {
+	t.Parallel()
+
+	acquiredAt := metav1.Now()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operationlock-plane",
+			Namespace: "default",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			OperationLock: &openbaov1alpha1.OperationLockStatus{
+				Operation:  openbaov1alpha1.ClusterOperationUpgrade,
+				Holder:     "openbao-adminops-controller/upgrade",
+				Message:    "upgrade in progress",
+				AcquiredAt: &acquiredAt,
+				RenewedAt:  &acquiredAt,
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster.DeepCopy()).
+		Build()
+
+	if err := ApplyOpenBaoClusterOperationLockStatus(context.Background(), k8sClient, cluster, OpenBaoClusterOperationLockStatusApplyOptions{}); err != nil {
+		t.Fatalf("ApplyOpenBaoClusterOperationLockStatus() error = %v", err)
+	}
+
+	stored := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if stored.Status.OperationLock == nil {
+		t.Fatal("stored operationLock = nil, want populated")
+	}
+	if stored.Status.OperationLock.Operation != cluster.Status.OperationLock.Operation {
+		t.Fatalf("stored operation = %q, want %q", stored.Status.OperationLock.Operation, cluster.Status.OperationLock.Operation)
+	}
+	if stored.Status.OperationLock.Holder != cluster.Status.OperationLock.Holder {
+		t.Fatalf("stored holder = %q, want %q", stored.Status.OperationLock.Holder, cluster.Status.OperationLock.Holder)
+	}
+	if stored.Status.OperationLock.Message != cluster.Status.OperationLock.Message {
+		t.Fatalf("stored message = %q, want %q", stored.Status.OperationLock.Message, cluster.Status.OperationLock.Message)
+	}
+	if stored.Status.OperationLock.AcquiredAt == nil || stored.Status.OperationLock.RenewedAt == nil {
+		t.Fatalf("stored timestamps = %#v, want acquired/renewed timestamps set", stored.Status.OperationLock)
+	}
+}
+
+func TestApplyOpenBaoClusterOperationLockStatus_ApplyOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		force     bool
+		wantForce bool
+	}{
+		{
+			name:      "without force ownership",
+			force:     false,
+			wantForce: false,
+		},
+		{
+			name:      "with force ownership",
+			force:     true,
+			wantForce: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "operationlock-options",
+					Namespace: "default",
+				},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					OperationLock: &openbaov1alpha1.OperationLockStatus{
+						Operation: openbaov1alpha1.ClusterOperationUpgrade,
+						Holder:    "owner/upgrade",
+					},
+				},
+			}
+
+			var capturedOptions client.SubResourceApplyOptions
+			var subResourceName string
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+				WithStatusSubresource(cluster).
+				WithObjects(cluster.DeepCopy()).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceApply: func(ctx context.Context, c client.Client, subResource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+						subResourceName = subResource
+						capturedOptions = *(&client.SubResourceApplyOptions{}).ApplyOpts(opts)
+						return c.Status().Apply(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			err := ApplyOpenBaoClusterOperationLockStatus(context.Background(), k8sClient, cluster, OpenBaoClusterOperationLockStatusApplyOptions{
+				ForceOwnership: tt.force,
+			})
+			if err != nil {
+				t.Fatalf("ApplyOpenBaoClusterOperationLockStatus() error = %v", err)
+			}
+
+			if subResourceName != "status" {
+				t.Fatalf("subResourceName = %q, want status", subResourceName)
+			}
+			if capturedOptions.FieldManager != constants.FieldOwnerOperationLockStatus {
+				t.Fatalf("FieldManager = %q, want %q", capturedOptions.FieldManager, constants.FieldOwnerOperationLockStatus)
+			}
+
+			force := capturedOptions.Force != nil && *capturedOptions.Force
+			if force != tt.wantForce {
+				t.Fatalf("Force = %v, want %v", force, tt.wantForce)
+			}
+		})
+	}
+}
+
+func TestMutateAndApplyOpenBaoClusterOperationLockStatus_PropagatesMutatorError(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operationlock-mutate-error",
+			Namespace: "default",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster.DeepCopy()).
+		Build()
+
+	wantErr := errors.New("boom")
+	_, err := MutateAndApplyOpenBaoClusterOperationLockStatus(
+		context.Background(),
+		k8sClient,
+		types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+		func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			return wantErr
+		},
+		OpenBaoClusterOperationLockStatusApplyOptions{},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("MutateAndApplyOpenBaoClusterOperationLockStatus() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/platform/statusapply/openbaocluster_test.go
+++ b/internal/platform/statusapply/openbaocluster_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
 
+const statusSubresourceName = "status"
+
 func TestApplyOpenBaoClusterAdminOpsStatus_PersistsFullAdminOpsPlane(t *testing.T) {
 	t.Parallel()
 
@@ -142,8 +144,8 @@ func TestApplyOpenBaoClusterAdminOpsStatus_ApplyOptions(t *testing.T) {
 				t.Fatalf("ApplyOpenBaoClusterAdminOpsStatus() error = %v", err)
 			}
 
-			if subResourceName != "status" {
-				t.Fatalf("subResourceName = %q, want status", subResourceName)
+			if subResourceName != statusSubresourceName {
+				t.Fatalf("subResourceName = %q, want %s", subResourceName, statusSubresourceName)
 			}
 			if capturedOptions.FieldManager != constants.FieldOwnerAdminOpsStatus {
 				t.Fatalf("FieldManager = %q, want %q", capturedOptions.FieldManager, constants.FieldOwnerAdminOpsStatus)

--- a/internal/service/backup/manager.go
+++ b/internal/service/backup/manager.go
@@ -24,6 +24,7 @@ var backupOperationLock = opslifecycle.OperationLock{
 // Manager reconciles backup configuration and execution for an OpenBaoCluster.
 type Manager struct {
 	client                client.Client
+	reader                client.Reader
 	scheme                *runtime.Scheme
 	recorder              events.EventRecorder
 	clientConfig          portopenbao.ClientConfig
@@ -40,12 +41,21 @@ func NewManager(c client.Client, scheme *runtime.Scheme, clientConfig portopenba
 	}
 	return &Manager{
 		client:                c,
+		reader:                c,
 		scheme:                scheme,
 		recorder:              eventRecorder,
 		clientConfig:          clientConfig,
 		operatorImageVerifier: operatorImageVerifier,
 		Platform:              platform,
 	}
+}
+
+// WithReader configures a live reader for status read-before-write flows.
+func (m *Manager) WithReader(reader client.Reader) *Manager {
+	if reader != nil {
+		m.reader = reader
+	}
+	return m
 }
 
 // BackupResult contains the result of a successful backup.

--- a/internal/service/backup/manager_execution.go
+++ b/internal/service/backup/manager_execution.go
@@ -108,7 +108,7 @@ func (m *Manager) acquireBackupLock(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	jobName string,
 ) (*recon.Result, error) {
-	if err := opslifecycle.Acquire(ctx, m.client, cluster, backupOperationLock, opslifecycle.AcquireOptions{
+	if err := opslifecycle.AcquireWithReader(ctx, m.reader, m.client, cluster, backupOperationLock, opslifecycle.AcquireOptions{
 		Message: fmt.Sprintf("backup job %s", jobName),
 	}); err != nil {
 		if opslifecycle.IsLockHeld(err) {

--- a/internal/service/backup/manager_reconcile.go
+++ b/internal/service/backup/manager_reconcile.go
@@ -133,7 +133,7 @@ func (m *Manager) handleRestoreInProgress(ctx context.Context, logger logr.Logge
 }
 
 func (m *Manager) releaseBackupLock(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, contextNote string) {
-	if err := opslifecycle.Release(ctx, m.client, cluster, backupOperationLock); err != nil && !opslifecycle.IsLockHeld(err) {
+	if err := opslifecycle.ReleaseWithReader(ctx, m.reader, m.client, cluster, backupOperationLock); err != nil && !opslifecycle.IsLockHeld(err) {
 		logger.Error(err, "Failed to release backup operation lock", "context", contextNote)
 		return
 	} else if err == nil {

--- a/internal/service/opslifecycle/lock.go
+++ b/internal/service/opslifecycle/lock.go
@@ -28,7 +28,20 @@ func (l OperationLock) IsHeldBy(lock *openbaov1alpha1.OperationLockStatus) bool 
 
 // Acquire acquires or renews the lock on the cluster status.
 func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, lock OperationLock, opts AcquireOptions) error {
-	return operationlock.Acquire(ctx, c, cluster, operationlock.AcquireOptions{
+	return AcquireWithReader(ctx, nil, c, cluster, lock, opts)
+}
+
+// AcquireWithReader acquires or renews the lock on the cluster status using a
+// dedicated reader for fresh read-before-write visibility.
+func AcquireWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	lock OperationLock,
+	opts AcquireOptions,
+) error {
+	return operationlock.AcquireWithReader(ctx, reader, c, cluster, operationlock.AcquireOptions{
 		Holder:    lock.Holder,
 		Operation: lock.Operation,
 		Message:   opts.Message,
@@ -38,7 +51,19 @@ func Acquire(ctx context.Context, c client.Client, cluster *openbaov1alpha1.Open
 
 // Release releases the lock when it is owned by the given operation identity.
 func Release(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, lock OperationLock) error {
-	return operationlock.Release(ctx, c, cluster, lock.Holder, lock.Operation)
+	return ReleaseWithReader(ctx, nil, c, cluster, lock)
+}
+
+// ReleaseWithReader releases the lock when it is owned by the given operation
+// identity using a dedicated reader for fresh read-before-write visibility.
+func ReleaseWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	lock OperationLock,
+) error {
+	return operationlock.ReleaseWithReader(ctx, reader, c, cluster, lock.Holder, lock.Operation)
 }
 
 // IsLockHeld reports whether err indicates the lock is currently held by another operation.

--- a/internal/service/restore/manager.go
+++ b/internal/service/restore/manager.go
@@ -31,6 +31,7 @@ const (
 // Manager orchestrates restore operations for OpenBao clusters.
 type Manager struct {
 	client                client.Client
+	reader                client.Reader
 	scheme                *runtime.Scheme
 	recorder              events.EventRecorder
 	operatorImageVerifier imageverify.Verifier
@@ -41,9 +42,18 @@ type Manager struct {
 func NewManager(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder, operatorImageVerifier imageverify.Verifier, platform string) *Manager {
 	return &Manager{
 		client:                c,
+		reader:                c,
 		scheme:                scheme,
 		recorder:              recorder,
 		operatorImageVerifier: operatorImageVerifier,
 		Platform:              platform,
 	}
+}
+
+// WithReader configures a live reader for lock/status read-before-write flows.
+func (m *Manager) WithReader(reader client.Reader) *Manager {
+	if reader != nil {
+		m.reader = reader
+	}
+	return m
 }

--- a/internal/service/restore/manager_running.go
+++ b/internal/service/restore/manager_running.go
@@ -24,7 +24,7 @@ import (
 func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore *openbaov1alpha1.OpenBaoRestore) (ctrl.Result, error) {
 	// Get target cluster for job configuration
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
-	if err := m.client.Get(ctx, types.NamespacedName{
+	if err := m.reader.Get(ctx, types.NamespacedName{
 		Namespace: restore.Namespace,
 		Name:      restore.Spec.Cluster,
 	}, cluster); err != nil {
@@ -33,7 +33,7 @@ func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore
 
 	lock := restoreOperationLock(restore)
 	lockHeldByUs := lock.IsHeldBy(cluster.Status.OperationLock)
-	if err := opslifecycle.Acquire(ctx, m.client, cluster, lock, opslifecycle.AcquireOptions{
+	if err := opslifecycle.AcquireWithReader(ctx, m.reader, m.client, cluster, lock, opslifecycle.AcquireOptions{
 		Message: restoreLockMessage(restore),
 	}); err != nil {
 		if opslifecycle.IsLockHeld(err) {

--- a/internal/service/restore/manager_status.go
+++ b/internal/service/restore/manager_status.go
@@ -174,7 +174,7 @@ func (m *Manager) releaseClusterLock(ctx context.Context, logger logr.Logger, re
 	}
 
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
-	if err := m.client.Get(ctx, types.NamespacedName{
+	if err := m.reader.Get(ctx, types.NamespacedName{
 		Namespace: restore.Namespace,
 		Name:      restore.Spec.Cluster,
 	}, cluster); err != nil {
@@ -185,7 +185,7 @@ func (m *Manager) releaseClusterLock(ctx context.Context, logger logr.Logger, re
 	}
 
 	lock := restoreOperationLock(restore)
-	if err := opslifecycle.Release(ctx, m.client, cluster, lock); err != nil {
+	if err := opslifecycle.ReleaseWithReader(ctx, m.reader, m.client, cluster, lock); err != nil {
 		if opslifecycle.IsLockHeld(err) {
 			return nil
 		}

--- a/internal/service/restore/manager_status.go
+++ b/internal/service/restore/manager_status.go
@@ -147,6 +147,9 @@ func (m *Manager) ensureFinalizer(ctx context.Context, restore *openbaov1alpha1.
 	if err := m.client.Patch(ctx, restore, client.MergeFrom(original)); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(restore), restore); err != nil {
+		return fmt.Errorf("failed to refresh restore after adding finalizer: %w", err)
+	}
 	return nil
 }
 

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -2,8 +2,10 @@ package restore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -318,10 +320,23 @@ func TestReconcileTerminalPhase_ReleasesOperationLock(t *testing.T) {
 	}
 	setTestResourceVersion(restore)
 
+	var applyPayloads []string
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(cluster, restore).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				if subResourceName == "status" {
+					payload, err := json.Marshal(obj)
+					if err != nil {
+						return err
+					}
+					applyPayloads = append(applyPayloads, string(payload))
+				}
+				return c.Status().Apply(ctx, obj, opts...)
+			},
+		}).
 		WithReturnManagedFields().
 		Build()
 
@@ -330,10 +345,10 @@ func TestReconcileTerminalPhase_ReleasesOperationLock(t *testing.T) {
 	result, err := mgr.Reconcile(context.Background(), testLogger(), restore)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), int64(result.RequeueAfter))
-
-	updatedCluster := &openbaov1alpha1.OpenBaoCluster{}
-	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: "default"}, updatedCluster))
-	assert.Nil(t, updatedCluster.Status.OperationLock)
+	require.Len(t, applyPayloads, 2, "expected lock takeover apply followed by omission clear apply")
+	assert.Contains(t, applyPayloads[0], `"operationLock":{"`)
+	assert.NotContains(t, applyPayloads[1], `"operationLock":{"`)
+	assert.Contains(t, applyPayloads[1], `"operationLock":null`)
 }
 
 func TestReconcileTerminalPhase_RetriesLockReleaseAfterTransientFailure(t *testing.T) {
@@ -373,20 +388,26 @@ func TestReconcileTerminalPhase_RetriesLockReleaseAfterTransientFailure(t *testi
 	}
 	setTestResourceVersion(restore)
 
-	failStatusPatchOnce := true
+	failStatusApplyOnce := true
+	var applyPayloads []string
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(cluster, restore).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 				if subResourceName == "status" {
-					if _, isCluster := obj.(*openbaov1alpha1.OpenBaoCluster); isCluster && failStatusPatchOnce {
-						failStatusPatchOnce = false
-						return apierrors.NewInternalError(fmt.Errorf("transient status patch failure"))
+					payload, err := json.Marshal(obj)
+					if err != nil {
+						return err
+					}
+					applyPayloads = append(applyPayloads, string(payload))
+					if failStatusApplyOnce {
+						failStatusApplyOnce = false
+						return apierrors.NewInternalError(fmt.Errorf("transient status apply failure"))
 					}
 				}
-				return c.Status().Patch(ctx, obj, patch, opts...)
+				return c.Status().Apply(ctx, obj, opts...)
 			},
 		}).
 		WithReturnManagedFields().
@@ -399,11 +420,8 @@ func TestReconcileTerminalPhase_RetriesLockReleaseAfterTransientFailure(t *testi
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to release cluster operation lock for terminal restore")
 	assert.Equal(t, int64(0), int64(result.RequeueAfter))
-	assert.False(t, failStatusPatchOnce, "expected injected transient patch failure to be consumed")
-
-	lockedCluster := &openbaov1alpha1.OpenBaoCluster{}
-	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: "default"}, lockedCluster))
-	assert.NotNil(t, lockedCluster.Status.OperationLock, "lock should still be present after first failed release")
+	assert.False(t, failStatusApplyOnce, "expected injected transient apply failure to be consumed")
+	require.Len(t, applyPayloads, 1, "first terminal reconcile should fail on the first lock SSA apply")
 
 	// Second terminal reconcile should succeed and clear the lock.
 	freshRestore := &openbaov1alpha1.OpenBaoRestore{}
@@ -412,10 +430,10 @@ func TestReconcileTerminalPhase_RetriesLockReleaseAfterTransientFailure(t *testi
 	result, err = mgr.Reconcile(context.Background(), testLogger(), freshRestore)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), int64(result.RequeueAfter))
-
-	unlockedCluster := &openbaov1alpha1.OpenBaoCluster{}
-	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: "default"}, unlockedCluster))
-	assert.Nil(t, unlockedCluster.Status.OperationLock, "lock should be released on subsequent terminal reconcile")
+	require.Len(t, applyPayloads, 3, "second terminal reconcile should issue takeover and clear applies")
+	assert.Contains(t, applyPayloads[1], `"operationLock":{"`)
+	assert.True(t, !strings.Contains(applyPayloads[2], `"operationLock":{"`) && strings.Contains(applyPayloads[2], `"operationLock":null`),
+		"final payload should explicitly null operationLock after ownership takeover: %s", applyPayloads[2])
 }
 
 func TestHandleValidating_PersistsOperationLockOverrideCondition(t *testing.T) {

--- a/internal/service/restore/manager_validation.go
+++ b/internal/service/restore/manager_validation.go
@@ -23,7 +23,7 @@ import (
 // Returns (cluster, result, error) where result is non-nil if validation failed and should return early.
 func (m *Manager) validateCluster(ctx context.Context, logger logr.Logger, restore *openbaov1alpha1.OpenBaoRestore) (*openbaov1alpha1.OpenBaoCluster, *ctrl.Result, error) {
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
-	if err := m.client.Get(ctx, types.NamespacedName{
+	if err := m.reader.Get(ctx, types.NamespacedName{
 		Namespace: restore.Namespace,
 		Name:      restore.Spec.Cluster,
 	}, cluster); err != nil {
@@ -61,7 +61,7 @@ func (m *Manager) acquireOperationLock(ctx context.Context, logger logr.Logger, 
 	}
 
 	lockBefore := cluster.Status.OperationLock
-	if err := opslifecycle.Acquire(ctx, m.client, cluster, lock, opslifecycle.AcquireOptions{
+	if err := opslifecycle.AcquireWithReader(ctx, m.reader, m.client, cluster, lock, opslifecycle.AcquireOptions{
 		Message: restoreLockMessage(restore),
 		Force:   forceAcquire,
 	}); err != nil {

--- a/internal/service/upgrade/bluegreen/manager.go
+++ b/internal/service/upgrade/bluegreen/manager.go
@@ -30,6 +30,7 @@ var (
 // Manager manages blue/green upgrade operations for OpenBaoCluster.
 type Manager struct {
 	client                client.Client
+	reader                client.Reader
 	scheme                *runtime.Scheme
 	infraRuntime          portinfra.BlueGreenRuntime
 	backupRuntime         portbackup.PreUpgradeSnapshotRuntime
@@ -60,6 +61,7 @@ func NewManager(
 	}
 	mgr := &Manager{
 		client:                c,
+		reader:                c,
 		scheme:                scheme,
 		infraRuntime:          infraRuntime,
 		backupRuntime:         backupRuntime,
@@ -72,6 +74,14 @@ func NewManager(
 	}
 	mgr.clusterOps = newOpenBaoClusterOps(c, mgr.clientFactory)
 	return mgr
+}
+
+// WithReader configures a live reader for lock/status read-before-write flows.
+func (m *Manager) WithReader(reader client.Reader) *Manager {
+	if reader != nil {
+		m.reader = reader
+	}
+	return m
 }
 
 func NewManagerWithClientFactory(

--- a/internal/service/upgrade/bluegreen/workflow_preflight.go
+++ b/internal/service/upgrade/bluegreen/workflow_preflight.go
@@ -33,7 +33,7 @@ func (m *Manager) ensureBlueGreenStatus(ctx context.Context, logger logr.Logger,
 }
 
 func (m *Manager) releaseUpgradeLockIfHeld(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	return core.ReleaseUpgradeLockIfHeld(ctx, m.client, logger, cluster)
+	return core.ReleaseUpgradeLockIfHeldWithReader(ctx, m.reader, m.client, logger, cluster)
 }
 
 func (m *Manager) finalizeUpgradeTerminalState(
@@ -111,10 +111,10 @@ func (m *Manager) validateIdleUpgradeInputs(ctx context.Context, logger logr.Log
 	}
 
 	if err := upgrade.ValidateUpgradeTargetVersion(logger, cluster.Status.CurrentVersion, cluster.Spec.Version); err != nil {
-		return core.ReleaseUpgradeLockOnErrorIfHeld(ctx, m.client, logger, cluster, true, err, "")
+		return core.ReleaseUpgradeLockOnErrorIfHeldWithReader(ctx, m.reader, m.client, logger, cluster, true, err, "")
 	}
 	if err := upgrade.ValidateImageRefMatchesVersion(cluster.Spec.Version, cluster.Spec.Image); err != nil {
-		return core.ReleaseUpgradeLockOnErrorIfHeld(ctx, m.client, logger, cluster, true, err, "")
+		return core.ReleaseUpgradeLockOnErrorIfHeldWithReader(ctx, m.reader, m.client, logger, cluster, true, err, "")
 	}
 
 	return nil
@@ -124,7 +124,7 @@ func (m *Manager) maybeAcquireUpgradeLock(ctx context.Context, logger logr.Logge
 	if !upgradeActive && !upgradeNeeded {
 		return false, recon.Result{}, nil
 	}
-	lockResult, err := core.AcquireUpgradeLock(ctx, m.client, logger, cluster, fmt.Sprintf("blue/green upgrade phase %s", core.CurrentBlueGreenPhase(cluster)))
+	lockResult, err := core.AcquireUpgradeLockWithReader(ctx, m.reader, m.client, logger, cluster, fmt.Sprintf("blue/green upgrade phase %s", core.CurrentBlueGreenPhase(cluster)))
 	if err != nil {
 		return true, recon.Result{}, fmt.Errorf("failed to acquire upgrade operation lock: %w", err)
 	}

--- a/internal/service/upgrade/core/lock.go
+++ b/internal/service/upgrade/core/lock.go
@@ -45,32 +45,68 @@ func IsUpgradeOperationLockHeldByUs(lock *openbaov1alpha1.OperationLockStatus) b
 
 // AcquireUpgradeOperationLock acquires the low-level upgrade operation lock.
 func AcquireUpgradeOperationLock(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, message string) error {
+	return AcquireUpgradeOperationLockWithReader(ctx, nil, c, cluster, message)
+}
+
+// AcquireUpgradeOperationLockWithReader acquires the low-level upgrade
+// operation lock using reader for fresh read-before-write visibility.
+func AcquireUpgradeOperationLockWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	message string,
+) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster is required")
 	}
-	return opslifecycle.Acquire(ctx, c, cluster, upgradeOperationLock, opslifecycle.AcquireOptions{
+	return opslifecycle.AcquireWithReader(ctx, reader, c, cluster, upgradeOperationLock, opslifecycle.AcquireOptions{
 		Message: message,
 	})
 }
 
 // ReleaseUpgradeOperationLock releases the low-level upgrade operation lock.
 func ReleaseUpgradeOperationLock(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	return ReleaseUpgradeOperationLockWithReader(ctx, nil, c, cluster)
+}
+
+// ReleaseUpgradeOperationLockWithReader releases the low-level upgrade
+// operation lock using reader for fresh read-before-write visibility.
+func ReleaseUpgradeOperationLockWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster is required")
 	}
-	return opslifecycle.Release(ctx, c, cluster, upgradeOperationLock)
+	return opslifecycle.ReleaseWithReader(ctx, reader, c, cluster, upgradeOperationLock)
 }
 
 // AcquireUpgradeLock acquires the upgrade lock and emits the common audit event
 // shape for success and lock contention.
 func AcquireUpgradeLock(ctx context.Context, c client.Client, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, message string) (LockAcquireResult, error) {
+	return AcquireUpgradeLockWithReader(ctx, nil, c, logger, cluster, message)
+}
+
+// AcquireUpgradeLockWithReader acquires the upgrade lock and emits the common
+// audit event shape for success and lock contention using a dedicated reader.
+func AcquireUpgradeLockWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	message string,
+) (LockAcquireResult, error) {
 	result := LockAcquireResult{}
 	lockHeldByUs := false
 	if cluster != nil {
 		lockHeldByUs = IsUpgradeOperationLockHeldByUs(cluster.Status.OperationLock)
 	}
 
-	if err := AcquireUpgradeOperationLock(ctx, c, cluster, message); err != nil {
+	if err := AcquireUpgradeOperationLockWithReader(ctx, reader, c, cluster, message); err != nil {
 		if !IsOperationLockHeld(err) {
 			return result, err
 		}
@@ -95,6 +131,18 @@ func AcquireUpgradeLock(ctx context.Context, c client.Client, logger logr.Logger
 // ReleaseUpgradeLockIfHeld releases the upgrade lock when it is currently owned
 // by the upgrade flow. Ownership races are treated as benign.
 func ReleaseUpgradeLockIfHeld(ctx context.Context, c client.Client, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	return ReleaseUpgradeLockIfHeldWithReader(ctx, nil, c, logger, cluster)
+}
+
+// ReleaseUpgradeLockIfHeld releases the upgrade lock when it is currently owned
+// by the upgrade flow using a dedicated reader for fresh read-before-write visibility.
+func ReleaseUpgradeLockIfHeldWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster is required")
 	}
@@ -102,7 +150,7 @@ func ReleaseUpgradeLockIfHeld(ctx context.Context, c client.Client, logger logr.
 		return nil
 	}
 
-	if err := ReleaseUpgradeOperationLock(ctx, c, cluster); err != nil {
+	if err := ReleaseUpgradeOperationLockWithReader(ctx, reader, c, cluster); err != nil {
 		if IsOperationLockHeld(err) {
 			logger.V(1).Info("Upgrade operation lock changed ownership before release")
 			return nil
@@ -126,11 +174,27 @@ func ReleaseUpgradeLockOnErrorIfHeld(
 	cause error,
 	releaseErrorMessage string,
 ) error {
+	return ReleaseUpgradeLockOnErrorIfHeldWithReader(ctx, nil, c, logger, cluster, shouldRelease, cause, releaseErrorMessage)
+}
+
+// ReleaseUpgradeLockOnErrorIfHeldWithReader joins the original cause with any
+// upgrade lock release error when the caller indicates the upgrade never
+// reached its active state, using a dedicated reader for fresh visibility.
+func ReleaseUpgradeLockOnErrorIfHeldWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	shouldRelease bool,
+	cause error,
+	releaseErrorMessage string,
+) error {
 	if cause == nil || cluster == nil || !shouldRelease {
 		return cause
 	}
 
-	if err := ReleaseUpgradeLockIfHeld(ctx, c, logger, cluster); err != nil {
+	if err := ReleaseUpgradeLockIfHeldWithReader(ctx, reader, c, logger, cluster); err != nil {
 		if releaseErrorMessage == "" {
 			return errors.Join(cause, err)
 		}

--- a/internal/service/upgrade/rolling/manager.go
+++ b/internal/service/upgrade/rolling/manager.go
@@ -26,6 +26,7 @@ var (
 // Manager reconciles version and Raft-aware upgrade behavior for an OpenBaoCluster.
 type Manager struct {
 	client                client.Client
+	reader                client.Reader
 	scheme                *runtime.Scheme
 	backupRuntime         portbackup.PreUpgradeSnapshotRuntime
 	recorder              events.EventRecorder
@@ -51,6 +52,7 @@ func NewManager(
 	}
 	return &Manager{
 		client:                c,
+		reader:                c,
 		scheme:                scheme,
 		backupRuntime:         backupRuntime,
 		recorder:              eventRecorder,
@@ -82,6 +84,7 @@ func NewManagerWithClientFactory(
 	}
 	return &Manager{
 		client:                c,
+		reader:                c,
 		scheme:                scheme,
 		backupRuntime:         backupRuntime,
 		recorder:              eventRecorder,
@@ -90,6 +93,14 @@ func NewManagerWithClientFactory(
 		operatorImageVerifier: operatorImageVerifier,
 		Platform:              platform,
 	}
+}
+
+// WithReader configures a live reader for status read-before-write flows.
+func (m *Manager) WithReader(reader client.Reader) *Manager {
+	if reader != nil {
+		m.reader = reader
+	}
+	return m
 }
 
 // Reconcile ensures upgrades progress safely for the given OpenBaoCluster.

--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -2,6 +2,7 @@ package rolling
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	openbaoapi "github.com/dc-tec/openbao-operator/internal/adapter/openbao"
@@ -966,10 +968,24 @@ func TestReconcile_ReleasesStaleUpgradeLockWhenUpgradeIsIdle(t *testing.T) {
 		},
 	}
 
+	var applyPayloads []string
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
 		WithObjects(cluster).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				if subResourceName == "status" {
+					payload, err := json.Marshal(obj)
+					if err != nil {
+						return err
+					}
+					applyPayloads = append(applyPayloads, string(payload))
+				}
+				return c.Status().Apply(ctx, obj, opts...)
+			},
+		}).
+		WithReturnManagedFields().
 		Build()
 	mgr := NewManager(k8sClient, scheme, nil, portopenbao.ClientConfig{}, nil, "")
 
@@ -981,12 +997,14 @@ func TestReconcile_ReleasesStaleUpgradeLockWhenUpgradeIsIdle(t *testing.T) {
 		t.Fatalf("Reconcile() result = %+v, want empty result", result)
 	}
 
-	latest := &openbaov1alpha1.OpenBaoCluster{}
-	if getErr := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), latest); getErr != nil {
-		t.Fatalf("failed to get cluster: %v", getErr)
+	if len(applyPayloads) != 2 {
+		t.Fatalf("expected takeover and clear SSA applies, got %d payloads", len(applyPayloads))
 	}
-	if latest.Status.OperationLock != nil {
-		t.Fatalf("expected operation lock to be released, got %+v", latest.Status.OperationLock)
+	if !strings.Contains(applyPayloads[0], `"operationLock":{"`) {
+		t.Fatalf("expected first payload to take ownership of operationLock, got %s", applyPayloads[0])
+	}
+	if strings.Contains(applyPayloads[1], `"operationLock":{"`) || !strings.Contains(applyPayloads[1], `"operationLock":null`) {
+		t.Fatalf("expected second payload to explicitly clear operationLock, got %s", applyPayloads[1])
 	}
 	if cluster.Status.OperationLock != nil {
 		t.Fatalf("expected in-memory operation lock to be released, got %+v", cluster.Status.OperationLock)

--- a/internal/service/upgrade/rolling/manager_workflow.go
+++ b/internal/service/upgrade/rolling/manager_workflow.go
@@ -59,7 +59,7 @@ func (m *Manager) ensureUpgradeLock(
 }
 
 func (m *Manager) releaseIdleUpgradeLock(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) {
-	if err := core.ReleaseUpgradeLockIfHeld(ctx, m.client, logger, cluster); err != nil {
+	if err := core.ReleaseUpgradeLockIfHeldWithReader(ctx, m.reader, m.client, logger, cluster); err != nil {
 		logger.Error(err, "Failed to release stale upgrade operation lock")
 	}
 }
@@ -76,7 +76,7 @@ func (m *Manager) acquireUpgradeLock(
 		lockMessage = fmt.Sprintf("upgrade to %s (in progress)", cluster.Status.Upgrade.TargetVersion)
 	}
 
-	lockResult, err := core.AcquireUpgradeLock(ctx, m.client, logger, cluster, lockMessage)
+	lockResult, err := core.AcquireUpgradeLockWithReader(ctx, m.reader, m.client, logger, cluster, lockMessage)
 	if err != nil {
 		return recon.Result{}, fmt.Errorf("failed to acquire upgrade operation lock: %w", err)
 	}

--- a/internal/service/upgrade/rolling/workflow_prepare.go
+++ b/internal/service/upgrade/rolling/workflow_prepare.go
@@ -61,8 +61,9 @@ func (m *Manager) handlePreStartUpgradeFailure(
 		return persistErr
 	}
 
-	return core.ReleaseUpgradeLockOnErrorIfHeld(
+	return core.ReleaseUpgradeLockOnErrorIfHeldWithReader(
 		ctx,
+		m.reader,
 		m.client,
 		logger,
 		cluster,


### PR DESCRIPTION
## Description

This is the SSA ownership foundation layer for the ownership-model refactor.

It introduces the shared status apply primitives and the lock-specific SSA path that the upper layers build on.

Key changes:
- add the shared read-mutate-apply status helper and tests
- add explicit SSA handling for `status.operationLock`, including takeover/clear behavior
- wire restore, backup, rolling, and blue/green lock users through live readers and the new status helpers
- make the status schema and generated docs align with the new clear semantics
- refresh the architecture and upgrade docs for the ownership model

### Boundary-risk notes

- This changes the shared status-write path and the operation-lock ownership contract.
- The main risk is legacy lock handoff and clear behavior on existing clusters.
- Coverage is concentrated in unit, EnvTest, integration, and restore/lock-focused tests.

### Policy exceptions

- No policy exceptions were added or changed.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

```sh
make verify-fmt
make lint-ci
make test-ci
make verify-generated
```
