### PR TITLE
refactor(controller): route adminops status through SSA gateway

### DIFF
--- a/internal/app/openbaocluster/adminops.go
+++ b/internal/app/openbaocluster/adminops.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	adminopsapp "github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminops"
@@ -29,7 +30,16 @@ func ReconcileAdminOps(
 		original,
 		cluster,
 		adminopsapp.ErrorRecorder(recordError),
-		PatchAdminOpsOwnedFields,
+		func(
+			ctx context.Context,
+			c client.Client,
+			logger logr.Logger,
+			original *openbaov1alpha1.OpenBaoCluster,
+			cluster *openbaov1alpha1.OpenBaoCluster,
+			reason string,
+		) error {
+			return PatchAdminOpsOwnedFieldsWithReader(ctx, deps.APIReader, c, logger, original, cluster, reason)
+		},
 		controllerErrorStatus,
 	)
 }

--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -163,7 +163,7 @@ func buildReconcilers(deps Dependencies) []subReconciler {
 			deps.OperatorImageVerifier,
 			deps.Platform,
 			deps.Recorder,
-		),
+		).WithReader(deps.APIReader),
 		rollingupgrade.NewManager(
 			deps.Client,
 			deps.Scheme,

--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -172,7 +172,7 @@ func buildReconcilers(deps Dependencies) []subReconciler {
 			deps.OperatorImageVerifier,
 			deps.Platform,
 			deps.Recorder,
-		),
+		).WithReader(deps.APIReader),
 		backupmanager.NewManager(
 			deps.Client,
 			deps.Scheme,
@@ -180,7 +180,7 @@ func buildReconcilers(deps Dependencies) []subReconciler {
 			deps.OperatorImageVerifier,
 			deps.Platform,
 			deps.Recorder,
-		),
+		).WithReader(deps.APIReader),
 	}
 }
 

--- a/internal/app/openbaocluster/patch.go
+++ b/internal/app/openbaocluster/patch.go
@@ -6,7 +6,9 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -79,6 +81,21 @@ func PatchAdminOpsOwnedFields(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	reason string,
 ) error {
+	return PatchAdminOpsOwnedFieldsWithReader(ctx, c, c, logger, original, cluster, reason)
+}
+
+// PatchAdminOpsOwnedFieldsWithReader patches only admin-ops controller owned
+// status fields, using reader for live read-before-write freshness when
+// available.
+func PatchAdminOpsOwnedFieldsWithReader(
+	ctx context.Context,
+	reader client.Reader,
+	c client.Client,
+	logger logr.Logger,
+	original *openbaov1alpha1.OpenBaoCluster,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	reason string,
+) error {
 	if original == nil || cluster == nil {
 		return nil
 	}
@@ -99,11 +116,36 @@ func PatchAdminOpsOwnedFields(
 	}
 
 	cluster.Status.AdminOps = adminOps
-	if err := statusapply.ApplyOpenBaoClusterAdminOpsStatus(ctx, c, cluster, statusapply.OpenBaoClusterAdminOpsStatusApplyOptions{
-		ForceOwnership: true,
-	}); err != nil {
+	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	updated, err := statusapply.MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(ctx, reader, c, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+		obj.Status.BlueGreen = cluster.Status.BlueGreen
+		obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
+		obj.Status.BreakGlass = cluster.Status.BreakGlass
+		obj.Status.AdminOps = adminOps
+		return nil
+	}, statusapply.OpenBaoClusterAdminOpsStatusApplyOptions{})
+	if err != nil && apierrors.IsConflict(err) {
+		// Ownership-conflict path: retry with force only on SSA conflict.
+		updated, err = statusapply.MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(ctx, reader, c, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.BlueGreen = cluster.Status.BlueGreen
+			obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
+			obj.Status.BreakGlass = cluster.Status.BreakGlass
+			obj.Status.AdminOps = adminOps
+			return nil
+		}, statusapply.OpenBaoClusterAdminOpsStatusApplyOptions{
+			ForceOwnership: true,
+		})
+	}
+	if err != nil {
 		return fmt.Errorf("failed to patch adminops status (%s) for OpenBaoCluster %s/%s: %w", reason, cluster.Namespace, cluster.Name, err)
 	}
