### PR TITLE
docs(copy): normalize documentation tone and wording

### DIFF
--- a/docs/architecture/backup-manager.md
+++ b/docs/architecture/backup-manager.md
@@ -50,7 +50,7 @@ description: Schedule snapshot jobs, enforce retention, and update backup status
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Backup orchestration belongs to the AdminOps path:
 
@@ -81,7 +81,7 @@ That keeps the controller focused on reconcile plumbing while the backup manager
   ]}
 />
 
-## Backup Flow
+## Backup flow
 
 <DiagramFrame
   title="Validate, launch, then record"
@@ -131,7 +131,7 @@ That keeps the controller focused on reconcile plumbing while the backup manager
   ]}
 />
 
-## Provider And Retention Surfaces
+## Provider and retention surfaces
 
 <DecisionTable
   kind="reference"

--- a/docs/architecture/backup-manager.md
+++ b/docs/architecture/backup-manager.md
@@ -3,12 +3,12 @@ title: Backup Manager
 hide_title: true
 pageType: concept
 journey: architecture
-description: Schedule snapshot jobs, enforce retention, and update backup status without moving backup data through the controller.
+description: Schedule snapshot jobs, enforce retention, and update backup status while keeping snapshot data transport out of the controller.
 ---
 
 <PageHeader
-  title="Run Raft snapshots as stateless jobs and keep retention out of the data plane."
-  lede="The backup manager owns scheduled and manual snapshot orchestration for `OpenBaoCluster`. It validates cluster readiness, acquires the operation lock, creates executor Jobs, and records backup state so backups stay auditable and resumable without embedding snapshot transport inside the controller."
+  title="Backup manager workflow"
+  lede="The backup manager owns scheduled and manual snapshot orchestration for `OpenBaoCluster`. It validates cluster readiness, acquires the operation lock, creates executor Jobs, and records backup state so backups stay auditable and resumable while snapshot transport stays outside the controller."
 />
 
 

--- a/docs/architecture/cert-manager.md
+++ b/docs/architecture/cert-manager.md
@@ -7,8 +7,8 @@ description: Manage TLS certificate sources, rotation windows, and hot-reload si
 ---
 
 <PageHeader
-  title="Own certificate sources, rotation, and hot reload without restarting pods."
-  lede="The cert manager keeps TLS lifecycle close to the workload contract. It decides whether certificates are operator-managed, externally supplied, or handled by ACME, and it turns certificate changes into safe reload signals instead of pod restarts."
+  title="Certificate lifecycle management"
+  lede="The cert manager keeps TLS lifecycle close to the workload contract. It decides whether certificates are operator-managed, externally supplied, or handled by ACME, and it turns certificate changes into reload signals rather than pod restarts."
 />
 
 

--- a/docs/architecture/cert-manager.md
+++ b/docs/architecture/cert-manager.md
@@ -50,7 +50,7 @@ description: Manage TLS certificate sources, rotation windows, and hot-reload si
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 TLS lifecycle stays on the workload reconcile path:
 
@@ -79,7 +79,7 @@ That keeps TLS behavior close to workload rendering while avoiding a second, dis
   ]}
 />
 
-## Rotation And Reload Path
+## Rotation and reload path
 
 <DiagramFrame
   title="TLS rotation loop"

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -7,8 +7,8 @@ description: Split-controller architecture for OpenBaoCluster, OpenBaoRestore, a
 ---
 
 <PageHeader
-  title="Split the control plane so pod churn, long-running operations, and status writes stay separate."
-  lede="OpenBao Operator avoids a single reconciliation loop. The control plane is divided into focused controllers, then delegated into app-layer orchestration and narrower domain managers so the system can react quickly without mixing unrelated responsibilities."
+  title="Split-controller control plane"
+  lede="OpenBao Operator divides the control plane into focused controllers, then delegates into app-layer orchestration and narrower domain managers so workload churn, long-running operations, and status writes stay separated."
 />
 
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -8,12 +8,12 @@ description: Split-controller architecture for OpenBaoCluster, OpenBaoRestore, a
 
 <PageHeader
   title="Split-controller control plane"
-  lede="OpenBao Operator divides the control plane into focused controllers, then delegates into app-layer orchestration and narrower domain managers so workload churn, long-running operations, and status writes stay separated."
+  lede="Focused controllers, app-layer orchestration, and narrow domain managers keep workload churn, long-running operations, and status writes separated."
 />
 
 
 
-## Controller Split
+## Controller split
 
 <DiagramFrame
   title="Controller split"
@@ -73,7 +73,7 @@ Restores are reconciled through the separate `OpenBaoRestore` controller, which 
 
 </Callout>
 
-## App Orchestration And Managers
+## App orchestration and managers
 
 <DiagramFrame
   title="App-layer orchestration"
@@ -140,22 +140,22 @@ Controller import surfaces are intentionally narrow and enforced by generated ar
   items={[
     {
       label: 'Infrastructure manager',
-      description: 'See how configuration rendering and StatefulSet ownership are coordinated.',
+      description: 'Configuration rendering and StatefulSet ownership.',
       docId: 'architecture/infra-manager',
     },
     {
       label: 'Upgrade manager',
-      description: 'Review how RollingUpdate and BlueGreen state transitions are modeled.',
+      description: 'RollingUpdate and BlueGreen state transitions.',
       docId: 'architecture/upgrade-manager',
     },
     {
       label: 'Restore manager',
-      description: 'Understand the destructive restore path and lock lifecycle behind OpenBaoRestore.',
+      description: 'Destructive restore path and lock lifecycle behind OpenBaoRestore.',
       docId: 'architecture/restore-manager',
     },
     {
       label: 'Lifecycle architecture',
-      description: 'Move from component boundaries into the day-by-day lifecycle flows that use them.',
+      description: 'Day-by-day lifecycle flows that use these components.',
       docId: 'architecture/lifecycle/index',
     },
   ]}

--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -11,7 +11,7 @@ description: Internal design, controller boundaries, lifecycle flows, invariants
   variant="landing"
   eyebrow="Architecture"
   title="Operator architecture"
-  lede="This section covers controller boundaries, lifecycle coordination, invariants, and implementation tradeoffs. Use it when you need to understand behavior, review design changes, or connect implementation back to status and security contracts."
+  lede="Controller boundaries, lifecycle coordination, invariants, and implementation tradeoffs behind OpenBao Operator."
   actions={[
     {label: 'Read the invariants', docId: 'architecture/operator-invariants', variant: 'primary'},
     {label: 'Open component design', docId: 'architecture/components', variant: 'secondary'},
@@ -40,13 +40,13 @@ description: Internal design, controller boundaries, lifecycle flows, invariants
     {
       eyebrow: '02',
       title: 'Component design',
-      description: 'See how the split-controller control plane, app layer, and manager boundaries work together.',
+      description: 'Split-controller control plane, app layer, and manager boundaries.',
       docId: 'architecture/components',
     },
     {
       eyebrow: '03',
       title: 'Operation lifecycle coordination',
-      description: 'Understand the shared lock, retry, and phase-transition primitives behind backup, restore, and upgrade flows.',
+      description: 'Shared lock, retry, and phase-transition primitives behind backup, restore, and upgrade flows.',
       docId: 'architecture/operation-lifecycle',
     },
     {
@@ -63,17 +63,17 @@ description: Internal design, controller boundaries, lifecycle flows, invariants
   items={[
     {
       label: 'Open security',
-      description: 'Architecture and security are tightly coupled through RBAC, admission, identity, and workload controls.',
+      description: 'Security contracts for RBAC, admission, identity, and workload controls.',
       docId: 'security/index',
     },
     {
       label: 'Open reference',
-      description: 'Use exact status and event semantics when you need to connect architecture back to observable behavior.',
+      description: 'Status conditions, events, and observable contracts.',
       docId: 'reference/status-and-events',
     },
     {
       label: 'Open Operate',
-      description: 'Compare the internal lifecycle design with the user-facing operating guides for upgrades, backups, and recovery.',
+      description: 'User-facing operating guides for upgrades, backups, and recovery.',
       docId: 'user-guide/openbaocluster/operations/index',
     },
   ]}

--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -10,8 +10,8 @@ description: Internal design, controller boundaries, lifecycle flows, invariants
 <PageHero
   variant="landing"
   eyebrow="Architecture"
-  title="Understand why the operator behaves the way it does."
-  lede="Architecture pages explain controller boundaries, lifecycle coordination, and the invariants the system depends on. Use this section when you need to reason about behavior, validate assumptions, review tradeoffs, or change the code safely."
+  title="Operator architecture"
+  lede="This section covers controller boundaries, lifecycle coordination, invariants, and implementation tradeoffs. Use it when you need to understand behavior, review design changes, or connect implementation back to status and security contracts."
   actions={[
     {label: 'Read the invariants', docId: 'architecture/operator-invariants', variant: 'primary'},
     {label: 'Open component design', docId: 'architecture/components', variant: 'secondary'},

--- a/docs/architecture/infra-manager.md
+++ b/docs/architecture/infra-manager.md
@@ -8,7 +8,7 @@ description: Render OpenBaoCluster into converged configuration, StatefulSet res
 
 <PageHeader
   title="Infrastructure manager workflow"
-  lede="The infrastructure manager is the workload path that turns `OpenBaoCluster` into running Kubernetes resources. It owns rendered configuration, StatefulSet-facing infrastructure, and the rollout triggers that keep configuration drift and pod lifecycle changes in sync."
+  lede="The infrastructure manager renders `OpenBaoCluster` into running Kubernetes resources. It owns rendered configuration, StatefulSet-facing infrastructure, and the rollout triggers that keep configuration drift and pod lifecycle changes aligned."
 />
 
 
@@ -50,7 +50,7 @@ description: Render OpenBaoCluster into converged configuration, StatefulSet res
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Infrastructure reconciliation belongs to the workload orchestration path:
 
@@ -81,7 +81,7 @@ That split keeps controller code as reconcile plumbing while the infra manager o
   ]}
 />
 
-## Render-Then-Apply Flow
+## Render-then-apply flow
 
 <DiagramFrame
   title="Render then apply"
@@ -108,7 +108,7 @@ That split keeps controller code as reconcile plumbing while the infra manager o
     class Config,Resources,Annotate,Apply,Rollout write;`}
 />
 
-## Configuration And Seal Rendering
+## Configuration and seal rendering
 
 The manager does not apply a static ConfigMap. It renders the config from the cluster spec and the selected integration modes.
 
@@ -144,13 +144,13 @@ When `spec.unseal.type` points at a cloud KMS integration, the manager stops gen
   </TabItem>
 </Tabs>
 
-<Callout type="note" title="TLS mode changes workload rendering">
+<Callout type="note" title="TLS mode affects rendering">
 
-TLS mode affects both rendered config and mounted resource expectations. `OperatorManaged`, `External`, and `ACME` are not only certificate sources, they change what the workload pod expects on disk and what the hot-reload path watches.
+TLS mode affects both rendered config and mounted resource expectations. `OperatorManaged`, `External`, and `ACME` change what the workload pod expects on disk and what the hot-reload path watches.
 
 </Callout>
 
-## Safety Boundaries
+## Safety boundaries
 
 <DecisionTable
   kind="reference"
@@ -183,7 +183,7 @@ TLS mode affects both rendered config and mounted resource expectations. `Operat
     },
     {
       label: 'Init manager',
-      description: 'See how the workload path hands off from first-boot infrastructure into cluster initialization.',
+      description: 'How the workload path hands off from first-boot infrastructure into cluster initialization.',
       docId: 'architecture/init-manager',
     },
     {

--- a/docs/architecture/infra-manager.md
+++ b/docs/architecture/infra-manager.md
@@ -7,7 +7,7 @@ description: Render OpenBaoCluster into converged configuration, StatefulSet res
 ---
 
 <PageHeader
-  title="Render the cluster spec into a converged StatefulSet and configuration."
+  title="Infrastructure manager workflow"
   lede="The infrastructure manager is the workload path that turns `OpenBaoCluster` into running Kubernetes resources. It owns rendered configuration, StatefulSet-facing infrastructure, and the rollout triggers that keep configuration drift and pod lifecycle changes in sync."
 />
 

--- a/docs/architecture/init-manager.md
+++ b/docs/architecture/init-manager.md
@@ -50,7 +50,7 @@ description: Bootstrap a new cluster safely, handle self-init or operator init f
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Initialization stays on the workload-side controller path while the cluster is not yet ready for normal steady-state reconciliation:
 
@@ -60,7 +60,7 @@ Initialization stays on the workload-side controller path while the cluster is n
 
 That separation prevents first-boot logic from leaking into every steady-state reconcile.
 
-## Bootstrap Flow
+## Bootstrap flow
 
 <DiagramFrame
   title="Initialize, then scale"
@@ -85,7 +85,7 @@ That separation prevents first-boot logic from leaking into every steady-state r
   `}
 />
 
-## Initialization Phases
+## Initialization phases
 
 <Tabs groupId="init-manager-phases">
   <TabItem value="bootstrap" label="Bootstrap one node">
@@ -126,7 +126,7 @@ That separation prevents first-boot logic from leaking into every steady-state r
   </TabItem>
 </Tabs>
 
-## Autopilot Defaults
+## Autopilot defaults
 
 <DecisionTable
   kind="reference"

--- a/docs/architecture/lifecycle/day0-provisioning.md
+++ b/docs/architecture/lifecycle/day0-provisioning.md
@@ -77,7 +77,7 @@ description: Tenant provisioning flow from OpenBaoTenant creation through namesp
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Day 0 provisioning uses the dedicated tenant-controller path:
 

--- a/docs/architecture/lifecycle/day1-creation.md
+++ b/docs/architecture/lifecycle/day1-creation.md
@@ -77,7 +77,7 @@ description: Cluster creation flow from OpenBaoCluster creation through TLS boot
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Day 1 creation crosses three workload-side services in sequence:
 

--- a/docs/architecture/lifecycle/day2-operations.md
+++ b/docs/architecture/lifecycle/day2-operations.md
@@ -77,7 +77,7 @@ description: Operational lifecycle for upgrades, maintenance controls, and long-
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Day 2 work is intentionally separated from the high-churn workload loop:
 

--- a/docs/architecture/lifecycle/day2-operations.md
+++ b/docs/architecture/lifecycle/day2-operations.md
@@ -7,7 +7,7 @@ description: Operational lifecycle for upgrades, maintenance controls, and long-
 ---
 
 <PageHeader
-  title="Hand off from cluster creation into upgrades, maintenance, and long-running operational work."
+  title="Day 2 operations lifecycle"
   lede="Day 2 starts once the cluster is initialized and the workload path is steady. From that point on, long-running operations such as upgrades and backups move through the admin operations path, while maintenance controls gate how much automation is allowed to continue during manual intervention."
 />
 

--- a/docs/architecture/lifecycle/dayN-backups.md
+++ b/docs/architecture/lifecycle/dayN-backups.md
@@ -77,7 +77,7 @@ description: Backup and restore lifecycle for live clusters, including snapshot 
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Durability work is shared across two explicit operation surfaces:
 

--- a/docs/architecture/lifecycle/index.md
+++ b/docs/architecture/lifecycle/index.md
@@ -9,8 +9,8 @@ description: Lifecycle overview for OpenBao Operator from Day 0 provisioning thr
 <PageHero
   variant="landing"
   eyebrow="Architecture / Lifecycle"
-  title="Follow the operator from tenant provisioning to day 2 operations and backup-driven restore."
-  lede="These pages explain the lifecycle from the controller and manager perspective. Use them to understand which internal responsibilities own Day 0 provisioning, Day 1 creation, Day 2 operations, and backup-and-restore flows rather than how an operator user performs those tasks."
+  title="Lifecycle architecture"
+  lede="These pages describe the operator lifecycle from the controller and manager perspective. They cover Day 0 provisioning, Day 1 creation, Day 2 operations, and backup-and-restore flows."
   actions={[
     {label: 'Start with Day 0 provisioning', docId: 'architecture/lifecycle/day0-provisioning', variant: 'primary'},
     {label: 'Open Day 2 operations', docId: 'architecture/lifecycle/day2-operations', variant: 'secondary'},

--- a/docs/architecture/lifecycle/index.md
+++ b/docs/architecture/lifecycle/index.md
@@ -10,14 +10,14 @@ description: Lifecycle overview for OpenBao Operator from Day 0 provisioning thr
   variant="landing"
   eyebrow="Architecture / Lifecycle"
   title="Lifecycle architecture"
-  lede="These pages describe the operator lifecycle from the controller and manager perspective. They cover Day 0 provisioning, Day 1 creation, Day 2 operations, and backup-and-restore flows."
+  lede="Operator lifecycle flows from the controller and manager perspective, covering Day 0 provisioning, Day 1 creation, Day 2 operations, and backup-and-restore behavior."
   actions={[
     {label: 'Start with Day 0 provisioning', docId: 'architecture/lifecycle/day0-provisioning', variant: 'primary'},
     {label: 'Open Day 2 operations', docId: 'architecture/lifecycle/day2-operations', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Lifecycle pages explain"
+    title="Lifecycle pages show"
     items={[
       'which controller and manager own each phase',
       'where security and tenant boundaries enter the lifecycle',

--- a/docs/architecture/operation-lifecycle.md
+++ b/docs/architecture/operation-lifecycle.md
@@ -50,7 +50,7 @@ description: Shared lock, retry, and phase-audit primitives used by backup, rest
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Operation lifecycle coordination sits below the concrete managers and above the lock adapter:
 
@@ -124,7 +124,7 @@ That keeps the shared safety model in one place instead of scattering lock and r
   ]}
 />
 
-## Retry And Lock Model
+## Retry and lock model
 
 <DecisionTable
   kind="reference"

--- a/docs/architecture/operation-lifecycle.md
+++ b/docs/architecture/operation-lifecycle.md
@@ -7,7 +7,7 @@ description: Shared lock, retry, and phase-audit primitives used by backup, rest
 ---
 
 <PageHeader
-  title="Coordinate locks, retries, and phase transitions across disruptive operations."
+  title="Operation lifecycle coordination"
   lede="`internal/service/opslifecycle` is the shared service-layer contract behind backup, restore, and upgrade orchestration. It does not own a controller or CRD of its own. Instead, it keeps operation lock identity, retry timing, and phase audit logging consistent whenever a manager needs to take disruptive action against a cluster."
 />
 

--- a/docs/architecture/operator-invariants.md
+++ b/docs/architecture/operator-invariants.md
@@ -7,8 +7,8 @@ journey: architecture
 ---
 
 <PageHeader
-  title="Start design changes from the contracts the operator is trying to preserve."
-  lede="These invariants are the cross-cutting rules behind the rest of the architecture. They explain why some designs are intentionally split, why certain shortcuts are blocked, and which safety properties should survive refactors, new features, or operational changes."
+  title="Operator invariants"
+  lede="Cross-cutting contracts behind the rest of the architecture. They explain why some designs are split, which shortcuts are blocked, and which safety properties must survive refactors, new features, and operational changes."
 />
 
 
@@ -35,14 +35,14 @@ journey: architecture
       cells: [
         'Production posture',
         'Hardened production means self-init, trusted TLS, and a non-static unseal path.',
-        'Production safety is a contract, not just a suggested configuration style.',
+        'Production safety is part of the supported operating contract.',
       ],
     },
     {
       cells: [
         'Integration assumptions',
         'External dependencies surface as explicit status and readiness conditions.',
-        'This turns environment assumptions into visible contracts instead of late runtime failures.',
+        'This makes environment assumptions visible before they become runtime failures.',
       ],
     },
     {
@@ -212,9 +212,9 @@ Related reading: <SiteLink docId="reference/status-and-events">Status and Events
 
 Related reading: <SiteLink docId="architecture/operation-lifecycle">Operation Lifecycle</SiteLink>, <SiteLink docId="user-guide/openbaorestore/restore">Restore from Backup</SiteLink>, and <SiteLink docId="user-guide/openbaocluster/recovery/index">Recovery and Restore</SiteLink>.
 
-<Callout type="tip" title="Treat invariant changes as contract changes">
+<Callout type="tip" title="Invariant changes affect the contract">
 
-If a change weakens one of these invariants, update the related architecture, security, and user-guide pages in the same change set. This is not only an implementation detail; it changes the operating contract of the product.
+If a change weakens one of these invariants, update the related architecture, security, and user-guide pages in the same change set. It changes the product operating contract.
 
 </Callout>
 
@@ -223,17 +223,17 @@ If a change weakens one of these invariants, update the related architecture, se
   items={[
     {
       label: 'Component design',
-      description: 'See where controllers, app facades, and managers split responsibilities to preserve these invariants.',
+      description: 'Where controllers, app facades, and managers split responsibilities to preserve these invariants.',
       docId: 'architecture/components',
     },
     {
       label: 'Operation lifecycle',
-      description: 'Trace how shared lifecycle coordination keeps upgrades, backups, and restores from colliding.',
+      description: 'Shared lifecycle coordination for upgrades, backups, and restores.',
       docId: 'architecture/operation-lifecycle',
     },
     {
       label: 'Security overview',
-      description: 'Move into the user-facing security model that these invariants are designed to protect.',
+      description: 'User-facing security model behind these invariants.',
       docId: 'security/index',
     },
   ]}

--- a/docs/architecture/provisioner-manager.md
+++ b/docs/architecture/provisioner-manager.md
@@ -50,7 +50,7 @@ description: Provision tenant namespaces with scoped RBAC, Secret allowlists, Po
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Provisioning follows a dedicated tenant-controller path:
 
@@ -81,7 +81,7 @@ That keeps tenant onboarding separate from `OpenBaoCluster` steady-state reconci
   ]}
 />
 
-## Provisioning Flow
+## Provisioning flow
 
 <DiagramFrame
   title="Tenant onboarding flow"

--- a/docs/architecture/restore-manager.md
+++ b/docs/architecture/restore-manager.md
@@ -7,7 +7,7 @@ description: Reconcile OpenBaoRestore requests, acquire operation locks, and orc
 ---
 
 <PageHeader
-  title="Treat restore as a destructive, explicit, lock-aware workflow."
+  title="Restore manager workflow"
   lede="The restore manager keeps disaster recovery separate from normal cluster reconciliation. It models restore as an immutable CRD-backed request, coordinates execution through a dedicated controller path, and protects the cluster with explicit validation and lock ownership."
 />
 

--- a/docs/architecture/restore-manager.md
+++ b/docs/architecture/restore-manager.md
@@ -8,7 +8,7 @@ description: Reconcile OpenBaoRestore requests, acquire operation locks, and orc
 
 <PageHeader
   title="Restore manager workflow"
-  lede="The restore manager keeps disaster recovery separate from normal cluster reconciliation. It models restore as an immutable CRD-backed request, coordinates execution through a dedicated controller path, and protects the cluster with explicit validation and lock ownership."
+  lede="Restore requests run outside normal cluster reconciliation. The manager models restore as an immutable CRD-backed request, coordinates execution through a dedicated controller path, and protects the cluster with explicit validation and lock ownership."
 />
 
 
@@ -50,7 +50,7 @@ description: Reconcile OpenBaoRestore requests, acquire operation locks, and orc
   ]}
 />
 
-## Request Model
+## Request model
 
 <DecisionTable
   kind="reference"
@@ -73,7 +73,7 @@ description: Reconcile OpenBaoRestore requests, acquire operation locks, and orc
   ]}
 />
 
-## Restore Lifecycle
+## Restore lifecycle
 
 <DiagramFrame
   title="Restore lifecycle"
@@ -125,7 +125,7 @@ description: Reconcile OpenBaoRestore requests, acquire operation locks, and orc
   ]}
 />
 
-## Safety Boundaries
+## Safety boundaries
 
 <DecisionTable
   kind="reference"
@@ -148,7 +148,7 @@ description: Reconcile OpenBaoRestore requests, acquire operation locks, and orc
   ]}
 />
 
-<Callout type="warning" title="Restore is not routine reconciliation">
+<Callout type="warning" title="Restore workflow scope">
 
 Restore is intentionally modeled outside the normal `OpenBaoCluster` lifecycle. The operator treats it as a destructive recovery operation with its own request object, its own controller path, and its own lock semantics.
 
@@ -164,12 +164,12 @@ Restore is intentionally modeled outside the normal `OpenBaoCluster` lifecycle. 
     },
     {
       label: 'Operation lifecycle coordination',
-      description: 'See how restore shares lock and retry primitives with other disruptive operations.',
+      description: 'Lock and retry primitives shared with other disruptive operations.',
       docId: 'architecture/operation-lifecycle',
     },
     {
       label: 'Restore guide',
-      description: 'Compare the internal restore controller model with the user-facing restore and recovery procedures.',
+      description: 'User-facing restore and recovery procedures.',
       docId: 'user-guide/openbaorestore/restore',
     },
   ]}

--- a/docs/architecture/upgrade-manager.md
+++ b/docs/architecture/upgrade-manager.md
@@ -7,8 +7,8 @@ description: Orchestrate rolling and blue-green upgrades, status-backed resumabi
 ---
 
 <PageHeader
-  title="Change workload versions without violating Raft safety."
-  lede="The upgrade manager owns disruptive version changes. It keeps upgrade orchestration out of the workload loop, persists state in status so upgrades survive controller restarts, and prioritizes cluster availability over finishing quickly."
+  title="Upgrade orchestration and safety model"
+  lede="The upgrade manager owns disruptive version changes. It keeps upgrade orchestration out of the workload loop, persists state in status so upgrades survive controller restarts, and prioritizes cluster availability throughout the rollout."
 />
 
 

--- a/docs/architecture/upgrade-manager.md
+++ b/docs/architecture/upgrade-manager.md
@@ -8,7 +8,7 @@ description: Orchestrate rolling and blue-green upgrades, status-backed resumabi
 
 <PageHeader
   title="Upgrade orchestration and safety model"
-  lede="The upgrade manager owns disruptive version changes. It keeps upgrade orchestration out of the workload loop, persists state in status so upgrades survive controller restarts, and prioritizes cluster availability throughout the rollout."
+  lede="The upgrade manager handles disruptive version changes. It keeps upgrade orchestration out of the workload loop, persists state in status so upgrades survive controller restarts, and prioritizes cluster availability during rollout."
 />
 
 
@@ -51,7 +51,7 @@ description: Orchestrate rolling and blue-green upgrades, status-backed resumabi
   ]}
 />
 
-## Architectural Placement
+## Architectural placement
 
 Upgrade execution belongs to the AdminOps orchestration path:
 
@@ -64,7 +64,7 @@ Upgrade execution belongs to the AdminOps orchestration path:
 
 That keeps upgrade state machines out of the workload loop and lets long-running transitions own their own retry model.
 
-## Package Shape
+## Package shape
 
 The upgrade subsystem is split so strategy packages keep workflow ownership while
 shared mechanics live behind narrower seams:
@@ -191,7 +191,7 @@ Blue-green creates a second revision and needs roughly double storage capacity f
   </TabItem>
 </Tabs>
 
-## State And Recovery Model
+## State and recovery model
 
 <DecisionTable
   kind="reference"
@@ -240,17 +240,17 @@ Blue-green creates a second revision and needs roughly double storage capacity f
   items={[
     {
       label: 'Operation lifecycle coordination',
-      description: 'See how lock, retry, and phase-transition helpers are shared with backup and restore.',
+      description: 'Lock, retry, and phase-transition helpers shared with backup and restore.',
       docId: 'architecture/operation-lifecycle',
     },
     {
       label: 'Backup manager',
-      description: 'Pre-upgrade snapshots and object-storage readiness are part of the upgrade safety model.',
+      description: 'Pre-upgrade snapshots and object-storage readiness.',
       docId: 'architecture/backup-manager',
     },
     {
       label: 'Upgrades guide',
-      description: 'Compare the internal state machine with the user-facing rolling and blue-green operating procedures.',
+      description: 'User-facing rolling and blue-green operating procedures.',
       docId: 'user-guide/openbaocluster/operations/upgrades',
     },
   ]}

--- a/docs/architecture/upgrade-manager.md
+++ b/docs/architecture/upgrade-manager.md
@@ -3,7 +3,7 @@ title: Upgrade Manager
 hide_title: true
 pageType: concept
 journey: architecture
-description: Orchestrate rolling and blue-green upgrades, status-backed resumability, and rollback safety without violating Raft consensus.
+description: Orchestrate rolling and blue-green upgrades, status-backed resumability, rollback safety, and Raft-aware rollout behavior.
 ---
 
 <PageHeader

--- a/docs/contribute/ci.md
+++ b/docs/contribute/ci.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Know what CI will enforce before you ask it to validate your branch."
-  lede="CI is optimized for signal, not ceremony. Pull requests route work based on changed files and labels, while `main`, edge, nightly, and release workflows enforce the heavier publication and hardening gates. Run the closest local equivalent first so CI is confirming your work, not discovering it for you."
+  title="CI workflow and local parity"
+  lede="This page explains how pull requests, `main`, nightly, and release workflows route checks and publication gates. Run the closest local equivalent first so CI confirms the change rather than discovering it."
 />
 
 <DiagramFrame

--- a/docs/contribute/ci.md
+++ b/docs/contribute/ci.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="CI workflow and local parity"
-  lede="This page covers pull request, `main`, nightly, and release workflows, and maps each validation lane to the closest local command set."
+  lede="Pull request, `main`, nightly, and release workflows, plus the closest local command set for each validation lane."
 />
 
 <DiagramFrame
@@ -38,7 +38,7 @@ journey: contribute
 make doctor
 make ci-core`}
 >
-  Use this as the default local baseline so routine branch issues are found before CI.
+  Default local baseline before handing work to CI.
 </CommandBlock>
 
 <DecisionTable

--- a/docs/contribute/ci.md
+++ b/docs/contribute/ci.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="CI workflow and local parity"
-  lede="This page explains how pull requests, `main`, nightly, and release workflows route checks and publication gates. Run the closest local equivalent first so CI confirms the change rather than discovering it."
+  lede="This page covers pull request, `main`, nightly, and release workflows, and maps each validation lane to the closest local command set."
 />
 
 <DiagramFrame
@@ -38,7 +38,7 @@ journey: contribute
 make doctor
 make ci-core`}
 >
-  Use this as the default local bar so CI confirms the branch state instead of being the first place a basic issue appears.
+  Use this as the default local baseline so routine branch issues are found before CI.
 </CommandBlock>
 
 <DecisionTable
@@ -57,7 +57,7 @@ make ci-core`}
       cells: [
         "Docs-only changes",
         "`make docs-build`",
-        "Use this when the change is isolated to documentation, routing, or site behavior.",
+        "For changes isolated to documentation, routing, or site behavior.",
       ],
     },
     {
@@ -78,7 +78,7 @@ make ci-core`}
       cells: [
         "Focused E2E and platform validation",
         "`make test-e2e-ci ...`, `make helm-e2e-smoke`, or `make test-e2e-existing ...`",
-        "Use label filters or the existing-cluster path when you need a smaller or platform-specific reproduction.",
+        "Label filters and the existing-cluster path provide smaller or platform-specific reproductions.",
       ],
     },
   ]}
@@ -115,7 +115,7 @@ Inline `nosemgrep` suppressions are reserved for bounded intentional exceptions.
       cells: [
         "Maintainer adds `ci:full-e2e`",
         "The broader E2E suite runs.",
-        "Use this when the change is wide enough that targeted routing is no longer sufficient.",
+        "This is appropriate when the change spans enough surface area that targeted routing is no longer sufficient.",
       ],
     },
     {
@@ -143,7 +143,7 @@ make helm-e2e-smoke
 make fuzz
 FUZZ_TARGET_FILTER='FuzzDiscoverConfig|internal/service/upgrade' make fuzz`}
 >
-  Use the smallest reproduction that still matches the CI lane you are trying to explain.
+  Choose the smallest reproduction that still matches the CI lane under investigation.
 </CommandBlock>
 
 <NextActions
@@ -151,17 +151,17 @@ FUZZ_TARGET_FILTER='FuzzDiscoverConfig|internal/service/upgrade' make fuzz`}
   items={[
     {
       label: "Testing strategy",
-      description: "Go back one level when you still need to choose the right validation depth before mapping it to a workflow.",
+      description: "Testing strategy covers validation depth before it is mapped to a workflow.",
       to: "/contribute/testing",
     },
     {
       label: "Release management",
-      description: "Move into release execution, stable-doc snapshot rules, and post-publish verification once the branch is release-ready.",
+      description: "Release management covers release execution, docs snapshots, and post-publish verification.",
       to: "/contribute/release-management",
     },
     {
       label: "Dependency license policy",
-      description: "Open the shipped-license rules when the failing gate is about allowlists rather than code or workflow behavior.",
+      description: "Dependency license policy covers shipped-license allowlists and their enforcement.",
       to: "/contribute/dependency-licenses",
     },
   ]}

--- a/docs/contribute/ci.md
+++ b/docs/contribute/ci.md
@@ -38,7 +38,7 @@ journey: contribute
 make doctor
 make ci-core`}
 >
-  Treat this as the default local bar. If this is red, CI is not the right place to learn that first.
+  Use this as the default local bar so CI confirms the branch state instead of being the first place a basic issue appears.
 </CommandBlock>
 
 <DecisionTable

--- a/docs/contribute/dependency-licenses.md
+++ b/docs/contribute/dependency-licenses.md
@@ -7,12 +7,12 @@ journey: contribute
 
 <PageHeader
   title="Dependency license policy"
-  lede="The repository enforces license policy on shipped dependencies. This page defines the allowed set, the extra handling required for MPL-2.0, and the checks maintainers expect before a dependency change is merged."
+  lede="Allowed license classes, MPL-2.0 handling, and the checks maintainers expect when dependency changes are proposed."
 />
 
 <Callout type="note" title="Policy, not legal advice">
 
-This page defines project policy for contributors and maintainers. It does not replace legal review.
+This is project policy for contributors and maintainers. It does not replace legal review.
 
 </Callout>
 
@@ -130,7 +130,7 @@ make license-report`}
       cells: [
         "Documentation and maintainer review",
         "Policy intent, special cases such as `MPL-2.0`, and explicit approval of allowlist changes.",
-        "This page, PR review, and matching CI configuration updates.",
+        "This policy, PR review, and matching CI configuration updates.",
       ],
     },
   ]}

--- a/docs/contribute/dependency-licenses.md
+++ b/docs/contribute/dependency-licenses.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use this page when a dependency change could affect what the project is allowed to ship."
-  lede="The repository enforces license policy on shipped dependencies, not just on whatever appears in the module graph during development. This page defines the allowed set, the extra handling required for MPL-2.0, and the checks maintainers expect before a dependency change is merged."
+  title="Dependency license policy"
+  lede="The repository enforces license policy on shipped dependencies. This page defines the allowed set, the extra handling required for MPL-2.0, and the checks maintainers expect before a dependency change is merged."
 />
 
 <Callout type="note" title="Policy, not legal advice">

--- a/docs/contribute/distribution.md
+++ b/docs/contribute/distribution.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Understand what we publish today, and what we deliberately do not publish yet."
-  lede="OpenBao Operator uses an Artifact Hub-first distribution model. We publish OCI Helm chart releases to GHCR, index them in Artifact Hub for discovery, and keep OLM bundle assets in-repo and CI-validated without treating public OperatorHub publication as part of the current supported surface."
+  title="Current distribution model"
+  lede="OpenBao Operator uses an Artifact Hub-first distribution model. OCI Helm chart releases are published to GHCR, indexed in Artifact Hub for discovery, and OLM bundle assets remain in-repo and CI-validated rather than being part of the current supported publication surface."
 />
 
 <DecisionTable

--- a/docs/contribute/docs-style-guide.md
+++ b/docs/contribute/docs-style-guide.md
@@ -6,7 +6,7 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use this guide to keep contributor and operator docs calm, exact, and structurally consistent."
+  title="Documentation style guide"
   lede="The docs are written for platform engineers, SREs, operators, maintainers, and contributors doing real work. This guide defines the voice, page contracts, navigation language, and shared components that keep the documentation product coherent as it grows."
 />
 
@@ -62,6 +62,17 @@ journey: contribute
 - Keep explanations short enough to scan under time pressure.
 - Be lightly opinionated when the project has a recommended path.
 
+## Wording and headings
+
+- Keep the page title as needed for navigation, but use sentence case for headings below the page title.
+- Start sections with the decision, scope, or instruction itself. Do not spend the first sentence explaining that the section exists.
+- Prefer direct wording over evaluative filler. Replace words such as `strong`, `practical`, `useful`, `good`, and `mature` with the actual recommendation.
+- Reduce repeated `This page...`, `This section...`, and `The goal is...` framing when the heading or surrounding structure already provides that context.
+- Prefer direct verbs such as `Use`, `Keep`, `Limit`, `Reserve`, `Place`, and `Do not give` over repetitive `should` phrasing.
+- Prefer operational wording over abstract noun clusters. Name the action, object, or control directly.
+- Vary sentence length and cadence. Do not let every section open with the same balanced or three-part construction.
+- Keep one main idea per paragraph when possible.
+
 ## Terms
 
 Use product and platform terms consistently:
@@ -80,6 +91,11 @@ Use product and platform terms consistently:
 - Abstract language when concrete verbs such as `install`, `upgrade`, `restore`, or `troubleshoot` are clearer.
 - Slogan-heavy copy on normal pages.
 - `not X, but Y` framing when it does not clarify a real technical distinction.
+- Repeated evaluative framing such as "a strong baseline", "a practical model", "a useful default", or "a good starting point".
+- Opening sections by restating the heading before making a point.
+- Generic transition sentences that only restate the obvious benefit of the previous line.
+- Stacked hedging such as `usually`, `often`, `generally`, `typically`, and `in most cases` when the docs are describing the baseline recommendation.
+- Taxonomy or categorization that does not drive an actual operator or maintainer decision.
 
 ## Metadata and shared components
 

--- a/docs/contribute/getting-started/development.md
+++ b/docs/contribute/getting-started/development.md
@@ -6,7 +6,7 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Get a workstation to the point where you can build, run, test, and debug the operator without fighting the toolchain."
+  title="Contributor workstation setup"
   lede="Start by bootstrapping the repository-managed tools, then choose the smallest development loop that matches your task. Most contributor work does not need a full cluster deployment on the first edit, although webhooks, RBAC, networking, and lifecycle behavior usually do."
 />
 

--- a/docs/contribute/getting-started/development.md
+++ b/docs/contribute/getting-started/development.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Get a workstation to the point where you can build, run, test, and debug the operator without fighting the toolchain."
-  lede="Start by bootstrapping the repository-managed tools, then choose the smallest development loop that matches your task. Most contributor work does not need a full cluster deployment on the first edit, but webhooks, RBAC, networking, and lifecycle behavior eventually do."
+  lede="Start by bootstrapping the repository-managed tools, then choose the smallest development loop that matches your task. Most contributor work does not need a full cluster deployment on the first edit, although webhooks, RBAC, networking, and lifecycle behavior usually do."
 />
 
 ## Prerequisites

--- a/docs/contribute/getting-started/index.md
+++ b/docs/contribute/getting-started/index.md
@@ -15,11 +15,11 @@ journey: contribute
   ]}
 >
   <Checklist
-    title="Use this page when you need to"
+    title="Use this page to"
     items={[
-      "prepare the required local tools before you run any repo-managed commands",
+      "prepare the required local tools for repo-managed commands",
       "understand the first commands maintainers expect you to run on a clean clone",
-      "see the basic contribution path before you dive into standards or CI details",
+      "see the basic contribution path before diving into standards or CI details",
       "find the right next page once the environment itself is working",
     ]}
   />
@@ -33,7 +33,7 @@ journey: contribute
 make doctor
 make ci-core`}
 >
-  Treat this as the baseline local proof before you open a pull request or ask someone else to debug your workstation.
+  Use this as the baseline local proof for a new branch or workstation setup.
 </CommandBlock>
 
 <RouteList
@@ -48,13 +48,13 @@ make ci-core`}
     {
       eyebrow: "02",
       title: "Learn the coding rules",
-      description: "Read the project conventions, code standards, and generated-artifact rules before you start reshaping code or manifests.",
+      description: "Read the project conventions, code standards, and generated-artifact rules before reshaping code or manifests.",
       to: "/contribute/standards",
     },
     {
       eyebrow: "03",
       title: "Understand the testing stack",
-      description: "Know which layers to run locally and what CI is going to enforce before you push a branch.",
+      description: "Know which layers to run locally and what CI is going to enforce for the branch.",
       to: "/contribute/testing",
     },
     {
@@ -105,7 +105,7 @@ make ci-core`}
     },
     {
       label: "Coding standards",
-      description: "Read the project rules before you make a code or docs change.",
+      description: "Read the project rules for code and docs changes.",
       to: "/contribute/standards",
     },
     {

--- a/docs/contribute/getting-started/index.md
+++ b/docs/contribute/getting-started/index.md
@@ -7,8 +7,8 @@ journey: contribute
 
 <PageHero
   eyebrow="Contribute / Start Here"
-  title="Get a clean local environment before you touch the codebase."
-  lede="Use this section when you are setting up your workstation, creating your first branch, or trying to understand the shortest contributor path from clone to a passing local gate."
+  title="Contributor setup"
+  lede="Start here to prepare a workstation, create a first branch, and run the initial local checks. This section covers the shortest path from clone to a passing local validation loop."
   actions={[
     {label: "Set up your environment", to: "/contribute/getting-started/development", variant: "primary"},
     {label: "Open testing strategy", to: "/contribute/testing", variant: "secondary"},

--- a/docs/contribute/getting-started/index.md
+++ b/docs/contribute/getting-started/index.md
@@ -8,7 +8,7 @@ journey: contribute
 <PageHero
   eyebrow="Contribute / Start Here"
   title="Contributor setup"
-  lede="Start here to prepare a workstation, create a first branch, and run the initial local checks. This section covers the shortest path from clone to a passing local validation loop."
+  lede="Prepare a workstation, create a first branch, and run the initial local checks."
   actions={[
     {label: "Set up your environment", to: "/contribute/getting-started/development", variant: "primary"},
     {label: "Open testing strategy", to: "/contribute/testing", variant: "secondary"},

--- a/docs/contribute/index.mdx
+++ b/docs/contribute/index.mdx
@@ -18,9 +18,9 @@ journey: contribute
   <Checklist
     title="Use this section to"
     items={[
-      "set up a clean contributor environment before your first change",
+      "set up a clean contributor environment for your first change",
       "follow the project conventions for code, docs, tests, and generated artifacts",
-      "run the right local checks before you ask CI or maintainers to validate your work",
+      "run the right local checks before handing the branch to CI or maintainers",
       "understand release, supply-chain, and policy material when you are maintaining the project itself",
     ]}
   />
@@ -67,17 +67,17 @@ AI assistance is welcome, but the submitter remains responsible for correctness,
   items={[
     {
       label: "Set up environment",
-      description: "Bootstrap the repo-managed tools and verify your workstation before you make a change.",
+      description: "Bootstrap the repo-managed tools and verify your workstation for a new change.",
       to: "/contribute/getting-started/development",
     },
     {
       label: "Coding standards",
-      description: "Learn the project rules that go beyond normal Go style before you open a PR.",
+      description: "Learn the project rules that go beyond normal Go style.",
       to: "/contribute/standards",
     },
     {
       label: "Testing strategy",
-      description: "Use the project testing model and local PR-equivalent checks before asking CI to prove the same thing again.",
+      description: "Use the project testing model and local PR-equivalent checks before expanding into CI.",
       to: "/contribute/testing",
     },
   ]}

--- a/docs/contribute/index.mdx
+++ b/docs/contribute/index.mdx
@@ -9,14 +9,14 @@ journey: contribute
 <PageHero
   eyebrow="Contribute"
   title="Contributor documentation"
-  lede="Use this section for local setup, coding standards, testing, release workflows, and project governance. It covers both day-to-day contributor work and maintainer-specific policy material."
+  lede="Local setup, coding standards, testing, release workflows, and project governance for contributors and maintainers."
   actions={[
     {label: "Start here", to: "/contribute/getting-started", variant: "primary"},
     {label: "Open testing strategy", to: "/contribute/testing", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use this section to"
+    title="Common uses"
     items={[
       "set up a clean contributor environment for your first change",
       "follow the project conventions for code, docs, tests, and generated artifacts",
@@ -72,12 +72,12 @@ AI assistance is welcome, but the submitter remains responsible for correctness,
     },
     {
       label: "Coding standards",
-      description: "Learn the project rules that go beyond normal Go style.",
+      description: "Project rules beyond standard Go style.",
       to: "/contribute/standards",
     },
     {
       label: "Testing strategy",
-      description: "Use the project testing model and local PR-equivalent checks before expanding into CI.",
+      description: "Project testing model and local PR-equivalent checks.",
       to: "/contribute/testing",
     },
   ]}

--- a/docs/contribute/index.mdx
+++ b/docs/contribute/index.mdx
@@ -8,8 +8,8 @@ journey: contribute
 
 <PageHero
   eyebrow="Contribute"
-  title="Choose the contributor path that matches the work you need to do."
-  lede="Use this section to get a workstation ready, understand the codebase rules, run the right local checks, and handle release or governance work without guessing where the project keeps those policies."
+  title="Contributor documentation"
+  lede="Use this section for local setup, coding standards, testing, release workflows, and project governance. It covers both day-to-day contributor work and maintainer-specific policy material."
   actions={[
     {label: "Start here", to: "/contribute/getting-started", variant: "primary"},
     {label: "Open testing strategy", to: "/contribute/testing", variant: "secondary"},

--- a/docs/contribute/project-governance.mdx
+++ b/docs/contribute/project-governance.mdx
@@ -8,19 +8,19 @@ journey: contribute
 <PageHero
   eyebrow="Contribute / Project Governance"
   title="Project governance and policy"
-  lede="This section covers SDLC, supply-chain controls, and dependency license policy for OpenBao Operator. It is intended for maintainer and policy work rather than normal feature development."
+  lede="SDLC, supply-chain controls, and dependency license policy for OpenBao Operator."
   actions={[
     {label: "Open SDLC", to: "/contribute/sdlc", variant: "primary"},
     {label: "Open supply chain security", to: "/contribute/supply-chain-security", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Covers"
     items={[
-      "understand how the project models secure development and release flow end to end",
-      "review or change supply-chain controls, provenance expectations, or reproducibility requirements",
-      "understand which dependency licenses are allowed for shipped binaries",
-      "separate project policy work from normal day-to-day implementation work",
+      "secure development and release flow across the project lifecycle",
+      "supply-chain controls, provenance expectations, and reproducibility requirements",
+      "dependency license policy for shipped binaries",
+      "maintainer and policy work outside day-to-day feature development",
     ]}
   />
 </PageHero>
@@ -31,7 +31,7 @@ journey: contribute
     {
       eyebrow: "01",
       title: "Software development lifecycle",
-      description: "See how planning, implementation, verification, release, and operations map into the project’s secure lifecycle.",
+      description: "Planning, implementation, verification, release, and operations in the project lifecycle.",
       to: "/contribute/sdlc",
     },
     {
@@ -43,7 +43,7 @@ journey: contribute
     {
       eyebrow: "03",
       title: "Supply-chain incident response",
-      description: "Use the maintainer runbook when you need to freeze Actions, suspend release automation, rotate trust roots, or inspect recent publication state.",
+      description: "Maintainer runbook for freezing Actions, suspending release automation, rotating trust roots, or inspecting publication state.",
       to: "/contribute/supply-chain-incident-response",
     },
     {
@@ -60,12 +60,12 @@ journey: contribute
   items={[
     {
       label: "Release management",
-      description: "Use the concrete release workflow when policy turns into an actual release event.",
+      description: "Release workflow for turning policy into an actual release event.",
       to: "/contribute/release-management",
     },
     {
       label: "Continuous integration",
-      description: "Review the CI implementation that enforces many of these policy expectations in practice.",
+      description: "CI implementation that enforces many of these policy expectations in practice.",
       to: "/contribute/ci",
     },
   ]}

--- a/docs/contribute/project-governance.mdx
+++ b/docs/contribute/project-governance.mdx
@@ -7,8 +7,8 @@ journey: contribute
 
 <PageHero
   eyebrow="Contribute / Project Governance"
-  title="Use these pages when you are changing how the project is governed, secured, or published."
-  lede="This section is for policy and maintainer work: SDLC expectations, supply-chain controls, and dependency license rules. It is not the place to start for normal feature work, but it is the right place when you are changing how OpenBao Operator proves trust or manages release risk."
+  title="Project governance and policy"
+  lede="This section covers SDLC, supply-chain controls, and dependency license policy for OpenBao Operator. It is intended for maintainer and policy work rather than normal feature development."
   actions={[
     {label: "Open SDLC", to: "/contribute/sdlc", variant: "primary"},
     {label: "Open supply chain security", to: "/contribute/supply-chain-security", variant: "secondary"},

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -7,12 +7,12 @@ journey: contribute
 
 <PageHeader
   title="Release management workflow"
-  lede="OpenBao Operator uses a build-once, promote-everywhere release model. This page covers versioning, changelog state, release orchestration, signing, docs deployment, and release evidence."
+  lede="Build-once, promote-everywhere release workflow covering versioning, changelog state, release orchestration, signing, docs deployment, and release evidence."
 />
 
 <Callout type="note" title="Maintainer workflow">
 
-Use [Release Policy](pathname:///docs/next/reference/release-policy) for the public release cadence, channel rules, and stable release gates. Use this page for the operational workflow maintainers follow once a release is actually being executed.
+[Release Policy](pathname:///docs/next/reference/release-policy) covers the public release cadence, channel rules, and stable release gates. The steps below cover the maintainer workflow once a release is being executed.
 
 </Callout>
 
@@ -94,9 +94,9 @@ git commit --allow-empty -m $'chore: release 0.1.0-rc.6\n\nRelease-As: 0.1.0-rc.
   This flow creates an explicit prerelease target on `main` when the inferred Conventional Commit bump is not the intended version.
 </CommandBlock>
 
-<Callout type="note" title="`workflow_dispatch` `release_as` input">
+<Callout type="note" title="`workflow_dispatch` `release_as` path">
 
-`Release Please PR` still exposes a `workflow_dispatch` `release_as` input, and it can be useful when it produces the expected release PR. The `Release-As:` PR path remains the fallback for release lines where the dispatch path is not yet reliable.
+`Release Please PR` still exposes a `workflow_dispatch` `release_as` input, and it can produce the expected release PR. The `Release-As:` PR path remains the fallback for release lines where the dispatch path is not yet reliable.
 
 </Callout>
 

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -55,7 +55,7 @@ Use [Release Policy](pathname:///docs/next/reference/release-policy) for the pub
         "Edge",
         "CI success on `main`.",
         "Mutable and immutable edge manifests plus signed images and provenance metadata.",
-        "Use for pre-release validation only; do not treat edge as production support policy.",
+        "Pre-release validation channel; production support expectations remain with stable releases.",
       ],
     },
     {
@@ -63,13 +63,13 @@ Use [Release Policy](pathname:///docs/next/reference/release-policy) for the pub
         "Nightly",
         "Nightly validation success.",
         "Nightly manifests, tags, and provenance metadata.",
-        "Use for scheduled validation and drift detection, not as a replacement for a stable release.",
+        "Scheduled validation and drift-detection channel; stable releases remain the publication path.",
       ],
     },
   ]}
 />
 
-<Callout type="important" title="Docs snapshots are for stable releases">
+<Callout type="important" title="Stable release docs snapshots">
 
 Before merging a stable release PR, snapshot the docs for the outgoing version and commit the generated artifacts. Prereleases continue to use `/docs/next` and do not need a permanent versioned docs snapshot.
 
@@ -91,12 +91,12 @@ Before merging a stable release PR, snapshot the docs for the outgoing version a
   code={`git switch -c chore/release-as-0.1.0-rc.6
 git commit --allow-empty -m $'chore: release 0.1.0-rc.6\n\nRelease-As: 0.1.0-rc.6\nSigned-off-by: Your Name <you@example.com>'`}
 >
-  Open a tiny PR with only this empty commit, merge it, and let `Release Please PR` recreate the release PR on `main`. Use this when you need a specific `-alpha`, `-beta`, or `-rc` target instead of the bump inferred from normal Conventional Commits.
+  This flow creates an explicit prerelease target on `main` when the inferred Conventional Commit bump is not the intended version.
 </CommandBlock>
 
-<Callout type="note" title="workflow_dispatch `release_as` is still optional, not the authoritative path">
+<Callout type="note" title="`workflow_dispatch` `release_as` input">
 
-`Release Please PR` still exposes a `workflow_dispatch` `release_as` input, and it is useful when it produces the expected release PR. Keep the `Release-As:` PR path as the reliable fallback until the dispatch path proves consistently correct for your release line.
+`Release Please PR` still exposes a `workflow_dispatch` `release_as` input, and it can be useful when it produces the expected release PR. The `Release-As:` PR path remains the fallback for release lines where the dispatch path is not yet reliable.
 
 </Callout>
 
@@ -181,22 +181,22 @@ Upload the matching public key to the GitHub identity that should show the `Veri
   items={[
     {
       label: "Release policy",
-      description: "Go back to the public cadence and release-gate contract when the release rules themselves need to change.",
+      description: "Release policy covers cadence and release-gate rules.",
       to: "/docs/next/reference/release-policy",
     },
     {
       label: "Distribution",
-      description: "Open the public-distribution model when you need to update Artifact Hub metadata, chart publishing assumptions, or deferred OLM posture.",
+      description: "Distribution covers Artifact Hub metadata, chart publishing assumptions, and deferred OLM posture.",
       to: "/contribute/distribution",
     },
     {
       label: "Continuous integration",
-      description: "Go back to workflow behavior if the release gate failed before publish.",
+      description: "Continuous integration covers workflow behavior before publish.",
       to: "/contribute/ci",
     },
     {
       label: "Project governance",
-      description: "Move into SDLC or supply-chain policy when the release rules themselves need to change.",
+      description: "Project governance covers SDLC and supply-chain policy changes.",
       to: "/contribute/project-governance",
     },
   ]}

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -6,11 +6,11 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Release once, promote by digest, and prove the published artifacts before you announce them."
-  lede="OpenBao Operator uses a build-once, promote-everywhere release model. `release-please` owns versioning, changelog state, and release orchestration, while publish workflows own build, verification, signing, docs deployment, and release evidence."
+  title="Release management workflow"
+  lede="OpenBao Operator uses a build-once, promote-everywhere release model. This page covers versioning, changelog state, release orchestration, signing, docs deployment, and release evidence."
 />
 
-<Callout type="note" title="This page is the maintainer workflow, not the public cadence contract">
+<Callout type="note" title="Maintainer workflow">
 
 Use [Release Policy](pathname:///docs/next/reference/release-policy) for the public release cadence, channel rules, and stable release gates. Use this page for the operational workflow maintainers follow once a release is actually being executed.
 

--- a/docs/contribute/sdlc.md
+++ b/docs/contribute/sdlc.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Software development lifecycle"
-  lede="This page describes how the project connects planning, implementation, verification, release, and operational feedback."
+  lede="How the project connects planning, implementation, verification, release, and operational feedback."
 />
 
 <DiagramFrame
@@ -76,9 +76,9 @@ journey: contribute
   ]}
 />
 
-<Callout type="note" title="How to use this page">
+<Callout type="note" title="How this page fits">
 
-This page describes the project change-control model. Workflow pages cover concrete commands and release execution. This page focuses on how the controls fit together.
+Workflow pages cover concrete commands and release execution. The sections below show how the controls fit together.
 
 </Callout>
 
@@ -133,7 +133,7 @@ This page describes the project change-control model. Workflow pages cover concr
     },
     {
       label: "Coding standards",
-      description: "Go back to implementation rules when the next question is how to make a change fit the repository correctly.",
+      description: "Implementation rules for fitting a change into the repository.",
       to: "/contribute/standards",
     },
   ]}

--- a/docs/contribute/sdlc.md
+++ b/docs/contribute/sdlc.md
@@ -6,13 +6,13 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use the SDLC to understand which controls prove a change is safe to ship."
-  lede="The SDLC is the maintainer model for how work moves from design to production. It ties normal implementation work to the governance controls that harden builds, gate releases, and feed operational learning back into the next change."
+  title="Software development lifecycle"
+  lede="This page describes how the project connects planning, implementation, verification, release, and operational feedback."
 />
 
 <DiagramFrame
   title="Lifecycle model"
-  caption="The lifecycle is a control loop, not a one-way checklist."
+  caption="The lifecycle links planning, implementation, verification, release, and operational feedback."
   code={`graph LR
     Plan["Plan and design"]
     Build["Implement"]
@@ -76,9 +76,9 @@ journey: contribute
   ]}
 />
 
-<Callout type="note" title="Governance model, not a task checklist">
+<Callout type="note" title="How to use this page">
 
-This page explains how the project models change control. Use the workflow pages for concrete commands and release execution. Use this page when you need to understand why those checks exist and where they fit.
+This page describes the project change-control model. Workflow pages cover concrete commands and release execution. This page focuses on how the controls fit together.
 
 </Callout>
 

--- a/docs/contribute/standards/error-handling.md
+++ b/docs/contribute/standards/error-handling.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Handle errors so callers keep context, reviewers can follow the failure path, and controllers stay alive."
-  lede="Most error-handling issues in this repository are not about catching more failures. They are about returning failures with enough structure and context that the next layer can make the right decision without guessing. These rules keep that path predictable."
+  lede="This page focuses on returning failures with enough structure and context that the next layer can make the right decision. These rules keep the failure path predictable for controllers, callers, and reviewers."
 />
 
 <DecisionTable

--- a/docs/contribute/standards/error-handling.md
+++ b/docs/contribute/standards/error-handling.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Handle errors so callers keep context, reviewers can follow the failure path, and controllers stay alive."
-  lede="This page focuses on returning failures with enough structure and context that the next layer can make the right decision. These rules keep the failure path predictable for controllers, callers, and reviewers."
+  title="Error-handling defaults"
+  lede="Return failures with enough structure and context for the next layer to act correctly."
 />
 
 <DecisionTable

--- a/docs/contribute/standards/generated-artifacts.md
+++ b/docs/contribute/standards/generated-artifacts.md
@@ -6,7 +6,7 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use this page when a change should have emitted files and you need to know which command owns them."
+  title="Generated artifact ownership"
   lede="Generated output is part of the source tree contract in this repository. If an API, policy, renderer, or chart input changes, the matching generated artifacts must change in the same PR. Do not edit generated files directly."
 />
 

--- a/docs/contribute/standards/go-style.md
+++ b/docs/contribute/standards/go-style.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use the Go style guide to keep implementation choices boring, predictable, and easy to review."
-  lede="This page captures the coding defaults maintainers expect in normal Go work: naming, error handling, logging, reconciler-safe concurrency, imports, and constants. The goal is not novelty. The goal is code that behaves like the rest of the repository."
+  title="Repository Go style defaults"
+  lede="This page captures the coding defaults maintainers expect in normal Go work: naming, error handling, logging, reconciler-safe concurrency, imports, and constants. The goal is consistent code that behaves like the rest of the repository."
 />
 
 <DecisionTable

--- a/docs/contribute/standards/go-style.md
+++ b/docs/contribute/standards/go-style.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Repository Go style defaults"
-  lede="This page captures the coding defaults maintainers expect in normal Go work: naming, error handling, logging, reconciler-safe concurrency, imports, and constants. The goal is consistent code that behaves like the rest of the repository."
+  lede="Naming, error handling, logging, reconciler-safe concurrency, imports, and constants used across the repository."
 />
 
 <DecisionTable

--- a/docs/contribute/standards/index.md
+++ b/docs/contribute/standards/index.md
@@ -8,18 +8,18 @@ journey: contribute
 <PageHero
   eyebrow="Contribute / Build & Change"
   title="Repository standards"
-  lede="This section defines the coding, documentation, generated-artifact, and commit-history standards for OpenBao Operator. Use it before changing APIs, manifests, controllers, or generated output."
+  lede="Coding, documentation, generated-artifact, and commit-history standards for OpenBao Operator."
   actions={[
     {label: "Open project conventions", to: "/contribute/standards/project-conventions", variant: "primary"},
     {label: "Open documentation style guide", to: "/contribute/docs-style-guide", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Use this section to"
     items={[
       "understand what the project considers idiomatic Go and acceptable controller patterns",
       "avoid common review feedback around error handling, logging, generated files, and commit shape",
-      "follow the project’s security, docs, and architecture expectations before you submit code",
+      "follow the project’s security, docs, and architecture expectations when you submit code",
       "know which standards are global and which are specific to OpenBao Operator itself",
     ]}
   />

--- a/docs/contribute/standards/index.md
+++ b/docs/contribute/standards/index.md
@@ -7,8 +7,8 @@ journey: contribute
 
 <PageHero
   eyebrow="Contribute / Build & Change"
-  title="Learn the project rules before your change becomes someone else’s cleanup."
-  lede="These standards define how OpenBao Operator code, docs, generated artifacts, and commit history should look. Use this section before you start refactoring, adding APIs, changing manifests, or touching generated output."
+  title="Repository standards"
+  lede="This section defines the coding, documentation, generated-artifact, and commit-history standards for OpenBao Operator. Use it before changing APIs, manifests, controllers, or generated output."
   actions={[
     {label: "Open project conventions", to: "/contribute/standards/project-conventions", variant: "primary"},
     {label: "Open documentation style guide", to: "/contribute/docs-style-guide", variant: "secondary"},

--- a/docs/contribute/standards/kubernetes-patterns.md
+++ b/docs/contribute/standards/kubernetes-patterns.md
@@ -6,7 +6,7 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use these patterns to keep controller code Kubernetes-native instead of drifting into ad hoc orchestration."
+  title="Kubernetes-native controller patterns"
   lede="The operator relies on predictable reconcile loops, explicit controller boundaries, and safe interaction with the API server. These patterns are the default shape of controller work in this repository, especially when app-layer orchestration and manager boundaries are involved."
 />
 

--- a/docs/contribute/standards/project-conventions.md
+++ b/docs/contribute/standards/project-conventions.md
@@ -6,7 +6,7 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use these conventions to make a change fit the repository before CI has to rescue it."
+  title="Repository project conventions"
   lede="These are the project-specific rules that go beyond generic Go style. They keep controller code predictable, reviews focused, architecture boundaries enforceable, and generated output aligned with the code that owns it."
 />
 
@@ -38,7 +38,7 @@ journey: contribute
     },
     {
       cells: [
-        "Treat architecture boundaries as policy",
+        "Keep architecture boundaries aligned with policy",
         "Update the boundary policy before adding new top-level internal packages or controller packages.",
         "The repository enforces these rules automatically, so design intent and CI stay aligned.",
       ],
@@ -53,9 +53,9 @@ journey: contribute
   ]}
 />
 
-<Callout type="warning" title="No `any` in core logic">
+<Callout type="warning" title="Avoid type erasure in core logic">
 
-Treat `any` and `interface{}` as escape hatches for external API boundaries, not as normal implementation tools. If a helper only works because it erases types, it usually needs a narrower contract.
+Reserve `any` and `interface{}` for external API boundaries. Helpers that only work because they erase types usually need a narrower contract.
 
 </Callout>
 
@@ -129,7 +129,7 @@ make lint-ast`}
     },
     {
       label: "Generated artifacts",
-      description: "Use the generation map when you know a change should have emitted files but are not sure which command owns them.",
+      description: "Generated artifacts maps emitted files back to their owning commands.",
       to: "/contribute/standards/generated-artifacts",
     },
     {

--- a/docs/contribute/standards/security-practices.md
+++ b/docs/contribute/standards/security-practices.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Secure coding practices"
-  lede="OpenBao Operator handles sensitive material and security-relevant control paths. This page covers least-privilege permissions, standard cryptographic primitives, controller-safe execution, and explicit care around secrets in memory and logs."
+  lede="Least-privilege permissions, standard cryptographic primitives, controller-safe execution, and careful handling of secrets in memory and logs."
 />
 
 <DecisionTable

--- a/docs/contribute/standards/security-practices.md
+++ b/docs/contribute/standards/security-practices.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use these practices when code touches keys, certificates, external input, filesystem state, or privileged controller behavior."
-  lede="OpenBao Operator handles sensitive material and security-relevant control paths. The safest implementation choice is usually the simplest one: least-privilege permissions, standard cryptographic primitives, no shell escapes from controllers, and explicit care around secrets in memory and logs."
+  title="Secure coding practices"
+  lede="OpenBao Operator handles sensitive material and security-relevant control paths. This page covers least-privilege permissions, standard cryptographic primitives, controller-safe execution, and explicit care around secrets in memory and logs."
 />
 
 <DecisionTable

--- a/docs/contribute/supply-chain-security.md
+++ b/docs/contribute/supply-chain-security.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Use this page to understand how OpenBao Operator proves that published artifacts are attributable and reproducible."
-  lede="OpenBao Operator follows a build-once, verify, then promote model. The goal is not only to build release assets, but to prove where they came from, how they were produced, and whether an independent rebuild arrives at the same bytes before anything is published."
+  lede="OpenBao Operator follows a build-once, verify, then promote model. This page covers provenance, reproducibility, and the checks maintainers use before publishing release assets."
 />
 
 <DiagramFrame

--- a/docs/contribute/supply-chain-security.md
+++ b/docs/contribute/supply-chain-security.md
@@ -6,8 +6,8 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Use this page to understand how OpenBao Operator proves that published artifacts are attributable and reproducible."
-  lede="OpenBao Operator follows a build-once, verify, then promote model. This page covers provenance, reproducibility, and the checks maintainers use before publishing release assets."
+  title="Supply-chain security controls"
+  lede="Provenance, reproducibility, and publish-time checks for OpenBao Operator release assets."
 />
 
 <DiagramFrame
@@ -124,7 +124,7 @@ journey: contribute
 sed -n '1,220p' .github/workflows/release.yml
 sed -n '1,220p' .github/workflows/reusable-channel-hardening.yml`}
 >
-  Use this when you need to trace where a trust gate is implemented before changing the workflow or the scripts that back it.
+  Use these commands to trace the workflow or script that implements a trust gate.
 </CommandBlock>
 
 <Callout type="warning" title="Single-maintainer operating constraint">
@@ -167,22 +167,22 @@ Human two-person approval controls are still limited by the current single-maint
   items={[
     {
       label: "Release management",
-      description: "Use the concrete release procedure when you need the exact sequence of verification, publish, and post-release steps.",
+      description: "Release procedure for verification, publish, and post-release steps.",
       to: "/contribute/release-management",
     },
     {
       label: "Continuous integration",
-      description: "Review how these controls appear earlier in the branch and PR lifecycle before a release exists.",
+      description: "How these controls appear earlier in the branch and PR lifecycle.",
       to: "/contribute/ci",
     },
     {
       label: "Dependency license policy",
-      description: "Open the policy that governs which shipped dependencies are allowed into the release graph at all.",
+      description: "Dependency policy for which shipped dependencies may enter the release graph.",
       to: "/contribute/dependency-licenses",
     },
     {
       label: "Incident response",
-      description: "Use the supply-chain incident runbook when you need to freeze publishing, rotate credentials, or inspect recent releases.",
+      description: "Supply-chain incident runbook for freezing publishing, rotating credentials, or inspecting recent releases.",
       to: "/contribute/supply-chain-incident-response",
     },
   ]}

--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -6,13 +6,13 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Choose the smallest test that proves the change you actually made."
-  lede="The testing stack is layered on purpose. Start with the cheapest signal that can fail for the right reason, then move outward only when the change touches controller wiring, real API semantics, full cluster lifecycle, or environment-specific behavior."
+  title="Choose test depth by change scope"
+  lede="The testing stack is layered. Start with the cheapest signal that can prove the change, then add integration, E2E, or exploratory coverage when the lower layer is no longer enough."
 />
 
 <DiagramFrame
   title="Testing layers"
-  caption="Move outward only when the cheaper layer can no longer prove the behavior you changed."
+  caption="Move outward when the cheaper layer can no longer prove the behavior you changed."
   code={`graph BT
     Unit["Unit tests"]
     Contract["Fast contracts"]

--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -84,7 +84,7 @@ Use the controller-runtime fake client as a fast contract tool, not as a substit
 make doctor
 make ci-core`}
 >
-  This is the default maintainer expectation before you open a PR or ask someone else to chase a failing branch.
+  This is the default maintainer expectation before you open a PR or hand a failing branch to someone else for review.
 </CommandBlock>
 
 <CommandBlock

--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -6,13 +6,13 @@ journey: contribute
 ---
 
 <PageHeader
-  title="Choose test depth by change scope"
-  lede="The testing stack is layered. Start with the cheapest signal that can prove the change, then add integration, E2E, or exploratory coverage when the lower layer is no longer enough."
+  title="Testing strategy by change scope"
+  lede="This page maps change scope to validation depth across unit, integration, E2E, fuzzing, and exploratory coverage."
 />
 
 <DiagramFrame
   title="Testing layers"
-  caption="Move outward when the cheaper layer can no longer prove the behavior you changed."
+  caption="Move to the next layer when the lower-cost layer no longer proves the behavior you changed."
   code={`graph BT
     Unit["Unit tests"]
     Contract["Fast contracts"]
@@ -84,7 +84,7 @@ Use the controller-runtime fake client as a fast contract tool, not as a substit
 make doctor
 make ci-core`}
 >
-  This is the default maintainer expectation before you open a PR or hand a failing branch to someone else for review.
+  This is the standard local validation baseline before review or handoff.
 </CommandBlock>
 
 <CommandBlock
@@ -100,7 +100,7 @@ export E2E_OPERATOR_IMAGE=quay.io/your-org/openbao-operator:dev
 export E2E_API_SERVER_CIDR=0.0.0.0/0
 make test-e2e-existing E2E_LABEL_FILTER='openshift'`}
 >
-  Use fuzzing when parsers, normalizers, auth helpers, or config rendering changed. Use `test-e2e-existing` when you need focused OpenShift or non-Kind validation against an existing cluster.
+  These commands cover parser, auth, renderer, and platform-specific validation that does not fit the default local gate.
 </CommandBlock>
 
 <DecisionTable
@@ -136,17 +136,17 @@ make test-e2e-existing E2E_LABEL_FILTER='openshift'`}
   items={[
     {
       label: "Continuous integration",
-      description: "See how CI maps these layers to workflow gates, routing, and label-driven E2E expansion.",
+      description: "Continuous integration maps these validation layers to workflow gates and routing.",
       to: "/contribute/ci",
     },
     {
       label: "Coding standards",
-      description: "Go back to project conventions when the implementation itself still needs cleanup before more test depth helps.",
+      description: "Coding standards cover implementation cleanup when more test depth would not help yet.",
       to: "/contribute/standards",
     },
     {
       label: "Release management",
-      description: "Move into release and publish flow once the branch is stable and ready for maintainer handling.",
+      description: "Release management covers release and publish flow once the branch is stable.",
       to: "/contribute/release-management",
     },
   ]}

--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -7,7 +7,7 @@ journey: contribute
 
 <PageHeader
   title="Testing strategy by change scope"
-  lede="This page maps change scope to validation depth across unit, integration, E2E, fuzzing, and exploratory coverage."
+  lede="Validation depth by change scope across unit, integration, E2E, fuzzing, and exploratory coverage."
 />
 
 <DiagramFrame
@@ -84,7 +84,7 @@ Use the controller-runtime fake client as a fast contract tool, not as a substit
 make doctor
 make ci-core`}
 >
-  This is the standard local validation baseline before review or handoff.
+  Standard local validation baseline before review or handoff.
 </CommandBlock>
 
 <CommandBlock

--- a/docs/contribute/validate-and-ship.mdx
+++ b/docs/contribute/validate-and-ship.mdx
@@ -7,8 +7,8 @@ journey: contribute
 
 <PageHero
   eyebrow="Contribute / Validate & Ship"
-  title="Run the right checks before you ask CI or release automation to prove the same thing."
-  lede="Use this section when you are validating a branch, understanding CI outcomes, preparing a release, or changing how OpenBao Operator is distributed. It groups the execution side of contribution work instead of scattering it across policy pages."
+  title="Validation and release workflows"
+  lede="Use this section for local validation, CI behavior, release execution, and distribution workflows. It groups the execution side of contributor and maintainer work."
   actions={[
     {label: "Open testing strategy", to: "/contribute/testing", variant: "primary"},
     {label: "Open release management", to: "/contribute/release-management", variant: "secondary"},

--- a/docs/contribute/validate-and-ship.mdx
+++ b/docs/contribute/validate-and-ship.mdx
@@ -8,19 +8,19 @@ journey: contribute
 <PageHero
   eyebrow="Contribute / Validate & Ship"
   title="Validation and release workflows"
-  lede="Use this section for local validation, CI behavior, release execution, and distribution workflows. It groups the execution side of contributor and maintainer work."
+  lede="Local validation, CI behavior, release execution, and distribution workflows."
   actions={[
     {label: "Open testing strategy", to: "/contribute/testing", variant: "primary"},
     {label: "Open release management", to: "/contribute/release-management", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Covers"
     items={[
-      "pick the right local test depth before you push a branch",
-      "understand how CI maps to local commands and why a workflow failed",
-      "run or review release flow, artifact publication, and distribution mechanics",
-      "distinguish contributor checks from maintainer-only release responsibilities",
+      "local test depth before a branch is pushed",
+      "CI-to-local command mapping and workflow failure triage",
+      "release flow, artifact publication, and distribution mechanics",
+      "the split between contributor checks and maintainer release responsibilities",
     ]}
   />
 </PageHero>
@@ -60,12 +60,12 @@ journey: contribute
   items={[
     {
       label: "Project governance",
-      description: "Move into SDLC, supply-chain, and dependency policy when your change affects project policy rather than just execution.",
+      description: "SDLC, supply-chain, and dependency policy when the change affects project policy.",
       to: "/contribute/project-governance",
     },
     {
       label: "Coding standards",
-      description: "Go back to the change rules if CI is failing because the implementation itself still violates project conventions.",
+      description: "Coding standards when CI is failing because the implementation still violates project conventions.",
       to: "/contribute/standards",
     },
   ]}

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,8 +9,8 @@ description: OpenBao Operator documentation for installation, configuration, ope
 <PageHero
   variant="landing"
   eyebrow="Operator docs"
-  title="Choose the route that matches the work."
-  lede="Use these docs to install OpenBao Operator, shape the cluster before go-live, run it in production, and check the exact security, architecture, and support contracts behind the platform."
+  title="OpenBao Operator documentation"
+  lede="Use these docs for installation, configuration, day 2 operations, security, architecture, and reference material. Recovery and restore guidance lives under Operate."
   actions={[
     {label: 'Start with Get Started', docId: 'user-guide/index', variant: 'primary'},
     {label: 'Open Operate', docId: 'user-guide/openbaocluster/operations/index', variant: 'secondary'},

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -10,14 +10,14 @@ description: OpenBao Operator documentation for installation, configuration, ope
   variant="landing"
   eyebrow="Operator docs"
   title="OpenBao Operator documentation"
-  lede="Use these docs for installation, configuration, day 2 operations, security, architecture, and reference material. Recovery and restore guidance lives under Operate."
+  lede="Installation, configuration, day 2 operations, security, architecture, and reference material for OpenBao Operator. Recovery and restore guidance lives under Operate."
   actions={[
     {label: 'Start with Get Started', docId: 'user-guide/index', variant: 'primary'},
     {label: 'Open Operate', docId: 'user-guide/openbaocluster/operations/index', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Use these docs to"
     items={[
       'deploy OpenBao Operator for the first time',
       'move from installation into configuration and day 2 operations',

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Use the compatibility matrix when you need the exact validation and support boundary for a platform or version."
-  lede="This page is the contract for what the project actively validates, what remains best-effort supported, and what should be treated as out of scope for the current pre-GA line. It is the fastest way to answer whether a target Kubernetes or OpenBao version sits inside the tested envelope."
+  title="Compatibility matrix"
+  lede="Validated versions, support posture, and production guidance for the current pre-GA line."
 />
 
 <Callout type="note" title="Terminology">
@@ -83,7 +83,7 @@ The current stable release line is intended for real deployments, but it remains
 <DecisionTable
   kind="reference"
   title="CI validation matrix"
-  caption="Treat the CI configuration as the source of truth for what is actually exercised."
+  caption="Versions and paths exercised by CI workflows."
   columns={['Workflow', 'Scope', 'Versions tested']}
   rows={[
     {
@@ -110,17 +110,17 @@ Always validate new Kubernetes or OpenBao versions in a staging environment befo
   items={[
     {
       label: 'Upgrade compatibility',
-      description: 'Use the exact upgrade-path contract when the next question is sequencing rather than version support.',
+      description: 'Upgrade sequencing and rollback stance for operator upgrades.',
       docId: 'reference/operator-upgrade-compatibility',
     },
     {
       label: 'Support policy',
-      description: 'Open the support contract when you need to know what the project maintains beyond raw validation coverage.',
+      description: 'Release-line maintenance beyond raw validation coverage.',
       docId: 'reference/support-policy',
     },
     {
       label: 'Known limitations',
-      description: 'Check current caveats and non-goals before assuming that an unvalidated path is only temporarily undocumented.',
+      description: 'Current caveats and explicit non-goals for unsupported paths.',
       docId: 'reference/known-limitations',
     },
   ]}

--- a/docs/reference/deprecation-policy.md
+++ b/docs/reference/deprecation-policy.md
@@ -6,7 +6,7 @@ journey: reference
 ---
 
 <PageHeader
-  title="Use this page when you need the exact contract for how APIs and behavior can change across releases."
+  title="Deprecation policy contract"
   lede="OpenBao Operator is still pre-GA, so compatibility rules are explicit rather than implied. This page defines how deprecations are announced, how removals happen, and what migration guidance must ship with a breaking or removing change."
 />
 

--- a/docs/reference/deprecation-policy.md
+++ b/docs/reference/deprecation-policy.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Deprecation policy contract"
-  lede="OpenBao Operator is still pre-GA, so compatibility rules are explicit rather than implied. This page defines how deprecations are announced, how removals happen, and what migration guidance must ship with a breaking or removing change."
+  title="Deprecation and API lifecycle policy"
+  lede="How deprecations are announced, how removals happen, and what migration guidance must ship with a breaking or removing change."
 />
 
 <DecisionTable
@@ -27,7 +27,7 @@ journey: reference
       cells: [
         'Patch releases (`0.Y.Z`)',
         'Should avoid intentional breaking changes.',
-        'Use only when the change is truly compatible or required for safety and integrity.',
+        'Reserved for compatible changes or changes required for safety and integrity.',
       ],
     },
     {
@@ -96,17 +96,17 @@ The project currently serves a single CRD API version, `v1alpha1`. When addition
   items={[
     {
       label: 'Compatibility matrix',
-      description: 'Open the validation matrix when the question is whether a target platform or version is still in scope.',
+      description: 'Platforms and versions that remain in scope.',
       docId: 'reference/compatibility',
     },
     {
       label: 'Upgrade compatibility',
-      description: 'Use the upgrade-path contract when you need sequencing and rollback guidance instead of API lifecycle rules.',
+      description: 'Sequencing and rollback guidance for operator upgrades.',
       docId: 'reference/operator-upgrade-compatibility',
     },
     {
       label: 'Release management',
-      description: 'Move to the maintainer workflow when the next step is shipping a release that contains the deprecation.',
+      description: 'Maintainer workflow for shipping a release that contains the deprecation.',
       to: '/contribute/release-management',
     },
   ]}

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -10,8 +10,8 @@ description: Generated API, compatibility, maintenance policy, upgrade compatibi
 <PageHero
   variant="landing"
   eyebrow="Reference"
-  title="Use the exact contract when the details matter."
-  lede="Use this section for generated API fields, compatibility expectations, upgrade constraints, support posture, and status and event semantics."
+  title="Reference documentation"
+  lede="Use this section for generated API fields, compatibility, upgrade constraints, support policy, and status and event semantics."
   actions={[
     {label: 'Open compatibility matrix', docId: 'reference/compatibility', variant: 'primary'},
     {label: 'Open status and events', docId: 'reference/status-and-events', variant: 'secondary'},

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -11,7 +11,7 @@ description: Generated API, compatibility, maintenance policy, upgrade compatibi
   variant="landing"
   eyebrow="Reference"
   title="Reference documentation"
-  lede="Use this section for generated API fields, compatibility, upgrade constraints, support policy, and status and event semantics."
+  lede="Generated API fields, compatibility, upgrade constraints, support policy, and status and event semantics."
   actions={[
     {label: 'Open compatibility matrix', docId: 'reference/compatibility', variant: 'primary'},
     {label: 'Open status and events', docId: 'reference/status-and-events', variant: 'secondary'},
@@ -53,12 +53,12 @@ description: Generated API, compatibility, maintenance policy, upgrade compatibi
   items={[
     {
       label: 'Release policy',
-      description: 'See the public cadence, release channels, and stable release gates before assuming how often the project ships.',
+      description: 'Public cadence, release channels, and stable release gates.',
       docId: 'reference/release-policy',
     },
     {
       label: 'Support policy',
-      description: 'See which release lines are in scope for best-effort maintenance and what that support actually means.',
+      description: 'Release lines in scope for best-effort maintenance.',
       docId: 'reference/support-policy',
     },
     {

--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -7,7 +7,7 @@ journey: reference
 
 <PageHeader
   title="Know which operator boundaries are real today."
-  lede="Not every missing feature is an accidental gap. This page captures the current constraints and explicit non-goals for the pre-GA line so operators and contributors can separate unsupported assumptions from issues the project actually intends to solve."
+  lede="This page captures the current constraints and explicit non-goals for the pre-GA line so operators and contributors can separate unsupported assumptions from issues the project intends to solve."
 />
 
 <DecisionTable

--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Know which operator boundaries are real today."
-  lede="This page captures the current constraints and explicit non-goals for the pre-GA line so operators and contributors can separate unsupported assumptions from issues the project intends to solve."
+  title="Known limitations and non-goals"
+  lede="Current constraints and explicit non-goals for the pre-GA line."
 />
 
 <DecisionTable
@@ -22,7 +22,7 @@ journey: reference
       cells: ['Cluster adoption', 'The operator assumes it manages clusters it created and reconciles; generic import of arbitrary unmanaged OpenBao clusters is out of scope.', 'Create operator-managed clusters directly, or use backup and restore workflows when you need to move data into a new operator-managed cluster.'],
     },
     {
-      cells: ['Operator downgrade', 'Downgrades are not treated as a normal rollback path.', 'Use the recovery and restore guidance when a release cannot move forward safely.'],
+      cells: ['Operator downgrade', 'Routine downgrades are unsupported.', 'Use the recovery and restore guidance when a release cannot move forward safely.'],
       emphasis: 'caution',
     },
     {
@@ -49,22 +49,22 @@ journey: reference
   items={[
     {
       label: 'Support policy',
-      description: 'Open the maintenance contract behind these constraints and the release lines that remain in scope.',
+      description: 'Maintenance contract and release lines that remain in scope.',
       docId: 'reference/support-policy',
     },
     {
       label: 'Upgrade compatibility',
-      description: 'Use the exact operator upgrade-path contract when the next question is rollback stance or CRD sequencing.',
+      description: 'Rollback stance and CRD sequencing for operator upgrades.',
       docId: 'reference/operator-upgrade-compatibility',
     },
     {
       label: 'Decommission a cluster',
-      description: 'Return to the operational decommission workflow for the data-path caveats around external backups.',
+      description: 'Operational decommissioning workflow for external-backup caveats.',
       docId: 'user-guide/openbaocluster/operations/deletion',
     },
     {
       label: 'Restore from backup',
-      description: 'Use the restore workflow when a limitation turns the next safe move into recovery or migration rather than in-place change.',
+      description: 'Recovery or migration workflow when an in-place change is not available.',
       docId: 'user-guide/openbaorestore/restore',
     },
   ]}

--- a/docs/reference/operator-upgrade-compatibility.md
+++ b/docs/reference/operator-upgrade-compatibility.md
@@ -7,7 +7,7 @@ journey: reference
 
 <PageHeader
   title="Operator upgrade compatibility"
-  lede="This page defines supported operator upgrade paths, required CRD sequencing, and the project stance on downgrade and rollback for the operator itself."
+  lede="Supported operator upgrade paths, required CRD sequencing, and the project stance on downgrade and rollback."
 />
 
 <DecisionTable
@@ -27,7 +27,7 @@ journey: reference
       emphasis: 'caution',
     },
     {
-      cells: ['Operator downgrades as routine rollback', 'Not supported', 'Treat downgrade pressure as a recovery decision, not as a normal release mechanism.'],
+      cells: ['Operator downgrades as routine rollback', 'Not supported', 'Plan downgrades only as recovery workflows with staging validation.'],
       emphasis: 'caution',
     },
   ]}
@@ -69,7 +69,7 @@ After upgrade:
 If an upgrade introduces issues:
 
 1. prefer a forward fix on a newer stable release
-2. if rollback is required, treat it as a recovery operation with staging validation first
+2. if rollback is required, validate it as a recovery workflow in staging first
 3. use backup and restore runbooks for data-path recovery scenarios
 
 <NextActions
@@ -82,12 +82,12 @@ If an upgrade introduces issues:
     },
     {
       label: 'Restore from backup',
-      description: 'Move into restore procedures when rollback is no longer enough to recover state safely.',
+      description: 'Restore procedures for cases where rollback is no longer sufficient.',
       docId: 'user-guide/openbaorestore/restore',
     },
     {
       label: 'Status conditions and events',
-      description: 'Use the status and events reference to interpret readiness and failure signals before and after the upgrade.',
+      description: 'Readiness and failure signals before and after an upgrade.',
       docId: 'reference/status-and-events',
     },
   ]}

--- a/docs/reference/operator-upgrade-compatibility.md
+++ b/docs/reference/operator-upgrade-compatibility.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Use this page when you need the exact upgrade-path contract for the operator itself."
-  lede="This page defines which operator upgrade paths are supported, how CRD sequencing must work, and why rollback should be treated as a recovery decision rather than a normal lifecycle shortcut. It is the exact contract for changing the operator version, not the managed OpenBao workload version."
+  title="Operator upgrade compatibility"
+  lede="This page defines supported operator upgrade paths, required CRD sequencing, and the project stance on downgrade and rollback for the operator itself."
 />
 
 <DecisionTable

--- a/docs/reference/release-policy.md
+++ b/docs/reference/release-policy.md
@@ -7,10 +7,10 @@ journey: reference
 
 <PageHeader
   title="Release channels and cadence"
-  lede="This page defines the public cadence, release channels, and gating rules behind how OpenBao Operator ships."
+  lede="Public cadence, release channels, and gating rules for OpenBao Operator."
 />
 
-<Callout type="important" title="Cadence is best-effort">
+<Callout type="important" title="Best-effort cadence">
 
 The project aims for one stable release every 4 weeks. If the stable release gates are not green, the release window is skipped rather than forced.
 
@@ -109,7 +109,7 @@ A stable release should meet all of the following:
 - no known upgrade, backup, or restore regressions
 - no open release-blocker issues
 
-<Callout type="note" title="Skip rather than force">
+<Callout type="note" title="Release window skips">
 
 If a monthly release window is not ready, skip it and say so. Predictability matters more than pushing a release that has not met the public gates.
 
@@ -130,17 +130,17 @@ Until the project reaches beta, the support window stays on the latest stable li
   items={[
     {
       label: 'Support policy',
-      description: 'Open the maintenance contract when the question is what receives best-effort support after a release ships.',
+      description: 'Maintenance contract for releases after they ship.',
       docId: 'reference/support-policy',
     },
     {
       label: 'Compatibility matrix',
-      description: 'Use the validation matrix when the next question is which Kubernetes or OpenBao versions are actually exercised.',
+      description: 'Kubernetes and OpenBao versions exercised by CI.',
       docId: 'reference/compatibility',
     },
     {
       label: 'Release management',
-      description: 'Move to the maintainer workflow when the next step is executing a release rather than understanding the public policy.',
+      description: 'Maintainer workflow for executing a release.',
       to: '/contribute/release-management',
     },
   ]}

--- a/docs/reference/release-policy.md
+++ b/docs/reference/release-policy.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Use this page when you need the public cadence, release channels, and gates behind how OpenBao Operator ships."
-  lede="The goal is not high-frequency shipping. The goal is a predictable rhythm, visible release gates, and a clear rule for when a release ships early or is skipped."
+  title="Release channels and cadence"
+  lede="This page defines the public cadence, release channels, and gating rules behind how OpenBao Operator ships."
 />
 
 <Callout type="important" title="Cadence is a target, not a promise">

--- a/docs/reference/release-policy.md
+++ b/docs/reference/release-policy.md
@@ -10,7 +10,7 @@ journey: reference
   lede="This page defines the public cadence, release channels, and gating rules behind how OpenBao Operator ships."
 />
 
-<Callout type="important" title="Cadence is a target, not a promise">
+<Callout type="important" title="Cadence is best-effort">
 
 The project aims for one stable release every 4 weeks. If the stable release gates are not green, the release window is skipped rather than forced.
 
@@ -111,7 +111,7 @@ A stable release should meet all of the following:
 
 <Callout type="note" title="Skip rather than force">
 
-If a monthly release window is not ready, skip it and say so. Predictability matters more than forcing a release that has not met the public gates.
+If a monthly release window is not ready, skip it and say so. Predictability matters more than pushing a release that has not met the public gates.
 
 </Callout>
 

--- a/docs/reference/status-and-events.md
+++ b/docs/reference/status-and-events.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Use this page to decode what the operator is telling you through conditions, events, and lifecycle signals."
-  lede="This is the exact lookup surface for status conditions and emitted events across `OpenBaoCluster`, `OpenBaoRestore`, and `OpenBaoTenant`. Use it when a cluster is stalled, degraded, upgrading, backing up, restoring, or otherwise behaving in a way that needs precise interpretation rather than a generic troubleshooting step."
+  title="Status conditions and event reference"
+  lede="Status conditions and emitted events across `OpenBaoCluster`, `OpenBaoRestore`, and `OpenBaoTenant`."
 />
 
 <CommandBlock
@@ -26,7 +26,7 @@ kubectl -n <ns> get events --sort-by=.lastTimestamp`}
 <DecisionTable
   kind="reference"
   title="Workflow checkpoints"
-  caption="Use these condition sets as the fastest contract checks for common workflows."
+  caption="Condition sets for quick checks of common workflows."
   columns={['Workflow', 'Conditions to watch']}
   rows={[
     {
@@ -210,12 +210,12 @@ Condition **types** are part of the API surface. Reason and event values may exp
   items={[
     {
       label: 'Unseal configuration',
-      description: 'Open the provider and Secret contract page when `CloudUnsealIdentityReady` or seal-mode setup is the real problem.',
+      description: 'Provider and Secret requirements behind `CloudUnsealIdentityReady` and seal-mode setup.',
       docId: 'user-guide/openbaocluster/configuration/unseal',
     },
     {
       label: 'Troubleshoot the cluster',
-      description: 'Use the operational troubleshooting page when you know something is wrong but do not yet know which signal matters.',
+      description: 'Operational troubleshooting when the relevant signal is not yet clear.',
       to: '/docs/operate/troubleshooting',
     },
     {

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -7,7 +7,7 @@ journey: reference
 
 <PageHeader
   title="Support and maintenance policy"
-  lede="This page defines which release lines receive best-effort maintenance attention, how channels differ, and what operators should expect when requesting issue triage."
+  lede="Release lines that receive best-effort maintenance attention, channel differences, and issue-triage expectations."
 />
 
 <Callout type="note" title="Current support window">
@@ -50,7 +50,7 @@ OpenBao Operator is still pre-GA:
 ## Validation versus support
 
 - [Compatibility Matrix](compatibility.md) defines what is explicitly validated in CI.
-- This page defines what receives best-effort maintenance attention.
+- This policy defines what receives best-effort maintenance attention.
 - `Recommended for production` means the documented hardened operating path, not a promise of long-lived pre-GA API stability.
 
 ## Security fixes
@@ -90,22 +90,22 @@ Security fixes follow [SECURITY.md](https://github.com/dc-tec/openbao-operator/b
   items={[
     {
       label: 'Release policy',
-      description: 'Open the public cadence and release-gate contract when the next question is when the project ships.',
+      description: 'Public cadence and release-gate rules.',
       docId: 'reference/release-policy',
     },
     {
       label: 'Compatibility matrix',
-      description: 'Open the validation matrix when the next question is whether a platform or version is exercised by CI.',
+      description: 'Platforms and versions exercised by CI.',
       docId: 'reference/compatibility',
     },
     {
       label: 'Known limitations',
-      description: 'Check current caveats and non-goals when an unsupported behavior might actually be a deliberate constraint.',
+      description: 'Current caveats and explicit non-goals behind unsupported behavior.',
       docId: 'reference/known-limitations',
     },
     {
       label: 'Release management',
-      description: 'Use the maintainer release workflow when you need the operational process behind these support promises.',
+      description: 'Maintainer release workflow behind these support expectations.',
       to: '/contribute/release-management',
     },
   ]}

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -6,8 +6,8 @@ journey: reference
 ---
 
 <PageHeader
-  title="Use this page when you need the exact maintenance contract behind a release line or channel."
-  lede="Validation and support are related, but they are not the same thing. This page defines which release lines receive best-effort maintenance attention, how channels differ, and what the project expects from operators before they ask for issue triage."
+  title="Support and maintenance policy"
+  lede="This page defines which release lines receive best-effort maintenance attention, how channels differ, and what operators should expect when requesting issue triage."
 />
 
 <Callout type="note" title="Current support window">

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -29,11 +29,11 @@ The project provides best-effort support for the latest stable release line.
       cells: ['Prerelease (`-rc`, `-beta`, `-alpha`)', 'Evaluation before the next stable release.', 'No expanded support window; use for testing and early adoption only.'],
     },
     {
-      cells: ['Edge (`main` snapshots)', 'Continuous validation and integration signal.', 'Not a production support channel.'],
+      cells: ['Edge (`main` snapshots)', 'Continuous validation and integration signal.', 'Evaluation and validation channel only.'],
       emphasis: 'caution',
     },
     {
-      cells: ['Nightly', 'Scheduled validation snapshots.', 'Not a production support channel.'],
+      cells: ['Nightly', 'Scheduled validation snapshots.', 'Evaluation and validation channel only.'],
       emphasis: 'caution',
     },
   ]}
@@ -90,7 +90,7 @@ Security fixes follow [SECURITY.md](https://github.com/dc-tec/openbao-operator/b
   items={[
     {
       label: 'Release policy',
-      description: 'Open the public cadence and release-gate contract when the next question is when the project ships, not just what it supports.',
+      description: 'Open the public cadence and release-gate contract when the next question is when the project ships.',
       docId: 'reference/release-policy',
     },
     {

--- a/docs/security/fundamentals/index.md
+++ b/docs/security/fundamentals/index.md
@@ -10,14 +10,14 @@ description: Core security fundamentals for OpenBao Operator including threat mo
   variant="landing"
   eyebrow="Security / Security Model"
   title="Security model and trust assumptions"
-  lede="This section covers the threat model, security profiles, and handling of trust material such as root tokens, unseal keys, and bootstrap identities. It is the starting point for understanding the operator's security assumptions."
+  lede="Threat model, security profiles, and trust material such as root tokens, unseal keys, and bootstrap identities."
   actions={[
     {label: 'Read the threat model', docId: 'security/fundamentals/threat-model', variant: 'primary'},
     {label: 'Review production posture', docId: 'security/fundamentals/profiles', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Covers"
     items={[
       'understand the security assumptions behind the operator architecture',
       'understand how Development and Hardened profiles change the supported security posture',
@@ -33,13 +33,13 @@ description: Core security fundamentals for OpenBao Operator including threat mo
     {
       eyebrow: '01',
       title: 'Threat model',
-      description: 'Read the trust boundaries, attacker assumptions, and design mitigations behind the operator.',
+      description: 'Trust boundaries, attacker assumptions, and design mitigations.',
       docId: 'security/fundamentals/threat-model',
     },
     {
       eyebrow: '02',
       title: 'Production posture',
-      description: 'Understand how Development and Hardened differ, and why Hardened is the supported production contract.',
+      description: 'How Development and Hardened differ, and the supported production contract.',
       docId: 'security/fundamentals/profiles',
     },
     {
@@ -55,12 +55,12 @@ description: Core security fundamentals for OpenBao Operator including threat mo
   items={[
     {
       label: 'Open platform controls',
-      description: 'Move from the trust model into the Kubernetes controls that enforce it.',
+      description: 'Kubernetes controls that enforce the trust model.',
       docId: 'security/infrastructure/index',
     },
     {
       label: 'Configure security profiles',
-      description: 'Switch to the user-guide task page when you are ready to set `spec.profile` on a real cluster.',
+      description: 'Task page for setting `spec.profile` on a cluster.',
       docId: 'user-guide/openbaocluster/configuration/security-profiles',
     },
   ]}

--- a/docs/security/fundamentals/index.md
+++ b/docs/security/fundamentals/index.md
@@ -9,8 +9,8 @@ description: Core security fundamentals for OpenBao Operator including threat mo
 <PageHero
   variant="landing"
   eyebrow="Security / Security Model"
-  title="Start from the trust model before you choose controls."
-  lede="This section explains what the operator is trying to defend, which production posture it considers safe, and how trust material such as root tokens, unseal keys, and bootstrap identities should behave across the lifecycle."
+  title="Security model and trust assumptions"
+  lede="This section covers the threat model, security profiles, and handling of trust material such as root tokens, unseal keys, and bootstrap identities. It is the starting point for understanding the operator's security assumptions."
   actions={[
     {label: 'Read the threat model', docId: 'security/fundamentals/threat-model', variant: 'primary'},
     {label: 'Review production posture', docId: 'security/fundamentals/profiles', variant: 'secondary'},

--- a/docs/security/fundamentals/index.md
+++ b/docs/security/fundamentals/index.md
@@ -20,7 +20,7 @@ description: Core security fundamentals for OpenBao Operator including threat mo
     title="Use this section when you need to"
     items={[
       'understand the security assumptions behind the operator architecture',
-      'decide what Hardened actually means before you deploy it',
+      'understand how Development and Hardened profiles change the supported security posture',
       'review how bootstrap and unseal trust material is handled',
       'anchor security review conversations before diving into RBAC or network policy details',
     ]}
@@ -39,7 +39,7 @@ description: Core security fundamentals for OpenBao Operator including threat mo
     {
       eyebrow: '02',
       title: 'Production posture',
-      description: 'Understand what Development and Hardened actually mean, and why Hardened is the supported production contract.',
+      description: 'Understand how Development and Hardened differ, and why Hardened is the supported production contract.',
       docId: 'security/fundamentals/profiles',
     },
     {

--- a/docs/security/fundamentals/profiles.md
+++ b/docs/security/fundamentals/profiles.md
@@ -127,7 +127,7 @@ description: What Development and Hardened mean as security contracts, and why H
 
 <Callout type="success" title="What Hardened is really saying">
 
-Hardened means the operator is allowed to assume an external trust root, explicit runtime identity, and production-ready lifecycle posture. It is a statement about the whole operating model, not only about one field in the CR.
+Hardened means the operator can rely on an external trust root, explicit runtime identity, and a production-ready lifecycle posture. It defines the operating model for the cluster, not just one field in the CR.
 
 </Callout>
 

--- a/docs/security/fundamentals/profiles.md
+++ b/docs/security/fundamentals/profiles.md
@@ -7,8 +7,8 @@ description: What Development and Hardened mean as security contracts, and why H
 ---
 
 <PageHeader
-  title="Treat security profiles as operating contracts, not just presets."
-  lede="`Development` and `Hardened` are different security contracts, not cosmetic defaults. This page explains what each one is optimizing for, what Hardened requires in production, and why the configuration task belongs in the user guide rather than here."
+  title="Security profile contracts"
+  lede="This page explains what `Development` and `Hardened` optimize for, what Hardened requires in production, and how the two profiles change the operating contract."
 />
 
 

--- a/docs/security/fundamentals/profiles.md
+++ b/docs/security/fundamentals/profiles.md
@@ -8,7 +8,7 @@ description: What Development and Hardened mean as security contracts, and why H
 
 <PageHeader
   title="Security profile contracts"
-  lede="This page explains what `Development` and `Hardened` optimize for, what Hardened requires in production, and how the two profiles change the operating contract."
+  lede="What `Development` and `Hardened` optimize for, what Hardened requires in production, and how the profiles change the operating contract."
 />
 
 
@@ -79,7 +79,7 @@ description: What Development and Hardened mean as security contracts, and why H
   ]}
 />
 
-## Why Hardened is the supported production contract
+## Hardened production contract
 
 <DecisionTable
   kind="reference"
@@ -125,15 +125,15 @@ description: What Development and Hardened mean as security contracts, and why H
   ]}
 />
 
-<Callout type="success" title="What Hardened is really saying">
+<Callout type="success" title="Hardened profile assumptions">
 
 Hardened means the operator can rely on an external trust root, explicit runtime identity, and a production-ready lifecycle posture. It defines the operating model for the cluster, not just one field in the CR.
 
 </Callout>
 
-## What Development deliberately relaxes
+## Development profile relaxations
 
-Development is still useful, but it should be understood as an intentional weakening of the production contract:
+Development intentionally relaxes the production contract:
 
 - bootstrap material can persist in cluster Secrets
 - static unseal remains available
@@ -141,22 +141,23 @@ Development is still useful, but it should be understood as an intentional weake
 - runtime and supply-chain controls can be less strict
 - the cluster reports a security-risk signal rather than pretending this posture is production-ready
 
-<Callout type="warning" title="Do not upgrade trust roots in place by assumption">
+<Callout type="warning" title="Trust-root migrations">
 
 Teams often start in Development for exploration. When moving to staging or production, create a new Hardened cluster rather than assuming a Development trust path can be promoted safely.
+Teams often start in Development for exploration. For staging or production, create a new Hardened cluster instead of promoting a Development trust path in place.
 
 </Callout>
 
-## Where configuration belongs
+## Configuration scope
 
-This page explains the contract. The actual task of setting `spec.profile`, choosing the unseal mode, and satisfying the production requirements belongs in <SiteLink docId="user-guide/openbaocluster/configuration/security-profiles">Configure Security Profiles</SiteLink>.
+Configuration steps for `spec.profile`, unseal mode, and the production requirements are in <SiteLink docId="user-guide/openbaocluster/configuration/security-profiles">Configure Security Profiles</SiteLink>.
 
 <NextActions
   title="Continue the security model"
   items={[
     {
       label: 'Configure security profiles',
-      description: 'Switch to the task page when you are ready to apply the profile to a real cluster.',
+      description: 'Cluster fields and configuration steps behind these profile requirements.',
       docId: 'user-guide/openbaocluster/configuration/security-profiles',
     },
     {
@@ -166,7 +167,7 @@ This page explains the contract. The actual task of setting `spec.profile`, choo
     },
     {
       label: 'Threat model',
-      description: 'Go back to the broader threat model if you need the rationale behind these profile boundaries.',
+      description: 'Rationale behind these profile boundaries.',
       docId: 'security/fundamentals/threat-model',
     },
   ]}

--- a/docs/security/fundamentals/secrets-management.md
+++ b/docs/security/fundamentals/secrets-management.md
@@ -7,8 +7,8 @@ description: How root tokens, unseal keys, TLS material, and generated job ident
 ---
 
 <PageHeader
-  title="Treat trust material as lifecycle state, not just as Kubernetes Secrets."
-  lede="The operator manages or coordinates several high-value trust surfaces: bootstrap credentials, unseal roots, TLS material, and the identities used by backup, restore, and upgrade workflows. The most important question is not only where they live, but whether the operating model can avoid creating them in the first place."
+  title="Secrets and trust material lifecycle"
+  lede="The operator manages or coordinates several high-value trust surfaces: bootstrap credentials, unseal roots, TLS material, and the identities used by backup, restore, and upgrade workflows. This page explains where they live, how they are bounded, and where the operating model avoids creating them altogether."
 />
 
 

--- a/docs/security/fundamentals/secrets-management.md
+++ b/docs/security/fundamentals/secrets-management.md
@@ -8,7 +8,7 @@ description: How root tokens, unseal keys, TLS material, and generated job ident
 
 <PageHeader
   title="Secrets and trust material lifecycle"
-  lede="The operator manages or coordinates several high-value trust surfaces: bootstrap credentials, unseal roots, TLS material, and the identities used by backup, restore, and upgrade workflows. This page explains where they live, how they are bounded, and where the operating model avoids creating them altogether."
+  lede="Bootstrap credentials, unseal roots, TLS material, and the identities used by backup, restore, and upgrade workflows."
 />
 
 
@@ -44,7 +44,7 @@ description: How root tokens, unseal keys, TLS material, and generated job ident
       cells: [
         'Backup, restore, and upgrade job auth',
         'Projected tokens, generated ServiceAccounts, or explicit credentials Secrets',
-        'Should remain separate from the main OpenBao workload identity.',
+        'Separate from the main OpenBao workload identity.',
       ],
     },
   ]}
@@ -154,7 +154,7 @@ Using transit, cloud KMS, or HSM-backed modes shifts the root of trust away from
       cells: [
         'Development bootstrap without self-init',
         'The root token can be stored in `<cluster>-root-token`.',
-        'This is useful for testing but creates a critical secret in the namespace.',
+        'Testing-oriented path that creates a critical secret in the namespace.',
       ],
     },
   ]}
@@ -170,7 +170,7 @@ If a root token or equivalent bootstrap credential exists in a Secret, anyone wh
 
 <DiagramFrame
   title="Job identity separation"
-  caption="The main OpenBao Pods, backup jobs, restore jobs, and upgrade jobs should not silently share one identity path. Each surface should stay explicit and observable."
+  caption="The main OpenBao Pods, backup jobs, restore jobs, and upgrade jobs use separate identity paths so each surface stays explicit and observable."
   code={`sequenceDiagram
     autonumber
     participant Operator as Operator
@@ -192,17 +192,17 @@ If a root token or equivalent bootstrap credential exists in a Secret, anyone wh
     Job->>Bao: Perform backup, restore, or upgrade work`}
 />
 
-The important boundary is this:
+Lifecycle job identities stay separate from the main workload identity:
 
 - main OpenBao Pods use the trust path selected for the cluster itself
 - backup, restore, and upgrade Jobs use separate generated identities
 - those Jobs do not automatically inherit the cloud or JWT path of the main workload unless the operator deliberately configured it
 
-This is why backup and restore readiness are surfaced independently in status rather than assumed from the main Pods.
+Backup and restore readiness are surfaced independently in status rather than inferred from the main Pods.
 
-## Where the task guidance lives
+## Related task pages
 
-This page owns the trust model. The operational task pages stay elsewhere:
+Operational task pages:
 
 - <SiteLink docId="user-guide/openbaocluster/configuration/security-profiles">Configure Security Profiles</SiteLink>
 - <SiteLink docId="user-guide/openbaocluster/operations/backups">Configure Backups</SiteLink>
@@ -213,17 +213,17 @@ This page owns the trust model. The operational task pages stay elsewhere:
   items={[
     {
       label: 'Production posture',
-      description: 'See how these trust-material choices map back to Development versus Hardened.',
+      description: 'How these trust-material choices map back to Development versus Hardened.',
       docId: 'security/fundamentals/profiles',
     },
     {
       label: 'Configure security profiles',
-      description: 'Switch to the task page when you are ready to set the actual cluster fields.',
+      description: 'Cluster fields behind these trust-model choices.',
       docId: 'user-guide/openbaocluster/configuration/security-profiles',
     },
     {
       label: 'Threat model',
-      description: 'Return to the broader threat model if you need the surrounding attacker and boundary assumptions.',
+      description: 'Attacker model and surrounding boundary assumptions.',
       docId: 'security/fundamentals/threat-model',
     },
   ]}

--- a/docs/security/fundamentals/threat-model.md
+++ b/docs/security/fundamentals/threat-model.md
@@ -7,15 +7,15 @@ description: Threat actors, trust boundaries, protected assets, and accepted res
 ---
 
 <PageHeader
-  title="Start from the trust boundaries the operator is designed to defend."
-  lede="This threat model focuses on the operator control plane, tenant isolation boundaries, and lifecycle workflows such as onboarding, upgrade, backup, and restore. It does not replace OpenBao's own internal threat model; it explains the extra surface introduced by running OpenBao through the operator."
+  title="Threat model and scope"
+  lede="Threat model for the operator control plane, tenant isolation boundaries, and lifecycle workflows such as onboarding, upgrade, backup, and restore. It complements OpenBao's own internal threat model by covering the extra surface introduced by the operator."
 />
 
 
 
 <Callout type="note" title="Scope">
 
-This page models threats to the OpenBao Operator control plane, tenant isolation boundaries, and lifecycle workflows. It assumes the operator manages clusters it created and reconciles; generic import of arbitrary unmanaged OpenBao clusters is out of scope.
+This model assumes the operator manages clusters it created and reconciles; generic import of arbitrary unmanaged OpenBao clusters is out of scope.
 
 </Callout>
 

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -11,7 +11,7 @@ description: Threat model, hardened profiles, RBAC, admission policy, network co
   variant="landing"
   eyebrow="Security"
   title="Security documentation"
-  lede="This section covers the operator trust model, production posture, platform controls, workload protections, and tenant isolation. Use it to review the security assumptions and controls behind an OpenBao Operator deployment."
+  lede="Operator trust model, production posture, platform controls, workload protections, and tenant isolation."
   actions={[
     {label: 'Read the security model', docId: 'security/fundamentals/index', variant: 'primary'},
     {label: 'Review platform controls', docId: 'security/infrastructure/index', variant: 'secondary'},
@@ -40,7 +40,7 @@ description: Threat model, hardened profiles, RBAC, admission policy, network co
     {
       eyebrow: '02',
       title: 'Platform controls',
-      description: 'RBAC architecture, admission policies, and network boundaries that protect the control plane first.',
+      description: 'RBAC architecture, admission policies, and network boundaries for the control plane.',
       docId: 'security/infrastructure/index',
     },
     {
@@ -63,12 +63,12 @@ description: Threat model, hardened profiles, RBAC, admission policy, network co
   items={[
     {
       label: 'Security profiles',
-      description: 'Map the security model back to the task page that configures `spec.profile` on a real cluster.',
+      description: 'Task page for configuring `spec.profile` on a cluster.',
       docId: 'user-guide/openbaocluster/configuration/security-profiles',
     },
     {
       label: 'Tenant onboarding',
-      description: 'Connect security guarantees back to the namespace introduction and governance path in the user guide.',
+      description: 'Namespace introduction and governance path in the user guide.',
       docId: 'user-guide/openbaotenant/overview',
     },
   ]}

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -10,8 +10,8 @@ description: Threat model, hardened profiles, RBAC, admission policy, network co
 <PageHero
   variant="landing"
   eyebrow="Security"
-  title="Security is part of the operating path, not an appendix."
-  lede="Use this section to understand the operator trust model, choose the production posture you actually want to defend, and verify the controls that enforce it from the platform layer down to workload and tenant boundaries."
+  title="Security documentation"
+  lede="This section covers the operator trust model, production posture, platform controls, workload protections, and tenant isolation. Use it to review the security assumptions and controls behind an OpenBao Operator deployment."
   actions={[
     {label: 'Read the security model', docId: 'security/fundamentals/index', variant: 'primary'},
     {label: 'Review platform controls', docId: 'security/infrastructure/index', variant: 'secondary'},

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -18,7 +18,7 @@ description: Threat model, hardened profiles, RBAC, admission policy, network co
   ]}
 >
   <Checklist
-    title="A production posture usually includes"
+    title="A production posture includes"
     items={[
       'Hardened profile by default',
       'admission enforcement enabled',

--- a/docs/security/infrastructure/admission-policies.md
+++ b/docs/security/infrastructure/admission-policies.md
@@ -7,8 +7,8 @@ description: How ValidatingAdmissionPolicy guardrails enforce managed-resource o
 ---
 
 <PageHeader
-  title="Reject unsafe intent before it becomes persisted state."
-  lede="The operator uses Kubernetes `ValidatingAdmissionPolicy` to enforce key safety rules at the API boundary. These policies are not a replacement for reconciliation logic; they are the front line that prevents invalid, privileged, or drifted state from landing in etcd in the first place."
+  title="Admission policies and fail-closed behavior"
+  lede="Kubernetes `ValidatingAdmissionPolicy` guardrails for key safety rules at the API boundary."
 />
 
 
@@ -93,14 +93,14 @@ description: How ValidatingAdmissionPolicy guardrails enforce managed-resource o
       cells: [
         'Required policy disappears or becomes misbound later',
         'Sensitive reconciliation paths pause and surface degraded status.',
-        'The admission dependency is part of the runtime safety model, not only a bootstrap check.',
+        'The admission dependency is part of the runtime safety model as well as startup validation.',
       ],
     },
     {
       cells: [
         'Unsafe mode explicitly enabled',
         'The operator can start without admission dependency enforcement.',
-        'This is intended only for development or break-glass scenarios and materially weakens defense in depth.',
+        'Reserved for development or explicit break-glass scenarios; materially weakens defense in depth.',
       ],
     },
   ]}
@@ -198,9 +198,9 @@ Disabling admission policies is treated as unsafe mode. Even if the cluster othe
   ]}
 />
 
-<Callout type="note" title="Optional canary">
+<Callout type="note" title="Admission canary">
 
-The provisioner supports an optional admission canary that submits a dry-run RBAC request which must be denied. This gives stronger assurance that policy enforcement is active, not only that the policy objects exist.
+The provisioner supports an optional admission canary that submits a dry-run RBAC request which must be denied. This adds evidence that policy enforcement is active, beyond the presence of the policy objects themselves.
 
 </Callout>
 
@@ -217,17 +217,17 @@ Admission policy is one of the reasons the operator can separate user intent fro
   items={[
     {
       label: 'RBAC architecture',
-      description: 'See how these policies reinforce the split-controller identity model.',
+      description: 'How these policies reinforce the split-controller identity model.',
       docId: 'security/infrastructure/rbac',
     },
     {
       label: 'Network security',
-      description: 'Review the default-deny network posture that complements admission enforcement.',
+      description: 'Default-deny network posture that complements admission enforcement.',
       docId: 'security/infrastructure/network-security',
     },
     {
       label: 'Threat model',
-      description: 'Connect admission guardrails back to the STRIDE threats they mitigate.',
+      description: 'STRIDE threats mitigated by the admission guardrails.',
       docId: 'security/fundamentals/threat-model',
     },
   ]}

--- a/docs/security/infrastructure/index.md
+++ b/docs/security/infrastructure/index.md
@@ -9,8 +9,8 @@ description: Infrastructure security controls in OpenBao Operator, including RBA
 <PageHero
   variant="landing"
   eyebrow="Security / Platform Controls"
-  title="Protect the control plane before you trust the workload."
-  lede="Platform controls are the Kubernetes-level mechanisms that keep operator identities narrow, reject unsafe objects before they persist, and limit traffic between tenants, control-plane components, and external dependencies."
+  title="Platform security controls"
+  lede="This section covers Kubernetes-level controls such as RBAC, validating admission policies, and network boundaries. Use it to review the protections around operator identities, unsafe object rejection, and traffic restrictions."
   actions={[
     {label: 'Open RBAC architecture', docId: 'security/infrastructure/rbac', variant: 'primary'},
     {label: 'Review admission policies', docId: 'security/infrastructure/admission-policies', variant: 'secondary'},

--- a/docs/security/infrastructure/index.md
+++ b/docs/security/infrastructure/index.md
@@ -10,19 +10,19 @@ description: Infrastructure security controls in OpenBao Operator, including RBA
   variant="landing"
   eyebrow="Security / Platform Controls"
   title="Platform security controls"
-  lede="This section covers Kubernetes-level controls such as RBAC, validating admission policies, and network boundaries. Use it to review the protections around operator identities, unsafe object rejection, and traffic restrictions."
+  lede="Kubernetes-level controls such as RBAC, validating admission policies, and network boundaries."
   actions={[
     {label: 'Open RBAC architecture', docId: 'security/infrastructure/rbac', variant: 'primary'},
     {label: 'Review admission policies', docId: 'security/infrastructure/admission-policies', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Scope"
     items={[
-      'review who can do what in the control plane',
-      'understand which unsafe changes are rejected before persistence',
-      'verify tenant and egress network boundaries',
-      'check which cluster prerequisites are required for the security model to hold',
+      'control-plane access review',
+      'unsafe changes rejected before persistence',
+      'tenant and egress network boundaries',
+      'cluster prerequisites for the security model',
     ]}
   />
 </PageHero>
@@ -33,19 +33,19 @@ description: Infrastructure security controls in OpenBao Operator, including RBA
     {
       eyebrow: '01',
       title: 'RBAC architecture',
-      description: 'Understand the split-controller model, narrow identities, and mutation-locked access boundaries.',
+      description: 'Split-controller model, narrow identities, and mutation-locked access boundaries.',
       docId: 'security/infrastructure/rbac',
     },
     {
       eyebrow: '02',
       title: 'Admission policies',
-      description: 'See how CEL-based guardrails reject unsafe configurations and pause sensitive reconciliation when enforcement disappears.',
+      description: 'CEL-based guardrails that reject unsafe configurations and pause sensitive reconciliation when enforcement disappears.',
       docId: 'security/infrastructure/admission-policies',
     },
     {
       eyebrow: '03',
       title: 'Network security',
-      description: 'Review default-deny traffic boundaries and the explicit egress model used for backups, upgrades, and integrations.',
+      description: 'Default-deny traffic boundaries and the explicit egress model used for backups, upgrades, and integrations.',
       docId: 'security/infrastructure/network-security',
     },
   ]}
@@ -62,12 +62,12 @@ description: Infrastructure security controls in OpenBao Operator, including RBA
   items={[
     {
       label: 'Open workload protections',
-      description: 'Move from platform enforcement into pod hardening, TLS, and supply-chain controls.',
+      description: 'Pod hardening, TLS, and supply-chain controls.',
       docId: 'security/workload/index',
     },
     {
       label: 'Open tenant isolation',
-      description: 'See how these platform controls support the multi-tenant security model.',
+      description: 'How platform controls support the multi-tenant security model.',
       docId: 'security/multi-tenancy/index',
     },
   ]}

--- a/docs/security/infrastructure/network-security.md
+++ b/docs/security/infrastructure/network-security.md
@@ -8,7 +8,7 @@ description: Default-deny network posture for OpenBao Pods and lifecycle jobs, p
 
 <PageHeader
   title="Network policy model"
-  lede="This page describes the default-deny posture for OpenBao Pods and lifecycle jobs, and the ingress and egress paths the operator expects when cluster management and integrations are configured."
+  lede="Default-deny posture for OpenBao Pods and lifecycle jobs, plus the ingress and egress paths the operator expects when cluster management and integrations are configured."
 />
 
 

--- a/docs/security/infrastructure/network-security.md
+++ b/docs/security/infrastructure/network-security.md
@@ -7,8 +7,8 @@ description: Default-deny network posture for OpenBao Pods and lifecycle jobs, p
 ---
 
 <PageHeader
-  title="Start from default deny and open only the traffic the lifecycle actually needs."
-  lede="The operator treats network policy as part of the security model, not as an optional hardening layer. OpenBao Pods and lifecycle jobs begin from explicit allowlists, and the allowed traffic should line up with clustering, management, and the integrations the cluster is deliberately configured to use."
+  title="Network policy model"
+  lede="This page describes the default-deny posture for OpenBao Pods and lifecycle jobs, and the ingress and egress paths the operator expects when cluster management and integrations are configured."
 />
 
 

--- a/docs/security/infrastructure/rbac.md
+++ b/docs/security/infrastructure/rbac.md
@@ -7,8 +7,8 @@ description: How the provisioner and controller identities stay separate, narrow
 ---
 
 <PageHeader
-  title="Keep the identity that grants access separate from the identity that uses it."
-  lede="The operator's RBAC model is built around a split-controller design. The provisioner introduces tenant access and namespace guardrails, while the controller consumes tenant-scoped permissions to manage workloads. Neither long-running identity should be able to do both jobs."
+  title="Split-controller RBAC model"
+  lede="The operator's RBAC model separates namespace introduction from workload reconciliation. The provisioner introduces tenant access and namespace guardrails, while the controller consumes tenant-scoped permissions to manage workloads."
 />
 
 

--- a/docs/security/infrastructure/rbac.md
+++ b/docs/security/infrastructure/rbac.md
@@ -8,7 +8,7 @@ description: How the provisioner and controller identities stay separate, narrow
 
 <PageHeader
   title="Split-controller RBAC model"
-  lede="The operator's RBAC model separates namespace introduction from workload reconciliation. The provisioner introduces tenant access and namespace guardrails, while the controller consumes tenant-scoped permissions to manage workloads."
+  lede="Provisioner and controller identities stay separate. The provisioner introduces tenant access and namespace guardrails, and the controller uses tenant-scoped permissions to manage workloads."
 />
 
 
@@ -61,7 +61,7 @@ description: How the provisioner and controller identities stay separate, narrow
 
 <Callout type="note" title="Projected Kubernetes API tokens">
 
-The operator disables default token auto-mounting and uses explicit projected ServiceAccount tokens for Kubernetes API access. Audience pinning can be configured, but the important contract here is that API identity stays explicit and short-lived rather than inherited implicitly.
+The operator disables default token auto-mounting and uses explicit projected ServiceAccount tokens for Kubernetes API access. Audience pinning can be configured. API identity remains explicit and short-lived through projected tokens.
 
 </Callout>
 
@@ -120,15 +120,15 @@ The operator disables default token auto-mounting and uses explicit projected Se
       cells: [
         'Create tenant guardrails such as `ResourceQuota` and `LimitRange`',
         'Day-0 governance belongs to provisioning, not to workload reconciliation.',
-        'The provisioner manages only the operator-owned fixed objects and does not treat these resources as general namespace inventory.',
+        'The provisioner manages only the operator-owned fixed objects; it does not manage general namespace inventory.',
       ],
     },
   ]}
 />
 
-<Callout type="note" title="Blind-write pattern">
+<Callout type="note" title="Access grant flow">
 
-The provisioner writes the RBAC that grants the controller access, but it does not grant itself those permissions. That is the core security property of the onboarding path.
+The provisioner writes the RBAC that grants the controller access, but it does not receive those tenant permissions itself. That separation is the core security property of the onboarding path.
 
 </Callout>
 
@@ -227,12 +227,12 @@ Installing with admission policies disabled materially weakens the RBAC defense-
   items={[
     {
       label: 'Admission policies',
-      description: 'See how RBAC writes and managed-resource mutations are constrained at the API boundary.',
+      description: 'RBAC writes and managed-resource mutations constrained at the API boundary.',
       docId: 'security/infrastructure/admission-policies',
     },
     {
       label: 'Network security',
-      description: 'Review the default-deny network posture that complements these identity boundaries.',
+      description: 'Default-deny network posture that complements these identity boundaries.',
       docId: 'security/infrastructure/network-security',
     },
     {

--- a/docs/security/multi-tenancy/index.md
+++ b/docs/security/multi-tenancy/index.md
@@ -9,8 +9,8 @@ description: Multi-tenancy security model for OpenBao Operator, describing tenan
 <PageHero
   variant="landing"
   eyebrow="Security / Tenant Isolation"
-  title="Treat multi-tenancy as an explicit isolation model, not a convenience feature."
-  lede="OpenBao Operator is designed for a shared platform with strict tenant boundaries. The security model depends on explicit namespace introduction, split controller identities, admission guardrails, and network isolation rather than on broad cluster-scoped trust."
+  title="Tenant isolation model"
+  lede="This section covers the multi-tenant security model for OpenBao Operator, including namespace introduction, split controller identities, admission guardrails, and network isolation."
   actions={[
     {label: 'Open the isolation model', docId: 'security/multi-tenancy/tenant-isolation', variant: 'primary'},
     {label: 'Review tenant onboarding', docId: 'user-guide/openbaotenant/overview', variant: 'secondary'},

--- a/docs/security/multi-tenancy/index.md
+++ b/docs/security/multi-tenancy/index.md
@@ -10,14 +10,14 @@ description: Multi-tenancy security model for OpenBao Operator, describing tenan
   variant="landing"
   eyebrow="Security / Tenant Isolation"
   title="Tenant isolation model"
-  lede="This section covers the multi-tenant security model for OpenBao Operator, including namespace introduction, split controller identities, admission guardrails, and network isolation."
+  lede="Multi-tenant security model for OpenBao Operator, including namespace introduction, split controller identities, admission guardrails, and network isolation."
   actions={[
     {label: 'Open the isolation model', docId: 'security/multi-tenancy/tenant-isolation', variant: 'primary'},
     {label: 'Review tenant onboarding', docId: 'user-guide/openbaotenant/overview', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Covers"
     items={[
       'understand what the multi-tenant operating model actually guarantees',
       'review the boundary between the provisioner and namespace-restricted controller',
@@ -67,17 +67,17 @@ description: Multi-tenancy security model for OpenBao Operator, describing tenan
   items={[
     {
       label: 'Read the isolation model',
-      description: 'Go deeper into the exact namespace, RBAC, and secret-boundary behavior.',
+      description: 'Namespace, RBAC, and secret-boundary behavior.',
       docId: 'security/multi-tenancy/tenant-isolation',
     },
     {
       label: 'Open RBAC architecture',
-      description: 'See how the split-controller model enforces the tenant boundary at the identity layer.',
+      description: 'How the split-controller model enforces the tenant boundary at the identity layer.',
       docId: 'security/infrastructure/rbac',
     },
     {
       label: 'Open tenancy and governance',
-      description: 'Switch to the user-guide path when you need the actual onboarding workflow instead of the security model.',
+      description: 'User-guide onboarding workflow and governance path.',
       docId: 'user-guide/openbaotenant/overview',
     },
   ]}

--- a/docs/security/multi-tenancy/tenant-isolation.md
+++ b/docs/security/multi-tenancy/tenant-isolation.md
@@ -7,7 +7,7 @@ description: How namespace introduction, split controller identities, admission 
 ---
 
 <PageHeader
-  title="Make tenant access explicit instead of discoverable."
+  title="Tenant isolation model"
   lede="The operator's multi-tenant model depends on deliberate namespace introduction. A tenant namespace becomes manageable only after onboarding introduces the controller through fixed RBAC, applies namespace guardrails, and keeps the identity that grants access separate from the identity that consumes it."
 />
 
@@ -98,7 +98,7 @@ description: How namespace introduction, split controller identities, admission 
 
 <Callout type="note" title="Task versus model">
 
-This page explains the isolation contract. Use <SiteLink docId="user-guide/openbaotenant/onboarding">Onboard the target namespace</SiteLink> when you need the concrete onboarding workflow and field-level configuration.
+Use <SiteLink docId="user-guide/openbaotenant/onboarding">Onboard the target namespace</SiteLink> when you need the concrete onboarding workflow and field-level configuration.
 
 </Callout>
 

--- a/docs/security/workload/index.md
+++ b/docs/security/workload/index.md
@@ -9,8 +9,8 @@ description: Workload security guidance for OpenBao Operator covering pod securi
 <PageHero
   variant="landing"
   eyebrow="Security / Workload Protections"
-  title="Treat pod hardening, TLS, and image trust as one runtime surface."
-  lede="Workload protections cover the controls that apply once the cluster is allowed to run: pod and container hardening, workload identity and TLS, and the supply-chain rules that decide which images the operator will trust."
+  title="Workload security controls"
+  lede="This section covers pod and container hardening, workload identity and TLS, and image verification. Use it to review the controls that apply once an OpenBao cluster is running."
   actions={[
     {label: 'Open pod and runtime security', docId: 'security/workload/workload-security', variant: 'primary'},
     {label: 'Review TLS and identity', docId: 'security/workload/tls', variant: 'secondary'},

--- a/docs/security/workload/index.md
+++ b/docs/security/workload/index.md
@@ -10,14 +10,14 @@ description: Workload security guidance for OpenBao Operator covering pod securi
   variant="landing"
   eyebrow="Security / Workload Protections"
   title="Workload security controls"
-  lede="This section covers pod and container hardening, workload identity and TLS, and image verification. Use it to review the controls that apply once an OpenBao cluster is running."
+  lede="Pod and container hardening, workload identity and TLS, and image verification."
   actions={[
     {label: 'Open pod and runtime security', docId: 'security/workload/workload-security', variant: 'primary'},
     {label: 'Review TLS and identity', docId: 'security/workload/tls', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Covers"
     items={[
       'verify the default pod hardening posture',
       'understand how server TLS, peer identity, and trust material are managed',
@@ -33,19 +33,19 @@ description: Workload security guidance for OpenBao Operator covering pod securi
     {
       eyebrow: '01',
       title: 'Pod and runtime security',
-      description: 'Review pod security context, filesystem, token, and container-hardening defaults.',
+      description: 'Pod security context, filesystem, token, and container-hardening defaults.',
       docId: 'security/workload/workload-security',
     },
     {
       eyebrow: '02',
       title: 'TLS and identity',
-      description: 'Understand server TLS, peer trust, certificate management, and workload-facing identity paths.',
+      description: 'Server TLS, peer trust, certificate management, and workload-facing identity paths.',
       docId: 'security/workload/tls',
     },
     {
       eyebrow: '03',
       title: 'Supply-chain verification',
-      description: 'Review digest pinning, signature verification, and the production guardrails around image trust.',
+      description: 'Digest pinning, signature verification, and image-trust guardrails.',
       docId: 'security/workload/supply-chain',
     },
   ]}
@@ -54,6 +54,7 @@ description: Workload security guidance for OpenBao Operator covering pod securi
 <Callout type="note" title="Default runtime hardening">
 
 OpenBao Pods are expected to run non-root with a read-only root filesystem, dropped Linux capabilities, and a `RuntimeDefault` seccomp profile. The detailed page should explain exceptions and platform dependencies, not re-argue the baseline.
+OpenBao Pods are expected to run non-root with a read-only root filesystem, dropped Linux capabilities, and a `RuntimeDefault` seccomp profile. The detailed page covers exceptions and platform dependencies.
 
 </Callout>
 
@@ -61,7 +62,7 @@ OpenBao Pods are expected to run non-root with a read-only root filesystem, drop
   items={[
     {
       label: 'Open platform controls',
-      description: 'Connect runtime protections back to RBAC, admission, and network boundaries.',
+      description: 'How runtime protections connect to RBAC, admission, and network boundaries.',
       docId: 'security/infrastructure/index',
     },
     {

--- a/docs/security/workload/supply-chain.md
+++ b/docs/security/workload/supply-chain.md
@@ -7,8 +7,8 @@ description: Signature verification, transparency-log checks, digest pinning, an
 ---
 
 <PageHeader
-  title="Verify what will run before the controller ever writes a Pod template."
-  lede="The operator's supply-chain model is built around signature verification, digest pinning, and separate trust roots for the main OpenBao image versus helper images such as init, backup, restore, and upgrade executors. The goal is to keep mutable tags and unverified images out of production reconciliation."
+  title="Supply-chain verification"
+  lede="Signature verification, digest pinning, and separate trust roots for the main OpenBao image and helper images such as init, backup, restore, and upgrade executors."
 />
 
 

--- a/docs/security/workload/tls.md
+++ b/docs/security/workload/tls.md
@@ -7,8 +7,8 @@ description: How peer trust, certificate rotation, and workload-facing TLS ident
 ---
 
 <PageHeader
-  title="TLS and workload identity paths"
-  lede="This page explains how pods trust each other, how clients verify the service, where certificate authority material lives, and how each TLS mode changes workload identity and certificate handling."
+  title="TLS and workload identity"
+  lede="How pods trust each other, how clients verify the service, where certificate authority material lives, and how each TLS mode changes workload identity and certificate handling."
 />
 
 
@@ -165,7 +165,7 @@ description: How peer trust, certificate rotation, and workload-facing TLS ident
 
 <Callout type="note" title="Configuration ownership">
 
-This page explains the TLS security model. Use the configuration guides when you need the exact cluster fields:
+Use the configuration guides below when you need the exact cluster fields:
 
 - <SiteLink docId="user-guide/openbaocluster/configuration/external-access">External access</SiteLink>
 - <SiteLink docId="user-guide/openbaocluster/configuration/gateway-api">Gateway API support</SiteLink>

--- a/docs/security/workload/tls.md
+++ b/docs/security/workload/tls.md
@@ -7,8 +7,8 @@ description: How peer trust, certificate rotation, and workload-facing TLS ident
 ---
 
 <PageHeader
-  title="Keep peer trust, edge exposure, and workload identity on deliberate paths."
-  lede="TLS in the operator is not just an ingress feature. It defines how pods trust each other, how clients verify the service, where certificate authority material lives, and whether the private key ever touches Kubernetes Secrets at all."
+  title="TLS and workload identity paths"
+  lede="This page explains how pods trust each other, how clients verify the service, where certificate authority material lives, and how each TLS mode changes workload identity and certificate handling."
 />
 
 

--- a/docs/user-guide/index.mdx
+++ b/docs/user-guide/index.mdx
@@ -70,7 +70,7 @@ description: Choose a deployment model, install OpenBao Operator, onboard the ta
     },
     {
       label: 'Tenancy & governance',
-      description: 'Understand what OpenBaoTenant introduces and why the default shared-operator path makes namespace onboarding explicit.',
+      description: 'Review OpenBaoTenant namespace introduction, default guardrails, and shared-operator boundaries.',
       docId: 'user-guide/openbaotenant/overview',
     },
     {

--- a/docs/user-guide/index.mdx
+++ b/docs/user-guide/index.mdx
@@ -44,7 +44,7 @@ description: Choose a deployment model, install OpenBao Operator, onboard the ta
     },
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant before you create a cluster.',
+      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant as part of cluster onboarding.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
     {
@@ -65,7 +65,7 @@ description: Choose a deployment model, install OpenBao Operator, onboard the ta
   items={[
     {
       label: 'Single-tenant mode',
-      description: 'Use this branch only when one team directly owns one namespace and intentionally bypasses the default tenant onboarding step.',
+      description: 'Use this path when one team directly owns one namespace and intentionally bypasses the default tenant onboarding step.',
       docId: 'user-guide/operator/single-tenant-mode',
     },
     {

--- a/docs/user-guide/index.mdx
+++ b/docs/user-guide/index.mdx
@@ -10,8 +10,8 @@ description: Choose a deployment model, install OpenBao Operator, onboard the ta
 <PageHero
   variant="landing"
   eyebrow="Get Started"
-  title="Deploy OpenBao Operator with a clear first path."
-  lede="This journey is for platform teams standing up OpenBao Operator for the first time. Leave with the right tenancy model, security posture, first cluster shape, and day 2 plan."
+  title="Get started with OpenBao Operator"
+  lede="Follow this path to choose a deployment model, install the operator, onboard the target namespace, and create a first cluster. It is the starting point for teams deploying OpenBao Operator for the first time."
   actions={[
     {label: 'Choose a deployment model', docId: 'user-guide/operator/deployment-decision-guide', variant: 'primary'},
     {label: 'Jump to installation', docId: 'user-guide/operator/installation', variant: 'secondary'},

--- a/docs/user-guide/index.mdx
+++ b/docs/user-guide/index.mdx
@@ -11,7 +11,7 @@ description: Choose a deployment model, install OpenBao Operator, onboard the ta
   variant="landing"
   eyebrow="Get Started"
   title="Get started with OpenBao Operator"
-  lede="Follow this path to choose a deployment model, install the operator, onboard the target namespace, and create a first cluster. It is the starting point for teams deploying OpenBao Operator for the first time."
+  lede="Choose a deployment model, install the operator, onboard the target namespace, and create a first cluster."
   actions={[
     {label: 'Choose a deployment model', docId: 'user-guide/operator/deployment-decision-guide', variant: 'primary'},
     {label: 'Jump to installation', docId: 'user-guide/operator/installation', variant: 'secondary'},

--- a/docs/user-guide/openbaocluster/configuration/air-gapped.md
+++ b/docs/user-guide/openbaocluster/configuration/air-gapped.md
@@ -7,8 +7,8 @@ description: Mirror operator and workload images, set the right repository defau
 ---
 
 <PageHeader
-  title="Mirror every image surface before you call the environment disconnected-ready."
-  lede="An air-gapped or private-registry deployment is not just one image override. The operator image, the default OpenBao workload image, and the helper executors for init, backup, and upgrade each have their own source of truth. Use this page to make those defaults explicit before you need to promote clusters through a disconnected path."
+  title="Air-gapped and private-registry image planning"
+  lede="An air-gapped or private-registry deployment involves operator, workload, and helper executor images. Use this page to make those image defaults explicit and wire pull access for disconnected or private-registry environments."
 />
 
 

--- a/docs/user-guide/openbaocluster/configuration/air-gapped.md
+++ b/docs/user-guide/openbaocluster/configuration/air-gapped.md
@@ -145,7 +145,7 @@ spec:
 <DecisionTable
   kind="reference"
   title="Disconnected-environment checks"
-  columns={["Check", "What good looks like", "Why it matters"]}
+  columns={["Check", "Expected state", "Why it matters"]}
   rows={[
     {
       cells: [
@@ -174,7 +174,7 @@ spec:
 
 <Callout type="tip" title="Keep image verification and registry strategy separate in your head">
 
-This page explains where images come from and how they are pulled. Signature verification, digest pinning, and trust roots are handled in the supply-chain security model, not by the mirror configuration alone.
+Use this guide to understand where images come from and how they are pulled. Signature verification, digest pinning, and trust roots are handled in the supply-chain security model, not by the mirror configuration alone.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/configuration/air-gapped.md
+++ b/docs/user-guide/openbaocluster/configuration/air-gapped.md
@@ -3,7 +3,7 @@ title: Air-Gapped and Private Registries
 hide_title: true
 pageType: task
 journey: configure
-description: Mirror operator and workload images, set the right repository defaults, and wire pull secrets before you move clusters into disconnected or private-registry environments.
+description: Mirror operator, workload, and helper images; set repository defaults; and wire pull secrets for disconnected or private-registry environments.
 ---
 
 <PageHeader
@@ -97,9 +97,9 @@ Use the same released operator version for the controller, provisioner, init, ba
 
 </Callout>
 
-<Callout type="note" title="Install defaults are not the only image contract">
+<Callout type="note" title="Use install defaults and cluster overrides together">
 
-Install-wide defaults are the safest starting point, but they do not replace cluster-level overrides when a specific OpenBaoCluster needs a different tag, mirror, or promotion cadence.
+Install-wide defaults provide the baseline image contract. Use cluster-level overrides when a specific `OpenBaoCluster` needs a different tag, mirror, or promotion cadence.
 
 </Callout>
 
@@ -151,7 +151,7 @@ spec:
       cells: [
         "Every runtime image is mirrored",
         "Operator, OpenBao, init, backup, and upgrade images exist in the internal registry before install or rollout.",
-        "A cluster that relies on public registry fallback is not disconnected-ready, even if the main OpenBao image is mirrored.",
+        "Disconnected operation requires every runtime image to be mirrored, not only the main OpenBao image.",
       ],
       emphasis: "recommended",
     },
@@ -159,14 +159,14 @@ spec:
       cells: [
         "Pull secrets exist in every runtime namespace",
         "The operator namespace and every tenant namespace that runs workloads have the correct registry credential Secret.",
-        "Install success does not imply workload success. Clusters can still fail to reconcile when the tenant namespace lacks the pull secret.",
+        "Install success and workload reconcile success are separate checks. Tenant namespaces still need the correct pull secret.",
       ],
     },
     {
       cells: [
         "Version and tag promotion is explicit",
         "Image tags and repository mirrors are tracked as part of the release process.",
-        "Disconnected environments make silent tag drift harder to notice and more painful to debug later.",
+        "Disconnected environments require explicit tag promotion records because drift is harder to detect later.",
       ],
     },
   ]}

--- a/docs/user-guide/openbaocluster/configuration/external-access.md
+++ b/docs/user-guide/openbaocluster/configuration/external-access.md
@@ -9,7 +9,7 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
 
 <PageHeader
   title="Choose an external access path"
-  lede="OpenBao can be exposed through Gateway API, Ingress, or a direct L4 Service. This page focuses on where TLS terminates, who owns certificate lifecycle, and how each edge path fits the intended operating posture."
+  lede="OpenBao can be exposed through Gateway API, Ingress, or a direct L4 Service. Use this page to choose where TLS terminates, who owns certificate lifecycle, and how each edge path fits the intended operating posture."
 />
 
 
@@ -128,7 +128,7 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"`}
 >
-  This is useful when you already operate an ingress-controller standard and do not need the richer Gateway API route model.
+  Use this when you already operate an ingress-controller standard and do not need the richer Gateway API route model.
 </CommandBlock>
 
   </TabItem>

--- a/docs/user-guide/openbaocluster/configuration/external-access.md
+++ b/docs/user-guide/openbaocluster/configuration/external-access.md
@@ -69,7 +69,7 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
       cells: [
         "Temporary operator-managed trust",
         "You are standing up a development or internal evaluation environment quickly.",
-        "This is convenient, but it is not the Hardened production contract and should not become the long-term default by inertia.",
+        "This is appropriate for development and internal evaluation paths, but it does not match the Hardened production contract.",
       ],
       emphasis: "caution",
     },
@@ -176,7 +176,7 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
       cells: [
         "OperatorManaged",
         "Development or internal evaluation paths only",
-        "This is easy to start with, but the operator becomes the certificate authority and that is not the Hardened production posture.",
+        "This keeps startup simple, but it makes the operator the certificate authority and does not match the Hardened production posture.",
       ],
       emphasis: "caution",
     },

--- a/docs/user-guide/openbaocluster/configuration/external-access.md
+++ b/docs/user-guide/openbaocluster/configuration/external-access.md
@@ -8,8 +8,8 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
 ---
 
 <PageHeader
-  title="Choose how traffic reaches the service before you optimize the edge."
-  lede="OpenBao can be exposed through Gateway API, Ingress, or a direct L4 Service. The important decision is not just which Kubernetes resource you use, but where TLS terminates, who owns certificate lifecycle, and whether the edge path matches the production posture you actually want to operate."
+  title="Choose an external access path"
+  lede="OpenBao can be exposed through Gateway API, Ingress, or a direct L4 Service. This page focuses on where TLS terminates, who owns certificate lifecycle, and how each edge path fits the intended operating posture."
 />
 
 

--- a/docs/user-guide/openbaocluster/configuration/external-access.md
+++ b/docs/user-guide/openbaocluster/configuration/external-access.md
@@ -69,7 +69,7 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
       cells: [
         "Temporary operator-managed trust",
         "You are standing up a development or internal evaluation environment quickly.",
-        "This is appropriate for development and internal evaluation paths, but it does not match the Hardened production contract.",
+        "This fits development and internal evaluation paths. Use `External` or `ACME` for the Hardened production baseline.",
       ],
       emphasis: "caution",
     },
@@ -176,7 +176,7 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
       cells: [
         "OperatorManaged",
         "Development or internal evaluation paths only",
-        "This keeps startup simple, but it makes the operator the certificate authority and does not match the Hardened production posture.",
+        "This keeps startup simple, but it also makes the operator the certificate authority. Use `External` or `ACME` for the Hardened production baseline.",
       ],
       emphasis: "caution",
     },

--- a/docs/user-guide/openbaocluster/configuration/gateway-api.md
+++ b/docs/user-guide/openbaocluster/configuration/gateway-api.md
@@ -149,7 +149,7 @@ When backend TLS is enabled, the operator creates a `BackendTLSPolicy` that pins
     {
       cells: [
         "GatewayClass exists and is accepted",
-        "A route is only useful if the controller owning the GatewayClass is real and healthy.",
+        "A route works only when the controller owning the GatewayClass is present and healthy.",
         "The selected `GatewayClass` exists and reports acceptance.",
       ],
     },

--- a/docs/user-guide/openbaocluster/configuration/gateway-api.md
+++ b/docs/user-guide/openbaocluster/configuration/gateway-api.md
@@ -7,8 +7,8 @@ description: Configure Gateway API as the primary edge path for OpenBao, includi
 ---
 
 <PageHeader
-  title="Use Gateway API when the edge should be explicit, portable, and multi-tenant aware."
-  lede="Gateway API is the preferred long-term edge model for OpenBao because it makes route ownership, listener mode, and cross-namespace attachment clearer than a generic Ingress path. For most production deployments, start with TLS passthrough so OpenBao remains the TLS endpoint."
+  title="Gateway API integration"
+  lede="Gateway API is the recommended edge model for explicit route ownership, listener mode, and cross-namespace attachment. For most production deployments, start with TLS passthrough so OpenBao remains the TLS endpoint."
 />
 
 
@@ -122,7 +122,7 @@ If `tls.mode` is `ACME`, do not terminate TLS at the Gateway. OpenBao must remai
       name: main-gateway
       namespace: gateway-system`}
 >
-  Use termination only when you actually need Gateway-side HTTP features. In that model the operator can create a `BackendTLSPolicy` so the backend hop stays encrypted and validated.
+  Use Gateway-side termination when you need HTTP-aware policy, WAF behavior, or centralized certificate handling. In that model the operator can create a `BackendTLSPolicy` so the backend hop stays encrypted and validated.
 </CommandBlock>
 
 <ExpandableCallout type="note" title="What the operator adds for backend TLS">

--- a/docs/user-guide/openbaocluster/configuration/index.mdx
+++ b/docs/user-guide/openbaocluster/configuration/index.mdx
@@ -4,14 +4,14 @@ slug: /configure
 hide_title: true
 pageType: landing
 journey: configure
-description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exposure, networking, and observability before you scale the service.
+description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exposure, networking, and observability for a repeatable service baseline.
 ---
 
 <PageHero
   variant="landing"
   eyebrow="Configure"
   title="Cluster configuration"
-  lede="Use this section to configure the OpenBaoCluster profile, bootstrap model, exposure pattern, storage, networking, and observability defaults. It is intended for choices you want in place before broader rollout."
+  lede="Use this section to configure the OpenBaoCluster profile, bootstrap model, exposure pattern, storage, networking, and observability defaults. It covers the choices that define the cluster baseline."
   actions={[
     {label: 'Open cluster overview', docId: 'user-guide/openbaocluster/overview', variant: 'primary'},
     {label: 'Review security profiles', docId: 'user-guide/openbaocluster/configuration/security-profiles', variant: 'secondary'},
@@ -23,7 +23,7 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
       'the right security profile for the environment',
       'bootstrap and server settings you can explain and repeat',
       'storage, network, and external access choices that match the service boundary',
-      'observability and recovery dependencies wired before day 2 pressure starts',
+      'observability and recovery dependencies wired for day 2 operations',
     ]}
   />
 </PageHero>
@@ -34,7 +34,7 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
     {
       eyebrow: '01',
       title: 'Read this first',
-      description: 'Start with the OpenBaoCluster contract so the rest of the section reads like cluster shaping rather than field-by-field trivia.',
+      description: 'Start with the OpenBaoCluster contract so the rest of the section reads as cluster design rather than isolated field settings.',
       docId: 'user-guide/openbaocluster/overview',
     },
     {
@@ -58,7 +58,7 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
     {
       eyebrow: '05',
       title: 'Platform readiness',
-      description: 'Set storage, observability, and environment-specific constraints such as private registries before the cluster becomes expensive to move.',
+      description: 'Set storage, observability, and environment-specific constraints such as private registries early in the cluster design.',
       docId: 'user-guide/openbaocluster/configuration/resources-storage',
     },
   ]}

--- a/docs/user-guide/openbaocluster/configuration/index.mdx
+++ b/docs/user-guide/openbaocluster/configuration/index.mdx
@@ -10,8 +10,8 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
 <PageHero
   variant="landing"
   eyebrow="Configure"
-  title="Shape the cluster before it becomes expensive to change."
-  lede="Use this section after installation and before broad rollout to set the OpenBaoCluster profile, bootstrap model, exposure pattern, storage, and observability defaults you intend to keep operating."
+  title="Cluster configuration"
+  lede="Use this section to configure the OpenBaoCluster profile, bootstrap model, exposure pattern, storage, networking, and observability defaults. It is intended for choices you want in place before broader rollout."
   actions={[
     {label: 'Open cluster overview', docId: 'user-guide/openbaocluster/overview', variant: 'primary'},
     {label: 'Review security profiles', docId: 'user-guide/openbaocluster/configuration/security-profiles', variant: 'secondary'},

--- a/docs/user-guide/openbaocluster/configuration/index.mdx
+++ b/docs/user-guide/openbaocluster/configuration/index.mdx
@@ -18,7 +18,7 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
   ]}
 >
   <Checklist
-    title="A good configuration baseline should leave you with"
+    title="A configuration baseline needs"
     items={[
       'the right security profile for the environment',
       'bootstrap and server settings you can explain and repeat',
@@ -89,7 +89,7 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
     },
     {
       label: 'Start from a validated deployment',
-      description: 'Use a tested architecture or recipe when you want a known-good baseline instead of assembling the topology yourself.',
+      description: 'Use a tested architecture or recipe when you want a validated baseline instead of assembling the topology yourself.',
       docId: 'user-guide/validated-deployments/index',
     },
   ]}

--- a/docs/user-guide/openbaocluster/configuration/index.mdx
+++ b/docs/user-guide/openbaocluster/configuration/index.mdx
@@ -11,14 +11,14 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
   variant="landing"
   eyebrow="Configure"
   title="Cluster configuration"
-  lede="Use this section to configure the OpenBaoCluster profile, bootstrap model, exposure pattern, storage, networking, and observability defaults. It covers the choices that define the cluster baseline."
+  lede="OpenBaoCluster profile, bootstrap model, exposure pattern, storage, networking, and observability defaults that define the cluster baseline."
   actions={[
     {label: 'Open cluster overview', docId: 'user-guide/openbaocluster/overview', variant: 'primary'},
     {label: 'Review security profiles', docId: 'user-guide/openbaocluster/configuration/security-profiles', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="A configuration baseline needs"
+    title="A cluster baseline includes"
     items={[
       'the right security profile for the environment',
       'bootstrap and server settings you can explain and repeat',

--- a/docs/user-guide/openbaocluster/configuration/network.md
+++ b/docs/user-guide/openbaocluster/configuration/network.md
@@ -7,8 +7,8 @@ description: Configure the operator-managed NetworkPolicy contract, including DN
 ---
 
 <PageHeader
-  title="Treat NetworkPolicy as part of the cluster contract, not as an afterthought."
-  lede="The operator uses a deny-by-default posture and then adds the ingress and egress paths the cluster needs to function. That means DNS, Kubernetes API access, edge peers, and backup or restore dependencies should be configured intentionally rather than discovered during an outage."
+  title="Network policy and traffic contracts"
+  lede="The operator starts from a deny-by-default posture and then adds the ingress and egress paths the cluster needs to function. Use this page to configure DNS, Kubernetes API access, edge peers, and external dependency traffic for backup and restore workflows."
 />
 
 
@@ -137,7 +137,7 @@ description: Configure the operator-managed NetworkPolicy contract, including DN
     dnsEndpointIPs:
       - "169.254.20.10"`}
 >
-  Use `dnsEndpointIPs` only when the resolver is enforced by IP rather than by Service-backed pod traffic. This also affects backup and restore Jobs.
+  Set `dnsEndpointIPs` when the resolver is enforced by IP rather than by Service-backed pod traffic. This setting also applies to backup and restore Jobs.
 </CommandBlock>
 
   </TabItem>

--- a/docs/user-guide/openbaocluster/configuration/observability.md
+++ b/docs/user-guide/openbaocluster/configuration/observability.md
@@ -254,7 +254,7 @@ spec:
 
 <Callout type="tip" title="Keep operator metrics and workload telemetry separate in your dashboards">
 
-The most useful dashboards show both surfaces together, but they should still make it obvious whether a failure is in the operator control plane or in the OpenBao workload itself.
+Build dashboards that show both surfaces together and still make it obvious whether a failure is in the operator control plane or in the OpenBao workload itself.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/configuration/observability.md
+++ b/docs/user-guide/openbaocluster/configuration/observability.md
@@ -3,7 +3,7 @@ title: Observability
 hide_title: true
 pageType: task
 journey: configure
-description: Wire operator metrics, cluster telemetry, dashboards, alerts, and logs before you have to troubleshoot the service under pressure.
+description: Configure operator metrics, cluster telemetry, dashboards, alerts, and logs for routine operations and incident response.
 ---
 
 <PageHeader
@@ -47,7 +47,7 @@ description: Wire operator metrics, cluster telemetry, dashboards, alerts, and l
         "Dashboards and alerts",
         "Grafana assets under `config/grafana/` and your own Prometheus or Alertmanager rules.",
         "A small, repeatable operator cockpit for upgrades, backups, and cluster readiness.",
-        "Dashboards should support decisions. They should not become an excuse to avoid explicit alerts on the failure modes that matter.",
+        "Use dashboards for context and alerts for time-sensitive failures.",
       ],
     },
   ]}
@@ -133,7 +133,7 @@ description: Wire operator metrics, cluster telemetry, dashboards, alerts, and l
       - targets:
           - <provisioner-metrics-service>.<operator-namespace>.svc:8443`}
 >
-  Use this only when you do not run a scrape operator. Keep the ServiceAccount permission to GET `/metrics` and the TLS assumptions explicit.
+  Use this path when you do not run a scrape operator. Keep the ServiceAccount permission to GET `/metrics` and the TLS assumptions explicit.
 </CommandBlock>
 
   </TabItem>
@@ -164,7 +164,7 @@ spec:
         interval: "30s"
         scrapeTimeout: "10s"`}
 >
-  This enables the OpenBao telemetry stanza with safe defaults and creates a Prometheus Operator ServiceMonitor when that is the scrape model you use. Use `spec.telemetry` only when you need lower-level OpenBao telemetry tuning.
+  This enables the OpenBao telemetry stanza with safe defaults and creates a Prometheus Operator ServiceMonitor when that is the scrape model you use. Reach for `spec.telemetry` when you need lower-level OpenBao telemetry tuning.
 </CommandBlock>
 
 <DecisionTable
@@ -176,7 +176,7 @@ spec:
       cells: [
         "Availability",
         "`openbao_cluster_ready_replicas` and cluster conditions such as `Available` or `Degraded`",
-        "This tells you whether the cluster is actually serving, not just whether Pods exist.",
+        "This tells you whether the cluster is serving traffic rather than only whether Pods exist.",
       ],
       emphasis: "recommended",
     },
@@ -184,14 +184,14 @@ spec:
       cells: [
         "Backup freshness",
         "`openbao_backup_last_success_timestamp`, `openbao_backup_consecutive_failures`, and the backup status conditions",
-        "Restore is only as real as the last backup you can prove succeeded.",
+        "These signals show whether the snapshots you plan to restore are current and successful.",
       ],
     },
     {
       cells: [
         "Upgrade safety",
         "`openbao_upgrade_in_progress`, `openbao_upgrade_failure_total`, and rollback counters",
-        "Upgrades should be observable as controlled workflows, not silent StatefulSet churn.",
+        "These signals distinguish orchestrated upgrade activity from normal steady state.",
       ],
     },
     {

--- a/docs/user-guide/openbaocluster/configuration/observability.md
+++ b/docs/user-guide/openbaocluster/configuration/observability.md
@@ -31,7 +31,7 @@ description: Configure operator metrics, cluster telemetry, dashboards, alerts, 
         "OpenBao workload telemetry",
         "The `spec.observability.metrics` block on each `OpenBaoCluster`, plus optional `spec.telemetry` overrides.",
         "Application-level metrics from the OpenBao Pods themselves.",
-        "This is separate from operator metrics. Do not assume enabling one layer automatically covers the other.",
+        "Configure this separately from operator metrics. Enabling one layer does not configure the other.",
       ],
     },
     {
@@ -39,7 +39,7 @@ description: Configure operator metrics, cluster telemetry, dashboards, alerts, 
         "Logs and health probes",
         "Operator install values such as log level and health probe settings.",
         "Fast incident triage when the issue is not obvious from metrics alone.",
-        "Use debug logging intentionally and temporarily. Do not leave broad debug enabled as the long-term default.",
+        "Use debug logging intentionally and temporarily, then return to the normal log level.",
       ],
     },
     {
@@ -226,7 +226,7 @@ spec:
           expr: rate(openbao_reconcile_errors_total[5m]) > 0.1
           for: 10m`}
 >
-  Keep the first alert set small. Availability, backup freshness, and sustained reconcile failure are the signals that change operator behavior fastest.
+  Keep the first alert set small. Availability, backup freshness, and sustained reconcile failure are the highest-value starting signals.
 </CommandBlock>
 
 ## Dashboards, logs, and health
@@ -263,7 +263,7 @@ The most useful dashboards show both surfaces together, but they should still ma
   items={[
     {
       label: "Configure backups",
-      description: "Backups are the first place good observability pays off. Wire them before you depend on restore.",
+      description: "Configure backup telemetry before restore depends on it.",
       docId: "user-guide/openbaocluster/operations/backups",
     },
     {

--- a/docs/user-guide/openbaocluster/configuration/observability.md
+++ b/docs/user-guide/openbaocluster/configuration/observability.md
@@ -7,8 +7,8 @@ description: Wire operator metrics, cluster telemetry, dashboards, alerts, and l
 ---
 
 <PageHeader
-  title="Observe both the operator and the workload before you call the cluster ready."
-  lede="OpenBao Operator has two observability layers: the operator control plane itself, and the OpenBao workload it renders. Use this page to wire both layers into your monitoring stack, choose the scrape model your platform already supports, and promote only the signals that help you operate upgrades, backups, and recovery."
+  title="Observability for operator and workload"
+  lede="OpenBao Operator has two observability layers: the operator control plane itself, and the OpenBao workload it renders. Use this page to wire both layers into your monitoring stack, choose the scrape model your platform already supports, and focus on the signals that matter for upgrades, backups, and recovery."
 />
 
 

--- a/docs/user-guide/openbaocluster/configuration/resources-storage.md
+++ b/docs/user-guide/openbaocluster/configuration/resources-storage.md
@@ -3,12 +3,12 @@ title: Resources and Storage
 hide_title: true
 pageType: task
 journey: configure
-description: Choose storage class, PVC size, and workload resource requests before the cluster becomes difficult to resize or move.
+description: Choose storage class, PVC size, and workload resource requests for the cluster data path and capacity baseline.
 ---
 
 <PageHeader
-  title="Choose storage and workload limits before the data path makes them expensive to change."
-  lede="The operator renders the core workload for you, but it does not choose the platform capacity or storage class you intend to live with. Use this page to understand which resources the cluster owns, how PVC growth works, and where explicit sizing is safer than inheriting whatever the platform happens to default."
+  title="Storage and workload sizing"
+  lede="The operator renders the workload, but storage class and capacity choices still belong to the platform baseline. Use this page to set resource requests, understand PVC growth behavior, and make storage decisions explicit."
 />
 
 
@@ -93,7 +93,7 @@ spec:
     size: "50Gi"
     storageClassName: "fast-ssd"`}
 >
-  Start with explicit requests and an explicit `storageClassName` in production. Defaults are fine for evaluation, but they are a weak contract once the cluster carries real data.
+  Set explicit requests and an explicit `storageClassName` in production. Defaults are acceptable for evaluation, but they provide less predictable long-term storage behavior.
 </CommandBlock>
 
 <DecisionTable
@@ -127,7 +127,7 @@ spec:
       cells: [
         "Filesystem expansion",
         "Some CSI drivers finish expansion only after a restart. The operator surfaces that and can use a controlled restart path when maintenance is enabled.",
-        "Do not assume a size increase is complete just because the PVC request changed. Check the PVC and cluster conditions before you move on.",
+        "A size increase is not complete until the PVC and cluster conditions confirm it.",
       ],
       emphasis: "caution",
     },
@@ -152,7 +152,7 @@ spec:
   code={`kubectl get openbaocluster <name> -n <namespace> \\
   -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\\t"}{.reason}{"\\n"}{end}'`}
 >
-  A healthy cluster should eventually report `StorageConfigured=True`. If it does not, fix the storage-path mismatch before you continue with upgrades or backups.
+  A healthy cluster should eventually report `StorageConfigured=True`. If it does not, fix the storage-path mismatch before continuing with upgrades or backups.
 </CommandBlock>
 
 <Callout type="note" title="Controlled restarts still matter after a PVC expansion">
@@ -176,7 +176,7 @@ If your CSI driver requires a restart to finish filesystem resize, use the maint
     },
     {
       label: "Configure backups",
-      description: "Snapshots depend on the storage path you chose and should be routine long before you need restore.",
+      description: "Configure backups against the storage path the cluster will use in steady state.",
       docId: "user-guide/openbaocluster/operations/backups",
     },
   ]}

--- a/docs/user-guide/openbaocluster/configuration/security-profiles.md
+++ b/docs/user-guide/openbaocluster/configuration/security-profiles.md
@@ -41,7 +41,7 @@ description: Choose the cluster posture first, including bootstrap, unseal, TLS,
 
 <DiagramFrame
   title="How the profile shapes the baseline"
-  caption="The profile is not cosmetic. It determines whether the cluster can rely on operator-generated trust material and stored bootstrap credentials or whether those paths are explicitly disallowed."
+  caption="The profile determines whether the cluster can rely on operator-generated trust material and stored bootstrap credentials or whether those paths are explicitly disallowed."
   code={`flowchart LR
     Profile["spec.profile"] --> Bootstrap["Bootstrap path"]
     Profile --> Unseal["Unseal root of trust"]
@@ -75,7 +75,7 @@ description: Choose the cluster posture first, including bootstrap, unseal, TLS,
       cells: [
         "Bootstrap credential handling",
         "Manual init is allowed and can leave a root token in a Secret when self-init is disabled.",
-        "Self-initialization is the supported path and root-token persistence is not the normal operating model.",
+        "Self-initialization is the expected path, and root-token persistence is reserved for exceptional workflows.",
       ],
       emphasis: "recommended",
     },
@@ -83,7 +83,7 @@ description: Choose the cluster posture first, including bootstrap, unseal, TLS,
       cells: [
         "Unseal",
         "Static unseal in a Secret is allowed for fast evaluation.",
-        "Use an external trust source such as cloud KMS or transit. Treat static unseal as a non-production exception.",
+        "Use an external trust source such as cloud KMS or transit. Static unseal is limited to development and other deliberate exceptions.",
       ],
     },
     {
@@ -97,7 +97,7 @@ description: Choose the cluster posture first, including bootstrap, unseal, TLS,
       cells: [
         "Image verification",
         "Can be introduced gradually and warning-only rollouts are possible.",
-        "Verification is expected, warning-only behavior is not the production posture, and official-image defaults still verify when trust material is omitted.",
+        "Use image verification as the steady-state posture. Warning-only behavior fits rollout or transition periods, and official-image defaults still verify when trust material is omitted.",
       ],
     },
     {
@@ -173,9 +173,9 @@ spec:
   </TabItem>
 </Tabs>
 
-<Callout type="warning" title="Do not let development defaults drift into production">
+<Callout type="warning" title="Switch the baseline before production use">
 
-The dangerous part of the Development profile is not that it exists; it is that it feels easy to keep. If the cluster matters, switch to Hardened before other systems begin to depend on it.
+If other systems will depend on the cluster, move from Development to Hardened before that production usage begins.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/configuration/security-profiles.md
+++ b/docs/user-guide/openbaocluster/configuration/security-profiles.md
@@ -8,8 +8,8 @@ description: Choose the cluster posture first, including bootstrap, unseal, TLS,
 ---
 
 <PageHeader
-  title="Choose the operating posture before you tune anything else."
-  lede="`spec.profile` is the top-level decision that shapes bootstrap, unseal, TLS, image verification, and failure tolerance. Pick the posture you plan to keep operating, then let the rest of the cluster baseline follow from that choice."
+  title="Choose a security profile"
+  lede="`spec.profile` is the top-level decision that shapes bootstrap, unseal, TLS, image verification, and failure tolerance. Use this page to choose the cluster posture and then align the rest of the baseline with it."
 />
 
 

--- a/docs/user-guide/openbaocluster/configuration/self-init.md
+++ b/docs/user-guide/openbaocluster/configuration/self-init.md
@@ -3,12 +3,12 @@ title: Self-Initialization
 hide_title: true
 pageType: task
 journey: configure
-description: Configure bootstrap requests, operator OIDC setup, and verification for self-initializing OpenBao clusters without leaving a persistent root token behind.
+description: Configure bootstrap requests, operator OIDC setup, and verification for self-initializing OpenBao clusters with an auto-revoked bootstrap credential.
 ---
 
 <PageHeader
-  title="Bootstrap the cluster declaratively and avoid carrying a root token forward."
-  lede="Self-initialization lets the cluster bring up auth methods, policies, audit devices, and other bootstrap state as part of the `OpenBaoCluster` manifest. It is the supported production bootstrap path because it avoids leaving a long-lived root token in a Kubernetes Secret."
+  title="Declarative cluster bootstrap"
+  lede="Self-initialization applies auth methods, policies, audit devices, and other bootstrap state from the `OpenBaoCluster` manifest and then revokes the bootstrap root token. Use this page to configure the bootstrap contract and the access paths that must exist after initialization."
 />
 
 
@@ -58,9 +58,9 @@ description: Configure bootstrap requests, operator OIDC setup, and verification
     class Auth,Audit,Ready write;`}
 />
 
-<Callout type="warning" title="Lockout is the real failure mode">
+<Callout type="warning" title="Plan the access path before enabling self-init">
 
-Self-init is safer only if you plan the access path up front. If you enable it without creating a usable auth method for operators or humans, the root token is revoked and the cluster can become effectively unreachable without recreation.
+If self-init is enabled and no usable auth method exists for operators or humans, the root token is revoked and the cluster can become effectively unreachable unless it is recreated.
 
 </Callout>
 
@@ -86,10 +86,9 @@ Self-init is safer only if you plan the access path up front. If you enable it w
   ]}
 />
 
-<Callout type="tip" title="Self-init is the whole bootstrap contract">
+<Callout type="tip" title="Define operator and human access in the same bootstrap contract">
 
-Do not think of operator auth as step one and human auth as something to add later.
-If the cluster will self-initialize, define the human login path in `selfInit.requests` as part of the same manifest that enables self-init.
+If the cluster will self-initialize, define the human login path in `selfInit.requests` as part of the same manifest that enables operator auth.
 
 </Callout>
 
@@ -111,7 +110,7 @@ If the cluster will self-initialize, define the human login path in `selfInit.re
           fileOptions:
             filePath: /tmp/audit.log`}
 >
-  Treat `requests` as part of the bootstrap contract. They should create the minimum auth, policy, and audit state required for the cluster to be useful after bootstrap.
+  `requests` defines the bootstrap state. Include the minimum auth, policy, and audit configuration the cluster needs immediately after initialization.
 </CommandBlock>
 
 <CommandBlock

--- a/docs/user-guide/openbaocluster/configuration/server.md
+++ b/docs/user-guide/openbaocluster/configuration/server.md
@@ -3,12 +3,12 @@ title: Server Configuration
 hide_title: true
 pageType: task
 journey: configure
-description: Configure server-runtime defaults such as UI, listener behavior, audit devices, plugins, and Raft autopilot without mixing in unrelated exposure or observability concerns.
+description: Configure server-runtime defaults such as UI, listener behavior, audit devices, plugins, and Raft autopilot, and use the dedicated pages for adjacent configuration areas.
 ---
 
 <PageHeader
-  title="Tune the server runtime without turning this page into a dump of every field."
-  lede="Use this page for the settings that shape how the OpenBao server itself runs: listener and lease behavior, Raft autopilot, audit devices, and plugin registration. Exposure, observability, and mirrored-image strategy each have their own configuration paths."
+  title="Configure the server runtime"
+  lede="Use this page for the settings that shape how the OpenBao server runs: listener and lease behavior, Raft autopilot, audit devices, and plugin registration. Exposure, observability, and mirrored-image settings are documented separately."
 />
 
 
@@ -107,7 +107,7 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
       cells: [
         "`raft.performanceMultiplier`",
         "Compensate for high-latency or slower control-plane environments.",
-        "Change this deliberately and observe cluster behavior rather than cargo-culting larger values.",
+        "Change this deliberately and verify that measured latency or failure behavior requires the larger value.",
       ],
     },
   ]}
@@ -131,7 +131,7 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
         file_path: "/var/log/openbao/audit.log"
         format: "json"`}
 >
-  Audit devices belong in the cluster baseline so the service does not come up “temporarily unaudited” and stay that way by accident.
+  Include audit devices in the cluster baseline so the service starts with the expected audit configuration.
 </CommandBlock>
 
   </TabItem>
@@ -234,7 +234,7 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
         maxTrailingLogs: 2000
         serverStabilizationTime: "30s"`}
 >
-  Override only when you have a concrete reason. Most clusters should start with the operator defaults and change them only after observing real failure or latency behavior.
+  Start with the operator defaults and override them only after measuring behavior that requires a change.
 </CommandBlock>
 
   </TabItem>
@@ -250,7 +250,7 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
       autopilot:
         cleanupDeadServers: false`}
 >
-  If you disable cleanup, you are taking manual ownership of peer removal. That is usually a temporary operational exception, not a steady-state recommendation.
+  If you disable cleanup, you are taking manual ownership of peer removal. This is usually a temporary operational exception rather than the steady-state configuration.
 </CommandBlock>
 
   </TabItem>
@@ -262,7 +262,7 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
   title="Inspect the full configuration schema"
   code={`kubectl explain openbaocluster.spec.configuration`}
 >
-  Use this when you need the exact field tree. Keep this page for the defaults and decision boundaries, not as a full API dump.
+  Use this when you need the exact field tree. Keep this page for defaults and decision boundaries rather than exhaustive field-by-field reference.
 </CommandBlock>
 
 <NextActions

--- a/docs/user-guide/openbaocluster/configuration/server.md
+++ b/docs/user-guide/openbaocluster/configuration/server.md
@@ -100,7 +100,7 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
       cells: [
         "`defaultLeaseTTL` / `maxLeaseTTL`",
         "Set sensible lease bounds for the workloads that depend on the cluster.",
-        "Treat very long leases as an operational contract, not just a convenience setting.",
+        "Very long leases change the operational contract for the workloads that depend on the cluster.",
       ],
     },
     {

--- a/docs/user-guide/openbaocluster/configuration/unseal.md
+++ b/docs/user-guide/openbaocluster/configuration/unseal.md
@@ -118,15 +118,15 @@ For production-oriented clusters, use an external trust source such as cloud KMS
     {
       cells: [
         "AWS KMS",
-        "Needed only when you are not using IRSA, ambient credentials, or another default AWS credential chain.",
+        "Required if you are not using IRSA, ambient credentials, or another default AWS credential chain.",
         "`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.",
-        "Use Secrets only when workload identity is not the intended path.",
+        "Prefer workload identity when that path is available and intended.",
       ],
     },
     {
       cells: [
         "GCP Cloud KMS",
-        "Needed only when `spec.unseal.gcpCloudKMS.credentials` points at a mounted file instead of using Workload Identity or ADC.",
+        "Required if `spec.unseal.gcpCloudKMS.credentials` points at a mounted file instead of using Workload Identity or ADC.",
         "A Secret key matching the configured file name, usually `credentials.json`, containing valid JSON credentials.",
         "The path must live under `/etc/bao/seal-creds`.",
       ],
@@ -134,7 +134,7 @@ For production-oriented clusters, use an external trust source such as cloud KMS
     {
       cells: [
         "Azure Key Vault",
-        "Needed only when you are not using Managed Identity or Azure Workload Identity.",
+        "Required if you are not using Managed Identity or Azure Workload Identity.",
         "`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`.",
         "Managed identity is the preferred Hardened path when your platform supports it.",
       ],
@@ -142,7 +142,7 @@ For production-oriented clusters, use an external trust source such as cloud KMS
     {
       cells: [
         "OCI KMS",
-        "Needed only when `spec.unseal.ocikms.authTypeAPIKey=true`.",
+        "Required if `spec.unseal.ocikms.authTypeAPIKey=true`.",
         "`config`, plus the Secret key referenced by `key_file` inside the OCI SDK config.",
         "The OCI config must define `user`, `fingerprint`, `tenancy`, `region`, and `key_file` in profile `[DEFAULT]`, and `key_file` must point under `/etc/bao/seal-creds`.",
       ],

--- a/docs/user-guide/openbaocluster/configuration/unseal.md
+++ b/docs/user-guide/openbaocluster/configuration/unseal.md
@@ -16,7 +16,7 @@ description: Configure the unseal root of trust and the Secret or mounted-file c
 
 <Callout type="important" title="Hardened posture prefers external trust">
 
-For production-oriented clusters, use an external trust source such as cloud KMS, transit, KMIP, OCI KMS, or PKCS#11. Static unseal remains useful for development and controlled exceptions, but it keeps decryption material inside Kubernetes.
+For production-oriented clusters, use an external trust source such as cloud KMS, transit, KMIP, OCI KMS, or PKCS#11. Reserve static unseal for development and controlled exceptions because it keeps decryption material inside Kubernetes.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/configuration/unseal.md
+++ b/docs/user-guide/openbaocluster/configuration/unseal.md
@@ -4,12 +4,12 @@ slug: /configure/unseal
 hide_title: true
 pageType: task
 journey: configure
-description: Choose the unseal root of trust deliberately and use the exact Secret and mounted-file contract the operator validates for each unseal mode.
+description: Configure the unseal root of trust and the Secret or mounted-file contract the operator validates for each supported unseal mode.
 ---
 
 <PageHeader
-  title="Treat unseal as a trust contract, not just a field to satisfy."
-  lede="The unseal path decides where the root of trust lives, how credentials reach the Pods, and which Secret keys or mounted files the operator expects. Use this page when you want the concrete contract, not just the high-level posture guidance."
+  title="Unseal trust and credential contracts"
+  lede="The unseal path defines where the root of trust lives, how credentials reach the Pods, and which Secret keys or mounted files each mode requires. Use this page to map a chosen unseal mode to the exact operator contract."
 />
 
 
@@ -136,7 +136,7 @@ For production-oriented clusters, use an external trust source such as cloud KMS
         "Azure Key Vault",
         "Needed only when you are not using Managed Identity or Azure Workload Identity.",
         "`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`.",
-        "Managed identity is the cleaner Hardened path when your platform supports it.",
+        "Managed identity is the preferred Hardened path when your platform supports it.",
       ],
     },
     {

--- a/docs/user-guide/openbaocluster/getting-started.md
+++ b/docs/user-guide/openbaocluster/getting-started.md
@@ -9,8 +9,8 @@ journeyStep: 4
 ---
 
 <PageHeader
-  title="Create the first cluster you can keep operating."
-  lede="By the time you reach this step, the operator is installed and the target namespace is already onboarded when you are in the default multi-tenant mode. Start with the closest safe baseline, verify the cluster becomes healthy, and then move directly into the next operating concern."
+  title="Create the first cluster"
+  lede="Start with the closest safe baseline, verify that the cluster becomes healthy, and then move directly into the next operating concern. In the default multi-tenant mode, the target namespace is already onboarded before this step."
 />
 
 <Checklist
@@ -26,7 +26,7 @@ journeyStep: 4
 
 <Callout type="note" title="Choose the namespace handoff first">
 
-- In the default multi-tenant mode, create the target namespace and finish [OpenBaoTenant onboarding](../openbaotenant/onboarding.md) before you apply `OpenBaoCluster`.
+- In the default multi-tenant mode, create the target namespace, finish [OpenBaoTenant onboarding](../openbaotenant/onboarding.md), then apply `OpenBaoCluster`.
 - In single-tenant mode, skip `OpenBaoTenant` and create the cluster only in the controller's watched namespace.
 
 </Callout>
@@ -37,7 +37,7 @@ journeyStep: 4
   items={[
     {
       label: 'Choose a deployment model',
-      description: 'Lock down tenancy, security posture, install method, and the main exceptions before you install.',
+      description: 'Choose tenancy, security posture, install method, and the main exceptions for the environment.',
       docId: 'user-guide/operator/deployment-decision-guide',
     },
     {
@@ -47,7 +47,7 @@ journeyStep: 4
     },
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant before you create a cluster.',
+      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant, then create a cluster.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
     {
@@ -71,7 +71,7 @@ journeyStep: 4
       cells: [
         'Local evaluation',
         'Development profile with operator-managed TLS and minimal storage choices.',
-        'Treat it as disposable. Do not carry this profile into production.',
+        'Use this for disposable evaluation clusters rather than a production baseline.',
         'Security profiles',
       ],
       emphasis: 'recommended',
@@ -221,7 +221,7 @@ If you are going straight to production, prefer a tested architecture or recipe 
   title="Watch the cluster pods stabilize"
   code={`kubectl get pods -l openbao.org/cluster=<name> -n <namespace> -w`}
 >
-  A healthy first cluster should converge without repeated crash loops or long-lived pending state.
+  A healthy first cluster converges without repeated crash loops or long-lived pending state.
 </CommandBlock>
 
 <Callout type="note" title="What to look for next">

--- a/docs/user-guide/openbaocluster/getting-started.md
+++ b/docs/user-guide/openbaocluster/getting-started.md
@@ -14,7 +14,7 @@ journeyStep: 4
 />
 
 <Checklist
-    title="Before you apply the cluster manifest"
+    title="Cluster manifest checklist"
     items={[
       'confirm the operator install is healthy in the namespace model you chose',
       'confirm the target namespace is already onboarded through OpenBaoTenant when you are in multi-tenant mode',
@@ -224,7 +224,7 @@ If you are going straight to production, prefer a tested architecture or recipe 
   A healthy first cluster should converge without repeated crash loops or long-lived pending state.
 </CommandBlock>
 
-<Callout type="note" title="What to look for before you move on">
+<Callout type="note" title="What to look for next">
 
 Confirm the cluster is available, TLS and storage match the shape you intended, and hardened clusters can realistically progress toward `ProductionReady=True`.
 

--- a/docs/user-guide/openbaocluster/next-steps.md
+++ b/docs/user-guide/openbaocluster/next-steps.md
@@ -12,7 +12,7 @@ journeyStep: 5
   variant="landing"
   eyebrow="Step 5"
   title="Next steps after initial setup"
-  lede="Use this page after the first cluster becomes healthy to choose the next operational concern. It helps route follow-up work such as hardening, exposure, backups, and day 2 procedures."
+  lede="Follow-up work after the first cluster becomes healthy, including hardening, exposure, backups, and day 2 procedures."
   actions={[
     {label: 'Open the production checklist', docId: 'user-guide/openbaocluster/operations/production-checklist', variant: 'primary'},
     {label: 'Open Operate', docId: 'user-guide/openbaocluster/operations/index', variant: 'secondary'},
@@ -35,7 +35,7 @@ journeyStep: 5
   items={[
     {
       label: 'Choose a deployment model',
-      description: 'Lock down tenancy, security posture, install method, and the main exceptions before you install.',
+      description: 'Choose tenancy, security posture, install method, and the main exceptions for the environment.',
       docId: 'user-guide/operator/deployment-decision-guide',
     },
     {
@@ -45,7 +45,7 @@ journeyStep: 5
     },
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant before you create a cluster.',
+      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant, then create a cluster.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
     {
@@ -77,14 +77,14 @@ journeyStep: 5
       cells: [
         'You have not yet proven backup or restore',
         'Backups',
-        'The first risky upgrade should not be the first time object storage, backup auth, and restore assumptions are tested.',
+        'Test object storage, backup auth, and restore assumptions before the first risky upgrade.',
       ],
     },
     {
       cells: [
         'You need user or edge access now',
         'External access',
-        'TLS mode, exposure path, and user auth assumptions should be settled before traffic and clients grow around a temporary shortcut.',
+        'Settle TLS mode, exposure path, and user auth assumptions before traffic and clients grow around a temporary shortcut.',
       ],
     },
     {
@@ -138,7 +138,7 @@ journeyStep: 5
   items={[
     {
       label: 'Browse validated deployments',
-      description: 'Use tested architectures, recipes, and runbooks when you want a known-good implementation path.',
+      description: 'Use tested architectures, recipes, and runbooks when you want a validated implementation path.',
       docId: 'user-guide/validated-deployments/index',
     },
     {

--- a/docs/user-guide/openbaocluster/next-steps.md
+++ b/docs/user-guide/openbaocluster/next-steps.md
@@ -11,8 +11,8 @@ journeyStep: 5
 <PageHero
   variant="landing"
   eyebrow="Step 5"
-  title="Choose the next operating concern before you walk away."
-  lede="A working cluster is not the end of setup. The next move should be deliberate: harden it, expose it, wire backups, or move into the operating guides that match the job in front of you."
+  title="Next steps after initial setup"
+  lede="Use this page after the first cluster becomes healthy to choose the next operational concern. It helps route follow-up work such as hardening, exposure, backups, and day 2 procedures."
   actions={[
     {label: 'Open the production checklist', docId: 'user-guide/openbaocluster/operations/production-checklist', variant: 'primary'},
     {label: 'Open Operate', docId: 'user-guide/openbaocluster/operations/index', variant: 'secondary'},

--- a/docs/user-guide/openbaocluster/next-steps.md
+++ b/docs/user-guide/openbaocluster/next-steps.md
@@ -2,7 +2,7 @@
 title: Prepare for Day 2
 slug: /get-started/next-steps
 hide_title: true
-description: Choose the next operating concern after the first cluster is healthy so backups, access, and hardening are not left as future cleanup.
+description: Choose the next operating concern after the first cluster is healthy so backups, access, and hardening become part of the operating baseline.
 pageType: landing
 journey: get-started
 journeyStep: 5

--- a/docs/user-guide/openbaocluster/next-steps.md
+++ b/docs/user-guide/openbaocluster/next-steps.md
@@ -19,7 +19,7 @@ journeyStep: 5
   ]}
 >
   <Checklist
-    title="Leave Get Started only when"
+    title="Move on from Get Started once"
     items={[
       'the access path and TLS posture are chosen',
       'backup and restore work has an owner',

--- a/docs/user-guide/openbaocluster/operations/backups.md
+++ b/docs/user-guide/openbaocluster/operations/backups.md
@@ -1,6 +1,6 @@
 ---
 title: Backup Operations
-description: Configure backup jobs, object-storage auth, retention, and verification before you depend on snapshot-based recovery.
+description: Configure backup jobs, object-storage auth, retention, and verification for snapshot-based recovery.
 slug: /operate/backups
 hide_title: true
 pageType: task
@@ -697,7 +697,7 @@ Confirm backup status before you start the upgrade rather than assuming the pre-
     },
     {
       label: 'Plan upgrades',
-      description: 'Backups should be validated before you depend on pre-upgrade snapshots and cutover safety.',
+      description: 'Validate backups as part of pre-upgrade snapshots and cutover safety.',
       docId: 'user-guide/openbaocluster/operations/upgrades',
     },
     {

--- a/docs/user-guide/openbaocluster/operations/backups.md
+++ b/docs/user-guide/openbaocluster/operations/backups.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Make snapshots routine before you need them for a restore."
-  lede="OpenBao Operator runs backups as transient Jobs that authenticate separately from the main workload, stream Raft snapshots directly to object storage, and record schedule and failure state on the cluster."
+  title="Backup operations and snapshot policy"
+  lede="OpenBao Operator runs backups as transient Jobs that authenticate separately from the main workload, stream Raft snapshots directly to object storage, and record schedule and failure state on the cluster. Use this page to configure auth, storage, schedules, retention, and verification."
 />
 
 
@@ -79,7 +79,7 @@ Check `CloudUnsealIdentityReady` for the main Pods and `BackupConfigurationReady
 ## First successful backup path
 
 <DecisionTable
-  title="Use this order the first time you wire backups"
+  title="Recommended first backup path"
   columns={['Step', 'What to do', 'What proves success']}
   rows={[
     {
@@ -655,7 +655,7 @@ Confirm backup status before you start the upgrade rather than assuming the pre-
 <CommandBlock
   language="bash"
   label="verify"
-  title="Check backup readiness before you wait for the schedule"
+  title="Check backup readiness"
   code={`kubectl get openbaocluster my-cluster -n <namespace> \\
   -o jsonpath='{range .status.conditions[*]}{.type}={.status}{\"\\n\"}{end}'`}
 >

--- a/docs/user-guide/openbaocluster/operations/backups.md
+++ b/docs/user-guide/openbaocluster/operations/backups.md
@@ -51,7 +51,7 @@ journey: operate
         'Static token',
         'JWT auth is not available yet and you need a compatibility path.',
         'The backup Job reads a long-lived token from a Secret in the cluster namespace.',
-        'This is a legacy path. Treat the token as a sensitive credential and rotate it deliberately.',
+        'This is a compatibility path. Treat the token as a sensitive credential and rotate it deliberately.',
       ],
       emphasis: 'caution',
     },

--- a/docs/user-guide/openbaocluster/operations/deletion.md
+++ b/docs/user-guide/openbaocluster/operations/deletion.md
@@ -1,6 +1,6 @@
 ---
 title: Decommission a Cluster
-description: Choose the right deletion policy before you tear down a cluster so you know exactly what happens to PVCs, secrets, and backups.
+description: Choose the deletion policy for a cluster teardown and verify what happens to PVCs, secrets, and backups.
 slug: /operate/decommission
 hide_title: true
 pageType: task
@@ -66,7 +66,7 @@ The default `Retain` behavior preserves the things you need if the deletion turn
 
 <Callout type="note" title="Why the unseal key is retained">
 
-The unseal key material is what makes the retained PVC data usable later. If the operator let Kubernetes garbage-collect that Secret automatically, you could keep the encrypted data and still lose the practical ability to recover it.
+The unseal key material is what makes the retained PVC data usable later. If the operator let Kubernetes garbage-collect that Secret automatically, you could keep the encrypted data and still lose the ability to recover it.
 
 </Callout>
 
@@ -133,7 +133,7 @@ Once the PVCs are deleted, the underlying volume data is gone unless you have an
   code={`kubectl delete openbaocluster <name> -n <namespace>`}
 />
 
-If the cluster still serves production traffic, stop here and confirm your cutover, backup, and recovery assumptions before you continue.
+If the cluster still serves production traffic, confirm your cutover, backup, and recovery assumptions before you continue.
 
 ## Verify the cleanup result
 

--- a/docs/user-guide/openbaocluster/operations/deletion.md
+++ b/docs/user-guide/openbaocluster/operations/deletion.md
@@ -13,7 +13,7 @@ journey: operate
 />
 
 <Checklist
-    title="Use this page when"
+    title="Use this page to"
     items={[
       'tear down a dev, staging, or production cluster intentionally',
       'change the deletion policy from the default retain behavior',

--- a/docs/user-guide/openbaocluster/operations/deletion.md
+++ b/docs/user-guide/openbaocluster/operations/deletion.md
@@ -8,12 +8,12 @@ journey: operate
 ---
 
 <PageHeader
-  title="Decommission the cluster without guessing what will be retained."
-  lede="Deleting an `OpenBaoCluster` is not just removing Pods. The deletion policy determines whether PVC-backed data stays behind, whether critical secrets are preserved, and what still requires manual cleanup after the control plane is gone."
+  title="Decommission a cluster"
+  lede="Deleting an `OpenBaoCluster` removes the control plane, but the deletion policy determines whether PVC-backed data stays behind, whether critical secrets are preserved, and what still requires manual cleanup after the control plane is gone."
 />
 
 <Checklist
-    title="Use this page before you"
+    title="Use this page when"
     items={[
       'tear down a dev, staging, or production cluster intentionally',
       'change the deletion policy from the default retain behavior',

--- a/docs/user-guide/openbaocluster/operations/index.mdx
+++ b/docs/user-guide/openbaocluster/operations/index.mdx
@@ -11,7 +11,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
   variant="landing"
   eyebrow="Operate"
   title="Cluster operations"
-  lede="This section covers the day 2 lifecycle of an OpenBao cluster, including production readiness, backups, upgrades, maintenance, troubleshooting, and decommissioning."
+  lede="Use these guides for the day 2 lifecycle of an OpenBao cluster, including production readiness, backups, upgrades, maintenance, troubleshooting, and decommissioning."
   actions={[
     {label: 'Open the production checklist', docId: 'user-guide/openbaocluster/operations/production-checklist', variant: 'primary'},
     {label: 'Open recovery and restore', docId: 'user-guide/openbaocluster/recovery/index', variant: 'secondary'},
@@ -32,17 +32,17 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
   title="How this section is organized"
   items={[
     {
-      label: 'Reliability & Change',
+      label: 'Reliability and change',
       description: 'Use the production checklist, backups, and upgrade planning to keep planned change safe.',
       docId: 'user-guide/openbaocluster/operations/production-checklist',
     },
     {
-      label: 'Cluster Controls',
+      label: 'Cluster controls',
       description: 'Use maintenance, pause, and decommission workflows to change controller behavior safely.',
       docId: 'user-guide/openbaocluster/operations/maintenance',
     },
     {
-      label: 'Troubleshooting & Recovery',
+      label: 'Troubleshooting and recovery',
       description: 'Start with symptoms and status, then move into recovery and restore when the incident crosses that line.',
       docId: 'user-guide/openbaocluster/operations/troubleshooting',
     },
@@ -50,7 +50,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
 />
 
 <RouteList
-  title="Reliability & Change"
+  title="Reliability and change"
   items={[
     {
       eyebrow: '01',
@@ -74,7 +74,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
 />
 
 <RouteList
-  title="Cluster Controls"
+  title="Cluster controls"
   items={[
     {
       eyebrow: '01',
@@ -98,7 +98,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
 />
 
 <RouteList
-  title="Troubleshooting & Recovery"
+  title="Troubleshooting and recovery"
   items={[
     {
       eyebrow: '01',

--- a/docs/user-guide/openbaocluster/operations/index.mdx
+++ b/docs/user-guide/openbaocluster/operations/index.mdx
@@ -10,8 +10,8 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
 <PageHero
   variant="landing"
   eyebrow="Operate"
-  title="Run the cluster as a service, not as a one-time install."
-  lede="This section covers the full day 2 lifecycle of an OpenBao cluster: make it reliable, protect data before risky change, use cluster controls deliberately, and move from troubleshooting into recovery when normal operations are no longer enough."
+  title="Cluster operations"
+  lede="This section covers the day 2 lifecycle of an OpenBao cluster, including production readiness, backups, upgrades, maintenance, troubleshooting, and decommissioning."
   actions={[
     {label: 'Open the production checklist', docId: 'user-guide/openbaocluster/operations/production-checklist', variant: 'primary'},
     {label: 'Open recovery and restore', docId: 'user-guide/openbaocluster/recovery/index', variant: 'secondary'},

--- a/docs/user-guide/openbaocluster/operations/index.mdx
+++ b/docs/user-guide/openbaocluster/operations/index.mdx
@@ -55,13 +55,13 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
     {
       eyebrow: '01',
       title: 'Production checklist',
-      description: 'Use the checklist before you call an environment production-ready or supportable.',
+      description: 'Use the checklist to confirm an environment is production-ready and supportable.',
       docId: 'user-guide/openbaocluster/operations/production-checklist',
     },
     {
       eyebrow: '02',
       title: 'Configure backups',
-      description: 'Set up snapshot streaming, backup identity, and restore readiness before you need them.',
+      description: 'Set up snapshot streaming, backup identity, and restore readiness as part of the operating baseline.',
       docId: 'user-guide/openbaocluster/operations/backups',
     },
     {

--- a/docs/user-guide/openbaocluster/operations/index.mdx
+++ b/docs/user-guide/openbaocluster/operations/index.mdx
@@ -22,7 +22,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
     items={[
       'close the gap between a working cluster and a supportable service',
       'put backups and upgrade planning in place before risky change',
-      'use maintenance and pause controls deliberately instead of improvising',
+      'use maintenance and pause controls with the intended operating model',
       'move into recovery and restore when troubleshooting is no longer enough',
     ]}
   />
@@ -38,7 +38,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
     },
     {
       label: 'Cluster Controls',
-      description: 'Use maintenance, pause, and decommission workflows when you need to change controller behavior deliberately.',
+      description: 'Use maintenance, pause, and decommission workflows to change controller behavior safely.',
       docId: 'user-guide/openbaocluster/operations/maintenance',
     },
     {
@@ -91,7 +91,7 @@ description: Upgrade, back up, maintain, troubleshoot, recover, and restore Open
     {
       eyebrow: '03',
       title: 'Decommission a cluster',
-      description: 'Remove a cluster deliberately with the right deletion policy for data, PVCs, and external backups.',
+      description: 'Remove a cluster with the deletion policy that matches data, PVCs, and external backups.',
       docId: 'user-guide/openbaocluster/operations/deletion',
     },
   ]}

--- a/docs/user-guide/openbaocluster/operations/maintenance.md
+++ b/docs/user-guide/openbaocluster/operations/maintenance.md
@@ -212,7 +212,7 @@ kubectl exec -n <namespace> -it <pod-name> -- bao operator raft list-peers`}
     },
     {
       label: 'Decommission a cluster',
-      description: 'Choose the right teardown policy before you remove a cluster and its storage.',
+      description: 'Choose the teardown policy that matches the cluster and storage cleanup you intend to perform.',
       docId: 'user-guide/openbaocluster/operations/deletion',
     },
     {

--- a/docs/user-guide/openbaocluster/operations/maintenance.md
+++ b/docs/user-guide/openbaocluster/operations/maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: Run Planned Maintenance
-description: Drain nodes, scale the cluster, enable maintenance mode, and restart Pods without guessing how quorum and admission policy interact.
+description: Drain nodes, scale the cluster, enable maintenance mode, and restart Pods with the expected quorum and admission-policy behavior.
 slug: /operate/maintenance
 hide_title: true
 pageType: task

--- a/docs/user-guide/openbaocluster/operations/maintenance.md
+++ b/docs/user-guide/openbaocluster/operations/maintenance.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Use cluster controls deliberately when you need to change the platform underneath OpenBao."
-  lede="Planned maintenance is where Kubernetes disruption rules, Raft quorum, and admission-policy guardrails all meet. Use this page to prepare drains and restarts, scale safely, and confirm the cluster is still healthy before you hand it back to normal operations."
+  title="Run planned maintenance safely"
+  lede="Planned maintenance is where Kubernetes disruption rules, Raft quorum, and admission-policy guardrails meet. Use this page to prepare drains and restarts, scale safely, and confirm the cluster returns to normal operation."
 />
 
 

--- a/docs/user-guide/openbaocluster/operations/maintenance.md
+++ b/docs/user-guide/openbaocluster/operations/maintenance.md
@@ -40,7 +40,7 @@ journey: operate
         'Maintenance mode',
         'Admission policy requires the `openbao.org/maintenance=true` signal before restarts or controlled deletes.',
         'The operator annotates managed resources so maintenance-only actions are allowed under the configured break-glass groups.',
-        'This is not a generic bypass for random edits. It is a controlled operational mode.',
+        'This is a controlled operational mode for maintenance-only actions under the configured break-glass groups.',
       ],
     },
     {
@@ -48,7 +48,7 @@ journey: operate
         'Pause reconciliation',
         'You need a short-lived window where the operator stops mutating the cluster while you inspect or repair it.',
         'The operator stops normal reconciliation until you resume it.',
-        'Pausing is not the same thing as recovery and is not enough for safe-mode incidents.',
+        'Pausing stops normal reconciliation, but safe-mode incidents still require the dedicated recovery flow.',
       ],
     },
   ]}

--- a/docs/user-guide/openbaocluster/operations/pausing.md
+++ b/docs/user-guide/openbaocluster/operations/pausing.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Pause the operator only when you need a short-lived manual window."
-  lede="Pausing tells the operator to stop normal reconciliation for a specific cluster while you inspect or repair it. Use it for deliberate tactical work, not as a substitute for recovery workflows or as a long-term steady state."
+  title="Pause reconciliation for a short manual window"
+  lede="Pausing tells the operator to stop normal reconciliation for a specific cluster while you inspect or repair it. Use it for short, deliberate manual work; recovery workflows and long-running manual management should use their own paths."
 />
 
 <Checklist

--- a/docs/user-guide/openbaocluster/operations/production-checklist.md
+++ b/docs/user-guide/openbaocluster/operations/production-checklist.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Make the cluster boring before you call it production."
-  lede="Use this checklist after the first cluster path succeeds and before teams depend on the service. The goal is to lock down the security posture, protect data, prove observability, and confirm that the operator reports a clean converged state."
+  title="Production readiness checklist"
+  lede="Use this checklist after the first cluster path succeeds and before teams depend on the service. It covers security posture, data protection, observability, and the operator-reported signals that should be clean before production use."
 />
 
 <DecisionTable

--- a/docs/user-guide/openbaocluster/operations/production-checklist.md
+++ b/docs/user-guide/openbaocluster/operations/production-checklist.md
@@ -1,6 +1,6 @@
 ---
 title: Production Checklist
-description: Verify security, durability, observability, and readiness before you route real traffic through an OpenBao cluster.
+description: Verify security, durability, observability, and readiness for an OpenBao cluster that will serve real traffic.
 slug: /operate/production-checklist
 hide_title: true
 pageType: task
@@ -46,7 +46,7 @@ journey: operate
       cells: [
         'Cluster readiness',
         'The status conditions show healthy convergence and no unresolved integration blockers.',
-        'A production launch should start from a stable status surface, not an optimistic assumption.',
+        'Start a production launch from a stable status surface rather than an optimistic assumption.',
         'Use the final verification commands on this page.',
       ],
     },
@@ -62,7 +62,7 @@ journey: operate
 - Enable `spec.selfInit` and configure real user authentication in `spec.selfInit.requests` so the first operator-driven bootstrap does not end in a lockout.
 - If you rely on operator lifecycle auth for backups and upgrades, enable `spec.selfInit.oidc.enabled: true` or deliberately provision the equivalent JWT roles yourself.
 
-<Callout type="warning" title="Do not stop at install success">
+<Callout type="warning" title="Install success is not the production gate">
 
 A cluster that initializes successfully still needs security hardening, backup readiness, and clean status conditions before it is ready for production.
 
@@ -92,7 +92,7 @@ A cluster that initializes successfully still needs security hardening, backup r
 kubectl get deploy -n <operator-namespace>
 kubectl get openbaotenant -A`}
 >
-  The exact number of policies and controller Deployments depends on the features you enabled, but the OpenBao guardrail set should be visible before you bring real tenants onto the platform.
+  The exact number of policies and controller Deployments depends on the features you enabled, but the OpenBao guardrail set must be visible before you bring real tenants onto the platform.
 </CommandBlock>
 
 ## Make the cluster durable
@@ -114,7 +114,7 @@ Include backup success and restore confidence in the launch checklist rather tha
 - Configure metrics scraping through Prometheus Operator (`ServiceMonitor`) or VictoriaMetrics Operator (`VMServiceScrape`).
 - Grant the scraping identity permission to read `/metrics` and keep TLS verification strict in production.
 - Make sure structured logs including `cluster_name` and `cluster_namespace` reach the log system your operators actually use.
-- Alert on backup staleness, degradation, reconciliation failures, and other conditions that should wake a human before tenants feel the failure.
+- Alert on backup staleness, degradation, reconciliation failures, and other conditions that warrant human intervention before tenants feel the failure.
 
 ## Verify the cluster before routing traffic
 
@@ -170,12 +170,12 @@ kubectl get openbaocluster <name> -n <namespace> -o jsonpath='{.status.phase}{"\
   items={[
     {
       label: 'Configure backups',
-      description: 'Lock in the snapshot path before you plan the first upgrade or maintenance window.',
+      description: 'Lock in the snapshot path as part of upgrade and maintenance planning.',
       docId: 'user-guide/openbaocluster/operations/backups',
     },
     {
       label: 'Plan upgrades',
-      description: 'Choose the right rollout strategy before you patch the version field on a production cluster.',
+      description: 'Choose the right rollout strategy for the next production version change.',
       docId: 'user-guide/openbaocluster/operations/upgrades',
     },
     {

--- a/docs/user-guide/openbaocluster/operations/production-checklist.md
+++ b/docs/user-guide/openbaocluster/operations/production-checklist.md
@@ -64,7 +64,7 @@ journey: operate
 
 <Callout type="warning" title="Do not stop at install success">
 
-A cluster that initializes successfully is not automatically ready for production. The production gate is the combination of security hardening, backup readiness, and clean status conditions, not the fact that pods started once.
+A cluster that initializes successfully still needs security hardening, backup readiness, and clean status conditions before it is ready for production.
 
 </Callout>
 
@@ -105,7 +105,7 @@ kubectl get openbaotenant -A`}
 
 <Callout type="note" title="Backups are part of the production gate">
 
-Treat backup success and restore confidence as part of the launch checklist, not as follow-up work for a later sprint.
+Include backup success and restore confidence in the launch checklist rather than deferring them to later follow-up work.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/operations/troubleshooting.md
+++ b/docs/user-guide/openbaocluster/operations/troubleshooting.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Start with the symptom, then decide whether you need a fix or a recovery path."
-  lede="Most day 2 incidents start as configuration drift, edge integration failures, or capability mismatches. Use this page to capture the failing surface, route the symptom to the right fix, and escalate into recovery only when normal convergence is no longer realistic."
+  title="Troubleshoot by symptom"
+  lede="Use this page to capture the failing surface, route the symptom to the right fix, and decide when recovery is the better path."
 />
 
 
@@ -22,7 +22,7 @@ journey: operate
 kubectl get pods -n <namespace>
 kubectl describe pod <pod> -n <namespace>`}
 >
-  Start here before you jump into a fix. The cluster status, recent events, and the specific pod failures usually tell you whether the problem is inside the workload, at the edge, or in cluster policy.
+  Start here to identify the failing surface. The cluster status, recent events, and the specific pod failures usually tell you whether the problem is inside the workload, at the edge, or in cluster policy.
 </CommandBlock>
 
 <DecisionTable

--- a/docs/user-guide/openbaocluster/operations/troubleshooting.md
+++ b/docs/user-guide/openbaocluster/operations/troubleshooting.md
@@ -263,7 +263,7 @@ Normal troubleshooting stops being the right tool when the incident is no longer
     },
     {
       label: 'Review backup operations',
-      description: 'Confirm the snapshot path is healthy before you rely on restore as part of the incident response.',
+      description: 'Confirm snapshot-path health before restore becomes part of the incident response.',
       docId: 'user-guide/openbaocluster/operations/backups',
     },
     {

--- a/docs/user-guide/openbaocluster/operations/upgrades.md
+++ b/docs/user-guide/openbaocluster/operations/upgrades.md
@@ -8,7 +8,7 @@ journey: operate
 ---
 
 <PageHeader
-  title="Treat version changes as planned operations, not a quick spec patch."
+  title="Upgrade planning and rollout"
   lede="The operator supports rolling and blue-green upgrades, but both paths depend on cluster health, backup posture, and explicit authentication for the executor Jobs. Use this page to choose the strategy, stage the right config, and verify the rollout cleanly."
 />
 
@@ -67,7 +67,7 @@ Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a s
     class Verify,Complete,Hold write;`}
 />
 
-## Before you patch `spec.version`
+## Prepare the rollout
 
 - Confirm the cluster is initialized, healthy, and already safe to change. An upgrade is not the time to discover a broken backup path or an unstable seal configuration.
 - Set `spec.version` to the target semantic version. The operator blocks downgrades and validates semver format.

--- a/docs/user-guide/openbaocluster/operations/upgrades.md
+++ b/docs/user-guide/openbaocluster/operations/upgrades.md
@@ -243,7 +243,7 @@ kubectl get jobs -n <namespace>`}
 
 <DecisionTable
   kind="reference"
-  title="What good looks like after the upgrade"
+  title="Expected signals after the upgrade"
   columns={['Surface', 'Healthy signal', 'Why it matters']}
   rows={[
     {
@@ -272,7 +272,7 @@ kubectl get jobs -n <namespace>`}
       cells: [
         'Protection path',
         'Backup status and external dependency conditions remain healthy.',
-        'A successful version change should not quietly break the next restore or backup window.',
+        'A successful version change keeps the next restore or backup window intact.',
       ],
     },
   ]}

--- a/docs/user-guide/openbaocluster/overview.md
+++ b/docs/user-guide/openbaocluster/overview.md
@@ -8,8 +8,8 @@ description: Understand what OpenBaoCluster owns, what the operator protects aut
 ---
 
 <PageHeader
-  title="Read OpenBaoCluster as the contract for the whole service, not just a CRD."
-  lede="`OpenBaoCluster` is the declarative contract for the running OpenBao service on Kubernetes. It sets the cluster shape, service boundary, storage path, and day 2 capabilities the operator will keep reconciling. Use this page to orient the rest of Configure before you start editing individual fields."
+  title="OpenBaoCluster as the service contract"
+  lede="`OpenBaoCluster` is the declarative contract for the running OpenBao service on Kubernetes. It sets the cluster shape, service boundary, storage path, and day 2 capabilities the operator will keep reconciling. Use this page to orient the rest of Configure and understand which areas to tune next."
 />
 
 <Checklist

--- a/docs/user-guide/openbaocluster/overview.md
+++ b/docs/user-guide/openbaocluster/overview.md
@@ -13,12 +13,12 @@ description: Understand what OpenBaoCluster owns, what the operator protects aut
 />
 
 <Checklist
-    title="A good read of this page should leave you with"
+    title="Use this page to understand"
     items={[
       "a clear view of what the operator owns versus what the platform still expects from you",
       "the right mental model for spec as desired state and status as the observed operating surface",
       "a shorter list of pages to read next instead of a flat wall of configuration topics",
-      "the confidence to shape the first cluster without treating the CR as an arbitrary field dump",
+      "how to shape the first cluster around the main operating decisions",
     ]}
   />
 
@@ -116,7 +116,7 @@ spec:
   backup:
     schedule: "0 3 * * *"`}
 >
-  The point is not to memorize every field. It is to see the major configuration surfaces that map to the rest of the section: baseline, service boundary, platform readiness, and day 2 operations.
+  This example shows the major configuration surfaces that map to the rest of the section: baseline, service boundary, platform readiness, and day 2 operations.
 </CommandBlock>
 
 <RouteList
@@ -148,7 +148,7 @@ spec:
   items={[
     {
       label: "Security profiles",
-      description: "Start with the production posture and bootstrap model before you spend time on edge or observability details.",
+      description: "Start with the production posture and bootstrap model, then refine edge and observability details.",
       docId: "user-guide/openbaocluster/configuration/security-profiles",
     },
     {

--- a/docs/user-guide/openbaocluster/recovery/failed-rollback.md
+++ b/docs/user-guide/openbaocluster/recovery/failed-rollback.md
@@ -8,7 +8,7 @@ journey: operate
 ---
 
 <PageHeader
-  title="Repair rollback failures without forcing a downgrade."
+  title="Recover from failed rollback"
   lede="A failed rollback means blue-green automation stopped because continuing automatically could worsen Raft safety or cluster availability. Start with the status surface and the last failed rollback Job, then decide whether the right next step is a retry, a controlled pause for manual repair, or a restore from backup."
 />
 

--- a/docs/user-guide/openbaocluster/recovery/failed-rollback.md
+++ b/docs/user-guide/openbaocluster/recovery/failed-rollback.md
@@ -18,7 +18,7 @@ journey: operate
       'a blue-green rollback enters break glass mode',
       'the rollback consensus repair job failed and automation stopped',
       'you need to decide whether the rollback can safely retry or needs manual repair',
-      'you need to restore from a known-good snapshot because rollback repair is no longer enough',
+      'you need to restore from a recovery snapshot because rollback repair is no longer enough',
     ]}
   />
 
@@ -51,7 +51,7 @@ Do not force `spec.version` back to an older release to escape the incident. Dow
     {
       cells: [
         'The cluster state is beyond safe rollback repair.',
-        'Restore from a known-good snapshot.',
+        'Restore from a recovery snapshot.',
         'Restore is the explicit recovery path when continuing the rollback is no longer trustworthy.',
       ],
     },
@@ -92,7 +92,7 @@ kubectl exec -n <namespace> -it <pod-name> -- bao operator raft list-peers`}
   Look for network isolation between blue and green Pods, stuck or sealed Pods, peer membership that no longer matches the intended rollback topology, or executor-job failures that prevented the rollback from completing.
 </CommandBlock>
 
-If the break-glass reason is `RollbackCleanupPeerRemovalFailed`, spend extra time verifying that no stale green peers remain in Raft membership before you acknowledge the nonce. A retry will create a fresh rollback-cleanup attempt, so the live peer list needs to match the rollback intent first.
+If the break-glass reason is `RollbackCleanupPeerRemovalFailed`, verify that no stale green peers remain in Raft membership before you acknowledge the nonce. A retry will create a fresh rollback-cleanup attempt, so the live peer list needs to match the rollback intent first.
 
 <Callout type="note" title="Use maintenance mode before disruptive manual repair">
 
@@ -159,7 +159,7 @@ After you repair the cluster, resume reconciliation and acknowledge the current 
 Use this when the rollback surface is no longer safe to repair in place.
 
 1. stop any further automation
-2. identify the last known-good snapshot
+2. identify the snapshot selected for recovery
 3. follow <SiteLink docId="user-guide/openbaorestore/recovery-restore-after-upgrade">Recover After Upgrade Restore</SiteLink>
 
 </TabItem>

--- a/docs/user-guide/openbaocluster/recovery/index.mdx
+++ b/docs/user-guide/openbaocluster/recovery/index.mdx
@@ -11,18 +11,18 @@ description: Choose the right incident recovery or backup-driven restore path wh
   variant="landing"
   eyebrow="Operate / Recovery & Restore"
   title="Recovery and restore"
-  lede="This section covers incident recovery and backup-driven restore workflows. Use it when troubleshooting is no longer enough and the cluster needs focused recovery steps or an explicit `OpenBaoRestore` request."
+  lede="Use these guides for incident recovery and backup-driven restore workflows when troubleshooting is no longer enough and the cluster needs focused recovery steps or an explicit `OpenBaoRestore` request."
   actions={[
     {label: 'Run a restore', docId: 'user-guide/openbaorestore/restore', variant: 'primary'},
     {label: 'Enter safe mode', docId: 'user-guide/openbaocluster/recovery/safe-mode', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use this section when you need to"
+    title="Use recovery when you need to"
     items={[
       'decide whether the cluster still has a normal repair path',
       'move from incident diagnosis into a narrow recovery runbook',
-      'restore state from backup without guessing at the destructive impact',
+      'restore state from backup with a clear view of the destructive impact',
       'return the cluster to normal operations only after the status surface is clean again',
     ]}
   />
@@ -120,7 +120,7 @@ description: Choose the right incident recovery or backup-driven restore path wh
     },
     {
       label: 'Check backup readiness',
-      description: 'Good recovery depends on the snapshot path already being healthy before the incident starts.',
+      description: 'Recovery depends on the snapshot path already being healthy before the incident starts.',
       docId: 'user-guide/openbaocluster/operations/backups',
     },
     {

--- a/docs/user-guide/openbaocluster/recovery/index.mdx
+++ b/docs/user-guide/openbaocluster/recovery/index.mdx
@@ -10,8 +10,8 @@ description: Choose the right incident recovery or backup-driven restore path wh
 <PageHero
   variant="landing"
   eyebrow="Operate / Recovery & Restore"
-  title="Separate incident recovery from backup-driven restore."
-  lede="This section exists for the moments when normal troubleshooting is no longer enough. Some failures need a focused recovery path such as safe mode or no-leader repair. Others are better handled by restoring known-good state from backup through an explicit `OpenBaoRestore` request."
+  title="Recovery and restore"
+  lede="This section covers incident recovery and backup-driven restore workflows. Use it when troubleshooting is no longer enough and the cluster needs focused recovery steps or an explicit `OpenBaoRestore` request."
   actions={[
     {label: 'Run a restore', docId: 'user-guide/openbaorestore/restore', variant: 'primary'},
     {label: 'Enter safe mode', docId: 'user-guide/openbaocluster/recovery/safe-mode', variant: 'secondary'},

--- a/docs/user-guide/openbaocluster/recovery/index.mdx
+++ b/docs/user-guide/openbaocluster/recovery/index.mdx
@@ -11,14 +11,14 @@ description: Choose the right incident recovery or backup-driven restore path wh
   variant="landing"
   eyebrow="Operate / Recovery & Restore"
   title="Recovery and restore"
-  lede="Use these guides for incident recovery and backup-driven restore workflows when troubleshooting is no longer enough and the cluster needs focused recovery steps or an explicit `OpenBaoRestore` request."
+  lede="Incident recovery and backup-driven restore workflows for clusters that need focused recovery steps or an explicit `OpenBaoRestore` request."
   actions={[
     {label: 'Run a restore', docId: 'user-guide/openbaorestore/restore', variant: 'primary'},
     {label: 'Enter safe mode', docId: 'user-guide/openbaocluster/recovery/safe-mode', variant: 'secondary'},
   ]}
 >
   <Checklist
-    title="Use recovery when you need to"
+    title="Use recovery to"
     items={[
       'decide whether the cluster still has a normal repair path',
       'move from incident diagnosis into a narrow recovery runbook',

--- a/docs/user-guide/openbaocluster/recovery/no-leader.md
+++ b/docs/user-guide/openbaocluster/recovery/no-leader.md
@@ -53,7 +53,7 @@ journey: operate
       cells: [
         'No node can form quorum and there is no healthy leader to remove peers from.',
         'Use manual quorum recovery with `peers.json` as a last resort.',
-        'This is destructive and should be used only when automatic recovery is no longer possible.',
+        'This is destructive. Use it only when automatic recovery is no longer possible.',
       ],
     },
   ]}
@@ -112,7 +112,7 @@ kubectl exec -n <namespace> -it <pod-a> -- nslookup <pod-b>.<headless-service>`}
 
 Check these first when the transport path is broken:
 
-- `NetworkPolicy` rules that should allow cluster-to-cluster traffic
+- `NetworkPolicy` rules that allow cluster-to-cluster traffic
 - service and headless-service DNS resolution
 - sidecar or mesh policies that may block direct Pod-to-Pod communication
 

--- a/docs/user-guide/openbaocluster/recovery/no-leader.md
+++ b/docs/user-guide/openbaocluster/recovery/no-leader.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Repair quorum before you change Raft membership."
-  lede="A no-leader incident is not one thing. Sometimes the cluster cannot elect because pods are crash-looping or the cluster port is blocked. Sometimes a dead peer still counts toward quorum. Only when those narrower fixes are exhausted should you move into manual quorum recovery."
+  title="Diagnose no-leader conditions before manual Raft recovery"
+  lede="A no-leader incident can come from crash-looping pods, blocked cluster traffic, or stale peers that still count toward quorum. Use this runbook to narrow the failure mode and decide whether a manual quorum-recovery path is actually required."
 />
 
 <Checklist
@@ -24,7 +24,7 @@ journey: operate
 
 
 <DecisionTable
-  title="Match the failure before you repair it"
+  title="Match the failure mode"
   columns={['Signal', 'Start with', 'Why']}
   rows={[
     {

--- a/docs/user-guide/openbaocluster/recovery/safe-mode.md
+++ b/docs/user-guide/openbaocluster/recovery/safe-mode.md
@@ -85,7 +85,7 @@ For blue-green rollback incidents, the most common reasons are:
 - `RollbackConsensusRepairFailed`: the operator could not complete the rollback repair path while the cluster was still in `RollingBack`.
 - `RollbackCleanupPeerRemovalFailed`: the rollback itself converged far enough to enter `RollbackCleanup`, but the peer-removal cleanup job failed and automation stopped before stale green peers were safely removed.
 
-## Repair the underlying issue before you acknowledge
+## Repair the underlying issue
 
 Start with the operator-visible status and the last failed job, then move into the narrower runbook that matches the cluster state.
 

--- a/docs/user-guide/openbaocluster/recovery/safe-mode.md
+++ b/docs/user-guide/openbaocluster/recovery/safe-mode.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Use safe mode to stop risky automation and recover control."
-  lede="Break glass or safe mode is the operator's explicit stop signal when continuing rollback automation could make availability or Raft safety worse. Use this page to inspect the break-glass state, stabilize the cluster, repair the failure, and only then let automation resume."
+  title="Safe mode and break-glass recovery"
+  lede="Break glass or safe mode is the operator's explicit stop signal when continuing rollback automation could make availability or Raft safety worse. Use this page to inspect the break-glass state, stabilize the cluster, repair the failure, and then resume automation."
 />
 
 <Checklist
@@ -39,7 +39,7 @@ journey: operate
       cells: [
         'status.breakGlass populated',
         'The cluster status contains the reason, message, nonce, and suggested next checks.',
-        'You should diagnose from that status first instead of guessing which internal job failed.',
+        'Start with that status so the recovery path follows the recorded failure reason and suggested checks.',
       ],
     },
     {

--- a/docs/user-guide/openbaocluster/recovery/sealed-cluster.md
+++ b/docs/user-guide/openbaocluster/recovery/sealed-cluster.md
@@ -8,8 +8,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Treat seal failures as trust and reachability problems first."
-  lede="A sealed cluster usually means the Pods can start but cannot complete the trust or unseal path they need to serve traffic. Start with the operator-visible conditions, then narrow the problem by seal mode before you reach for emergency manual unseal."
+  title="Diagnose a sealed cluster"
+  lede="A sealed cluster usually means the Pods can start but cannot complete the configured trust or unseal path they need to serve traffic. Use this runbook to start with operator-visible conditions, then narrow the problem by seal mode and move to emergency manual unseal only if needed."
 />
 
 <Checklist
@@ -24,7 +24,7 @@ journey: operate
 
 
 <DecisionTable
-  title="Read the first conditions before you dig into logs"
+  title="Read the first conditions"
   columns={['Condition or signal', 'What it usually means', 'Where to look next']}
   rows={[
     {

--- a/docs/user-guide/openbaorestore/overview.md
+++ b/docs/user-guide/openbaorestore/overview.md
@@ -21,7 +21,7 @@ journey: operate
       cells: [
         'Disaster recovery',
         'You need to reintroduce known-good state after severe corruption, cluster loss, or a failed repair path.',
-        'Restore overwrites the target cluster. Validate the snapshot and target before you create the request.',
+        'Restore overwrites the target cluster. Validate the snapshot and target as part of request preparation.',
       ],
       emphasis: 'recommended',
     },
@@ -42,8 +42,8 @@ journey: operate
     {
       cells: [
         'Ordinary troubleshooting',
-        'Start with the incident recovery or troubleshooting guides unless snapshot restore is already the selected recovery action.',
-        'Prefer a narrower repair path while it can still recover the cluster without overwriting state.',
+        'Use the incident recovery or troubleshooting guides unless snapshot restore is already the selected recovery action.',
+        'Restore remains a destructive action while narrower repair paths are still viable.',
       ],
     },
   ]}
@@ -145,7 +145,7 @@ spec:
     },
     {
       label: 'Recover after upgrade restore',
-      description: 'Use the override-lock runbook when a failed upgrade blocks the normal restore workflow.',
+      description: 'Use the override-lock runbook if a failed upgrade blocks the normal restore workflow.',
       docId: 'user-guide/openbaorestore/recovery-restore-after-upgrade',
     },
     {

--- a/docs/user-guide/openbaorestore/overview.md
+++ b/docs/user-guide/openbaorestore/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Restore Overview
-description: Understand when restore is the right tool, why it is modeled as OpenBaoRestore, and what safety boundaries it keeps in place.
+description: Understand when restore is appropriate, why it is modeled as OpenBaoRestore, and which safety boundaries it enforces.
 hide_title: true
 pageType: concept
 journey: operate
@@ -21,7 +21,7 @@ journey: operate
       cells: [
         'Disaster recovery',
         'You need to reintroduce known-good state after severe corruption, cluster loss, or a failed repair path.',
-        'Restore overwrites the target cluster. Validate the snapshot and target before you start.',
+        'Restore overwrites the target cluster. Validate the snapshot and target before you create the request.',
       ],
       emphasis: 'recommended',
     },
@@ -51,7 +51,7 @@ journey: operate
 
 <DiagramFrame
   title="Restore control flow"
-  caption="A restore request is validated, acquires the cluster operation lock, then launches a restore Job that pulls the snapshot and injects it into the target cluster. The workflow is explicit so destructive recovery does not hide inside normal reconciliation."
+  caption="A restore request is validated, acquires the cluster operation lock, then launches a restore Job that pulls the snapshot and injects it into the target cluster. The explicit request keeps destructive recovery separate from normal reconciliation."
   code={`flowchart LR
     Request["OpenBaoRestore request"] --> Validate["Validate target, source, and auth"]
     Validate --> Lock["Acquire restore lock"]
@@ -145,7 +145,7 @@ spec:
     },
     {
       label: 'Recover after upgrade restore',
-      description: 'Use the override-lock runbook only when a failed upgrade blocks the normal restore workflow.',
+      description: 'Use the override-lock runbook when a failed upgrade blocks the normal restore workflow.',
       docId: 'user-guide/openbaorestore/recovery-restore-after-upgrade',
     },
     {

--- a/docs/user-guide/openbaorestore/overview.md
+++ b/docs/user-guide/openbaorestore/overview.md
@@ -7,8 +7,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Treat restore as an explicit destructive workflow."
-  lede="Restore is modeled as `OpenBaoRestore`, an immutable request object that keeps disaster recovery visible, auditable, and separate from normal cluster reconciliation. Use this page to understand when restore is appropriate and what boundaries it enforces before you run it."
+  title="Restore workflow overview"
+  lede="Restore is modeled as `OpenBaoRestore`, an immutable request object that keeps disaster recovery visible, auditable, and separate from normal cluster reconciliation. Use this page to understand when restore is appropriate and what boundaries it enforces."
 />
 
 

--- a/docs/user-guide/openbaorestore/overview.md
+++ b/docs/user-guide/openbaorestore/overview.md
@@ -42,8 +42,8 @@ journey: operate
     {
       cells: [
         'Ordinary troubleshooting',
-        'Restore is usually not the first move. Start with the incident recovery or troubleshooting guides first.',
-        'Do not overwrite state while a narrower repair path is still viable.',
+        'Start with the incident recovery or troubleshooting guides unless snapshot restore is already the selected recovery action.',
+        'Prefer a narrower repair path while it can still recover the cluster without overwriting state.',
       ],
     },
   ]}

--- a/docs/user-guide/openbaorestore/recovery-restore-after-upgrade.md
+++ b/docs/user-guide/openbaorestore/recovery-restore-after-upgrade.md
@@ -7,12 +7,12 @@ journey: operate
 ---
 
 <PageHeader
-  title="Use override restore only when the cluster is locked after a failed upgrade."
-  lede="This runbook exists for the narrow case where the normal restore path is blocked by an existing cluster operation lock, usually after a failed rollback or another crashed automation loop. It is a break-glass restore path, not the default way to restore a cluster."
+  title="Override-lock restore after a failed upgrade"
+  lede="This runbook covers the case where the normal restore path is blocked by an existing cluster operation lock, usually after a failed rollback or another crashed automation loop. Use it for recovery when the restore request cannot proceed through the normal lock path."
 />
 
 <Checklist
-    title="Use this runbook only when"
+    title="Use this runbook when"
     items={[
       'the cluster is stuck behind an operation lock after a failed upgrade or rollback',
       'a normal OpenBaoRestore request is blocked by that lock',

--- a/docs/user-guide/openbaorestore/recovery-restore-after-upgrade.md
+++ b/docs/user-guide/openbaorestore/recovery-restore-after-upgrade.md
@@ -44,7 +44,7 @@ This path ignores the current lock owner, overwrites cluster state with the sele
       cells: [
         '`overrideOperationLock: true`',
         'Clears the existing cluster operation lock so restore can proceed.',
-        'This is the field that turns the request into an override path rather than a routine restore.',
+        'This field marks the request as an override path rather than a routine restore.',
       ],
     },
     {
@@ -57,7 +57,7 @@ This path ignores the current lock owner, overwrites cluster state with the sele
   ]}
 />
 
-## Create the break-glass restore request
+## Create the override restore request
 
 <CommandBlock
   language="yaml"
@@ -83,7 +83,7 @@ spec:
   force: true
   overrideOperationLock: true`}
 >
-  `force` is required when restore targets an unhealthy cluster. `overrideOperationLock` bypasses the stuck upgrade or backup lock. Keep them together for this override path.
+  `force` is required when restore targets an unhealthy cluster. `overrideOperationLock` bypasses the stuck upgrade or backup lock. Together they define the override request.
 </CommandBlock>
 
 <CommandBlock
@@ -103,7 +103,7 @@ spec:
 kubectl describe openbaocluster <cluster> -n <namespace>
 kubectl get jobs -n <namespace>`}
 >
-  A completed restore only means the restore workflow finished. The target cluster may still require unseal, Raft repair, or break-glass acknowledgment before it is truly operational again.
+  A completed restore means the restore workflow finished. The target cluster may still require unseal, Raft repair, or break-glass acknowledgment before it is ready for service again.
 </CommandBlock>
 
 <NextActions

--- a/docs/user-guide/openbaorestore/recovery-restore-after-upgrade.md
+++ b/docs/user-guide/openbaorestore/recovery-restore-after-upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Recover After Upgrade Restore
-description: Use the override-lock restore path only when a failed upgrade or rollback blocks the normal restore workflow.
+description: Use the override-lock restore path when a failed upgrade or rollback blocks the normal restore workflow.
 hide_title: true
 pageType: runbook
 journey: operate
@@ -44,7 +44,7 @@ This path ignores the current lock owner, overwrites cluster state with the sele
       cells: [
         '`overrideOperationLock: true`',
         'Clears the existing cluster operation lock so restore can proceed.',
-        'This is what makes the workflow break-glass instead of routine restore.',
+        'This is the field that turns the request into an override path rather than a routine restore.',
       ],
     },
     {
@@ -83,7 +83,7 @@ spec:
   force: true
   overrideOperationLock: true`}
 >
-  `force` is required when restore targets an unhealthy cluster. `overrideOperationLock` is what bypasses the stuck upgrade or backup lock. Keep them together only for this break-glass path.
+  `force` is required when restore targets an unhealthy cluster. `overrideOperationLock` bypasses the stuck upgrade or backup lock. Keep them together for this override path.
 </CommandBlock>
 
 <CommandBlock

--- a/docs/user-guide/openbaorestore/restore.md
+++ b/docs/user-guide/openbaorestore/restore.md
@@ -7,8 +7,8 @@ journey: operate
 ---
 
 <PageHeader
-  title="Run a restore only when you are ready to overwrite the target cluster."
-  lede="The operator restores snapshot state through an explicit `OpenBaoRestore` request. That request validates the target, acquires the restore operation lock, launches a dedicated restore Job, and records the outcome for audit. Use this page when restore is the right answer, not as a substitute for ordinary troubleshooting."
+  title="Restore from a snapshot"
+  lede="The operator restores snapshot state through an explicit `OpenBaoRestore` request. That request validates the target, acquires the restore operation lock, launches a dedicated restore Job, and records the outcome for audit. Use this page when snapshot restore is the right recovery workflow for the target cluster."
 />
 
 
@@ -100,7 +100,7 @@ Restore replaces the target cluster state with the contents of the selected snap
     class Status write;`}
 />
 
-## Before you create the restore request
+## Prepare the restore request
 
 - Make sure the snapshot you want already exists in object storage and has been validated as usable.
 - Create or keep the target `OpenBaoCluster` in the same namespace as the restore request. The target cluster must exist and be initialized, even if it is otherwise empty.

--- a/docs/user-guide/openbaorestore/restore.md
+++ b/docs/user-guide/openbaorestore/restore.md
@@ -15,7 +15,7 @@ journey: operate
 
 <Callout type="danger" title="Restore overwrites the target cluster">
 
-Restore replaces the target cluster state with the contents of the selected snapshot. All current secrets, policies, auth methods, and keys in that cluster are treated as replaceable state. Confirm the target namespace, target cluster, and snapshot key before you apply the request.
+Restore replaces the target cluster state with the contents of the selected snapshot. All current secrets, policies, auth methods, and keys in that cluster are treated as replaceable state. Verify the target namespace, target cluster, and snapshot key as part of the restore request.
 
 </Callout>
 
@@ -73,7 +73,7 @@ Restore replaces the target cluster state with the contents of the selected snap
         'Static token',
         'JWT auth is not available yet and you need a compatibility path for recovery.',
         'The restore Job reads a long-lived OpenBao token from a Secret in the same namespace.',
-        'Treat the token as a high-sensitivity credential and rotate it intentionally.',
+        'Store the token as a high-sensitivity credential and rotate it intentionally.',
       ],
     },
   ]}
@@ -225,7 +225,7 @@ That keeps the restore path aligned with the backup path you have already proven
   tokenSecretRef:
     name: restore-token`}
 >
-  Use this path only when JWT auth is not available. The Secret must be in the same namespace as the restore request.
+  Use this path if JWT auth is not available. The Secret must be in the same namespace as the restore request.
 </CommandBlock>
 
 </TabItem>
@@ -327,7 +327,7 @@ kubectl describe openbaocluster <cluster> -n <namespace>`}
     },
     {
       label: 'Recover after upgrade restore',
-      description: 'Use the override-lock path only when a failed upgrade or rollback blocks the normal restore request.',
+      description: 'Use the override-lock path if a failed upgrade or rollback blocks the normal restore request.',
       docId: 'user-guide/openbaorestore/recovery-restore-after-upgrade',
     },
   ]}

--- a/docs/user-guide/openbaorestore/restore.md
+++ b/docs/user-guide/openbaorestore/restore.md
@@ -1,6 +1,6 @@
 ---
 title: Restore from Backup
-description: Create an OpenBaoRestore request, wire snapshot access and restore auth, and verify the destructive recovery workflow deliberately.
+description: Create an OpenBaoRestore request, configure snapshot access and restore auth, and verify the restore workflow.
 hide_title: true
 pageType: task
 journey: operate
@@ -26,7 +26,7 @@ Restore replaces the target cluster state with the contents of the selected snap
     {
       cells: [
         '1. Prove the backup path first',
-        'Do not start here if the snapshot was never validated. Use the backup guide to confirm the object exists and the storage/auth path is already known-good.',
+        'Confirm the snapshot exists and that the backup storage and auth path already succeeded in the backup workflow.',
         'You know the exact snapshot key and can point to a successful backup object in storage.',
       ],
       emphasis: 'recommended',
@@ -34,7 +34,7 @@ Restore replaces the target cluster state with the contents of the selected snap
     {
       cells: [
         '2. Prepare the target cluster deliberately',
-        'Keep the target `OpenBaoCluster` in the same namespace, and make sure it already exists and can be reached by the restore Job.',
+        'Keep the target `OpenBaoCluster` in the same namespace, make sure it already exists, and confirm the restore Job can reach it.',
         'The target cluster resource exists, the namespace is correct, and the restore Job can reach object storage.',
       ],
     },
@@ -115,8 +115,8 @@ The `OpenBaoRestore`, the target `OpenBaoCluster`, and any referenced token Secr
 
 <Callout type="tip" title="For most first-time restores">
 
-If the target cluster already uses `spec.selfInit.oidc.enabled=true`, start with `jwtAuthRole: openbao-operator-restore` and the same object-storage provider shape you already proved in the backup flow.
-That is the shortest path from a tested backup to a tested restore.
+If the target cluster already uses `spec.selfInit.oidc.enabled=true`, start with `jwtAuthRole: openbao-operator-restore` and the same object-storage provider shape you already validated in the backup flow.
+That keeps the restore path aligned with the backup path you have already proven.
 
 </Callout>
 

--- a/docs/user-guide/openbaotenant/multi-tenancy.md
+++ b/docs/user-guide/openbaotenant/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenant Security
-description: Understand the default shared-operator security model, including namespace introduction, split controllers, RBAC boundaries, and tenant guardrails.
+description: Default shared-operator security model, including namespace introduction, split controllers, RBAC boundaries, and tenant guardrails.
 slug: /tenant-onboarding/multi-tenant-security
 hide_title: true
 pageType: concept
@@ -8,8 +8,8 @@ journey: security
 ---
 
 <PageHeader
-  title="Shared-operator boundaries in multi-tenant mode"
-  lede="This page explains why multi-tenant mode is the default production model, how namespace introduction stays explicit, and how the Provisioner and Controller split tenant access from workload reconciliation."
+  title="Shared-operator boundaries"
+  lede="This page covers namespace introduction, split controllers, RBAC boundaries, and tenant guardrails in the default multi-tenant model."
 />
 
 
@@ -22,7 +22,7 @@ Use [Single-Tenant Mode](../operator/single-tenant-mode.md) for dedicated enviro
 </Callout>
 
 <DiagramFrame
-  title="Why the control plane is split"
+  title="Control-plane split"
   caption="Namespace introduction and tenant guardrails stay with the Provisioner. Workload reconciliation stays with the tenant-scoped Controller. That separation prevents one long-running identity from both granting and consuming tenant access."
   code={`graph LR
     subgraph Cluster["Shared Kubernetes cluster"]
@@ -44,7 +44,7 @@ Use [Single-Tenant Mode](../operator/single-tenant-mode.md) for dedicated enviro
 />
 
 <DecisionTable
-  title="The control-plane split is the security model"
+  title="Control-plane security boundaries"
   columns={['Surface', 'Primary owner', 'Why it stays separate', 'If you shortcut it']}
   rows={[
     {

--- a/docs/user-guide/openbaotenant/multi-tenancy.md
+++ b/docs/user-guide/openbaotenant/multi-tenancy.md
@@ -8,8 +8,8 @@ journey: security
 ---
 
 <PageHeader
-  title="Understand the shared-operator boundary before you rely on multi-tenancy."
-  lede="Multi-tenant mode is the default production model because namespace introduction is explicit, the Provisioner and Controller stay separate, tenant access stays scoped, and guardrails are applied before a cluster ever lands in the namespace."
+  title="Shared-operator boundaries in multi-tenant mode"
+  lede="This page explains why multi-tenant mode is the default production model, how namespace introduction stays explicit, and how the Provisioner and Controller split tenant access from workload reconciliation."
 />
 
 
@@ -17,7 +17,7 @@ journey: security
 <Callout type="success" title="Default production model">
 
 Multi-tenant mode is the recommended production operating model for OpenBao Operator.
-Use [Single-Tenant Mode](../operator/single-tenant-mode.md) only when one team directly owns one namespace and intentionally bypasses the default tenant-onboarding boundary.
+Use [Single-Tenant Mode](../operator/single-tenant-mode.md) for dedicated environments where one team directly owns one namespace and does not need the default tenant-onboarding boundary.
 
 </Callout>
 

--- a/docs/user-guide/openbaotenant/multi-tenancy.md
+++ b/docs/user-guide/openbaotenant/multi-tenancy.md
@@ -9,7 +9,7 @@ journey: security
 
 <PageHeader
   title="Shared-operator boundaries"
-  lede="This page covers namespace introduction, split controllers, RBAC boundaries, and tenant guardrails in the default multi-tenant model."
+  lede="Review namespace introduction, split controllers, RBAC boundaries, and tenant guardrails in the default multi-tenant model."
 />
 
 
@@ -93,7 +93,7 @@ Use [Single-Tenant Mode](../operator/single-tenant-mode.md) for dedicated enviro
         '`openbaocluster-admin-role`',
         'Cluster',
         'Platform-level administration and exceptional cluster ownership.',
-        'It should not be the normal tenant user path.',
+        'Reserve this role for platform-level administration and exceptional cluster ownership.',
       ],
       emphasis: 'recommended',
     },
@@ -148,7 +148,7 @@ Use [Single-Tenant Mode](../operator/single-tenant-mode.md) for dedicated enviro
     {
       cells: [
         'Backup storage isolation',
-        'Each tenant should use object-storage credentials or prefixes that do not overlap with other tenants.',
+        'Use object-storage credentials or prefixes that do not overlap with other tenants.',
         'Make sure backup credentials cannot list or read other tenants\' snapshot paths.',
         'Backup operations',
       ],
@@ -175,7 +175,7 @@ kubectl get rolebinding,resourcequota,limitrange,networkpolicy -n <target-namesp
   code={`kubectl auth can-i create openbaoclusters.openbao.org -n <target-namespace> --as <tenant-user>
 kubectl auth can-i get secrets -n <target-namespace> --as <tenant-user>`}
 >
-  The normal tenant editor path should allow cluster lifecycle work without granting broad Secret reads by default.
+  Expect the normal tenant editor path to allow cluster lifecycle work without granting broad Secret reads by default.
 </CommandBlock>
 
 <Callout type="note" title="Supplemental policy engines are optional">

--- a/docs/user-guide/openbaotenant/onboarding.md
+++ b/docs/user-guide/openbaotenant/onboarding.md
@@ -9,8 +9,8 @@ journeyStep: 3
 ---
 
 <PageHeader
-  title="Introduce the target namespace before you create the first cluster."
-  lede="In the default multi-tenant model, the operator does not discover namespaces implicitly. You onboard a namespace with `OpenBaoTenant`, which gives the control plane the RBAC and tenant guardrails it needs before the first cluster lands there."
+  title="Onboard the target namespace"
+  lede="In the default multi-tenant model, the operator does not discover namespaces implicitly. You onboard a namespace with `OpenBaoTenant`, which installs the RBAC and tenant guardrails needed before the first cluster lands there."
 />
 
 <Callout type="note" title="Skip this in single-tenant mode">
@@ -160,7 +160,7 @@ If a namespace owner creates `OpenBaoTenant` in one namespace and targets a diff
 
 </Callout>
 
-## Verify onboarding before you create the cluster
+## Verify onboarding
 
 <CommandBlock
   language="bash"

--- a/docs/user-guide/openbaotenant/onboarding.md
+++ b/docs/user-guide/openbaotenant/onboarding.md
@@ -10,7 +10,7 @@ journeyStep: 3
 
 <PageHeader
   title="Onboard the target namespace"
-  lede="In the default multi-tenant model, the operator does not discover namespaces implicitly. You onboard a namespace with `OpenBaoTenant`, which installs the RBAC and tenant guardrails needed before the first cluster lands there."
+  lede="In the default multi-tenant model, you onboard a namespace with `OpenBaoTenant` before creating the first cluster there. This task installs the RBAC and tenant guardrails the operator depends on."
 />
 
 <Callout type="note" title="Skip this in single-tenant mode">
@@ -168,7 +168,7 @@ If a namespace owner creates `OpenBaoTenant` in one namespace and targets a diff
   title="Inspect the OpenBaoTenant status"
   code={`kubectl get openbaotenant <name> -n <namespace> -o yaml`}
 >
-  Look for `status.provisioned: true` and a healthy `Provisioned` condition before you move on to the first cluster manifest.
+  Look for `status.provisioned: true` and a healthy `Provisioned` condition before you apply the first cluster manifest.
 </CommandBlock>
 
 <DecisionTable

--- a/docs/user-guide/openbaotenant/onboarding.md
+++ b/docs/user-guide/openbaotenant/onboarding.md
@@ -1,6 +1,6 @@
 ---
 title: Onboard the Target Namespace
-description: Introduce the target namespace through OpenBaoTenant before you create the first cluster in the default multi-tenant path.
+description: Introduce the target namespace through OpenBaoTenant for the first cluster in the default multi-tenant path.
 slug: /get-started/onboard-target-namespace
 hide_title: true
 pageType: task
@@ -31,7 +31,7 @@ Create the Kubernetes namespace through your normal platform workflow first, the
   items={[
     {
       label: 'Choose a deployment model',
-      description: 'Lock down tenancy, security posture, install method, and the main exceptions before you install.',
+      description: 'Set tenancy, security posture, install method, and the main exceptions.',
       docId: 'user-guide/operator/deployment-decision-guide',
     },
     {

--- a/docs/user-guide/openbaotenant/onboarding.md
+++ b/docs/user-guide/openbaotenant/onboarding.md
@@ -168,7 +168,7 @@ If a namespace owner creates `OpenBaoTenant` in one namespace and targets a diff
   title="Inspect the OpenBaoTenant status"
   code={`kubectl get openbaotenant <name> -n <namespace> -o yaml`}
 >
-  Look for `status.provisioned: true` and a healthy `Provisioned` condition before you apply the first cluster manifest.
+  Confirm `status.provisioned: true` and a healthy `Provisioned` condition, then apply the first cluster manifest.
 </CommandBlock>
 
 <DecisionTable

--- a/docs/user-guide/openbaotenant/overview.md
+++ b/docs/user-guide/openbaotenant/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Tenancy & Governance
-description: Understand how OpenBaoTenant introduces namespaces, default guardrails, and the shared-operator boundary in the multi-tenant model.
+description: OpenBaoTenant namespace introduction, default guardrails, and the shared-operator boundary in the multi-tenant model.
 slug: /tenant-onboarding
 hide_title: true
 pageType: concept
@@ -8,8 +8,8 @@ journey: get-started
 ---
 
 <PageHeader
-  title="Introduce namespaces deliberately instead of letting the operator discover them."
-  lede="`OpenBaoTenant` is the namespace-introduction contract in the default multi-tenant model. It tells the operator which namespace should become an authorized tenant and lets the control plane create the RBAC and guardrails that make shared operation safe."
+  title="OpenBaoTenant namespace introduction"
+  lede="`OpenBaoTenant` introduces namespaces in the default multi-tenant model. This page covers the RBAC, guardrails, and control-plane behavior that follow from that onboarding step."
 />
 
 

--- a/docs/user-guide/openbaotenant/overview.md
+++ b/docs/user-guide/openbaotenant/overview.md
@@ -9,13 +9,13 @@ journey: get-started
 
 <PageHeader
   title="OpenBaoTenant namespace introduction"
-  lede="`OpenBaoTenant` introduces namespaces in the default multi-tenant model. This page covers the RBAC, guardrails, and control-plane behavior that follow from that onboarding step."
+  lede="`OpenBaoTenant` introduces namespaces in the default multi-tenant model. Use this page for the RBAC, guardrails, and control-plane behavior that follow from that onboarding step."
 />
 
 
 
 <DiagramFrame
-  title="OpenBaoTenant is the namespace introduction point"
+  title="OpenBaoTenant as the namespace introduction point"
   caption="The Provisioner reacts to OpenBaoTenant, introduces the namespace boundary, and only then can the rest of the operator safely manage cluster resources there."
   code={`graph LR
     Tenant["Target namespace owner or platform admin"] --> Request["OpenBaoTenant"]

--- a/docs/user-guide/operator/authn.md
+++ b/docs/user-guide/operator/authn.md
@@ -9,7 +9,7 @@ journey: get-started
 
 <PageHeader
   title="Operator authentication paths"
-  lede="The operator authenticates to OpenBao with a projected Kubernetes ServiceAccount token by default. This page explains the default JWT path, the audience and role-binding requirements behind it, and the checks to run when you customize controller identity wiring."
+  lede="Default JWT authentication, the audience contract behind it, and the checks to run when you customize controller identity wiring."
 />
 
 
@@ -140,7 +140,7 @@ path "sys/storage/raft/autopilot/configuration" {
   capabilities = ["read", "update"]
 }`}
 >
-  Keep the controller policy focused on maintenance work. Backup, restore, and upgrade jobs should authenticate through their own roles instead of inheriting the controller scope.
+  Keep the controller policy focused on maintenance work. Backup, restore, and upgrade jobs authenticate through their own roles instead of inheriting the controller scope.
 </CommandBlock>
 
 <CommandBlock

--- a/docs/user-guide/operator/authn.md
+++ b/docs/user-guide/operator/authn.md
@@ -1,6 +1,6 @@
 ---
 title: Operator Authentication
-description: Understand the projected JWT auth path, audience contract, and custom-install checks before you change controller identity wiring.
+description: Understand the projected JWT auth path, audience contract, and custom-install checks for controller identity wiring.
 slug: /get-started/operator-authentication
 hide_title: true
 pageType: concept
@@ -71,7 +71,7 @@ journey: get-started
 
 `spec.selfInit.oidc.enabled: true` bootstraps the controller auth path only.
 It does not create a human login method by itself.
-If you use self-init, human access should be created in the same bootstrap contract through `selfInit.requests`, not bolted on later as an afterthought.
+If you use self-init, create human access in the same bootstrap contract through `selfInit.requests` so the cluster has an operator path and a human path from the start.
 
 </Callout>
 

--- a/docs/user-guide/operator/authn.md
+++ b/docs/user-guide/operator/authn.md
@@ -8,8 +8,8 @@ journey: get-started
 ---
 
 <PageHeader
-  title="Keep controller auth short-lived, bound, and boring."
-  lede="The operator authenticates to OpenBao with a projected Kubernetes ServiceAccount token by default. That path is safer than static root credentials, but it only stays safe when the rendered controller identity, JWT audience, and OpenBao-side role binding still match."
+  title="Operator authentication paths"
+  lede="The operator authenticates to OpenBao with a projected Kubernetes ServiceAccount token by default. This page explains the default JWT path, the audience and role-binding requirements behind it, and the checks to run when you customize controller identity wiring."
 />
 
 

--- a/docs/user-guide/operator/authn.md
+++ b/docs/user-guide/operator/authn.md
@@ -1,6 +1,6 @@
 ---
 title: Operator Authentication
-description: Understand the projected JWT auth path, audience contract, and custom-install checks for controller identity wiring.
+description: Projected JWT auth path, audience contract, and custom-install checks for controller identity wiring.
 slug: /get-started/operator-authentication
 hide_title: true
 pageType: concept
@@ -32,7 +32,7 @@ journey: get-started
 />
 
 <DecisionTable
-  title="Why the JWT path is the default"
+  title="JWT default path"
   columns={['Property', 'What you get', 'Why it matters']}
   rows={[
     {
@@ -67,7 +67,7 @@ journey: get-started
   ]}
 />
 
-<Callout type="note" title="Operator auth is not human auth">
+<Callout type="note" title="Controller and human authentication are separate">
 
 `spec.selfInit.oidc.enabled: true` bootstraps the controller auth path only.
 It does not create a human login method by itself.
@@ -76,7 +76,7 @@ If you use self-init, create human access in the same bootstrap contract through
 </Callout>
 
 <DecisionTable
-  title="Treat bootstrap auth as two access surfaces"
+  title="Bootstrap authentication surfaces"
   columns={['Surface', 'Where it is defined', 'Why it exists']}
   rows={[
     {
@@ -127,7 +127,7 @@ If you use self-init, create human access in the same bootstrap contract through
 <CommandBlock
   language="hcl"
   label="configure"
-  title="The operator policy is intentionally narrow"
+  title="Controller policy scope"
   code={`path "sys/health" {
   capabilities = ["read"]
 }
@@ -155,7 +155,7 @@ path "sys/storage/raft/autopilot/configuration" {
   token_policies="openbao-operator" \\
   token_ttl="1h"`}
 >
-  Replace the namespace, ServiceAccount name, and audience with the values produced by your rendered install, not the defaults from an example manifest.
+  Replace the namespace, ServiceAccount name, and audience with the values from your rendered install, not the example defaults.
 </CommandBlock>
 
 ## What must stay aligned

--- a/docs/user-guide/operator/authz.md
+++ b/docs/user-guide/operator/authz.md
@@ -9,7 +9,7 @@ journey: get-started
 
 <PageHeader
   title="Operator authorization surfaces"
-  lede="This page covers the policy surfaces for controller, backup, restore, and upgrade work. Each path should authenticate separately and receive only the capabilities it needs."
+  lede="Use separate policy surfaces for controller, backup, restore, and upgrade work. Each path authenticates separately and receives only the capabilities it needs."
 />
 
 
@@ -61,7 +61,7 @@ journey: get-started
         'Controller maintenance',
         'The main controller Deployment',
         '`sys/health`, `sys/step-down`, and autopilot configuration reads or updates',
-        'This path should stay available for routine reconciliation and maintenance without inheriting destructive restore powers.',
+        'Keep this path available for routine reconciliation and maintenance without adding destructive restore powers.',
       ],
       emphasis: 'recommended',
     },
@@ -70,7 +70,7 @@ journey: get-started
         'Backup',
         'The generated backup Job',
         '`sys/storage/raft/snapshot` read access',
-        'Snapshot reads are narrower than normal controller maintenance and should be easy to reason about independently.',
+        'Snapshot reads are narrower than controller maintenance and remain easier to reason about independently.',
       ],
     },
     {
@@ -78,7 +78,7 @@ journey: get-started
         'Restore',
         'The generated restore Job',
         '`sys/storage/raft/snapshot-force` update access',
-        'Restore can replace the full cluster state and should only exist on the specific workload that performs restore.',
+        'Restore can replace the full cluster state and belongs only on the workload that performs restore.',
       ],
       emphasis: 'caution',
     },
@@ -87,7 +87,7 @@ journey: get-started
         'Upgrade',
         'The generated upgrade Job',
         'Step-down, autopilot state, snapshot read, and optional peer-management operations for blue-green flows',
-        'Upgrade paths often need time-bounded orchestration permissions that should not widen steady-state controller access.',
+        'Upgrade paths often need time-bounded orchestration permissions without widening steady-state controller access.',
       ],
     },
   ]}
@@ -122,7 +122,7 @@ path "sys/storage/raft/autopilot/configuration" {
   capabilities = ["read", "update"]
 }`}
 >
-  This is the steady-state controller scope. It should not expand to cover backup, restore, or blue-green peer management unless you are intentionally breaking the model.
+  This is the steady-state controller scope. Keep backup, restore, and blue-green peer management in separate roles unless you are intentionally changing the model.
 </CommandBlock>
 
 </TabItem>

--- a/docs/user-guide/operator/authz.md
+++ b/docs/user-guide/operator/authz.md
@@ -1,6 +1,6 @@
 ---
 title: Operator Authorization
-description: Understand which policies belong to controller, backup, restore, and upgrade work so destructive capabilities stay scoped to the right identities.
+description: Policy surfaces for controller, backup, restore, and upgrade work, with destructive capabilities scoped to the right identities.
 slug: /get-started/operator-authorization
 hide_title: true
 pageType: concept
@@ -8,15 +8,15 @@ journey: get-started
 ---
 
 <PageHeader
-  title="Keep each operator capability on its own policy surface."
-  lede="Authentication answers who a workload is. Authorization answers what that workload can do. OpenBao Operator stays safer when controller, backup, restore, and upgrade work authenticate separately and only receive the policies each path actually needs."
+  title="Operator authorization surfaces"
+  lede="This page covers the policy surfaces for controller, backup, restore, and upgrade work. Each path should authenticate separately and receive only the capabilities it needs."
 />
 
 
 
 <DiagramFrame
   title="Policies stay attached to job-specific identities"
-  caption="Each operator path maps to its own JWT role and policy set. The controller is not the universal credential for all day 2 work."
+  caption="Each operator path maps to its own JWT role and policy set, with separate controller, backup, restore, and upgrade identities."
   code={`graph LR
     subgraph K8s["Kubernetes identities"]
       Controller["Controller SA"]
@@ -53,7 +53,7 @@ journey: get-started
 />
 
 <DecisionTable
-  title="Keep policies separated by lifecycle capability"
+  title="Policy surfaces by lifecycle capability"
   columns={['Policy surface', 'Used by', 'Typical capabilities', 'Why it stays separate']}
   rows={[
     {
@@ -93,7 +93,7 @@ journey: get-started
   ]}
 />
 
-<Callout type="danger" title="Treat restore as a destructive role">
+<Callout type="danger" title="Restore is a destructive role">
 
 The restore capability can replace data, policies, and keys across the cluster.
 Do not bind the restore policy to the controller or to a broad multi-purpose ServiceAccount just because it is convenient during setup.

--- a/docs/user-guide/operator/deployment-decision-guide.md
+++ b/docs/user-guide/operator/deployment-decision-guide.md
@@ -60,8 +60,8 @@ journeyStep: 1
 />
 
 <DecisionTable
-  title="Stay on the default path unless one of these is true"
-  columns={['Decision area', 'Default', 'Branch only when', 'Go deeper']}
+  title="Default deployment decisions and exceptions"
+  columns={['Decision area', 'Default', 'Use an alternative when', 'Go deeper']}
   rows={[
     {
       cells: [
@@ -118,7 +118,7 @@ journeyStep: 1
 <Callout type="warning" title="Operator auth is not human auth">
 
 `spec.selfInit.oidc.enabled: true` bootstraps operator authentication only.
-Before you move on, decide which human login path will be created as part of `spec.selfInit.requests` during bootstrap.
+Decide which human login path will be created as part of `spec.selfInit.requests` during bootstrap before you finalize the cluster design.
 
 </Callout>
 

--- a/docs/user-guide/operator/deployment-decision-guide.md
+++ b/docs/user-guide/operator/deployment-decision-guide.md
@@ -10,7 +10,7 @@ journeyStep: 1
 
 <PageHeader
   title="Choose the deployment path"
-  lede="This page covers the tenancy model, security posture, bootstrap flow, and install path for a new deployment. The default path is multi-tenant, Hardened, self-init, and the standard install flow."
+  lede="Choose the tenancy model, security posture, bootstrap flow, and install path for a new deployment. The default path is multi-tenant, Hardened, self-init, and the standard install flow."
 />
 
 <Checklist
@@ -43,7 +43,7 @@ journeyStep: 1
     },
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, use OpenBaoTenant before you create the first cluster.',
+      description: 'In the default multi-tenant path, use OpenBaoTenant, then create the first cluster.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
     {
@@ -118,7 +118,7 @@ journeyStep: 1
 <Callout type="warning" title="Operator auth is not human auth">
 
 `spec.selfInit.oidc.enabled: true` bootstraps operator authentication only.
-Decide which human login path will be created as part of `spec.selfInit.requests` during bootstrap before you finalize the cluster design.
+Decide which human login path will be created as part of `spec.selfInit.requests` during bootstrap, then finalize the cluster design.
 
 </Callout>
 
@@ -142,7 +142,7 @@ Decide which human login path will be created as part of `spec.selfInit.requests
     {
       eyebrow: 'C',
       title: 'Validated deployments',
-      description: 'Use a tested architecture or recipe when you want a known-good starting point instead of building a path from scratch.',
+      description: 'Use a tested architecture or recipe when you want a validated starting point instead of building the path from scratch.',
       docId: 'user-guide/validated-deployments/index',
       actionLabel: 'Open',
     },
@@ -150,7 +150,7 @@ Decide which human login path will be created as part of `spec.selfInit.requests
 />
 
 <Checklist
-  title="Check these decisions before you continue"
+  title="Check these decisions"
   items={[
     'Am I running multi-tenant or single-tenant mode?',
     'Is this environment Hardened or Development?',
@@ -166,12 +166,12 @@ Decide which human login path will be created as part of `spec.selfInit.requests
   items={[
     {
       label: 'Install the operator',
-      description: 'Use the supported install flow and verify the rendered controller identity before you continue.',
+      description: 'Use the supported install flow and verify the rendered controller identity.',
       docId: 'user-guide/operator/installation',
     },
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant before you create the first cluster.',
+      description: 'In the default multi-tenant path, introduce the namespace through OpenBaoTenant, then create the first cluster.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
   ]}

--- a/docs/user-guide/operator/deployment-decision-guide.md
+++ b/docs/user-guide/operator/deployment-decision-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment Decision Guide
-description: Choose the tenancy model, security posture, bootstrap flow, and install path you want to keep operating after the first install.
+description: Choose the tenancy model, security posture, bootstrap flow, and install path for a new deployment.
 slug: /get-started/deployment-decision-guide
 hide_title: true
 pageType: task
@@ -10,11 +10,11 @@ journeyStep: 1
 
 <PageHeader
   title="Choose the deployment path"
-  lede="Use this page to choose the tenancy model, security posture, bootstrap flow, and install path. Most teams should stay on the default production path unless namespace ownership, local evaluation, or platform constraints require a different setup."
+  lede="This page covers the tenancy model, security posture, bootstrap flow, and install path for a new deployment. The default path is multi-tenant, Hardened, self-init, and the standard install flow."
 />
 
 <Checklist
-    title="Default production path"
+    title="Default starting point"
     items={[
       'multi-tenant mode',
       'Hardened profile',
@@ -33,7 +33,7 @@ journeyStep: 1
   items={[
     {
       label: 'Choose a deployment model',
-      description: 'Lock down tenancy, security posture, install method, and the main exceptions before you install.',
+      description: 'Set tenancy, security posture, install method, and any planned exceptions.',
       docId: 'user-guide/operator/deployment-decision-guide',
     },
     {
@@ -150,7 +150,7 @@ Decide which human login path will be created as part of `spec.selfInit.requests
 />
 
 <Checklist
-  title="Do not move on until you can answer these plainly"
+  title="Check these decisions before you continue"
   items={[
     'Am I running multi-tenant or single-tenant mode?',
     'Is this environment Hardened or Development?',

--- a/docs/user-guide/operator/deployment-decision-guide.md
+++ b/docs/user-guide/operator/deployment-decision-guide.md
@@ -9,8 +9,8 @@ journeyStep: 1
 ---
 
 <PageHeader
-  title="Choose the path you want to keep operating."
-  lede="Make the main operating decisions before you install anything. Most teams should stay on the default production path and only branch when namespace ownership, local evaluation, or platform constraints give you a real reason."
+  title="Choose the deployment path"
+  lede="Use this page to choose the tenancy model, security posture, bootstrap flow, and install path. Most teams should stay on the default production path unless namespace ownership, local evaluation, or platform constraints require a different setup."
 />
 
 <Checklist
@@ -123,7 +123,7 @@ Before you move on, decide which human login path will be created as part of `sp
 </Callout>
 
 <RouteList
-  title="Branch only when you need one of these exceptions"
+  title="Exceptions that change the default path"
   items={[
     {
       eyebrow: 'A',

--- a/docs/user-guide/operator/identity-and-access.md
+++ b/docs/user-guide/operator/identity-and-access.md
@@ -9,7 +9,7 @@ journey: get-started
 
 <PageHeader
   title="Operator identity surfaces"
-  lede="The controller, workload pods, and day 2 executor jobs use different identities. This page maps each Kubernetes ServiceAccount to the corresponding OpenBao auth and authorization surface."
+  lede="The controller, workload pods, and day 2 executor jobs use different identities. Use this page to map each Kubernetes ServiceAccount to the corresponding OpenBao auth and authorization surface."
 />
 
 

--- a/docs/user-guide/operator/identity-and-access.md
+++ b/docs/user-guide/operator/identity-and-access.md
@@ -8,8 +8,8 @@ journey: get-started
 ---
 
 <PageHeader
-  title="Keep the operator identity surfaces separate in your head."
-  lede="The controller, workload pods, and day 2 executor jobs do not share one identity. This page helps you trace which Kubernetes ServiceAccount maps to which OpenBao auth and authorization surface so custom installs do not drift."
+  title="Operator identity surfaces"
+  lede="The controller, workload pods, and day 2 executor jobs use different identities. This page maps each Kubernetes ServiceAccount to the corresponding OpenBao auth and authorization surface."
 />
 
 

--- a/docs/user-guide/operator/installation.md
+++ b/docs/user-guide/operator/installation.md
@@ -11,12 +11,12 @@ journeyStep: 2
 <!-- id: installation-guide -->
 
 <PageHeader
-  title="Install the operator in the mode you actually intend to run."
-  lede="Choose a supported install path, keep the rendered namespace and identity explicit, and verify the controller wiring before you create your first OpenBaoCluster."
+  title="Install the operator for the intended tenancy mode"
+  lede="Choose a supported install path, keep the rendered namespace and identity explicit, and verify the controller wiring for the tenancy mode you intend to run."
 />
 
 <Checklist
-    title="Preflight before you install"
+    title="Installation preflight"
     items={[
       'confirm Kubernetes compatibility and cluster-admin access for CRDs, RBAC, and admission policies',
       'decide whether Helm or raw manifests own the install lifecycle',

--- a/docs/user-guide/operator/installation.md
+++ b/docs/user-guide/operator/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Operator Installation
-description: Install OpenBao Operator with the right tenancy mode, rendered identity, and verification checks before you create a cluster.
+description: Install OpenBao Operator with the intended tenancy mode, rendered identity, and verification checks.
 slug: /get-started/install
 hide_title: true
 pageType: task
@@ -83,7 +83,7 @@ See [Single-Tenant Mode](single-tenant-mode.md) for single-tenant deployments.
 
 ## Install Profiles
 
-Use this table to choose the supported install path before you start changing values or overlays. For most environments, the default answer is Helm plus multi-tenant mode unless your namespace ownership model says otherwise.
+Use this table to choose the supported install path before changing values or overlays. For most environments, the default answer is Helm plus multi-tenant mode unless your namespace ownership model requires a different shape.
 
 <DecisionTable
   title="Supported installation paths"
@@ -124,8 +124,8 @@ Use `config/overlays/single-tenant-custom-identity` when you also need a custom 
 <Callout type="info" title="Default recommendation">
 
 Start with Helm, keep the default multi-tenant mode, pin the chart release for production,
-and leave admission policies enabled. Deviate from that path only when raw-manifest
-control or single-tenant namespace ownership is an explicit requirement.
+and leave admission policies enabled. Move away from that path only for explicit raw-manifest
+control or single-tenant namespace ownership requirements.
 
 </Callout>
 

--- a/docs/user-guide/operator/installation.md
+++ b/docs/user-guide/operator/installation.md
@@ -28,7 +28,7 @@ journeyStep: 2
 
 
 <JourneyRail
-  title="Installation is the handoff between design choices and a working control plane"
+  title="Installation sequence"
   current={2}
   items={[
     {
@@ -427,7 +427,7 @@ Expected output (multi-tenant mode):
 <provisioner-pod>                                 1/1     Running   0          1m`}
 />
 
-<Callout type="success" title="Do not move on until the operator namespace looks exactly how you expect.">
+<Callout type="success" title="Verify the operator namespace before continuing.">
 
 A good install checkpoint is more than pods in `Running`:
 

--- a/docs/user-guide/operator/installation.md
+++ b/docs/user-guide/operator/installation.md
@@ -43,7 +43,7 @@ journeyStep: 2
     },
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, let OpenBaoTenant introduce the namespace before you create a cluster.',
+      description: 'In the default multi-tenant path, let OpenBaoTenant introduce the namespace, then create the cluster.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
     {
@@ -81,7 +81,7 @@ See [Single-Tenant Mode](single-tenant-mode.md) for single-tenant deployments.
 
 </Callout>
 
-## Install Profiles
+## Install profiles
 
 Use this table to choose the supported install path before changing values or overlays. For most environments, the default answer is Helm plus multi-tenant mode unless your namespace ownership model requires a different shape.
 
@@ -114,7 +114,7 @@ Use this table to choose the supported install path before changing values or ov
   ]}
 />
 
-<Callout type="note" title="Single-Tenant Customization Boundary">
+<Callout type="note" title="Single-tenant customization boundary">
 
 Use `config/overlays/single-tenant` when you only need a custom operator namespace or target namespace.
 Use `config/overlays/single-tenant-custom-identity` when you also need a custom operator identity, such as an extra `namePrefix`.
@@ -133,7 +133,7 @@ control or single-tenant namespace ownership requirements.
 
 <Tabs groupId="helm-recommended-openshift-yaml-manifests-developer-source">
 
-<TabItem value="helm-recommended" label="Helm (Recommended)">
+<TabItem value="helm-recommended" label="Helm (recommended)">
 
 Install the operator using the official Helm chart. For production, pin the chart release explicitly with `--version`.
 
@@ -153,7 +153,7 @@ The examples below use the default release namespace `openbao-operator-system`. 
   --create-namespace`}
 />
 
-### Common Configuration
+### Common configuration
 
 <CommandBlock
   language="bash"
@@ -178,7 +178,7 @@ Use `image.tag` only when you intentionally need a non-default operator image fo
 
 </Callout>
 
-### Single-Tenant With Custom Helm Identity
+### Single-tenant with custom Helm identity
 
 Helm already supports the equivalent of the raw-manifest custom-identity overlays through the release name and `fullnameOverride`.
 
@@ -220,7 +220,7 @@ Artifact Hub indexing can lag shortly after a release is published.
 
 </Callout>
 
-### Full Values Reference
+### Full values reference
 
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
@@ -240,7 +240,7 @@ Artifact Hub indexing can lag shortly after a release is published.
 
 [Full values.yaml](https://github.com/dc-tec/openbao-operator/blob/main/charts/openbao-operator/values.yaml)
 
-<Callout type="info" title="Air-Gapped Environments">
+<Callout type="info" title="Air-gapped environments">
 
 To use private registries for the operator and its sidecars (init, backup, upgrade), see the [Air-Gapped / Private Registries](../openbaocluster/configuration/air-gapped.md) guide.
 
@@ -264,7 +264,7 @@ You can optionally force the platform mode to ensure compatibility with Security
   --set platform=openshift`}
 />
 
-<Callout type="tip" title="What this does">
+<Callout type="tip" title="What this setting does">
 
 This setting instructs the chart/operator to omit pinned `runAsUser` / `fsGroup` IDs in generated Pods, allowing OpenShift's SCC admission controller to inject namespace-scoped IDs automatically.
 
@@ -296,25 +296,25 @@ Raw-manifest installs have three supported starting points:
 - `config/overlays/single-tenant`: direct single-tenant install without the provisioner
 - `config/overlays/single-tenant-custom-identity`: direct single-tenant install without the provisioner plus custom operator identity support
 
-<Callout type="tip" title="Custom Namespace Or Prefix">
+<Callout type="tip" title="Custom namespace or prefix">
 
 For raw-manifest installs with a custom operator namespace or extra name prefix, start from `config/overlays/custom-identity`. Set `namespace` there and optionally add `namePrefix`. The controller and provisioner ServiceAccount identities, RoleBinding subjects, and admission-policy identity checks follow the installed ServiceAccounts automatically.
 
 </Callout>
 
-<Callout type="tip" title="Single-Tenant Raw Manifests">
+<Callout type="tip" title="Single-tenant raw manifests">
 
 For direct single-tenant installs, start from `config/overlays/single-tenant`. That overlay owns the operator namespace and target namespace wiring instead of relying on manual `WATCH_NAMESPACE` patches.
 
 </Callout>
 
-<Callout type="tip" title="Single-Tenant With Custom Identity">
+<Callout type="tip" title="Single-tenant with custom identity">
 
 If you need single-tenant mode and a custom operator identity, such as an extra `namePrefix`, start from `config/overlays/single-tenant-custom-identity`. That overlay keeps the single-tenant namespace wiring and the controller admission-policy identity rewrites aligned in one supported path.
 
 </Callout>
 
-<Callout type="note" title="Operator JWT Auth">
+<Callout type="note" title="Operator JWT auth">
 
 If you use custom raw-manifest identities together with manual OpenBao JWT configuration or self-init OIDC bootstrap, verify the rendered controller ServiceAccount name and namespace first. See [Operator Authentication](./operator-authentication#what-must-stay-aligned).
 
@@ -341,11 +341,11 @@ make deploy IMG=ghcr.io/dc-tec/openbao-operator:dev`}
 
 </Tabs>
 
-## Render Verification
+## Render verification
 
-Use this checklist for raw-manifest installs before you apply the manifests.
+Use this checklist for raw-manifest installs.
 
-### Multi-Tenant With Custom Identity
+### Multi-tenant with custom identity
 
 Render the overlay:
 
@@ -366,7 +366,7 @@ Confirm:
 
 See [Operator Authentication](./operator-authentication#what-must-stay-aligned) for the OpenBao-side JWT binding checks.
 
-### Single-Tenant Raw Manifests
+### Single-tenant raw manifests
 
 Render the overlay:
 
@@ -386,7 +386,7 @@ Confirm:
 
 If you customize the single-tenant overlay beyond those supported fields, treat the render output as the source of truth.
 
-### Single-Tenant With Custom Identity
+### Single-tenant with custom identity
 
 Render the overlay:
 
@@ -405,7 +405,7 @@ Confirm:
 4. the single-tenant `RoleBinding` subject points at the rendered controller `ServiceAccount`
 5. controller admission-policy variables reference the same rendered namespace and `ServiceAccount` name
 
-## Verify Installation
+## Verify installation
 
 Check that the operator pods are running:
 
@@ -427,9 +427,9 @@ Expected output (multi-tenant mode):
 <provisioner-pod>                                 1/1     Running   0          1m`}
 />
 
-<Callout type="success" title="Verify the operator namespace before continuing.">
+<Callout type="success" title="Verify the operator namespace before continuing">
 
-A good install checkpoint is more than pods in `Running`:
+Use this install checkpoint to verify more than pods in `Running`:
 
 - the controller and provisioner pods match the tenancy mode you chose
 - the rendered namespace and ServiceAccount names match your install plan
@@ -441,9 +441,9 @@ A good install checkpoint is more than pods in `Running`:
 
 ## Upgrading
 
-### Helm Upgrades
+### Helm upgrades
 
-<Callout type="warning" title="CRD Updates">
+<Callout type="warning" title="CRD updates">
 
 Helm does not automatically upgrade CRDs. For releases with CRD changes:
 
@@ -460,7 +460,7 @@ Helm does not automatically upgrade CRDs. For releases with CRD changes:
 
 </Callout>
 
-### YAML Manifest Upgrades
+### YAML manifest upgrades
 
 ```bash
 kubectl apply -f https://github.com/dc-tec/openbao-operator/releases/download/X.Y.Z/install.yaml
@@ -499,13 +499,13 @@ kubectl delete -f https://github.com/dc-tec/openbao-operator/releases/download/X
 
 </Tabs>
 
-## Next Steps
+## Next steps
 
 <NextActions
   items={[
     {
       label: 'Onboard the target namespace',
-      description: 'In the default multi-tenant path, create OpenBaoTenant before you create the first cluster.',
+      description: 'In the default multi-tenant path, create OpenBaoTenant, then create the first cluster.',
       docId: 'user-guide/openbaotenant/onboarding',
     },
     {

--- a/docs/user-guide/operator/single-tenant-mode.md
+++ b/docs/user-guide/operator/single-tenant-mode.md
@@ -1,6 +1,6 @@
 ---
 title: Single-Tenant Mode
-description: Use the controller-only install path when one team owns one namespace and does not need the default tenant-onboarding model.
+description: Single-tenant operator deployment for one team that owns one namespace and does not use the default tenant-onboarding model.
 slug: /get-started/single-tenant-mode
 hide_title: true
 pageType: task
@@ -15,7 +15,7 @@ journey: get-started
 
 
 <DecisionTable
-  title="Stay on multi-tenant unless this is true"
+  title="When to choose single-tenant mode"
   columns={['Question', 'Multi-tenant default', 'Choose single-tenant when', 'Go deeper']}
   rows={[
     {

--- a/docs/user-guide/operator/single-tenant-mode.md
+++ b/docs/user-guide/operator/single-tenant-mode.md
@@ -9,7 +9,7 @@ journey: get-started
 
 <PageHeader
   title="Single-tenant deployment model"
-  lede="Single-tenant mode removes the Provisioner and lets the controller watch one target namespace directly. It is a good fit for dedicated team environments that do not need the default tenant-onboarding path."
+  lede="Single-tenant mode removes the Provisioner and lets the controller watch one target namespace directly. Use it for dedicated team environments that do not need the default tenant-onboarding path."
 />
 
 
@@ -178,7 +178,7 @@ That is simpler for a dedicated team, but it also means the operator is no longe
   title="Check that only the controller is running"
   code={`kubectl get pods -n <operator-namespace>`}
 >
-  In single-tenant mode you should see the controller deployment running, but not a Provisioner pod.
+  In single-tenant mode, expect the controller deployment to be running and no Provisioner pod to exist.
 </CommandBlock>
 
 <CommandBlock
@@ -188,7 +188,7 @@ That is simpler for a dedicated team, but it also means the operator is no longe
   code={`kubectl get deploy -n <operator-namespace> openbao-operator-controller \\
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="WATCH_NAMESPACE")].value}'`}
 >
-  This value should match the target namespace you plan to use for the first `OpenBaoCluster`.
+  Confirm this value matches the target namespace you plan to use for the first `OpenBaoCluster`.
 </CommandBlock>
 
 ## Migration guidance

--- a/docs/user-guide/operator/single-tenant-mode.md
+++ b/docs/user-guide/operator/single-tenant-mode.md
@@ -8,8 +8,8 @@ journey: get-started
 ---
 
 <PageHeader
-  title="Use single-tenant mode when one team owns one namespace."
-  lede="Single-tenant mode removes the Provisioner and lets the controller watch one target namespace directly. It is a good fit for dedicated team environments, but it is a branch from the default platform path rather than the starting point for every install."
+  title="Single-tenant deployment model"
+  lede="Single-tenant mode removes the Provisioner and lets the controller watch one target namespace directly. It is a good fit for dedicated team environments that do not need the default tenant-onboarding path."
 />
 
 
@@ -137,7 +137,7 @@ Single-tenant mode skips `OpenBaoTenant`, but it does not invent the namespace f
 <CommandBlock
   language="yaml"
   label="configure"
-  title="Set the target namespace before you apply the overlay"
+  title="Set the target namespace"
   code={`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -153,7 +153,7 @@ data:
 <CommandBlock
   language="bash"
   label="verify"
-  title="Render the overlay once before you apply it"
+  title="Render the overlay"
   code={`kubectl kustomize config/overlays/single-tenant`}
 >
   Confirm that the controller ServiceAccount subject, RoleBinding namespace, and `WATCH_NAMESPACE` value all point at the same intended target.
@@ -170,7 +170,7 @@ That is simpler for a dedicated team, but it also means the operator is no longe
 
 </Callout>
 
-## Verify the install before you create a cluster
+## Verify the install
 
 <CommandBlock
   language="bash"

--- a/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3.md
@@ -12,7 +12,7 @@ description: Validated cloud baseline for a development-profile OpenBao deployme
 />
 
 <Checklist
-    title="This lane proves"
+    title="Validated coverage"
     items={[
       "a Development-profile cluster can bootstrap on EKS with AWS KMS auto-unseal and no static root-token workflow",
       "JWT bootstrap and human admin JWT access both work under the cloud control-plane conditions EKS introduces",
@@ -44,7 +44,7 @@ Cloud reference architecture. This is a realistic EKS validation and bring-up to
       cells: [
         "Seal path",
         "AWS KMS via workload identity",
-        "The main workload proves real cloud auto-unseal behavior instead of a local or static secret fallback.",
+        "The main workload uses cloud auto-unseal through AWS KMS rather than local or static secret material.",
       ],
     },
     {
@@ -58,21 +58,21 @@ Cloud reference architecture. This is a realistic EKS validation and bring-up to
       cells: [
         "Backup path",
         "S3 with a separate backup identity",
-        "The lane proves that backup execution stays separate from the main KMS identity surface.",
+        "Backup execution stays separate from the main KMS identity surface.",
       ],
     },
     {
       cells: [
         "Validation scope",
         "Manual EKS validation plus operator lifecycle behavior",
-        "The lane proves the cloud integration path you need before deciding whether to harden the endpoint.",
+        "The baseline covers the cloud integration path used in the validated EKS development environment.",
       ],
     },
   ]}
 />
 
 <DiagramFrame
-  title="Validated lane topology"
+  title="Baseline topology"
   caption="The main workload uses one cloud identity for KMS, backup Jobs use another for S3, and the public edge remains a shared terminating layer rather than a dedicated passthrough stack."
   code={`flowchart LR
     Client["Operator or admin"] -->|"HTTPS"| Edge["Shared Gateway API edge"]
@@ -139,15 +139,15 @@ Cloud reference architecture. This is a realistic EKS validation and bring-up to
   ]}
 />
 
-<Callout type="success" title="What this lane validated">
+<Callout type="success" title="Validated coverage">
 
 The EKS development lane covered bootstrap, AWS KMS auto-unseal, JWT bootstrap on EKS, human admin JWT login, Gateway exposure through the shared edge, and successful S3 backups.
 
 </Callout>
 
-<Callout type="warning" title="What this lane is not">
+<Callout type="warning" title="Out of scope">
 
-This is not a hardened public-endpoint reference, not proof of ACME passthrough, and not a final production posture. It is the shortest cloud lane that still proves the important AWS control-plane integrations.
+This baseline does not cover the hardened public-endpoint path, ACME passthrough, or a final production posture. It covers the AWS control-plane integrations used in the validated development environment.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3.md
@@ -22,14 +22,14 @@ description: Validated cloud baseline for a development-profile OpenBao deployme
   />
 
 
-<Callout type="note" title="Classification">
+<Callout type="note" title="Baseline scope">
 
 Cloud reference architecture. This is a realistic EKS validation and bring-up topology, but it is intentionally a Development lane rather than a production target.
 
 </Callout>
 
 <DecisionTable
-  title="Lane summary"
+  title="Baseline summary"
   columns={["Surface", "Choice", "Why it matters"]}
   rows={[
     {
@@ -129,7 +129,7 @@ Cloud reference architecture. This is a realistic EKS validation and bring-up to
 
 <Checklist
   tone="warning"
-  title="Stay on the validated path"
+  title="Baseline requirements"
   items={[
     "keep `spec.profile: Development` and treat the lane as bring-up coverage, not a production recommendation",
     "keep the shared terminating edge and do not switch the same lane to passthrough midstream",
@@ -152,7 +152,7 @@ This baseline does not cover the hardened public-endpoint path, ACME passthrough
 </Callout>
 
 <NextActions
-  title="Use the lane"
+  title="Next steps"
   items={[
     {
       label: "Deployment recipe",

--- a/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3.md
@@ -7,8 +7,8 @@ description: Validated cloud baseline for a development-profile OpenBao deployme
 ---
 
 <PageHeader
-  title="Use this lane to validate the EKS bring-up path with real AWS integrations before you move to a hardened public endpoint."
-  lede="This cloud baseline keeps the posture intentionally Development, but it proves the integrations that matter for cloud bring-up: KMS auto-unseal, workload identity, shared-edge exposure, JWT bootstrap, and snapshot upload to S3."
+  title="EKS development baseline with AWS integrations"
+  lede="This cloud baseline keeps the posture intentionally Development while validating the AWS integrations needed for cloud bring-up: KMS auto-unseal, workload identity, shared-edge exposure, JWT bootstrap, and snapshot upload to S3."
 />
 
 <Checklist

--- a/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme.md
@@ -7,12 +7,12 @@ description: Validated hardened cloud baseline for OpenBao on Amazon EKS with AW
 ---
 
 <PageHeader
-  title="Use this lane when you need the production-style EKS baseline that keeps OpenBao as the public TLS endpoint."
-  lede="This cloud baseline is the current hardened EKS reference shape validated by the project. It keeps the unseal root in AWS KMS, keeps the public hostname on a dedicated passthrough Gateway, and lets OpenBao manage ACME issuance directly while backup Jobs write to S3 through a separate identity."
+  title="Hardened EKS baseline with public ACME"
+  lede="This cloud baseline is the hardened EKS topology validated by the project. It uses AWS KMS for auto-unseal, a dedicated public passthrough Gateway, OpenBao-managed ACME, and S3 backups through a separate identity."
 />
 
 <Checklist
-    title="This lane proves"
+    title="Validated coverage"
     items={[
       "a Hardened-profile cluster can bootstrap on EKS with KMS auto-unseal and signed helper images",
       "OpenBao-managed ACME can issue and serve the public certificate while the Gateway remains pure passthrough",
@@ -36,7 +36,7 @@ Cloud reference architecture. This is the production-style Amazon EKS baseline v
       cells: [
         "Profile",
         "`spec.profile: Hardened`",
-        "The lane proves the production-style posture rather than the relaxed bring-up defaults used in the development baseline.",
+        "The baseline uses the hardened production-style posture rather than the development baseline defaults.",
       ],
       emphasis: "recommended",
     },
@@ -44,7 +44,7 @@ Cloud reference architecture. This is the production-style Amazon EKS baseline v
       cells: [
         "Seal path",
         "AWS KMS via workload identity",
-        "The main workload uses a cloud-native unseal path instead of static or external secret material.",
+        "The main workload uses a cloud-native unseal path rather than static or external secret material.",
       ],
     },
     {
@@ -65,14 +65,14 @@ Cloud reference architecture. This is the production-style Amazon EKS baseline v
       cells: [
         "Backup path",
         "S3 with a separate backup identity",
-        "The lane proves that backup execution remains separate from KMS unseal and public-edge concerns.",
+        "Backup execution remains separate from KMS unseal and public-edge concerns.",
       ],
     },
   ]}
 />
 
 <DiagramFrame
-  title="Validated lane topology"
+  title="Baseline topology"
   caption="The hardened hostname lives on its own passthrough edge, OpenBao handles ACME itself, and the cluster still keeps backup and unseal identity surfaces separate."
   code={`flowchart LR
     Client["OpenBao client"] -->|"HTTPS (SNI)"| Edge["Dedicated public passthrough Gateway"]
@@ -148,15 +148,15 @@ Cloud reference architecture. This is the production-style Amazon EKS baseline v
   ]}
 />
 
-<Callout type="success" title="What this lane validated">
+<Callout type="success" title="Validated coverage">
 
 The hardened EKS lane covered bootstrap, KMS auto-unseal, OpenBao-managed public ACME certificate issuance, Gateway passthrough, JWT bootstrap, human admin JWT login, and successful S3 backups.
 
 </Callout>
 
-<Callout type="warning" title="What this lane is not">
+<Callout type="warning" title="Out of scope">
 
-This is not the right lane if you need a source-restricted public hostname, externally managed TLS, or a terminating Gateway in front of OpenBao. Those choices are different contracts, not small tweaks to this one.
+This baseline does not cover source-restricted public hostnames, externally managed TLS, or a terminating Gateway in front of OpenBao. Those choices require a different topology.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme.md
@@ -22,14 +22,14 @@ description: Validated hardened cloud baseline for OpenBao on Amazon EKS with AW
   />
 
 
-<Callout type="note" title="Classification">
+<Callout type="note" title="Baseline scope">
 
 Cloud reference architecture. This is the production-style Amazon EKS baseline validated by the project.
 
 </Callout>
 
 <DecisionTable
-  title="Lane summary"
+  title="Baseline summary"
   columns={["Surface", "Choice", "Why it matters"]}
   rows={[
     {
@@ -138,7 +138,7 @@ Cloud reference architecture. This is the production-style Amazon EKS baseline v
 
 <Checklist
   tone="warning"
-  title="Stay on the validated path"
+  title="Baseline requirements"
   items={[
     "keep the hardened hostname publicly reachable on port `443` for ACME validation",
     "keep the public OpenBao hostname on a dedicated passthrough Gateway instead of the shared terminating edge",
@@ -161,7 +161,7 @@ This baseline does not cover source-restricted public hostnames, externally mana
 </Callout>
 
 <NextActions
-  title="Use the lane"
+  title="Next steps"
   items={[
     {
       label: "Deployment recipe",

--- a/docs/user-guide/validated-deployments/architectures/cloud/index.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/index.md
@@ -8,8 +8,8 @@ description: Validated cloud baselines for OpenBao Operator, pairing each tested
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Cloud Baselines"
-  title="Pick the cloud lane that matches the posture you want to prove."
-  lede="The current cloud validated scope comes from Amazon EKS. Each lane keeps the tested topology and the matching deployment recipe adjacent, so you can confirm the architecture first and then reproduce it without jumping across unrelated nav branches."
+  title="Validated cloud baselines"
+  lede="This section covers the validated cloud baselines currently exercised on Amazon EKS. Each baseline links to the matching deployment recipe so the tested topology and procedure stay together."
   actions={[
     {label: "Open EKS Development", docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3", variant: "primary"},
     {label: "Open EKS Hardened", docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/architectures/cloud/index.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/index.md
@@ -9,14 +9,14 @@ description: Validated cloud baselines for OpenBao Operator, pairing each tested
   variant="landing"
   eyebrow="Validated Deployments / Cloud Baselines"
   title="Validated cloud baselines"
-  lede="This section covers the validated cloud baselines currently exercised on Amazon EKS. Each baseline links to the matching deployment recipe so the tested topology and procedure stay together."
+  lede="Amazon EKS validated baselines are listed here, each linked to its matching deployment recipe."
   actions={[
     {label: "Open EKS Development", docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3", variant: "primary"},
     {label: "Open EKS Hardened", docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use cloud baselines when you need to"
+    title="Use cloud baselines to"
     items={[
       "compare validated development and hardened EKS topologies",
       "see the exact trust boundary, edge model, and storage assumptions before deployment",
@@ -31,14 +31,14 @@ description: Validated cloud baselines for OpenBao Operator, pairing each tested
     {
       eyebrow: "01",
       title: "EKS Development",
-      description: "Shared terminating edge, AWS KMS auto-unseal, JWT bootstrap, and S3 backups in the validated EKS development baseline.",
+      description: "EKS development baseline with shared terminating edge, AWS KMS auto-unseal, JWT bootstrap, and S3 backups.",
       docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3",
       actionLabel: "Open lane",
     },
     {
       eyebrow: "02",
       title: "EKS Hardened",
-      description: "Dedicated passthrough edge, AWS KMS auto-unseal, OpenBao-managed ACME, and the hardened cloud baseline.",
+      description: "EKS hardened baseline with dedicated passthrough edge, AWS KMS auto-unseal, OpenBao-managed ACME, and S3 backups.",
       docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme",
       actionLabel: "Open lane",
     },

--- a/docs/user-guide/validated-deployments/architectures/cloud/index.md
+++ b/docs/user-guide/validated-deployments/architectures/cloud/index.md
@@ -31,14 +31,14 @@ description: Validated cloud baselines for OpenBao Operator, pairing each tested
     {
       eyebrow: "01",
       title: "EKS Development",
-      description: "Shared terminating edge, AWS KMS auto-unseal, JWT bootstrap, and S3 backups for a realistic but non-production lane.",
+      description: "Shared terminating edge, AWS KMS auto-unseal, JWT bootstrap, and S3 backups in the validated EKS development baseline.",
       docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-development-awskms-s3",
       actionLabel: "Open lane",
     },
     {
       eyebrow: "02",
       title: "EKS Hardened",
-      description: "Dedicated passthrough edge, AWS KMS auto-unseal, OpenBao-managed ACME, and the tighter production posture used in the hardened cloud lane.",
+      description: "Dedicated passthrough edge, AWS KMS auto-unseal, OpenBao-managed ACME, and the hardened cloud baseline.",
       docId: "user-guide/validated-deployments/architectures/cloud/amazon-eks-hardened-awskms-acme",
       actionLabel: "Open lane",
     },

--- a/docs/user-guide/validated-deployments/architectures/index.md
+++ b/docs/user-guide/validated-deployments/architectures/index.md
@@ -28,7 +28,7 @@ description: Catalog of validated reference architectures, grouped by cloud and 
     {
       eyebrow: "02",
       title: "Local baselines",
-      description: "Validated k3d lanes for development, hardened rehearsal, and cross-cluster DR proof.",
+      description: "Validated k3d lanes for development, hardened rehearsal, and cross-cluster DR.",
       docId: "user-guide/validated-deployments/architectures/local/index",
     },
   ]}

--- a/docs/user-guide/validated-deployments/architectures/index.md
+++ b/docs/user-guide/validated-deployments/architectures/index.md
@@ -9,7 +9,7 @@ description: Catalog of validated reference architectures, grouped by cloud and 
   variant="landing"
   eyebrow="Validated Deployments / Architecture Catalog"
   title="Validated architecture catalog"
-  lede="This catalog groups the reference architecture side of each validated deployment baseline. Use it when you want to review topology, invariants, and assumptions before the deployment recipe."
+  lede="Reference architectures are grouped by validated deployment baseline. Review topology, invariants, and assumptions here before following a recipe."
   actions={[
     {label: "Open cloud baselines", docId: "user-guide/validated-deployments/architectures/cloud/index", variant: "primary"},
     {label: "Open local baselines", docId: "user-guide/validated-deployments/architectures/local/index", variant: "secondary"},
@@ -22,7 +22,7 @@ description: Catalog of validated reference architectures, grouped by cloud and 
     {
       eyebrow: "01",
       title: "Cloud baselines",
-      description: "Validated EKS topologies with clear invariants and matching recipes.",
+      description: "Amazon EKS topologies with matching recipes.",
       docId: "user-guide/validated-deployments/architectures/cloud/index",
     },
     {

--- a/docs/user-guide/validated-deployments/architectures/index.md
+++ b/docs/user-guide/validated-deployments/architectures/index.md
@@ -8,8 +8,8 @@ description: Catalog of validated reference architectures, grouped by cloud and 
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Architecture Catalog"
-  title="Use the architecture catalog when you want topology first."
-  lede="This page exists for readers who arrive looking specifically for the reference architecture side of a validated lane. The main section navigation is now lane-first, so you can move from topology to recipe without switching sections in your head."
+  title="Validated architecture catalog"
+  lede="This catalog groups the reference architecture side of each validated deployment baseline. Use it when you want to review topology, invariants, and assumptions before the deployment recipe."
   actions={[
     {label: "Open cloud baselines", docId: "user-guide/validated-deployments/architectures/cloud/index", variant: "primary"},
     {label: "Open local baselines", docId: "user-guide/validated-deployments/architectures/local/index", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/architectures/local/index.md
+++ b/docs/user-guide/validated-deployments/architectures/local/index.md
@@ -8,8 +8,8 @@ description: Validated local baselines for k3d, including development, hardened 
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Local Baselines"
-  title="Use local lanes for rehearsal, validation, and DR proof, not as accidental production defaults."
-  lede="The local validated scope comes from the project's k3d environment. These lanes are valuable because they prove concrete behaviors such as hardened bootstrap, passthrough access, ACME issuance, and cross-cluster restore. They are not a substitute for making an explicit production platform choice."
+  title="Validated local baselines"
+  lede="This section covers the validated local baselines exercised on k3d, including development, hardened rehearsal, and cross-cluster DR. Use it for local validation and rehearsal, not as a generic production recommendation."
   actions={[
     {label: "Open k3d Development", docId: "user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs", variant: "primary"},
     {label: "Open k3d Cross-Cluster DR", docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/architectures/local/index.md
+++ b/docs/user-guide/validated-deployments/architectures/local/index.md
@@ -9,14 +9,14 @@ description: Validated local baselines for k3d, including development, hardened 
   variant="landing"
   eyebrow="Validated Deployments / Local Baselines"
   title="Validated local baselines"
-  lede="This section covers the validated local baselines exercised on k3d, including development, hardened rehearsal, and cross-cluster DR."
+  lede="Validated k3d baselines are listed here for development, hardened rehearsal, and cross-cluster DR."
   actions={[
     {label: "Open k3d Development", docId: "user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs", variant: "primary"},
     {label: "Open k3d Cross-Cluster DR", docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use local baselines when you need to"
+    title="Use local baselines to"
     items={[
       "rehearse a development or hardened lane on workstation-grade infrastructure",
       "exercise a boundary such as external TLS passthrough, internal ACME, or shared Transit unseal",
@@ -31,28 +31,28 @@ description: Validated local baselines for k3d, including development, hardened 
     {
       eyebrow: "01",
       title: "k3d Development",
-      description: "Shared terminating edge, RustFS backups, JWT bootstrap, and a development-profile lane for rehearsal and integration work.",
+      description: "Development profile with shared terminating edge, RustFS backups, and JWT bootstrap for rehearsal and integration work.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs",
       actionLabel: "Open lane",
     },
     {
       eyebrow: "02",
       title: "k3d Hardened / External TLS",
-      description: "Transit auto-unseal, external TLS Secrets, and user-managed passthrough for the closest local analogue to a hardened external-certificate deployment.",
+      description: "Hardened external-certificate baseline with Transit auto-unseal, external TLS Secrets, and user-managed passthrough.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls",
       actionLabel: "Open lane",
     },
     {
       eyebrow: "03",
       title: "k3d Hardened / ACME",
-      description: "Transit auto-unseal with OpenBao-managed ACME and validated hostname resolution in the local hardened ACME lane.",
+      description: "Hardened ACME baseline with Transit auto-unseal, OpenBao-managed ACME, and local hostname resolution.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme",
       actionLabel: "Open lane",
     },
     {
       eyebrow: "04",
       title: "k3d Cross-Cluster DR",
-      description: "A lane for shared Transit, shared snapshot storage, and restore rehearsal across separate source and target clusters.",
+      description: "Cross-cluster DR baseline with shared Transit, shared snapshot storage, and restore rehearsal across source and target clusters.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs",
       actionLabel: "Open lane",
     },
@@ -61,7 +61,7 @@ description: Validated local baselines for k3d, including development, hardened 
 
 <Callout type="note" title="Lane-specific runbook scope">
 
-Generic backup and restore procedures belong in the main `Operate` docs. The cross-cluster DR restore procedure remains in this section because it depends on the exact validated DR lane assumptions.
+Generic backup and restore procedures belong in the main `Operate` docs. The cross-cluster DR restore procedure stays here because it depends on the DR-lane assumptions used in this catalog.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/local/index.md
+++ b/docs/user-guide/validated-deployments/architectures/local/index.md
@@ -9,7 +9,7 @@ description: Validated local baselines for k3d, including development, hardened 
   variant="landing"
   eyebrow="Validated Deployments / Local Baselines"
   title="Validated local baselines"
-  lede="This section covers the validated local baselines exercised on k3d, including development, hardened rehearsal, and cross-cluster DR. Use it for local validation and rehearsal, not as a generic production recommendation."
+  lede="This section covers the validated local baselines exercised on k3d, including development, hardened rehearsal, and cross-cluster DR."
   actions={[
     {label: "Open k3d Development", docId: "user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs", variant: "primary"},
     {label: "Open k3d Cross-Cluster DR", docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs", variant: "secondary"},
@@ -19,7 +19,7 @@ description: Validated local baselines for k3d, including development, hardened 
     title="Use local baselines when you need to"
     items={[
       "rehearse a development or hardened lane on workstation-grade infrastructure",
-      "prove a boundary such as external TLS passthrough, internal ACME, or shared Transit unseal",
+      "exercise a boundary such as external TLS passthrough, internal ACME, or shared Transit unseal",
       "practice restore and cutover behavior in the validated cross-cluster DR lane",
     ]}
   />
@@ -52,14 +52,14 @@ description: Validated local baselines for k3d, including development, hardened 
     {
       eyebrow: "04",
       title: "k3d Cross-Cluster DR",
-      description: "A proving lane for shared Transit, shared snapshot storage, and restore rehearsal across separate source and target clusters.",
+      description: "A lane for shared Transit, shared snapshot storage, and restore rehearsal across separate source and target clusters.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs",
       actionLabel: "Open lane",
     },
   ]}
 />
 
-<Callout type="note" title="Only the DR restore runbook stays lane-specific here">
+<Callout type="note" title="Lane-specific runbook scope">
 
 Generic backup and restore procedures belong in the main `Operate` docs. The cross-cluster DR restore procedure remains in this section because it depends on the exact validated DR lane assumptions.
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
@@ -24,7 +24,7 @@ description: Validated local disaster-recovery baseline for OpenBao on k3d with 
 
 <Callout type="note" title="Classification">
 
-Local disaster-recovery reference architecture. k3d is not the production target, but this lane is the proving ground for the DR invariants that matter before you move to a cloud recovery pair.
+This local disaster-recovery reference architecture uses k3d to validate the DR invariants for backup, restore, unseal, and manual cutover before moving to a cloud recovery pair.
 
 </Callout>
 
@@ -126,7 +126,7 @@ Local disaster-recovery reference architecture. k3d is not the production target
       cells: [
         "Shared RustFS bucket",
         "The restore uses the same object-transfer shape as a real remote-storage path.",
-        "The lane is meant to prove the handoff through storage, not just a local disk copy.",
+        "The lane exercises snapshot handoff through shared object storage instead of a local disk copy.",
       ],
     },
     {
@@ -160,7 +160,7 @@ The local DR lane proved source backup to RustFS, restore into a separate target
 
 <Callout type="warning" title="What this lane is not">
 
-This is not an automatic failover design, not a cloud DR reference, and not proof that any backup can restore into any target shape. It is a validated manual recovery lane with explicit preconditions.
+This lane does not define automatic failover or a cloud DR reference. It is a validated manual recovery lane with explicit preconditions for backup, restore, and cutover.
 
 </Callout>
 
@@ -169,7 +169,7 @@ This is not an automatic failover design, not a cloud DR reference, and not proo
   items={[
     {
       label: "Bootstrap recipe",
-      description: "Stand up the infra, source, and target clusters that make up the DR proving ground.",
+      description: "Stand up the infra, source, and target clusters that make up the DR validation environment.",
       docId: "user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap",
     },
     {

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
@@ -7,8 +7,8 @@ description: Validated local disaster-recovery baseline for OpenBao on k3d with 
 ---
 
 <PageHeader
-  title="Use this lane to rehearse restore across a real cluster boundary before you trust a cloud DR pair."
-  lede="This local DR baseline keeps the source, target, and shared trust services separated so backup, restore, unseal, and cutover all cross the same kinds of boundaries they will cross in a real disaster-recovery event."
+  title="Local cross-cluster DR baseline"
+  lede="This local DR baseline keeps the source, target, and shared trust services separated so backup, restore, unseal, and cutover all cross the same kinds of boundaries used in a real disaster-recovery event."
 />
 
 <Checklist

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
@@ -12,7 +12,7 @@ description: Validated local disaster-recovery baseline for OpenBao on k3d with 
 />
 
 <Checklist
-    title="This lane proves"
+    title="Validated coverage"
     items={[
       "a snapshot can leave the source cluster, cross an object-storage boundary, and restore into a different target cluster",
       "the restored target can unseal only because it shares the same external Transit root of trust as the source",
@@ -65,14 +65,14 @@ This local disaster-recovery reference architecture uses k3d to validate the DR 
       cells: [
         "Cutover model",
         "Manual restore and manual client or DNS cutover",
-        "The lane proves restore correctness, not automatic failover orchestration.",
+        "The baseline covers restore correctness and does not include automatic failover orchestration.",
       ],
     },
   ]}
 />
 
 <DiagramFrame
-  title="Validated lane topology"
+  title="Baseline topology"
   caption="The source cluster writes snapshots to shared storage, the target cluster restores from that storage, and both sides depend on the same external Transit key to make restored data usable."
   code={`flowchart LR
     Client["Operator or admin"] -->|"HTTPS (SNI)"| SourceEdge["Source passthrough edge"]
@@ -152,15 +152,15 @@ This local disaster-recovery reference architecture uses k3d to validate the DR 
   ]}
 />
 
-<Callout type="success" title="What this lane validated">
+<Callout type="success" title="Validated coverage">
 
 The local DR lane proved source backup to RustFS, restore into a separate target cluster, target unseal with the shared Transit key, and post-restore checks that source credentials and source data replaced the target bootstrap state.
 
 </Callout>
 
-<Callout type="warning" title="What this lane is not">
+<Callout type="warning" title="Out of scope">
 
-This lane does not define automatic failover or a cloud DR reference. It is a validated manual recovery lane with explicit preconditions for backup, restore, and cutover.
+This baseline does not define automatic failover or a cloud DR reference. It covers a validated manual recovery flow with explicit preconditions for backup, restore, and cutover.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs.md
@@ -22,14 +22,14 @@ description: Validated local disaster-recovery baseline for OpenBao on k3d with 
   />
 
 
-<Callout type="note" title="Classification">
+<Callout type="note" title="Baseline scope">
 
 This local disaster-recovery reference architecture uses k3d to validate the DR invariants for backup, restore, unseal, and manual cutover before moving to a cloud recovery pair.
 
 </Callout>
 
 <DecisionTable
-  title="Lane summary"
+  title="Baseline summary"
   columns={["Surface", "Choice", "Why it matters"]}
   rows={[
     {
@@ -142,7 +142,7 @@ This local disaster-recovery reference architecture uses k3d to validate the DR 
 
 <Checklist
   tone="warning"
-  title="Stay on the validated path"
+  title="Baseline requirements"
   items={[
     "keep the source and target on the same OpenBao version for the restore event",
     "keep the source and target pointed at the same Transit address, CA bundle, SNI, and key name",
@@ -165,7 +165,7 @@ This baseline does not define automatic failover or a cloud DR reference. It cov
 </Callout>
 
 <NextActions
-  title="Use the lane"
+  title="Next steps"
   items={[
     {
       label: "Bootstrap recipe",

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs.md
@@ -22,14 +22,14 @@ description: Validated local baseline for a development-profile OpenBao deployme
   />
 
 
-<Callout type="note" title="Classification">
+<Callout type="note" title="Baseline scope">
 
 This local reference architecture uses k3d as a development environment for operator bring-up, UI checks, backup rehearsal, and upgrade behavior. It is a validated local lane rather than a production target.
 
 </Callout>
 
 <DecisionTable
-  title="Lane summary"
+  title="Baseline summary"
   columns={["Surface", "Choice", "Why it matters"]}
   rows={[
     {
@@ -136,7 +136,7 @@ This local reference architecture uses k3d as a development environment for oper
 
 <Checklist
   tone="warning"
-  title="Stay on the validated path"
+  title="Baseline requirements"
   items={[
     "keep `spec.profile: Development` and do not treat the lane as a production hardening reference",
     "keep the shared terminating Gateway in front of the cluster instead of switching to passthrough mid-lane",
@@ -159,7 +159,7 @@ This lane does not define a production reference or a hardened security posture.
 </Callout>
 
 <NextActions
-  title="Use the lane"
+  title="Next steps"
   items={[
     {
       label: "Deployment recipe",

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs.md
@@ -12,12 +12,12 @@ description: Validated local baseline for a development-profile OpenBao deployme
 />
 
 <Checklist
-    title="This lane proves"
+    title="Validated coverage"
     items={[
       "a Development-profile cluster can bootstrap cleanly on k3d without extra cloud dependencies",
       "the shared terminating edge can front OpenBao alongside the rest of the local platform toolchain",
       "operator-managed TLS, self-init, JWT bootstrap, and RustFS backups can coexist in one repeatable lane",
-      "blue/green upgrades can be rehearsed locally before you touch a hardened or cloud baseline",
+      "blue/green upgrades can be rehearsed locally before moving to a hardened or cloud baseline",
     ]}
   />
 
@@ -58,7 +58,7 @@ This local reference architecture uses k3d as a development environment for oper
       cells: [
         "Backup target",
         "RustFS via the S3-compatible API",
-        "The lane proves snapshot behavior against a real object-storage boundary without needing cloud credentials.",
+        "The baseline covers snapshot behavior against a real object-storage boundary without cloud credentials.",
       ],
     },
     {
@@ -72,7 +72,7 @@ This local reference architecture uses k3d as a development environment for oper
 />
 
 <DiagramFrame
-  title="Validated lane topology"
+  title="Baseline topology"
   caption="The shared terminating edge stays simple, the operator owns TLS and bootstrap, and the backup path leaves the cluster through a separate RustFS boundary."
   code={`flowchart LR
     Client["Operator or admin"] -->|"HTTPS"| Edge["Shared Gateway API edge"]
@@ -146,13 +146,13 @@ This local reference architecture uses k3d as a development environment for oper
   ]}
 />
 
-<Callout type="success" title="What this lane validated">
+<Callout type="success" title="Validated coverage">
 
 The local development lane exercised self-init bootstrap, JWT admin login, optional demo UI login, shared-edge exposure, scheduled and manual backup behavior to RustFS, and blue/green upgrade rehearsal.
 
 </Callout>
 
-<Callout type="warning" title="What this lane is not">
+<Callout type="warning" title="Out of scope">
 
 This lane does not define a production reference or a hardened security posture. It is a local validation environment for shared-edge routing, backup behavior, and upgrade rehearsal.
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-development-shared-edge-rustfs.md
@@ -7,8 +7,8 @@ description: Validated local baseline for a development-profile OpenBao deployme
 ---
 
 <PageHeader
-  title="Use this lane to validate operator bring-up, shared-edge routing, and backup flows without pretending a dev profile is production."
-  lede="This local baseline is the lowest-friction validated path for development work on k3d. It keeps the edge simple, keeps TLS operator-managed, keeps backups pointed at an S3-compatible store, and still exercises the cluster lifecycle with a realistic control-plane shape."
+  title="Local development lane with shared edge and RustFS"
+  lede="This validated local baseline covers development work on k3d with a shared terminating edge, operator-managed TLS, RustFS backups, and blue/green upgrades. Use it to exercise the cluster lifecycle with a low-friction local topology."
 />
 
 <Checklist
@@ -24,7 +24,7 @@ description: Validated local baseline for a development-profile OpenBao deployme
 
 <Callout type="note" title="Classification">
 
-Local reference architecture. k3d is not a production target, but this lane is the preferred proving ground for local operator bring-up, UI checks, backup rehearsal, and upgrade behavior.
+This local reference architecture uses k3d as a development environment for operator bring-up, UI checks, backup rehearsal, and upgrade behavior. It is a validated local lane rather than a production target.
 
 </Callout>
 
@@ -113,7 +113,7 @@ Local reference architecture. k3d is not a production target, but this lane is t
       cells: [
         "RustFS for backups",
         "A real S3-compatible transfer boundary with no cloud dependency.",
-        "The lane should prove snapshot upload and retention behavior, not just configuration syntax.",
+        "The lane exercises snapshot upload and retention behavior against an S3-compatible API.",
       ],
     },
     {
@@ -154,7 +154,7 @@ The local development lane exercised self-init bootstrap, JWT admin login, optio
 
 <Callout type="warning" title="What this lane is not">
 
-This is not a production reference, not a hardened security posture, and not proof that the shared terminating edge is the right answer for public OpenBao endpoints. It is a fast, realistic local validation lane.
+This lane does not define a production reference or a hardened security posture. It is a local validation environment for shared-edge routing, backup behavior, and upgrade rehearsal.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme.md
@@ -22,14 +22,14 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
   />
 
 
-<Callout type="note" title="Classification">
+<Callout type="note" title="Baseline scope">
 
 This local reference architecture uses k3d to rehearse hardened deployments that keep TLS passthrough in OpenBao and use a private ACME trust chain. It is a local validation lane rather than a production target.
 
 </Callout>
 
 <DecisionTable
-  title="Lane summary"
+  title="Baseline summary"
   columns={["Surface", "Choice", "Why it matters"]}
   rows={[
     {
@@ -135,7 +135,7 @@ This local reference architecture uses k3d to rehearse hardened deployments that
 
 <Checklist
   tone="warning"
-  title="Stay on the validated path"
+  title="Baseline requirements"
   items={[
     "keep `spec.profile: Hardened` and keep the trust-services endpoint reachable for both Transit and ACME",
     "keep the ACME hostname resolving back to the passthrough edge from the validating environment",
@@ -158,7 +158,7 @@ This lane does not prove public ACME behavior or replace a cloud ingress baselin
 </Callout>
 
 <NextActions
-  title="Use the lane"
+  title="Next steps"
   items={[
     {
       label: "Deployment recipe",

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme.md
@@ -7,8 +7,8 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
 ---
 
 <PageHeader
-  title="Use this lane to rehearse hardened ACME issuance locally without swapping in public internet dependencies."
-  lede="This local baseline keeps the hardened posture, keeps the unseal root external, and keeps OpenBao as the TLS endpoint while an internal ACME CA proves certificate issuance through a user-managed passthrough edge."
+  title="Local hardened lane with private ACME"
+  lede="This validated local baseline keeps the hardened posture, keeps the unseal root external, and keeps OpenBao as the TLS endpoint while an internal ACME CA validates certificate issuance through a user-managed passthrough edge."
 />
 
 <Checklist
@@ -17,14 +17,14 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
       "a Hardened cluster can bootstrap locally while keeping the seal dependency outside the tenant namespace",
       "OpenBao-managed ACME issuance works when the validator reaches the passthrough edge with the expected hostname",
       "Transit auto-unseal and ACME trust material can coexist in one shared trust-services dependency",
-      "local rehearsal can cover ACME readiness and probe behavior before you move to a public cloud baseline",
+      "local rehearsal covers ACME readiness and probe behavior before a public-cloud baseline",
     ]}
   />
 
 
 <Callout type="note" title="Classification">
 
-Local reference architecture. k3d is not the production target, but this lane is the preferred local analogue for hardened deployments that keep TLS passthrough in OpenBao and use a private ACME trust chain.
+This local reference architecture uses k3d to rehearse hardened deployments that keep TLS passthrough in OpenBao and use a private ACME trust chain. It is a local validation lane rather than a production target.
 
 </Callout>
 
@@ -153,7 +153,7 @@ The validated local lane exercised hardened bootstrap with self-init, Transit au
 
 <Callout type="warning" title="What this lane is not">
 
-This is not proof that public ACME will work, not a substitute for a cloud ingress baseline, and not a generic passthrough recommendation. It is a local rehearsal lane for the hardened ACME control path.
+This lane does not prove public ACME behavior or replace a cloud ingress baseline. It is a local rehearsal environment for the hardened ACME control path.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-acme.md
@@ -12,7 +12,7 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
 />
 
 <Checklist
-    title="This lane proves"
+    title="Validated coverage"
     items={[
       "a Hardened cluster can bootstrap locally while keeping the seal dependency outside the tenant namespace",
       "OpenBao-managed ACME issuance works when the validator reaches the passthrough edge with the expected hostname",
@@ -65,14 +65,14 @@ This local reference architecture uses k3d to rehearse hardened deployments that
       cells: [
         "Validation scope",
         "Local ACME lifecycle coverage plus hardened bootstrap",
-        "The lane is valuable because it proves ACME readiness, trust material, and bootstrap behavior together.",
+        "The baseline covers ACME readiness, trust material, and bootstrap behavior together.",
       ],
     },
   ]}
 />
 
 <DiagramFrame
-  title="Validated lane topology"
+  title="Baseline topology"
   caption="The same external trust-services dependency supplies both Transit auto-unseal and the private ACME directory, while the ingress layer remains pure passthrough."
   code={`flowchart LR
     Client["OpenBao client"] -->|"HTTPS (SNI)"| Edge["Traefik IngressRouteTCP"]
@@ -145,13 +145,13 @@ This local reference architecture uses k3d to rehearse hardened deployments that
   ]}
 />
 
-<Callout type="success" title="What this lane validated">
+<Callout type="success" title="Validated coverage">
 
 The validated local lane exercised hardened bootstrap with self-init, Transit auto-unseal through shared trust services, OpenBao-managed ACME issuance from a private CA, human admin JWT login, and external access over user-managed passthrough.
 
 </Callout>
 
-<Callout type="warning" title="What this lane is not">
+<Callout type="warning" title="Out of scope">
 
 This lane does not prove public ACME behavior or replace a cloud ingress baseline. It is a local rehearsal environment for the hardened ACME control path.
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls.md
@@ -22,14 +22,14 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
   />
 
 
-<Callout type="note" title="Classification">
+<Callout type="note" title="Baseline scope">
 
 This local reference architecture uses k3d to rehearse a hardened deployment with an external seal provider and externally managed certificates. It is a local validation lane rather than a production target.
 
 </Callout>
 
 <DecisionTable
-  title="Lane summary"
+  title="Baseline summary"
   columns={["Surface", "Choice", "Why it matters"]}
   rows={[
     {
@@ -128,7 +128,7 @@ This local reference architecture uses k3d to rehearse a hardened deployment wit
 
 <Checklist
   tone="warning"
-  title="Stay on the validated path"
+  title="Baseline requirements"
   items={[
     "keep `spec.profile: Hardened`",
     "keep the shared Transit provider reachable and trusted",
@@ -151,7 +151,7 @@ This lane does not define a cloud reference or a GitOps reference. It is a local
 </Callout>
 
 <NextActions
-  title="Use the lane"
+  title="Next steps"
   items={[
     {
       label: "Deployment recipe",

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls.md
@@ -7,8 +7,8 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
 ---
 
 <PageHeader
-  title="Use this lane to rehearse a hardened deployment with external certificates and a separate unseal root."
-  lede="This local baseline is the closest validated rehearsal path to a hardened deployment that keeps TLS outside the operator, keeps the seal dependency external, and exposes OpenBao through user-managed TCP passthrough instead of a shared terminating edge."
+  title="Local hardened lane with external TLS"
+  lede="This validated local baseline rehearses a hardened deployment that keeps TLS outside the operator, keeps the seal dependency external, and exposes OpenBao through user-managed TCP passthrough instead of a shared terminating edge."
 />
 
 <Checklist
@@ -24,7 +24,7 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
 
 <Callout type="note" title="Classification">
 
-Local reference architecture. k3d is not the production target, but this lane is the closest validated local analogue to a hardened deployment with an external seal provider and externally managed certificates.
+This local reference architecture uses k3d to rehearse a hardened deployment with an external seal provider and externally managed certificates. It is a local validation lane rather than a production target.
 
 </Callout>
 
@@ -146,7 +146,7 @@ The validated local lane exercised hardened bootstrap with self-init, Transit au
 
 <Callout type="warning" title="What this lane is not">
 
-This is not a cloud reference, not a GitOps reference, and not proof that `spec.gateway` itself is the right path for hardened passthrough. It is a local rehearsal lane with explicit external dependencies.
+This lane does not define a cloud reference or a GitOps reference. It is a local rehearsal environment for hardened bootstrap, external TLS, and passthrough access with explicit external dependencies.
 
 </Callout>
 

--- a/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls.md
+++ b/docs/user-guide/validated-deployments/architectures/local/k3d-hardened-transit-external-tls.md
@@ -8,16 +8,16 @@ description: Validated local baseline for a hardened OpenBao deployment on k3d w
 
 <PageHeader
   title="Local hardened lane with external TLS"
-  lede="This validated local baseline rehearses a hardened deployment that keeps TLS outside the operator, keeps the seal dependency external, and exposes OpenBao through user-managed TCP passthrough instead of a shared terminating edge."
+  lede="This validated local baseline covers a hardened deployment with external TLS, an external seal dependency, and user-managed TCP passthrough."
 />
 
 <Checklist
-    title="This lane proves"
+    title="Validated coverage"
     items={[
       "a Hardened cluster can bootstrap locally without falling back to operator-managed TLS or static unseal",
       "Transit auto-unseal can stay outside the cluster while self-init and JWT bootstrap still succeed",
       "externally managed TLS Secrets and passthrough traffic can remain separate from the operator's edge integration model",
-      "the local environment can rehearse a production-style trust split without pretending k3d itself is the production target",
+      "the local environment can rehearse a production-style trust split",
     ]}
   />
 
@@ -44,7 +44,7 @@ This local reference architecture uses k3d to rehearse a hardened deployment wit
       cells: [
         "Seal path",
         "External Transit provider",
-        "The unseal root stays outside the cluster so the lane tests a real external dependency instead of collapsing back into static secrets.",
+        "The unseal root stays outside the cluster so the baseline exercises a real external dependency rather than static secrets.",
       ],
     },
     {
@@ -65,14 +65,14 @@ This local reference architecture uses k3d to rehearse a hardened deployment wit
       cells: [
         "Validation scope",
         "Local validation environment plus hardened E2E lifecycle coverage",
-        "The lane proves bootstrap, unseal, admin JWT login, and passthrough access in a repeatable local rehearsal path.",
+        "The baseline covers bootstrap, unseal, admin JWT login, and passthrough access in a repeatable local rehearsal path.",
       ],
     },
   ]}
 />
 
 <DiagramFrame
-  title="Validated lane topology"
+  title="Baseline topology"
   caption="The lane keeps the unseal root external, keeps TLS external, and keeps the passthrough path user-managed. That separation is the reason this local baseline is useful."
   code={`flowchart LR
     Client["OpenBao client"] -->|"HTTPS (SNI)"| Edge["Traefik IngressRouteTCP"]
@@ -138,13 +138,13 @@ This local reference architecture uses k3d to rehearse a hardened deployment wit
   ]}
 />
 
-<Callout type="success" title="What this lane validated">
+<Callout type="success" title="Validated coverage">
 
 The validated local lane exercised hardened bootstrap with self-init, Transit auto-unseal through a shared external OpenBao service, JWT login for a human admin `ServiceAccount`, and passthrough external access with externally managed TLS Secrets.
 
 </Callout>
 
-<Callout type="warning" title="What this lane is not">
+<Callout type="warning" title="Out of scope">
 
 This lane does not define a cloud reference or a GitOps reference. It is a local rehearsal environment for hardened bootstrap, external TLS, and passthrough access with explicit external dependencies.
 

--- a/docs/user-guide/validated-deployments/index.mdx
+++ b/docs/user-guide/validated-deployments/index.mdx
@@ -9,8 +9,8 @@ description: Tested OpenBao Operator baselines grouped by validated lane, with p
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments"
-  title="Choose a tested baseline by lane, then adapt it without forgetting what was actually proven."
-  lede="This section is for teams that want a known-good starting point instead of assembling a topology from scratch. Each validated lane pairs a reference architecture with the deployment recipe that reproduces it. Generic operator setup, backup, and restore guidance still lives in the main docs."
+  title="Validated deployment baselines"
+  lede="This section groups tested deployment baselines by environment, with a reference architecture and matching recipe for each validated baseline. Use it when you want to start from a project-tested topology rather than assemble one from scratch."
   actions={[
     {label: "Open cloud baselines", docId: "user-guide/validated-deployments/architectures/cloud/index", variant: "primary"},
     {label: "Open local baselines", docId: "user-guide/validated-deployments/architectures/local/index", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/index.mdx
+++ b/docs/user-guide/validated-deployments/index.mdx
@@ -3,14 +3,14 @@ title: Validated Deployments
 slug: /validated-deployments
 hide_title: true
 pageType: landing
-description: Tested OpenBao Operator baselines grouped by validated lane, with paired reference architecture and deployment recipe pages.
+description: Validated OpenBao Operator baselines grouped by lane, with paired reference architecture and deployment recipe pages.
 ---
 
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments"
   title="Validated deployment baselines"
-  lede="This section groups tested deployment baselines by environment, with a reference architecture and matching recipe for each validated baseline. Use it when you want to start from a project-tested topology rather than assemble one from scratch."
+  lede="This section groups validated deployment baselines by environment, with a reference architecture and matching recipe for each one. Use it when you want to start from a project-tested topology."
   actions={[
     {label: "Open cloud baselines", docId: "user-guide/validated-deployments/architectures/cloud/index", variant: "primary"},
     {label: "Open local baselines", docId: "user-guide/validated-deployments/architectures/local/index", variant: "secondary"},
@@ -22,7 +22,7 @@ description: Tested OpenBao Operator baselines grouped by validated lane, with p
       "start from a topology that the project exercised end to end",
       "compare cloud and local lanes without stitching together architecture and recipe pages yourself",
       "pick a lane with clear invariants, assumptions, and validation scope",
-      "adapt a known baseline rather than improvising the first production shape",
+      "adapt a known baseline as the starting point for environment-specific changes",
     ]}
   />
 </PageHero>
@@ -39,21 +39,21 @@ description: Tested OpenBao Operator baselines grouped by validated lane, with p
     {
       eyebrow: "02",
       title: "Local baselines",
-      description: "Use the k3d lanes for workstation validation, hardened rehearsal, and cross-cluster DR practice without treating them as generic production blueprints.",
+      description: "Use the k3d lanes for workstation validation, hardened rehearsal, and cross-cluster DR practice.",
       docId: "user-guide/validated-deployments/architectures/local/index",
     },
     {
       eyebrow: "03",
       title: "Cross-cluster DR lane",
-      description: "Go directly to the validated DR architecture when the goal is restore rehearsal, shared Transit, and snapshot cutover proof.",
+      description: "Go directly to the validated DR architecture for restore rehearsal, shared Transit, and snapshot cutover validation.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs",
     },
   ]}
 />
 
-<Callout type="note" title="Validated lane pages are not the canonical operator runbooks">
+<Callout type="note" title="Scope of this section">
 
-The main operator guides remain the source of truth for install, backup, restore, upgrade, and recovery behavior. This section proves specific environment shapes and links to the exact lane that was exercised.
+The main operator guides remain the source of truth for install, backup, restore, upgrade, and recovery behavior. This section covers specific validated environment shapes and links to the exact lane that was exercised.
 
 </Callout>
 
@@ -72,7 +72,7 @@ The main operator guides remain the source of truth for install, backup, restore
     },
     {
       label: "Open Get Started",
-      description: "Return to the general operator path when you need the product-wide install and onboarding journey instead of a validated lane.",
+      description: "Return to the general operator path for the product-wide install and onboarding journey.",
       docId: "user-guide/index",
     },
   ]}

--- a/docs/user-guide/validated-deployments/index.mdx
+++ b/docs/user-guide/validated-deployments/index.mdx
@@ -10,17 +10,17 @@ description: Validated OpenBao Operator baselines grouped by lane, with paired r
   variant="landing"
   eyebrow="Validated Deployments"
   title="Validated deployment baselines"
-  lede="This section groups validated deployment baselines by environment, with a reference architecture and matching recipe for each one. Use it when you want to start from a project-tested topology."
+  lede="Validated deployment baselines are grouped by environment, with a reference architecture and matching recipe for each baseline."
   actions={[
     {label: "Open cloud baselines", docId: "user-guide/validated-deployments/architectures/cloud/index", variant: "primary"},
     {label: "Open local baselines", docId: "user-guide/validated-deployments/architectures/local/index", variant: "secondary"},
   ]}
 >
   <Checklist
-    title="Use validated deployments when you want to"
+    title="Use validated deployments to"
     items={[
       "start from a topology that the project exercised end to end",
-      "compare cloud and local lanes without stitching together architecture and recipe pages yourself",
+      "compare cloud and local baselines with architecture and recipe pages kept together",
       "pick a lane with clear invariants, assumptions, and validation scope",
       "adapt a known baseline as the starting point for environment-specific changes",
     ]}
@@ -33,19 +33,19 @@ description: Validated OpenBao Operator baselines grouped by lane, with paired r
     {
       eyebrow: "01",
       title: "Cloud baselines",
-      description: "Start here when you want the Amazon EKS development or hardened lanes and need the architecture and recipe kept together.",
+      description: "Amazon EKS development and hardened baselines with paired architecture and recipe pages.",
       docId: "user-guide/validated-deployments/architectures/cloud/index",
     },
     {
       eyebrow: "02",
       title: "Local baselines",
-      description: "Use the k3d lanes for workstation validation, hardened rehearsal, and cross-cluster DR practice.",
+      description: "k3d baselines for workstation validation, hardened rehearsal, and cross-cluster DR.",
       docId: "user-guide/validated-deployments/architectures/local/index",
     },
     {
       eyebrow: "03",
       title: "Cross-cluster DR lane",
-      description: "Go directly to the validated DR architecture for restore rehearsal, shared Transit, and snapshot cutover validation.",
+      description: "Validated DR architecture for restore rehearsal, shared Transit, and snapshot cutover verification.",
       docId: "user-guide/validated-deployments/architectures/local/k3d-cross-cluster-dr-transit-rustfs",
     },
   ]}
@@ -53,7 +53,7 @@ description: Validated OpenBao Operator baselines grouped by lane, with paired r
 
 <Callout type="note" title="Scope of this section">
 
-The main operator guides remain the source of truth for install, backup, restore, upgrade, and recovery behavior. This section covers specific validated environment shapes and links to the exact lane that was exercised.
+Main operator guides remain the source of truth for install, backup, restore, upgrade, and recovery behavior. These pages document the validated environment shapes used for specific baselines.
 
 </Callout>
 
@@ -62,17 +62,17 @@ The main operator guides remain the source of truth for install, backup, restore
   items={[
     {
       label: "Open configure",
-      description: "Adapt the validated lane to your actual storage, edge, and observability choices without losing the cluster-shaping model.",
+      description: "Adapt storage, edge, and observability choices for your environment.",
       docId: "user-guide/openbaocluster/configuration/index",
     },
     {
       label: "Open Operate",
-      description: "Use the main operating guides for backups, upgrades, troubleshooting, and recovery once the lane is running.",
+      description: "Use the main operating guides for backups, upgrades, troubleshooting, and recovery after the baseline is running.",
       docId: "user-guide/openbaocluster/operations/index",
     },
     {
       label: "Open Get Started",
-      description: "Return to the general operator path for the product-wide install and onboarding journey.",
+      description: "Return to the general operator path for install and onboarding guidance.",
       docId: "user-guide/index",
     },
   ]}

--- a/docs/user-guide/validated-deployments/index.mdx
+++ b/docs/user-guide/validated-deployments/index.mdx
@@ -10,7 +10,7 @@ description: Validated OpenBao Operator baselines grouped by lane, with paired r
   variant="landing"
   eyebrow="Validated Deployments"
   title="Validated deployment baselines"
-  lede="Validated deployment baselines are grouped by environment, with a reference architecture and matching recipe for each baseline."
+  lede="Reference architectures and matching deployment recipes grouped by validated deployment baseline."
   actions={[
     {label: "Open cloud baselines", docId: "user-guide/validated-deployments/architectures/cloud/index", variant: "primary"},
     {label: "Open local baselines", docId: "user-guide/validated-deployments/architectures/local/index", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3.md
@@ -30,12 +30,12 @@ This recipe matches the EKS development lane validated in the project cloud envi
 
 <Callout type="note" title="Use the main docs for generic operator behavior">
 
-Use <SiteLink docId="user-guide/openbaotenant/onboarding">tenant onboarding</SiteLink>, <SiteLink docId="user-guide/openbaocluster/configuration/gateway-api">Gateway API support</SiteLink>, and <SiteLink docId="user-guide/openbaocluster/operations/backups">backup operations</SiteLink> for the product-wide guidance. This page captures the exact validated lane.
+Use <SiteLink docId="user-guide/openbaotenant/onboarding">tenant onboarding</SiteLink>, <SiteLink docId="user-guide/openbaocluster/configuration/gateway-api">Gateway API support</SiteLink>, and <SiteLink docId="user-guide/openbaocluster/operations/backups">backup operations</SiteLink> for the product-wide guidance. This recipe documents the validated lane.
 
 </Callout>
 
 <DecisionTable
-  title="What this lane assumes"
+  title="Baseline assumptions"
   columns={["Assumption", "Why it exists", "What breaks if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3.md
@@ -7,8 +7,8 @@ description: Reproduce the validated development baseline on Amazon EKS with AWS
 ---
 
 <PageHeader
-  title="Reproduce the validated EKS development lane without mixing the quick bring-up path with hardened endpoint requirements."
-  lede="This recipe applies the EKS development baseline with KMS auto-unseal, shared-edge exposure, JWT bootstrap, and S3 backups. Use it when you need the exact validated cloud bring-up path, not a generic EKS example."
+  title="Reproduce the validated EKS development lane"
+  lede="This recipe applies the EKS development baseline with KMS auto-unseal, shared-edge exposure, JWT bootstrap, and S3 backups. Use it when you need the exact validated cloud bring-up path for this topology."
 />
 
 <Checklist

--- a/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3.md
@@ -12,7 +12,7 @@ description: Reproduce the validated development baseline on Amazon EKS with AWS
 />
 
 <Checklist
-    title="This recipe should leave you with"
+    title="Recipe outcomes"
     items={[
       "an onboarded tenant namespace and admin ServiceAccount",
       "a Development-profile cluster that unseals with AWS KMS through workload identity",
@@ -22,7 +22,7 @@ description: Reproduce the validated development baseline on Amazon EKS with AWS
   />
 
 
-<Callout type="success" title="Validated lane">
+<Callout type="success" title="Validated coverage">
 
 This recipe matches the EKS development lane validated in the project cloud environment. The tested path covered KMS unseal, JWT bootstrap, Gateway exposure, and successful S3 backups.
 

--- a/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme.md
@@ -7,12 +7,12 @@ description: Reproduce the validated hardened baseline on Amazon EKS with AWS KM
 ---
 
 <PageHeader
-  title="Reproduce the validated hardened EKS lane without diluting the public-edge and ACME assumptions it depends on."
-  lede="This recipe applies the hardened cloud baseline with KMS auto-unseal, a dedicated public passthrough Gateway, OpenBao-managed ACME, JWT bootstrap, and S3 backups. Use it when you want the production-style EKS path the project has actually validated."
+  title="Reproduce the validated hardened EKS baseline"
+  lede="This recipe applies the hardened cloud baseline with KMS auto-unseal, a dedicated public passthrough Gateway, OpenBao-managed ACME, JWT bootstrap, and S3 backups."
 />
 
 <Checklist
-    title="This recipe should leave you with"
+    title="Recipe outcomes"
     items={[
       "an onboarded tenant namespace and admin ServiceAccount",
       "a Hardened-profile cluster that unseals with AWS KMS and serves the public hostname through passthrough",
@@ -22,7 +22,7 @@ description: Reproduce the validated hardened baseline on Amazon EKS with AWS KM
   />
 
 
-<Callout type="success" title="Validated lane">
+<Callout type="success" title="Validated coverage">
 
 This recipe matches the hardened Amazon EKS lane validated in the project cloud environment. The tested path covered KMS auto-unseal, public ACME issuance, dedicated passthrough ingress, JWT bootstrap, and successful S3 backups.
 

--- a/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme.md
@@ -35,7 +35,7 @@ A public ACME CA such as Let's Encrypt must reach the hardened hostname on port 
 </Callout>
 
 <DecisionTable
-  title="What this lane assumes"
+  title="Baseline assumptions"
   columns={["Assumption", "Why it exists", "What breaks if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/recipes/cloud/index.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/index.md
@@ -9,7 +9,7 @@ description: Cloud deployment recipes for the validated Amazon EKS lanes.
   variant="landing"
   eyebrow="Validated Deployments / Cloud Recipe Catalog"
   title="Validated cloud recipes"
-  lede="This catalog contains the deployment recipes for the validated Amazon EKS baselines. Keep the matching reference architecture nearby so the recipe stays tied to the tested topology and assumptions."
+  lede="Deployment recipes for the validated Amazon EKS baselines are listed here. Keep the matching reference architecture nearby during deployment."
   actions={[
     {label: "Open EKS Development recipe", docId: "user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3", variant: "primary"},
     {label: "Open EKS Hardened recipe", docId: "user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/cloud/index.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/index.md
@@ -28,7 +28,7 @@ description: Cloud deployment recipes for the validated Amazon EKS lanes.
     {
       eyebrow: "02",
       title: "EKS Hardened recipe",
-      description: "Deploy the hardened EKS lane with passthrough edge, AWS KMS, ACME, and the tighter production posture.",
+      description: "Deploy the hardened EKS lane with passthrough edge, AWS KMS, ACME, and the hardened production posture.",
       docId: "user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme",
     },
   ]}

--- a/docs/user-guide/validated-deployments/recipes/cloud/index.md
+++ b/docs/user-guide/validated-deployments/recipes/cloud/index.md
@@ -8,8 +8,8 @@ description: Cloud deployment recipes for the validated Amazon EKS lanes.
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Cloud Recipe Catalog"
-  title="Run the cloud procedure that matches the lane you already chose."
-  lede="These recipes reproduce the validated Amazon EKS lanes. Keep the matching reference architecture nearby so the recipe stays connected to the topology and assumptions it was actually proven against."
+  title="Validated cloud recipes"
+  lede="This catalog contains the deployment recipes for the validated Amazon EKS baselines. Keep the matching reference architecture nearby so the recipe stays tied to the tested topology and assumptions."
   actions={[
     {label: "Open EKS Development recipe", docId: "user-guide/validated-deployments/recipes/cloud/amazon-eks-development-awskms-s3", variant: "primary"},
     {label: "Open EKS Hardened recipe", docId: "user-guide/validated-deployments/recipes/cloud/amazon-eks-hardened-awskms-acme", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/index.md
+++ b/docs/user-guide/validated-deployments/recipes/index.md
@@ -8,8 +8,8 @@ description: Catalog of validated deployment recipes, grouped by cloud and local
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Recipe Catalog"
-  title="Use the recipe catalog when you already know the lane and just need the procedure."
-  lede="Recipes are the task-oriented half of a validated lane. They assume you either already know the topology or will keep the matching reference architecture close while you apply the manifests."
+  title="Validated recipe catalog"
+  lede="This catalog groups the deployment recipes for each validated baseline. Use it when you already know the baseline or want to keep the matching reference architecture nearby while you deploy."
   actions={[
     {label: "Open cloud recipe catalog", docId: "user-guide/validated-deployments/recipes/cloud/index", variant: "primary"},
     {label: "Open local recipe catalog", docId: "user-guide/validated-deployments/recipes/local/index", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/index.md
+++ b/docs/user-guide/validated-deployments/recipes/index.md
@@ -28,7 +28,7 @@ description: Catalog of validated deployment recipes, grouped by cloud and local
     {
       eyebrow: "02",
       title: "Local recipes",
-      description: "Deployment procedures for the validated k3d development, hardened, and cross-cluster DR lanes.",
+      description: "Deployment procedures for the validated k3d development, hardened, and cross-cluster DR baselines.",
       docId: "user-guide/validated-deployments/recipes/local/index",
     },
   ]}

--- a/docs/user-guide/validated-deployments/recipes/index.md
+++ b/docs/user-guide/validated-deployments/recipes/index.md
@@ -9,7 +9,7 @@ description: Catalog of validated deployment recipes, grouped by cloud and local
   variant="landing"
   eyebrow="Validated Deployments / Recipe Catalog"
   title="Validated recipe catalog"
-  lede="This catalog groups the deployment recipes for each validated baseline. Use it when you already know the baseline or want to keep the matching reference architecture nearby while you deploy."
+  lede="Deployment recipes are grouped by validated baseline. Keep the matching reference architecture nearby while you deploy."
   actions={[
     {label: "Open cloud recipe catalog", docId: "user-guide/validated-deployments/recipes/cloud/index", variant: "primary"},
     {label: "Open local recipe catalog", docId: "user-guide/validated-deployments/recipes/local/index", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/local/development-self-init-userpass.md
+++ b/docs/user-guide/validated-deployments/recipes/local/development-self-init-userpass.md
@@ -7,12 +7,12 @@ description: Reproduce the validated local development lane with self-init, oper
 ---
 
 <PageHeader
-  title="Reproduce the validated local development lane without turning a quick-start cluster into a pile of one-off overrides."
+  title="Reproduce the validated local development baseline"
   lede="This recipe stands up the local development baseline with tenant onboarding, operator-managed TLS, a shared terminating edge, JWT bootstrap, an optional demo login, and an S3-compatible backup path backed by RustFS."
 />
 
 <Checklist
-    title="This recipe should leave you with"
+    title="Recipe outcomes"
     items={[
       "an onboarded tenant namespace and admin ServiceAccount",
       "a Development-profile cluster that self-initializes and exposes the UI through the shared edge",
@@ -22,7 +22,7 @@ description: Reproduce the validated local development lane with self-init, oper
   />
 
 
-<Callout type="success" title="Validated lane">
+<Callout type="success" title="Validated coverage">
 
 This recipe follows the development lifecycle, backup, and blue/green patterns exercised in the local validation environment and the in-repo E2E suites. The optional `userpass` login remains local-only convenience layered on top of the validated cluster path.
 

--- a/docs/user-guide/validated-deployments/recipes/local/development-self-init-userpass.md
+++ b/docs/user-guide/validated-deployments/recipes/local/development-self-init-userpass.md
@@ -35,7 +35,7 @@ Use <SiteLink docId="user-guide/openbaotenant/onboarding">tenant onboarding</Sit
 </Callout>
 
 <DecisionTable
-  title="What this lane assumes"
+  title="Baseline assumptions"
   columns={["Assumption", "Why it exists", "What breaks if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/recipes/local/hardened-transit-acme-tls.md
+++ b/docs/user-guide/validated-deployments/recipes/local/hardened-transit-acme-tls.md
@@ -7,22 +7,22 @@ description: Reproduce the validated local hardened ACME lane with Transit auto-
 ---
 
 <PageHeader
-  title="Reproduce the validated hardened ACME lane while keeping OpenBao as the TLS endpoint all the way through the local edge."
+  title="Reproduce the validated hardened ACME baseline"
   lede="This recipe stands up the local hardened ACME baseline with tenant onboarding, a shared trust-services dependency for Transit and ACME, an internal ACME CA, and a user-managed passthrough route that preserves `tls-alpn-01` behavior."
 />
 
 <Checklist
-    title="This recipe should leave you with"
+    title="Recipe outcomes"
     items={[
       "an onboarded tenant namespace and admin ServiceAccount",
       "a trust Secret that carries both the Transit CA bundle and the private ACME issuer trust root",
       "a hardened cluster that self-initializes, unseals with Transit, and serves ACME traffic through passthrough",
-      "conditions and services that prove ACME is working before you move to a public cloud lane",
+      "conditions and services that confirm ACME is working before you move to a public cloud lane",
     ]}
   />
 
 
-<Callout type="success" title="Validated lane">
+<Callout type="success" title="Validated coverage">
 
 This recipe follows the local ACME lifecycle covered by the in-repo ACME suite and the project validation environment. The tested path covers private ACME trust material, Transit auto-unseal, ACME readiness, and human admin JWT access.
 

--- a/docs/user-guide/validated-deployments/recipes/local/hardened-transit-acme-tls.md
+++ b/docs/user-guide/validated-deployments/recipes/local/hardened-transit-acme-tls.md
@@ -35,7 +35,7 @@ Use <SiteLink docId="user-guide/openbaocluster/configuration/external-access">ex
 </Callout>
 
 <DecisionTable
-  title="What this lane assumes"
+  title="Baseline assumptions"
   columns={["Assumption", "Why it exists", "What breaks if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/recipes/local/hardened-transit-external-tls.md
+++ b/docs/user-guide/validated-deployments/recipes/local/hardened-transit-external-tls.md
@@ -35,7 +35,7 @@ Use the main guides for the product-wide source of truth on <SiteLink docId="use
 </Callout>
 
 <DecisionTable
-  title="What this lane assumes"
+  title="Baseline assumptions"
   columns={["Assumption", "Why it exists", "What breaks if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/recipes/local/hardened-transit-external-tls.md
+++ b/docs/user-guide/validated-deployments/recipes/local/hardened-transit-external-tls.md
@@ -12,7 +12,7 @@ description: Reproduce the validated local hardened lane with Transit auto-unsea
 />
 
 <Checklist
-    title="This recipe should leave you with"
+    title="Recipe outcomes"
     items={[
       "an onboarded tenant namespace and admin ServiceAccount",
       "a hardened cluster that self-initializes and never persists a root token Secret",
@@ -22,7 +22,7 @@ description: Reproduce the validated local hardened lane with Transit auto-unsea
   />
 
 
-<Callout type="success" title="Validated lane">
+<Callout type="success" title="Validated coverage">
 
 This recipe follows the hardened external-TLS lifecycle covered by the in-repo E2E suite and the local validation environment. The tested path includes tenant onboarding, external TLS Secrets, Transit auto-unseal, self-init, and successful JWT admin login.
 

--- a/docs/user-guide/validated-deployments/recipes/local/hardened-transit-external-tls.md
+++ b/docs/user-guide/validated-deployments/recipes/local/hardened-transit-external-tls.md
@@ -7,8 +7,8 @@ description: Reproduce the validated local hardened lane with Transit auto-unsea
 ---
 
 <PageHeader
-  title="Reproduce the validated hardened local lane without collapsing the trust boundaries it depends on."
-  lede="This recipe stands up the local hardened lane with tenant onboarding, external Transit unseal, externally managed TLS Secrets, and user-managed TCP passthrough. Use it when you want the exact validated path, not a generic local example."
+  title="Reproduce the validated hardened local lane"
+  lede="This recipe stands up the local hardened lane with tenant onboarding, external Transit unseal, externally managed TLS Secrets, and user-managed TCP passthrough. Use it when you want the exact validated path for this topology."
 />
 
 <Checklist

--- a/docs/user-guide/validated-deployments/recipes/local/index.md
+++ b/docs/user-guide/validated-deployments/recipes/local/index.md
@@ -9,7 +9,7 @@ description: Local deployment recipes for the validated k3d lanes.
   variant="landing"
   eyebrow="Validated Deployments / Local Recipe Catalog"
   title="Validated local recipes"
-  lede="This catalog contains the deployment recipes for the validated k3d baselines. These procedures reproduce the project-tested local environments and should be read together with the matching baseline."
+  lede="Deployment recipes for the validated k3d baselines are listed here. Read them with the matching baseline."
   actions={[
     {label: "Open k3d Development recipe", docId: "user-guide/validated-deployments/recipes/local/development-self-init-userpass", variant: "primary"},
     {label: "Open k3d Cross-Cluster DR bootstrap", docId: "user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/local/index.md
+++ b/docs/user-guide/validated-deployments/recipes/local/index.md
@@ -40,7 +40,7 @@ description: Local deployment recipes for the validated k3d lanes.
     {
       eyebrow: "04",
       title: "k3d Cross-Cluster DR bootstrap",
-      description: "Bootstrap the source and target clusters for the validated DR proving lane.",
+      description: "Bootstrap the source and target clusters for the validated DR lane.",
       docId: "user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap",
     },
   ]}

--- a/docs/user-guide/validated-deployments/recipes/local/index.md
+++ b/docs/user-guide/validated-deployments/recipes/local/index.md
@@ -8,8 +8,8 @@ description: Local deployment recipes for the validated k3d lanes.
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Local Recipe Catalog"
-  title="Run the local procedure that matches the validated lane you want to rehearse."
-  lede="These recipes reproduce the local k3d validation lanes. They are useful because they follow the exact assumptions exercised by the project environment, but they should still be read as lane procedures, not as generic operator setup."
+  title="Validated local recipes"
+  lede="This catalog contains the deployment recipes for the validated k3d baselines. These procedures reproduce the project-tested local environments and should be read together with the matching baseline."
   actions={[
     {label: "Open k3d Development recipe", docId: "user-guide/validated-deployments/recipes/local/development-self-init-userpass", variant: "primary"},
     {label: "Open k3d Cross-Cluster DR bootstrap", docId: "user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
+++ b/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
@@ -3,7 +3,7 @@ title: k3d Cross-Cluster DR Bootstrap
 hide_title: true
 pageType: task
 journey: validated-deployments
-description: Stand up the validated local disaster-recovery proving ground with separate infra, source, and target clusters, shared Transit, RustFS storage, and passthrough ingress.
+description: Stand up the validated local disaster-recovery environment with separate infra, source, and target clusters, shared Transit, RustFS storage, and passthrough ingress.
 ---
 
 <PageHeader

--- a/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
+++ b/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
@@ -12,7 +12,7 @@ description: Stand up the validated local disaster-recovery environment with sep
 />
 
 <Checklist
-    title="This recipe should leave you with"
+    title="Recipe outcomes"
     items={[
       "an infra cluster that hosts shared trust services and the shared Transit key",
       "a healthy source cluster and target cluster with distinct namespaces and external endpoints",
@@ -22,7 +22,7 @@ description: Stand up the validated local disaster-recovery environment with sep
   />
 
 
-<Callout type="success" title="Validated lane">
+<Callout type="success" title="Validated coverage">
 
 This bootstrap path matches the local DR lane that was proven end to end on March 16, 2026, including source backup, restore into the target cluster, target unseal, and credential plus data verification after restore.
 
@@ -67,7 +67,7 @@ This bootstrap path matches the local DR lane that was proven end to end on Marc
 
 <DecisionTable
   kind="reference"
-  title="Validated lane defaults"
+  title="Baseline defaults"
   columns={["Value", "Default", "Purpose"]}
   rows={[
     {cells: ["Infra context", "`k3d-openbao-dr-infra`", "Shared trust-services cluster."]},
@@ -86,7 +86,7 @@ This bootstrap path matches the local DR lane that was proven end to end on Marc
 <CommandBlock
   language="text"
   label="configure"
-  title="Run the bootstrap automation or manifests you keep for the validated lane"
+  title="Run the bootstrap automation or manifests for this baseline"
   code={`The validated bootstrap needs to create and wire:
 - one infra cluster for shared trust services
 - one source cluster

--- a/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
+++ b/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
@@ -7,8 +7,8 @@ description: Stand up the validated local disaster-recovery proving ground with 
 ---
 
 <PageHeader
-  title="Bootstrap the DR proving ground before you test the restore event itself."
-  lede="This recipe prepares the validated local disaster-recovery lane: a shared trust-services cluster, a source cluster, and a target cluster, all wired so the restore event will cross the same kinds of trust, storage, and ingress boundaries you expect in a real DR rehearsal."
+  title="Bootstrap the local cross-cluster DR baseline"
+  lede="This recipe prepares the validated local disaster-recovery lane: a shared trust-services cluster, a source cluster, and a target cluster, all wired so the restore event crosses the same trust, storage, and ingress boundaries used in a real DR rehearsal."
 />
 
 <Checklist

--- a/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
+++ b/docs/user-guide/validated-deployments/recipes/local/k3d-cross-cluster-dr-bootstrap.md
@@ -29,7 +29,7 @@ This bootstrap path matches the local DR lane that was proven end to end on Marc
 </Callout>
 
 <DecisionTable
-  title="What this lane assumes"
+  title="Baseline assumptions"
   columns={["Assumption", "Why it exists", "What breaks if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs.md
+++ b/docs/user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs.md
@@ -12,7 +12,7 @@ description: Restore the validated local disaster-recovery target from a source 
 />
 
 <Checklist
-    title="This runbook should leave you with"
+    title="Runbook outcomes"
     items={[
       "a fresh source snapshot written to shared RustFS storage",
       "an `OpenBaoRestore` object that completes on the target cluster",
@@ -67,7 +67,7 @@ This workflow overwrites the target cluster state. Existing auth methods, polici
 
 <DecisionTable
   kind="reference"
-  title="Validated lane defaults"
+  title="Baseline defaults"
   columns={["Value", "Default", "Purpose"]}
   rows={[
     {cells: ["Source context", "`k3d-openbao-dr-source`", "Primary cluster that creates the backup."]},

--- a/docs/user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs.md
+++ b/docs/user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs.md
@@ -7,7 +7,7 @@ description: Restore the validated local disaster-recovery target from a source 
 ---
 
 <PageHeader
-  title="Run the destructive restore step only after the source snapshot, target health, and shared seal root are all known-good."
+  title="Restore the target in the local DR lane"
   lede="This runbook restores the target cluster in the validated local DR lane from a source snapshot stored in RustFS. It assumes the source and target already share the same external Transit key and that you are ready to overwrite the target bootstrap state."
 />
 
@@ -29,7 +29,7 @@ This workflow overwrites the target cluster state. Existing auth methods, polici
 </Callout>
 
 <DecisionTable
-  title="Before you restore"
+  title="Restore prerequisites"
   columns={["Requirement", "Why it exists", "What happens if it is wrong"]}
   rows={[
     {

--- a/docs/user-guide/validated-deployments/runbooks/index.md
+++ b/docs/user-guide/validated-deployments/runbooks/index.md
@@ -8,8 +8,8 @@ description: Minimal catalog for validated procedures that still need lane-speci
 <PageHero
   variant="landing"
   eyebrow="Validated Deployments / Procedure Catalog"
-  title="Use this catalog only for procedures that still depend on a validated lane."
-  lede="Generic backup and restore workflows now live in the main `Operate` and `Recovery & Restore` sections. This catalog remains only for the k3d cross-cluster DR restore runbook, because that workflow still depends on the assumptions of one validated lane."
+  title="Validated runbooks"
+  lede="This catalog contains the procedures that still depend on a specific validated baseline. Generic backup and restore guidance lives in the main `Operate` and `Recovery & Restore` sections."
   actions={[
     {label: "Open DR restore runbook", docId: "user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs", variant: "primary"},
     {label: "Open generic restore guide", docId: "user-guide/openbaorestore/restore", variant: "secondary"},

--- a/docs/user-guide/validated-deployments/runbooks/index.md
+++ b/docs/user-guide/validated-deployments/runbooks/index.md
@@ -9,7 +9,7 @@ description: Catalog of validated procedures that still need lane-specific treat
   variant="landing"
   eyebrow="Validated Deployments / Procedure Catalog"
   title="Validated runbooks"
-  lede="This catalog contains the procedures that still depend on a specific validated baseline. Generic backup and restore guidance lives in the main `Operate` and `Recovery & Restore` sections."
+  lede="Runbooks that still depend on a specific validated baseline are listed here. Generic backup and restore guidance lives in the main `Operate` and `Recovery & Restore` sections."
   actions={[
     {label: "Open DR restore runbook", docId: "user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs", variant: "primary"},
     {label: "Open generic restore guide", docId: "user-guide/openbaorestore/restore", variant: "secondary"},
@@ -22,7 +22,7 @@ description: Catalog of validated procedures that still need lane-specific treat
     {
       eyebrow: "01",
       title: "Cross-cluster DR restore",
-      description: "Lane-specific restore procedure for the validated k3d DR environment with shared Transit and shared snapshot storage.",
+      description: "Restore procedure for the validated k3d DR environment with shared Transit and shared snapshot storage.",
       docId: "user-guide/validated-deployments/runbooks/cross-cluster-dr-restore-rustfs",
     },
   ]}

--- a/docs/user-guide/validated-deployments/runbooks/index.md
+++ b/docs/user-guide/validated-deployments/runbooks/index.md
@@ -2,7 +2,7 @@
 title: Validated Procedure Catalog
 hide_title: true
 pageType: landing
-description: Minimal catalog for validated procedures that still need lane-specific treatment, with generic backup and restore workflows handed off to the main operator docs.
+description: Catalog of validated procedures that still need lane-specific treatment, with generic backup and restore workflows handed off to the main operator docs.
 ---
 
 <PageHero
@@ -29,7 +29,7 @@ description: Minimal catalog for validated procedures that still need lane-speci
 />
 
 <NextActions
-  title="Use the main operator docs for generic procedures"
+  title="Main operator docs for generic procedures"
   items={[
     {
       label: "Backup operations",

--- a/website/tests/smoke.spec.ts
+++ b/website/tests/smoke.spec.ts
@@ -31,11 +31,7 @@ test('legacy latest user-guide route redirects into the new IA', async ({page}) 
 test('next docs expose the version banner and feedback controls', async ({page}) => {
   await page.goto('docs/next/get-started/deployment-decision-guide');
 
-  await expect(
-    page.getByRole('heading', {
-      name: 'Choose the path you want to keep operating.',
-    }),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Choose the deployment path'})).toBeVisible();
   await expect(page.getByText('Next release documentation')).toBeVisible();
   await expect(page.getByText('Was this page helpful?')).toBeVisible();
   await expect(page.getByRole('button', {name: 'Yes'})).toBeVisible();
@@ -56,9 +52,7 @@ test('stable docs expose the current release banner', async ({page}) => {
 test('architecture section exposes grouped local navigation', async ({page}) => {
   await page.goto('docs/next/architecture');
 
-  await expect(
-    page.getByRole('heading', {name: 'Understand why the operator behaves the way it does.'}),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Operator architecture'})).toBeVisible();
   await expect(page.getByText('Read This First', {exact: true})).toBeVisible();
   await expect(page.getByText('Workload Managers', {exact: true})).toBeVisible();
   await expect(page.getByText('Operations Managers', {exact: true})).toBeVisible();
@@ -70,9 +64,7 @@ test('architecture section exposes grouped local navigation', async ({page}) => 
 test('security section exposes grouped local navigation', async ({page}) => {
   await page.goto('docs/next/security');
 
-  await expect(
-    page.getByRole('heading', {name: 'Security is part of the operating path, not an appendix.'}),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Security documentation'})).toBeVisible();
   await expect(page.getByText('Security Model', {exact: true})).toBeVisible();
   await expect(page.getByText('Platform Controls', {exact: true})).toBeVisible();
   await expect(page.getByText('Workload Protections', {exact: true})).toBeVisible();
@@ -82,9 +74,7 @@ test('security section exposes grouped local navigation', async ({page}) => {
 test('configure section exposes grouped local navigation', async ({page}) => {
   await page.goto('docs/next/configure');
 
-  await expect(
-    page.getByRole('heading', {name: 'Shape the cluster before it becomes expensive to change.'}),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Cluster configuration'})).toBeVisible();
   await expect(page.getByText('Read This First', {exact: true})).toBeVisible();
   await expect(page.getByText('Cluster Baseline', {exact: true})).toBeVisible();
   await expect(page.getByText('Service Boundary', {exact: true})).toBeVisible();
@@ -96,7 +86,7 @@ test('validated deployments expose lane-first local navigation', async ({page}) 
 
   await expect(
     page.getByRole('heading', {
-      name: 'Choose a tested baseline by lane, then adapt it without forgetting what was actually proven.',
+      name: 'Validated deployment baselines',
     }),
   ).toBeVisible();
   await expect(page.getByText('Cloud Baselines', {exact: true})).toBeVisible();
@@ -108,7 +98,7 @@ test('validated deployments expose lane-first local navigation', async ({page}) 
 test('reference section exposes grouped lookup navigation', async ({page}) => {
   await page.goto('docs/next/reference');
 
-  await expect(page.getByRole('heading', {name: 'Use the exact contract when the details matter.'})).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Reference documentation'})).toBeVisible();
   await expect(page.getByText('Quick Checks', {exact: true})).toBeVisible();
   await expect(page.getByText('API Surface', {exact: true})).toBeVisible();
   await expect(page.getByText('Lifecycle & Support Contract', {exact: true})).toBeVisible();
@@ -119,11 +109,7 @@ test('contribute section exposes grouped contributor navigation', async ({page})
   await page.goto('contribute');
   const sidebar = page.locator('.theme-doc-sidebar-container');
 
-  await expect(
-    page.getByRole('heading', {
-      name: 'Choose the contributor path that matches the work you need to do.',
-    }),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Contributor documentation'})).toBeVisible();
   await expect(sidebar.getByRole('link', {name: 'Start Here', exact: true})).toBeVisible();
   await expect(sidebar.getByRole('link', {name: 'Build & Change', exact: true})).toBeVisible();
   await expect(sidebar.getByRole('link', {name: 'Validate & Ship', exact: true})).toBeVisible();


### PR DESCRIPTION
## Description

This PR normalizes documentation tone and wording across the docs tree.

It makes the docs more direct and operational by:
- toning down editorial or argumentative headings, ledes, and body copy
- normalizing sentence case below page titles
- reducing repetitive phrasing and filler wording
- updating the docs style guide with explicit wording guidance for future edits

This is a docs-only change. It does not change operator behavior, APIs, or user workflows.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

```sh
make docs-build
```