+	cluster.Status.BlueGreen = updated.Status.BlueGreen
+	cluster.Status.UpgradeRequests = updated.Status.UpgradeRequests
+	cluster.Status.Backup = updated.Status.Backup
+	cluster.ResourceVersion = updated.ResourceVersion
+	cluster.Status.BreakGlass = updated.Status.BreakGlass
+	cluster.Status.AdminOps = updated.Status.AdminOps
+
 	logger.V(1).Info("Patched OpenBaoCluster adminops status (SSA)", "reason", reason, "fieldOwner", constants.FieldOwnerAdminOpsStatus)
 	return nil
 }

--- a/internal/app/openbaocluster/patch_test.go
+++ b/internal/app/openbaocluster/patch_test.go
@@ -67,8 +67,8 @@ func TestPatchAdminOpsOwnedFields_PatchesAdminOpsFieldsWithoutBackup(t *testing.
 		t.Fatalf("PatchAdminOpsOwnedFields() error = %v", err)
 	}
 
-	if applyCalls != 1 {
-		t.Fatalf("status apply calls = %d, want 1", applyCalls)
+	if applyCalls < 1 {
+		t.Fatalf("status apply calls = %d, want >=1", applyCalls)
 	}
 	if subResourceName != "status" {
 		t.Fatalf("subResourceName = %q, want status", subResourceName)
@@ -76,8 +76,12 @@ func TestPatchAdminOpsOwnedFields_PatchesAdminOpsFieldsWithoutBackup(t *testing.
 	if capturedOptions.FieldManager != constants.FieldOwnerAdminOpsStatus {
 		t.Fatalf("FieldManager = %q, want %q", capturedOptions.FieldManager, constants.FieldOwnerAdminOpsStatus)
 	}
-	if capturedOptions.Force == nil || !*capturedOptions.Force {
-		t.Fatalf("Force = %v, want true", capturedOptions.Force)
+	if applyCalls > 1 {
+		if capturedOptions.Force == nil || !*capturedOptions.Force {
+			t.Fatalf("Force = %v, want true on conflict-retry apply", capturedOptions.Force)
+		}
+	} else if capturedOptions.Force != nil && *capturedOptions.Force {
+		t.Fatalf("Force = %v, want unset/false when no retry is needed", capturedOptions.Force)
 	}
 
 	stored := &openbaov1alpha1.OpenBaoCluster{}
@@ -97,8 +101,8 @@ func TestPatchAdminOpsOwnedFields_PatchesAdminOpsFieldsWithoutBackup(t *testing.
 	if !reflect.DeepEqual(stored.Status.AdminOps, desired.Status.AdminOps) {
 		t.Fatalf("stored adminOps = %#v, want %#v", stored.Status.AdminOps, desired.Status.AdminOps)
 	}
-	if !reflect.DeepEqual(stored.Status.Backup, desired.Status.Backup) {
-		t.Fatalf("stored backup = %#v, want %#v", stored.Status.Backup, desired.Status.Backup)
+	if !reflect.DeepEqual(stored.Status.Backup, original.Status.Backup) {
+		t.Fatalf("stored backup = %#v, want preserved original %#v", stored.Status.Backup, original.Status.Backup)
 	}
 }
 

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -174,7 +174,11 @@ func (r *openBaoClusterAdminOpsReconciler) Reconcile(ctx context.Context, req ct
 	logger.Info("Reconciling OpenBaoCluster admin operations")
 
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
-	if err := r.parent.Get(ctx, req.NamespacedName, cluster); err != nil {
+	reader := r.parent.APIReader
+	if reader == nil {
+		reader = r.parent.Client
+	}
+	if err := reader.Get(ctx, req.NamespacedName, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}

--- a/internal/controller/openbaocluster/split_reconcilers_test.go
+++ b/internal/controller/openbaocluster/split_reconcilers_test.go
@@ -1,0 +1,54 @@
+package openbaocluster
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestOpenBaoClusterAdminOpsReconcilerReconcile_UsesAPIReaderWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	scheme := newOpenBaoClusterTestScheme(t)
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adminops-api-reader",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Paused: true,
+		},
+	}
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+		Build()
+	apiReader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+		WithObjects(cluster.DeepCopy()).
+		Build()
+
+	reconciler := &openBaoClusterAdminOpsReconciler{
+		parent: &OpenBaoClusterReconciler{
+			Client: cachedClient,
+			ControllerRuntime: ControllerRuntime{
+				APIReader: apiReader,
+			},
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}

--- a/internal/service/backup/events_test.go
+++ b/internal/service/backup/events_test.go
@@ -106,7 +106,7 @@ func TestProcessBackupJobResult_EmitsCompletedEvent(t *testing.T) {
 	}
 
 	recorder := events.NewFakeRecorder(10)
-	k8sClient := newTestClient(t, job)
+	k8sClient := newTestClient(t, cluster, job)
 	manager := NewManager(
 		k8sClient,
 		testScheme,
@@ -144,7 +144,7 @@ func TestProcessBackupJobResult_EmitsFailedEvent(t *testing.T) {
 	}
 
 	recorder := events.NewFakeRecorder(10)
-	k8sClient := newTestClient(t, job)
+	k8sClient := newTestClient(t, cluster, job)
 	manager := NewManager(
 		k8sClient,
 		testScheme,

--- a/internal/service/backup/job_test.go
+++ b/internal/service/backup/job_test.go
@@ -44,7 +44,9 @@ const (
 
 func newTestClient(t *testing.T, objs ...client.Object) client.Client {
 	t.Helper()
-	builder := fake.NewClientBuilder().WithScheme(testScheme)
+	builder := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{})
 	if len(objs) > 0 {
 		builder = builder.WithObjects(objs...)
 	}
@@ -821,7 +823,7 @@ func TestProcessBackupJobResult_JobSucceeded(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logr.Discard()
-	k8sClient := newTestClient(t, succeededJob)
+	k8sClient := newTestClient(t, cluster, succeededJob)
 	manager := NewManager(k8sClient, testScheme, portopenbao.ClientConfig{}, security.NewImageVerifier(logr.Discard(), k8sClient, nil), "")
 
 	statusUpdated, err := manager.processBackupJobResult(ctx, logger, cluster, jobName)
@@ -872,7 +874,7 @@ func TestProcessBackupJobResult_JobFailed(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logr.Discard()
-	k8sClient := newTestClient(t, failedJob)
+	k8sClient := newTestClient(t, cluster, failedJob)
 	manager := NewManager(k8sClient, testScheme, portopenbao.ClientConfig{}, security.NewImageVerifier(logr.Discard(), k8sClient, nil), "")
 
 	statusUpdated, err := manager.processBackupJobResult(ctx, logger, cluster, jobName)
@@ -944,7 +946,7 @@ func TestProcessBackupJobResult_JobFailedIdempotent(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logr.Discard()
-	k8sClient := newTestClient(t, failedJob)
+	k8sClient := newTestClient(t, cluster, failedJob)
 	manager := NewManager(k8sClient, testScheme, portopenbao.ClientConfig{}, security.NewImageVerifier(logr.Discard(), k8sClient, nil), "")
 
 	// First call should update status

--- a/internal/service/backup/manager_metrics_test.go
+++ b/internal/service/backup/manager_metrics_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -529,7 +530,9 @@ func TestBackfillBackupGaugesFromLatestSuccess(t *testing.T) {
 		defer func() { openBlobStoreFn = originalOpenBlobStoreFn }()
 
 		err := manager.backfillBackupGaugesFromLatestSuccess(context.Background(), logr.Discard(), cluster, metrics, job)
-		if err == nil || err.Error() != "failed to patch backup status after metrics backfill: apply failed" {
+		if err == nil ||
+			!strings.Contains(err.Error(), "failed to patch backup status after metrics backfill: failed to apply adminops status") ||
+			!strings.Contains(err.Error(), "apply failed") {
 			t.Fatalf("backfillBackupGaugesFromLatestSuccess() error = %v, want wrapped apply failure", err)
 		}
 	})

--- a/internal/service/backup/manager_status.go
+++ b/internal/service/backup/manager_status.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/statusapply"
@@ -12,9 +14,33 @@ import (
 
 // patchStatusSSA updates the backup status using Server-Side Apply.
 func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	return statusapply.ApplyOpenBaoClusterAdminOpsStatus(ctx, m.client, cluster, statusapply.OpenBaoClusterAdminOpsStatusApplyOptions{
-		ForceOwnership: true,
-	})
+	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	applyBackup := func(forceOwnership bool) (*openbaov1alpha1.OpenBaoCluster, error) {
+		return statusapply.MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(ctx, m.reader, m.client, key, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.Backup = cluster.Status.Backup
+			return nil
+		}, statusapply.OpenBaoClusterAdminOpsStatusApplyOptions{
+			ForceOwnership: forceOwnership,
+		})
+	}
+
+	updated, err := applyBackup(false)
+	if err != nil && apierrors.IsConflict(err) {
+		// Migration/takeover path: retry with force only when ownership conflict occurs.
+		updated, err = applyBackup(true)
+	}
+	if err != nil {
+		return err
+	}
+
+	cluster.ResourceVersion = updated.ResourceVersion
+	cluster.Status.Upgrade = updated.Status.Upgrade
+	cluster.Status.UpgradeRequests = updated.Status.UpgradeRequests
+	cluster.Status.Backup = updated.Status.Backup
+	cluster.Status.BlueGreen = updated.Status.BlueGreen
+	cluster.Status.BreakGlass = updated.Status.BreakGlass
+	cluster.Status.AdminOps = updated.Status.AdminOps
+	return nil
 }
 
 func (m *Manager) recordBackupAttempt(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, now time.Time, scheduledTime time.Time, nextScheduled time.Time) error {

--- a/internal/service/backup/manager_status_test.go
+++ b/internal/service/backup/manager_status_test.go
@@ -16,15 +16,20 @@ import (
 )
 
 func TestRecordBackupAttemptPersistsStatus(t *testing.T) {
-	cluster := newTestClusterWithBackup("record-attempt", "backup-ns")
-	cluster.Status.Backup = nil
+	stored := newTestClusterWithBackup("record-attempt", "backup-ns")
+	stored.Status.Backup = nil
+	stored.Status.UpgradeRequests = &openbaov1alpha1.UpgradeRequestStatus{
+		LastHandledRetry: "persist-me",
+	}
+	cluster := stored.DeepCopy()
+	cluster.Status.UpgradeRequests = nil
 	var capturedOptions client.SubResourceApplyOptions
 	var sawStatusApply bool
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
-		WithStatusSubresource(cluster).
-		WithObjects(cluster).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+		WithObjects(stored.DeepCopy()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			SubResourceApply: func(ctx context.Context, c client.Client, subResource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 				if subResource == "status" {
@@ -64,13 +69,19 @@ func TestRecordBackupAttemptPersistsStatus(t *testing.T) {
 	if updated.Status.Backup == nil || updated.Status.Backup.LastAttemptTime == nil || !updated.Status.Backup.LastAttemptTime.Time.Equal(now) {
 		t.Fatalf("persisted LastAttemptTime = %#v, want %v", updated.Status.Backup, now)
 	}
+	if updated.Status.UpgradeRequests == nil || updated.Status.UpgradeRequests.LastHandledRetry != "persist-me" {
+		t.Fatalf("persisted UpgradeRequests = %#v, want sibling adminops field preserved", updated.Status.UpgradeRequests)
+	}
+	if cluster.Status.UpgradeRequests == nil || cluster.Status.UpgradeRequests.LastHandledRetry != "persist-me" {
+		t.Fatalf("in-memory UpgradeRequests = %#v, want refreshed sibling adminops field", cluster.Status.UpgradeRequests)
+	}
 	if !sawStatusApply {
 		t.Fatal("expected backup status persistence to use status apply")
 	}
 	if capturedOptions.FieldManager != constants.FieldOwnerAdminOpsStatus {
 		t.Fatalf("FieldManager = %q, want %q", capturedOptions.FieldManager, constants.FieldOwnerAdminOpsStatus)
 	}
-	if capturedOptions.Force == nil || !*capturedOptions.Force {
-		t.Fatalf("Force = %v, want true", capturedOptions.Force)
+	if capturedOptions.Force != nil && *capturedOptions.Force {
+		t.Fatalf("Force = %v, want unset/false", capturedOptions.Force)
 	}
 }


### PR DESCRIPTION
## Description

This layer moves adminops status writes onto the SSA gateway introduced in PR 1.

Key changes:
- route adminops status writes through the fresh-read SSA gateway
- wire live API readers into the adminops reconcile path
- convert backup/adminops status writers away from stale full-plane applies
- add controller and service tests around the gateway behavior

### Boundary-risk notes

- This changes how the shared adminops status plane is written.
- The main risk is stale-object sibling clobbering if a writer still bypasses the gateway.
- Coverage is concentrated in adminops, backup, and split-controller tests.

### Policy exceptions

- No policy exceptions were added or changed.

## Related Issues

Depends on PR 1 in this stack.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

```sh
make verify-fmt
make lint-ci
make test-ci
make verify-generated
```
