### PR TITLE
feat(admission): authorize maintenance through RBAC

### DIFF
--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -262,13 +262,38 @@ spec:
               has(oldObject.metadata.annotations) &&
               ("openbao.org/maintenance" in oldObject.metadata.annotations) &&
               oldObject.metadata.annotations["openbao.org/maintenance"] == "true"))
-    - name: break_glass_admin_groups
+    - name: maintenance_current_labels
       expression: >-
-        {{ toJson .Values.admissionPolicies.maintenanceBreakGlassGroups }}
-    - name: is_break_glass_admin
+        (object != null && has(object.metadata) && has(object.metadata.labels)) ? object.metadata.labels : {}
+    - name: maintenance_old_labels
       expression: >-
-        variables.break_glass_admin_groups.exists(group,
-          request.userInfo.groups.exists(g, g == group))
+        (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.labels)) ? oldObject.metadata.labels : {}
+    - name: maintenance_cluster_name
+      expression: >-
+        request.operation == "DELETE" ?
+          ("openbao.org/cluster" in variables.maintenance_old_labels ?
+            variables.maintenance_old_labels["openbao.org/cluster"] :
+            ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
+              variables.maintenance_old_labels["app.kubernetes.io/instance"] : "")) :
+          ("openbao.org/cluster" in variables.maintenance_current_labels ?
+            variables.maintenance_current_labels["openbao.org/cluster"] :
+            ("openbao.org/cluster" in variables.maintenance_old_labels ?
+              variables.maintenance_old_labels["openbao.org/cluster"] :
+              ("app.kubernetes.io/instance" in variables.maintenance_current_labels ?
+                variables.maintenance_current_labels["app.kubernetes.io/instance"] :
+                ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
+                  variables.maintenance_old_labels["app.kubernetes.io/instance"] : ""))))
+    - name: maintenance_authorized
+      expression: >-
+        variables.maintenance_enabled &&
+        request.namespace != "" &&
+        variables.maintenance_cluster_name != "" &&
+        authorizer.group("openbao.org").
+          resource("openbaoclusters").
+          namespace(request.namespace).
+          name(variables.maintenance_cluster_name).
+          check("maintenance").
+          allowed()
   validations:
     - expression: >-
         !variables.is_managed ||
@@ -287,7 +312,7 @@ spec:
         variables.is_service_registration_label_update ||
         variables.is_kube_system_pod_finalizer_update ||
         variables.is_kube_system_job_finalizer_update ||
-        (variables.maintenance_enabled && variables.is_break_glass_admin)
+        variables.maintenance_authorized
       message: Direct modification of OpenBao-managed resources is prohibited; modify the parent OpenBaoCluster/OpenBaoTenant instead.
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/openbao-operator/values.schema.json
+++ b/charts/openbao-operator/values.schema.json
@@ -465,7 +465,7 @@
         },
         "maintenanceBreakGlassGroups": {
           "type": "array",
-          "description": "Groups allowed to bypass managed-resource mutation locks when the target resource is explicitly marked for maintenance",
+          "description": "Deprecated and no longer used. Maintenance authorization now comes from Kubernetes RBAC via the custom `maintenance` verb on `openbaoclusters.openbao.org`.",
           "items": {
             "type": "string",
             "minLength": 1

--- a/charts/openbao-operator/values.yaml
+++ b/charts/openbao-operator/values.yaml
@@ -287,8 +287,9 @@ admissionPolicies:
       - aws-
       - aks-
       - azure-
-  # -- Kubernetes groups allowed to bypass managed-resource mutation locks when
-  # -- a cluster explicitly enables maintenance mode.
+  # -- Deprecated: no longer used.
+  # -- Maintenance authorization is now delegated through Kubernetes RBAC using
+  # -- the custom `maintenance` verb on `openbaoclusters.openbao.org`.
   maintenanceBreakGlassGroups:
     - system:masters
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,7 +19,6 @@ resources:
   - ../rbac
   - ../manager
   - ../policy
-  - maintenance_break_glass_settings.yaml
   - openbao_jwt_settings.yaml
   # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
   #- ../prometheus
@@ -434,19 +433,6 @@ replacements:
         options:
           delimiter: "'"
           index: 1
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: maintenance-break-glass-settings
-      fieldPath: data.BREAK_GLASS_GROUPS_JSON
-    targets:
-      - select:
-          group: admissionregistration.k8s.io
-          version: v1
-          kind: ValidatingAdmissionPolicy
-          name: openbao-operator-openbao-lock-managed-resource-mutations
-        fieldPaths:
-          - spec.variables.[name=break_glass_admin_groups].expression
   - source:
       group: admissionregistration.k8s.io
       version: v1

--- a/config/default/maintenance_break_glass_settings.yaml
+++ b/config/default/maintenance_break_glass_settings.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: maintenance-break-glass-settings
-  annotations:
-    config.kubernetes.io/local-config: "true"
-data:
-  BREAK_GLASS_GROUPS_JSON: '["system:masters"]'

--- a/config/overlays/custom-identity/kustomization.yaml
+++ b/config/overlays/custom-identity/kustomization.yaml
@@ -220,16 +220,3 @@ replacements:
         options:
           delimiter: "'"
           index: 1
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: maintenance-break-glass-settings
-      fieldPath: data.BREAK_GLASS_GROUPS_JSON
-    targets:
-      - select:
-          group: admissionregistration.k8s.io
-          version: v1
-          kind: ValidatingAdmissionPolicy
-          name: openbao-operator-openbao-lock-managed-resource-mutations
-        fieldPaths:
-          - spec.variables.[name=break_glass_admin_groups].expression

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -259,13 +259,38 @@ spec:
               has(oldObject.metadata.annotations) &&
               ("openbao.org/maintenance" in oldObject.metadata.annotations) &&
               oldObject.metadata.annotations["openbao.org/maintenance"] == "true"))
-    - name: break_glass_admin_groups
+    - name: maintenance_current_labels
       expression: >-
-        ["system:masters"]
-    - name: is_break_glass_admin
+        (object != null && has(object.metadata) && has(object.metadata.labels)) ? object.metadata.labels : {}
+    - name: maintenance_old_labels
       expression: >-
-        variables.break_glass_admin_groups.exists(group,
-          request.userInfo.groups.exists(g, g == group))
+        (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.labels)) ? oldObject.metadata.labels : {}
+    - name: maintenance_cluster_name
+      expression: >-
+        request.operation == "DELETE" ?
+          ("openbao.org/cluster" in variables.maintenance_old_labels ?
+            variables.maintenance_old_labels["openbao.org/cluster"] :
+            ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
+              variables.maintenance_old_labels["app.kubernetes.io/instance"] : "")) :
+          ("openbao.org/cluster" in variables.maintenance_current_labels ?
+            variables.maintenance_current_labels["openbao.org/cluster"] :
+            ("openbao.org/cluster" in variables.maintenance_old_labels ?
+              variables.maintenance_old_labels["openbao.org/cluster"] :
+              ("app.kubernetes.io/instance" in variables.maintenance_current_labels ?
+                variables.maintenance_current_labels["app.kubernetes.io/instance"] :
+                ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
+                  variables.maintenance_old_labels["app.kubernetes.io/instance"] : ""))))
+    - name: maintenance_authorized
+      expression: >-
+        variables.maintenance_enabled &&
+        request.namespace != "" &&
+        variables.maintenance_cluster_name != "" &&
+        authorizer.group("openbao.org").
+          resource("openbaoclusters").
+          namespace(request.namespace).
+          name(variables.maintenance_cluster_name).
+          check("maintenance").
+          allowed()
   validations:
     - expression: >-
         !variables.is_managed ||
@@ -284,5 +309,5 @@ spec:
         variables.is_service_registration_label_update ||
         variables.is_kube_system_pod_finalizer_update ||
         variables.is_kube_system_job_finalizer_update ||
-        (variables.maintenance_enabled && variables.is_break_glass_admin)
+        variables.maintenance_authorized
       message: Direct modification of OpenBao-managed resources is prohibited; modify the parent OpenBaoCluster/OpenBaoTenant instead.

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -35,4 +35,5 @@ resources:
   # if you do not want those helpers be installed with your Project.
   - openbaocluster_admin_role.yaml
   - openbaocluster_editor_role.yaml
+  - openbaocluster_maintenance_role.yaml
   - openbaocluster_viewer_role.yaml

--- a/config/rbac/namespace_scoped_example.yaml
+++ b/config/rbac/namespace_scoped_example.yaml
@@ -60,6 +60,56 @@ subjects:
     name: monitoring # Change to actual group name
     apiGroup: rbac.authorization.k8s.io
 ---
+# Example: Grant maintenance-window intervention on one cluster
+#
+# This namespaced Role grants the custom `maintenance` verb only for a single
+# OpenBaoCluster object. It can be bound to a break-glass group or service account
+# that is allowed to delete or restart managed Pods/StatefulSet only while
+# `spec.maintenance.enabled` is enabled for that cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openbaocluster-maintenance-team-a-example
+  namespace: team-a-prod # Change to target namespace
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters
+    resourceNames:
+      - example-cluster # Change to target OpenBaoCluster name
+    verbs:
+      - get
+      - maintenance
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters/status
+    resourceNames:
+      - example-cluster # Change to target OpenBaoCluster name
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbaocluster-maintenance-team-a-example
+  namespace: team-a-prod # Change to target namespace
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbaocluster-maintenance-team-a-example
+subjects:
+  - kind: Group
+    name: team-a-break-glass # Change to actual group name
+    apiGroup: rbac.authorization.k8s.io
+---
 # Example: Grant admin permissions to platform team (cluster-wide)
 #
 # This ClusterRoleBinding grants platform administrators full access

--- a/config/rbac/openbaocluster_maintenance_role.yaml
+++ b/config/rbac/openbaocluster_maintenance_role.yaml
@@ -1,0 +1,30 @@
+# This rule is not used by the project openbao-operator itself.
+# It is provided to allow cluster administrators to delegate direct,
+# maintenance-window-only intervention on OpenBao-managed workload resources
+# without granting full edit or admin permissions on OpenBaoCluster objects.
+#
+# Multi-tenancy: This ClusterRole can be bound via RoleBinding for
+# namespace-scoped maintenance permissions, or copied into a namespaced Role
+# with resourceNames for a single-cluster maintenance window.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: openbaocluster-maintenance-role
+rules:
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters
+    verbs:
+      - get
+      - maintenance
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters/status
+    verbs:
+      - get

--- a/docs/security/fundamentals/threat-model.md
+++ b/docs/security/fundamentals/threat-model.md
@@ -295,7 +295,7 @@ Operator-managed PVCs are intentionally CR-driven and status-observed rather tha
 
 - Emit structured operator audit logs for startup gating, upgrades, backups, restore, and operation-lock transitions.
 - Use Kubernetes API audit logs and admission denials as the primary mutation trail.
-- Keep maintenance mode explicit and break-glass groups narrow by default.
+- Keep maintenance mode explicit and grant the custom maintenance permission only to trusted operators.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/operations/maintenance.md
+++ b/docs/user-guide/openbaocluster/operations/maintenance.md
@@ -39,8 +39,8 @@ journey: operate
       cells: [
         'Maintenance mode',
         'Admission policy requires the `openbao.org/maintenance=true` signal before restarts or controlled deletes.',
-        'The operator annotates managed resources so maintenance-only actions are allowed under the configured break-glass groups.',
-        'This is a controlled operational mode for maintenance-only actions under the configured break-glass groups.',
+        'The operator annotates managed resources so callers with maintenance permission on the owning OpenBaoCluster can perform planned restarts or deletes.',
+        'Grant the custom `maintenance` verb on the owning OpenBaoCluster before using this path.',
       ],
     },
     {
@@ -165,7 +165,7 @@ Enable maintenance mode when your admission policies require a deliberate mainte
   maintenance:
     enabled: true`}
 >
-  In this mode, the operator annotates managed Pods and the StatefulSet with `openbao.org/maintenance=true`. By default, maintenance-only bypass is limited to callers in the Kubernetes group `system:masters` unless you changed the configured break-glass groups at install time.
+  In this mode, the operator annotates managed Pods and the StatefulSet with `openbao.org/maintenance=true`. Callers still need normal Kubernetes RBAC on the target resource plus the custom `maintenance` verb on the owning `OpenBaoCluster`.
 </CommandBlock>
 
 This mode is also required for some day 2 changes that need a controlled restart path, such as finishing filesystem expansion after increasing `spec.storage.size`.

--- a/hack/helmchart/main.go
+++ b/hack/helmchart/main.go
@@ -323,11 +323,6 @@ func transformPolicyToHelm(content string) string {
 		`'openbao-operator-controller'`,
 		`'{{ include "openbao-operator.controllerServiceAccountName" . }}'`)
 
-	// Replace the default maintenance break-glass admin group list with the Helm values-driven list.
-	content = strings.ReplaceAll(content,
-		`["system:masters"]`,
-		`{{ toJson .Values.admissionPolicies.maintenanceBreakGlassGroups }}`)
-
 	return content
 }
 

--- a/test/e2e/Cluster_Profile_Hardened_test.go
+++ b/test/e2e/Cluster_Profile_Hardened_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -544,41 +545,61 @@ var _ = Describe("Hardened profile (External TLS + Transit auto-unseal + SelfIni
 		// that auto-unseal works after pod restart.
 		//
 		// ValidatingAdmissionPolicy blocks direct mutations of OpenBao-managed resources
-		// unless maintenance mode is enabled on the object and the request is made by a
-		// break-glass admin (system:masters). For this test, mark each Pod as being in
-		// maintenance mode before deleting it to trigger a restart.
+		// unless maintenance mode is enabled on the object and the caller is authorized
+		// for the custom maintenance verb on the owning OpenBaoCluster.
+		maintenanceGroup := "e2e-hardened-maintainers"
+		maintenanceRole := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "e2e-hardened-maintenance",
+				Namespace: f.Namespace,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list", "delete"},
+				},
+				{
+					APIGroups:     []string{"openbao.org"},
+					Resources:     []string{"openbaoclusters"},
+					ResourceNames: []string{clusterName},
+					Verbs:         []string{"get", "maintenance"},
+				},
+				{
+					APIGroups:     []string{"openbao.org"},
+					Resources:     []string{"openbaoclusters/status"},
+					ResourceNames: []string{clusterName},
+					Verbs:         []string{"get"},
+				},
+			},
+		}
+		Expect(e2ehelpers.EnsureRoleBinding(ctx, c, maintenanceRole, []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: maintenanceGroup,
+			},
+		})).To(Succeed())
+		Expect(f.SetMaintenanceEnabled(ctx, clusterName, true)).To(Succeed())
+
 		By("deleting pods to verify auto-unseal works after restart (maintenance mode)")
 		podList := &corev1.PodList{}
-		err = c.List(ctx, podList, client.InNamespace(f.Namespace), client.MatchingLabels{
-			"app.kubernetes.io/instance":   clusterName,
-			"app.kubernetes.io/name":       "openbao",
-			"app.kubernetes.io/managed-by": "openbao-operator",
-		})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(len(podList.Items)).To(BeNumerically(">=", 1), "At least one pod should exist")
+		Eventually(func(g Gomega) {
+			g.Expect(c.List(ctx, podList, client.InNamespace(f.Namespace), client.MatchingLabels{
+				"app.kubernetes.io/instance":   clusterName,
+				"app.kubernetes.io/name":       "openbao",
+				"app.kubernetes.io/managed-by": "openbao-operator",
+			})).To(Succeed())
+			g.Expect(podList.Items).NotTo(BeEmpty(), "At least one pod should exist")
+			for _, pod := range podList.Items {
+				g.Expect(pod.Annotations).To(HaveKeyWithValue(constants.AnnotationMaintenance, "true"))
+			}
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		// Delete all pods to trigger restart
 		for _, pod := range podList.Items {
 			_, _ = fmt.Fprintf(GinkgoWriter, "Deleting pod %q to test auto-unseal after restart\n", pod.Name)
 
-			podPatch := &corev1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Pod",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      pod.Name,
-					Namespace: pod.Namespace,
-					Annotations: map[string]string{
-						constants.AnnotationMaintenance: "true",
-					},
-				},
-			}
-
-			err := e2ehelpers.RunWithImpersonation(ctx, cfg, scheme, "e2e-break-glass", []string{"system:masters"}, func(ic client.Client) error {
-				if err := ic.Patch(ctx, podPatch, client.Apply, client.FieldOwner("e2e-break-glass")); err != nil {
-					return err
-				}
+			err := e2ehelpers.RunWithImpersonation(ctx, cfg, scheme, "e2e-hardened-maintainer", []string{"system:authenticated", maintenanceGroup}, func(ic client.Client) error {
 				return ic.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace}})
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/Security_Guardrails_test.go
+++ b/test/e2e/Security_Guardrails_test.go
@@ -47,33 +47,12 @@ const (
 // === Shared Helpers ===
 
 func createRoleBindingForGroup(ctx context.Context, c client.Client, namespace string, role *rbacv1.Role) {
-	err := c.Create(ctx, role)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		Expect(err).NotTo(HaveOccurred(), "Failed to create Role %q in namespace %q", role.Name, namespace)
-	}
-
-	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      role.Name + "-binding",
-			Namespace: namespace,
+	Expect(e2ehelpers.EnsureRoleBinding(ctx, c, role, []rbacv1.Subject{
+		{
+			Kind: "Group",
+			Name: impersonatedGroup,
 		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     "Role",
-			Name:     role.Name,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "Group",
-				Name: impersonatedGroup,
-			},
-		},
-	}
-
-	err = c.Create(ctx, rb)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		Expect(err).NotTo(HaveOccurred(), "Failed to create RoleBinding %q in namespace %q", rb.Name, namespace)
-	}
+	})).To(Succeed(), "Failed to ensure RoleBinding for %q in namespace %q", role.Name, namespace)
 }
 
 func containsString(values []string, needle string) bool {
@@ -901,6 +880,11 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 						Verbs:     []string{"get", "list", "delete"},
 					},
 					{
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+						Verbs:     []string{"get", "list", "delete"},
+					},
+					{
 						APIGroups: []string{"apps"},
 						Resources: []string{"statefulsets"},
 						Verbs:     []string{"get", "list", "update"},
@@ -1004,6 +988,87 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Direct modification of OpenBao-managed resources is prohibited"))
+		})
+
+		It("prevents managed Pod deletion during maintenance without cluster maintenance permission", func() {
+			Expect(tenantFW.SetMaintenanceEnabled(ctx, victim.Name, true)).To(Succeed())
+
+			var targetPod corev1.Pod
+			Eventually(func(g Gomega) {
+				pods := &corev1.PodList{}
+				g.Expect(admin.List(ctx, pods,
+					client.InNamespace(tenantNamespace),
+					client.MatchingLabels{
+						"openbao.org/cluster": victim.Name,
+					},
+				)).To(Succeed())
+				g.Expect(pods.Items).NotTo(BeEmpty())
+				targetPod = pods.Items[0]
+				g.Expect(targetPod.Annotations).To(HaveKeyWithValue(constants.AnnotationMaintenance, "true"))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+			err := e2ehelpers.RunWithImpersonation(ctx, cfg, scheme, impersonatedUser, []string{"system:authenticated", impersonatedGroup}, func(c client.Client) error {
+				return c.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: targetPod.Name, Namespace: targetPod.Namespace}})
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Direct modification of OpenBao-managed resources is prohibited"))
+		})
+
+		It("allows managed Pod deletion during maintenance with cluster maintenance permission", func() {
+			maintenanceRole := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "e2e-victim-maintenance",
+					Namespace: tenantNamespace,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{"openbao.org"},
+						Resources:     []string{"openbaoclusters"},
+						ResourceNames: []string{victim.Name},
+						Verbs:         []string{"get", "maintenance"},
+					},
+					{
+						APIGroups:     []string{"openbao.org"},
+						Resources:     []string{"openbaoclusters/status"},
+						ResourceNames: []string{victim.Name},
+						Verbs:         []string{"get"},
+					},
+				},
+			}
+			createRoleBindingForGroup(ctx, admin, tenantNamespace, maintenanceRole)
+			Expect(tenantFW.SetMaintenanceEnabled(ctx, victim.Name, true)).To(Succeed())
+
+			var targetPod corev1.Pod
+			Eventually(func(g Gomega) {
+				pods := &corev1.PodList{}
+				g.Expect(admin.List(ctx, pods,
+					client.InNamespace(tenantNamespace),
+					client.MatchingLabels{
+						"openbao.org/cluster": victim.Name,
+					},
+				)).To(Succeed())
+				g.Expect(pods.Items).NotTo(BeEmpty())
+				targetPod = pods.Items[0]
+				g.Expect(targetPod.Annotations).To(HaveKeyWithValue(constants.AnnotationMaintenance, "true"))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+			originalUID := targetPod.UID
+
+			err := e2ehelpers.RunWithImpersonation(ctx, cfg, scheme, impersonatedUser, []string{"system:authenticated", impersonatedGroup}, func(c client.Client) error {
+				return c.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: targetPod.Name, Namespace: targetPod.Namespace}})
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				pods := &corev1.PodList{}
+				g.Expect(admin.List(ctx, pods,
+					client.InNamespace(tenantNamespace),
+					client.MatchingLabels{
+						"openbao.org/cluster": victim.Name,
+					},
+				)).To(Succeed())
+				g.Expect(pods.Items).NotTo(BeEmpty())
+				g.Expect(pods.Items[0].UID).NotTo(Equal(originalUID))
+			}, 4*time.Minute, 2*time.Second).Should(Succeed())
 		})
 	})
 

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,7 +12,7 @@ Notes:
 ## Summary
 
 - Files: `18`
-- Specs: `87`
+- Specs: `89`
 - Explicit case IDs: `17`
 - Coverage tags: `44`
 
@@ -30,7 +30,7 @@ Notes:
 | [Manager Resilience](suites/Manager_Resilience_test.md) | 3 | 3 | 0 | `manager`, `cluster` | `test/e2e/Manager_Resilience_test.go` |
 | [Manager](suites/Operator_Manager_test.md) | 2 | 0 | 0 | `manager`, `critical`, `smoke` | `test/e2e/Operator_Manager_test.go` |
 | [OpenShift Platform](suites/Platform_OpenShift_test.md) | 2 | 0 | 0 | `openshift`, `platform` | `test/e2e/Platform_OpenShift_test.go` |
-| [Security Guardrails](suites/Security_Guardrails_test.md) | 21 | 1 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
+| [Security Guardrails](suites/Security_Guardrails_test.md) | 23 | 1 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
 | [Tenant Data Isolation](suites/Tenant_Data_Isolation_test.md) | 1 | 1 | 0 | `security`, `tenant`, `tenancy` | `test/e2e/Tenant_Data_Isolation_test.go` |
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow` | `test/e2e/Upgrade_Operation_Lock_test.go` |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -1625,6 +1625,60 @@
     "suiteTitle": ""
   },
   {
+    "id": "security-guardrails-allows-managed-pod-deletion-during-maintenance-80b5ee0d",
+    "generatedId": "security-guardrails-allows-managed-pod-deletion-during-maintenance-80b5ee0d",
+    "file": "test/e2e/Security_Guardrails_test.go",
+    "type": "It",
+    "name": "allows managed Pod deletion during maintenance with cluster maintenance permission",
+    "path": [
+      "Security Guardrails",
+      "Resource Locking (anti-tamper)",
+      "allows managed Pod deletion during maintenance with cluster maintenance permission"
+    ],
+    "labels": [
+      "security",
+      "critical",
+      "tamper"
+    ],
+    "domainLabels": [
+      "security",
+      "critical",
+      "tamper"
+    ],
+    "steps": null,
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
+    "id": "security-guardrails-prevents-managed-pod-deletion-during-maintenance-238e18f8",
+    "generatedId": "security-guardrails-prevents-managed-pod-deletion-during-maintenance-238e18f8",
+    "file": "test/e2e/Security_Guardrails_test.go",
+    "type": "It",
+    "name": "prevents managed Pod deletion during maintenance without cluster maintenance permission",
+    "path": [
+      "Security Guardrails",
+      "Resource Locking (anti-tamper)",
+      "prevents managed Pod deletion during maintenance without cluster maintenance permission"
+    ],
+    "labels": [
+      "security",
+      "critical",
+      "tamper"
+    ],
+    "domainLabels": [
+      "security",
+      "critical",
+      "tamper"
+    ],
+    "steps": null,
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "security-guardrails-prevents-sidecar-injection-via-statefulset-updates-145c71ee",
     "generatedId": "security-guardrails-prevents-sidecar-injection-via-statefulset-updates-145c71ee",
     "file": "test/e2e/Security_Guardrails_test.go",

--- a/test/e2e/catalog/suites/Security_Guardrails_test.md
+++ b/test/e2e/catalog/suites/Security_Guardrails_test.md
@@ -26,6 +26,8 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `security-guardrails-has-required-validatingadmissionpolicy-dependencies-installed-and-87ec7cda` | has required ValidatingAdmissionPolicy dependencies installed and correctly bound | active | _none_ | `security`, `critical`, `rbac` |
 | `security-guardrails-restricts-openbao-pod-serviceaccount-pod-patching-abbf5716` | restricts OpenBao pod ServiceAccount pod patching to cluster pods | active | _none_ | `security`, `critical`, `rbac`, `pentest` |
 | `security-guardrails-scopes-secret-access-via-allowlist-roles-7c98a6a9` | scopes Secret access via allowlist Roles | active | _none_ | `security`, `critical`, `rbac` |
+| `security-guardrails-allows-managed-pod-deletion-during-maintenance-80b5ee0d` | allows managed Pod deletion during maintenance with cluster maintenance permission | active | _none_ | `security`, `critical`, `tamper` |
+| `security-guardrails-prevents-managed-pod-deletion-during-maintenance-238e18f8` | prevents managed Pod deletion during maintenance without cluster maintenance permission | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-sidecar-injection-via-statefulset-updates-145c71ee` | prevents sidecar injection via StatefulSet updates | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-unauthorized-deletion-of-the-tls-9e011135` | prevents unauthorized deletion of the TLS CA secret | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-unauthorized-deletion-of-the-unseal-2ea235de` | prevents unauthorized deletion of the unseal Secret | active | _none_ | `security`, `critical`, `tamper` |
@@ -268,6 +270,28 @@ Recorded checkpoints:
 - verifying the tenant role does not grant broad Secret access
 - verifying the dedicated Secrets writer role only grants the expected allowlisted access
 - verifying the Secrets writer RoleBinding points at the allowlist role
+
+
+## `security-guardrails-allows-managed-pod-deletion-during-maintenance-80b5ee0d`
+
+Path: `Security Guardrails > Resource Locking (anti-tamper) > allows managed Pod deletion during maintenance with cluster maintenance permission`
+
+State: `active`
+
+Covers: _none_
+
+Labels: `security`, `critical`, `tamper`
+
+
+## `security-guardrails-prevents-managed-pod-deletion-during-maintenance-238e18f8`
+
+Path: `Security Guardrails > Resource Locking (anti-tamper) > prevents managed Pod deletion during maintenance without cluster maintenance permission`
+
+State: `active`
+
+Covers: _none_
+
+Labels: `security`, `critical`, `tamper`
 
 
 ## `security-guardrails-prevents-sidecar-injection-via-statefulset-updates-145c71ee`

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -32,10 +32,6 @@ import (
 )
 
 const (
-	// MaintenanceAnnotationKey enables "maintenance mode" to allow disruptive operations
-	// (e.g., deleting managed resources) that would otherwise be blocked by admission policies.
-	MaintenanceAnnotationKey = "openbao.org/maintenance"
-
 	// ReconcileTriggerAnnotationKey is used by tests to force a reconcile by mutating
 	// an annotation on the OpenBaoCluster.
 	ReconcileTriggerAnnotationKey = "e2e.openbao.org/reconcile-trigger"
@@ -488,8 +484,8 @@ func (f *Framework) WaitForClusterPhase(ctx context.Context, clusterName string,
 	}
 }
 
-// SetMaintenanceMode enables or disables maintenance mode on the OpenBaoCluster by patching the maintenance annotation.
-func (f *Framework) SetMaintenanceMode(ctx context.Context, clusterName string, enabled bool) error {
+// SetMaintenanceEnabled enables or disables cluster maintenance mode through spec.maintenance.enabled.
+func (f *Framework) SetMaintenanceEnabled(ctx context.Context, clusterName string, enabled bool) error {
 	if f == nil || f.Client == nil {
 		return fmt.Errorf("framework client is required")
 	}
@@ -506,20 +502,24 @@ func (f *Framework) SetMaintenanceMode(ctx context.Context, clusterName string, 
 	}
 
 	original := cluster.DeepCopy()
-	annotations := cluster.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
 
 	if enabled {
-		annotations[MaintenanceAnnotationKey] = "true"
+		if cluster.Spec.Maintenance == nil {
+			cluster.Spec.Maintenance = &openbaov1alpha1.MaintenanceConfig{}
+		}
+		cluster.Spec.Maintenance.Enabled = true
 	} else {
-		delete(annotations, MaintenanceAnnotationKey)
+		if cluster.Spec.Maintenance == nil {
+			return nil
+		}
+		cluster.Spec.Maintenance.Enabled = false
+		if cluster.Spec.Maintenance.RestartAt == "" {
+			cluster.Spec.Maintenance = nil
+		}
 	}
-	cluster.SetAnnotations(annotations)
 
 	if err := f.Client.Patch(ctx, cluster, client.MergeFrom(original)); err != nil {
-		return fmt.Errorf("failed to patch OpenBaoCluster %s/%s maintenance annotation: %w", f.Namespace, clusterName, err)
+		return fmt.Errorf("failed to patch OpenBaoCluster %s/%s maintenance config: %w", f.Namespace, clusterName, err)
 	}
 
 	return nil

--- a/test/e2e/helpers/k8s.go
+++ b/test/e2e/helpers/k8s.go
@@ -7,6 +7,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -15,7 +18,7 @@ import (
 
 // RunWithImpersonation runs the provided action as the specified user/group(s)
 // using Kubernetes impersonation. This is used in E2E tests to validate RBAC and
-// ValidatingAdmissionPolicy enforcement without relying on system:masters.
+// ValidatingAdmissionPolicy enforcement under explicit caller identities.
 func RunWithImpersonation(
 	ctx context.Context,
 	baseConfig *rest.Config,
@@ -50,6 +53,47 @@ func RunWithImpersonation(
 
 	if err := action(impersonatedClient); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// EnsureRoleBinding creates a Role and same-named RoleBinding if they do not already exist.
+func EnsureRoleBinding(ctx context.Context, c client.Client, role *rbacv1.Role, subjects []rbacv1.Subject) error {
+	if ctx == nil {
+		return fmt.Errorf("context is required")
+	}
+	if c == nil {
+		return fmt.Errorf("kubernetes client is required")
+	}
+	if role == nil {
+		return fmt.Errorf("role is required")
+	}
+	if role.Name == "" || role.Namespace == "" {
+		return fmt.Errorf("role name and namespace are required")
+	}
+	if len(subjects) == 0 {
+		return fmt.Errorf("at least one subject is required")
+	}
+
+	if err := c.Create(ctx, role); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create role %s/%s: %w", role.Namespace, role.Name, err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      role.Name + "-binding",
+			Namespace: role.Namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: subjects,
+	}
+	if err := c.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create rolebinding %s/%s: %w", binding.Namespace, binding.Name, err)
 	}
 
 	return nil

--- a/test/integration/kube_apply_test.go
+++ b/test/integration/kube_apply_test.go
@@ -104,8 +104,17 @@ func ensureProvisionerRBACApplied(t *testing.T) {
 func newImpersonatedClient(t *testing.T, username string) client.Client {
 	t.Helper()
 
+	return newImpersonatedClientWithGroups(t, username)
+}
+
+func newImpersonatedClientWithGroups(t *testing.T, username string, groups ...string) client.Client {
+	t.Helper()
+
 	impersonated := rest.CopyConfig(cfg)
-	impersonated.Impersonate = rest.ImpersonationConfig{UserName: username}
+	impersonated.Impersonate = rest.ImpersonationConfig{
+		UserName: username,
+		Groups:   groups,
+	}
 
 	c, err := client.New(impersonated, client.Options{Scheme: k8sScheme})
 	if err != nil {

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -158,8 +158,8 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	}
 
 	var hasOpenBaoLabelExpression string
-	var breakGlassAdminGroupsExpression string
-	var isBreakGlassAdminExpression string
+	var maintenanceAuthorizedExpression string
+	var maintenanceClusterNameExpression string
 	var isManagedExpression string
 	for _, variable := range variables {
 		variableMap, ok := variable.(map[string]any)
@@ -171,10 +171,10 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		switch name {
 		case "has_openbao_specific_label":
 			hasOpenBaoLabelExpression = expression
-		case "break_glass_admin_groups":
-			breakGlassAdminGroupsExpression = expression
-		case "is_break_glass_admin":
-			isBreakGlassAdminExpression = expression
+		case "maintenance_authorized":
+			maintenanceAuthorizedExpression = expression
+		case "maintenance_cluster_name":
+			maintenanceClusterNameExpression = expression
 		case "is_managed":
 			isManagedExpression = expression
 		}
@@ -186,11 +186,17 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	if !strings.Contains(isManagedExpression, "variables.has_openbao_specific_label") {
 		t.Fatalf("is_managed expression does not require has_openbao_specific_label: %q", isManagedExpression)
 	}
-	if !strings.Contains(breakGlassAdminGroupsExpression, `"system:masters"`) {
-		t.Fatalf("break_glass_admin_groups expression does not include the default admin group: %q", breakGlassAdminGroupsExpression)
+	if !strings.Contains(maintenanceClusterNameExpression, `"openbao.org/cluster"`) {
+		t.Fatalf("maintenance_cluster_name expression does not prefer openbao.org/cluster: %q", maintenanceClusterNameExpression)
 	}
-	if !strings.Contains(isBreakGlassAdminExpression, "variables.break_glass_admin_groups.exists") {
-		t.Fatalf("is_break_glass_admin expression does not reference break_glass_admin_groups: %q", isBreakGlassAdminExpression)
+	if !strings.Contains(maintenanceClusterNameExpression, `"app.kubernetes.io/instance"`) {
+		t.Fatalf("maintenance_cluster_name expression does not fall back to app.kubernetes.io/instance: %q", maintenanceClusterNameExpression)
+	}
+	if !strings.Contains(maintenanceAuthorizedExpression, `authorizer.group("openbao.org")`) {
+		t.Fatalf("maintenance_authorized expression does not use the CEL authorizer: %q", maintenanceAuthorizedExpression)
+	}
+	if !strings.Contains(maintenanceAuthorizedExpression, `check("maintenance")`) {
+		t.Fatalf("maintenance_authorized expression does not check the custom maintenance verb: %q", maintenanceAuthorizedExpression)
 	}
 }
 

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -8,29 +8,20 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	provisionerpkg "github.com/dc-tec/openbao-operator/internal/service/provisioner"
 )
 
 func newPrivilegedImpersonatedClient(t *testing.T, username string) client.Client {
 	t.Helper()
 
-	impersonated := rest.CopyConfig(cfg)
-	impersonated.Impersonate = rest.ImpersonationConfig{
-		UserName: username,
-		Groups:   []string{"system:masters"},
-	}
-
-	c, err := client.New(impersonated, client.Options{Scheme: k8sScheme})
-	if err != nil {
-		t.Fatalf("create privileged impersonated client: %v", err)
-	}
-	return c
+	return newImpersonatedClientWithGroups(t, username, "system:masters")
 }
 
 func ensureControllerRBACManager(t *testing.T, namespace string) {
@@ -81,6 +72,160 @@ func ensureControllerRBACManager(t *testing.T, namespace string) {
 	}
 	if err := k8sClient.Create(ctx, binding); err != nil {
 		t.Fatalf("create controller rbac rolebinding: %v", err)
+	}
+}
+
+func grantPodDeleteAccess(t *testing.T, namespace, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-pod-maintenance",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"delete", "get"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create pod maintenance role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-pod-maintenance-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create pod maintenance binding: %v", err)
+	}
+}
+
+func grantClusterMaintenanceAccess(t *testing.T, namespace, clusterName, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-maintenance-access",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"openbao.org"},
+				Resources:     []string{"openbaoclusters"},
+				ResourceNames: []string{clusterName},
+				Verbs:         []string{"get", "maintenance"},
+			},
+			{
+				APIGroups:     []string{"openbao.org"},
+				Resources:     []string{"openbaoclusters/status"},
+				ResourceNames: []string{clusterName},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create maintenance role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-maintenance-access-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create maintenance rolebinding: %v", err)
+	}
+}
+
+func createManagedMaintenancePod(t *testing.T, c client.Client, namespace, clusterName, podName string) {
+	t.Helper()
+
+	cluster := newMinimalClusterObj(namespace, clusterName)
+	cluster.Spec.InitContainer = &openbaov1alpha1.InitContainerConfig{
+		Image: "openbao/openbao-init:latest",
+	}
+	cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeOperatorManaged
+	if err := c.Create(ctx, cluster); err != nil {
+		t.Fatalf("create OpenBaoCluster: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"openbao.org/maintenance": "true",
+			},
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "openbao",
+				"app.kubernetes.io/instance":   clusterName,
+				"app.kubernetes.io/managed-by": "openbao-operator",
+				"openbao.org/cluster":          clusterName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:3.9",
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	if err := c.Create(ctx, pod); err != nil {
+		t.Fatalf("create managed maintenance pod: %v", err)
 	}
 }
 
@@ -149,6 +294,58 @@ func TestVAP_LockManagedRBAC_DeniesDirectMutationOfControllerManagedRole(t *test
 	}
 
 	t.Fatalf("expected VAP to deny direct mutation of controller-managed Role after retries")
+}
+
+func TestVAP_LockManagedRBAC_DeniesMaintenanceMutationWithoutClusterMaintenanceVerb(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	clusterName := "example"
+	podName := "example-maintenance-pod"
+	editorUsername := "maintenance-editor-no-verb"
+	controllerClient := newPrivilegedImpersonatedClient(t, controllerUsername)
+	createManagedMaintenancePod(t, controllerClient, namespace, clusterName, podName)
+	grantPodDeleteAccess(t, namespace, editorUsername)
+
+	editorClient := newImpersonatedClient(t, editorUsername)
+	for attempt := 0; attempt < 25; attempt++ {
+		err := editorClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace}})
+		if err == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		if !strings.Contains(err.Error(), "Direct modification of OpenBao-managed resources is prohibited") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+		return
+	}
+
+	t.Fatalf("expected VAP to deny maintenance mutation without the cluster maintenance verb")
+}
+
+func TestVAP_LockManagedRBAC_AllowsMaintenanceMutationWithClusterMaintenanceVerb(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	clusterName := "example"
+	podName := "example-maintenance-pod"
+	editorUsername := "maintenance-editor"
+	controllerClient := newPrivilegedImpersonatedClient(t, controllerUsername)
+	createManagedMaintenancePod(t, controllerClient, namespace, clusterName, podName)
+	grantPodDeleteAccess(t, namespace, editorUsername)
+	grantClusterMaintenanceAccess(t, namespace, clusterName, editorUsername)
+
+	editorClient := newImpersonatedClient(t, editorUsername)
+	if err := editorClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace}}); err != nil {
+		t.Fatalf("expected maintenance-authorized pod delete to succeed, got: %v", err)
+	}
+
+	var deleted corev1.Pod
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, &deleted); err == nil {
+		t.Fatalf("expected Pod %s/%s to be deleted", namespace, podName)
+	}
 }
 
 func TestVAP_LockManagedRBAC_DeniesDirectMutationOfProvisionerManagedRoleBinding(t *testing.T) {


### PR DESCRIPTION
## Description

Replace the global maintenance bypass group model with RBAC-backed maintenance authorization on the owning `OpenBaoCluster`.

This change:
- updates the managed-resource mutation VAP to authorize direct maintenance actions through the custom `maintenance` verb
- adds installable maintenance RBAC assets and namespace-scoped examples
- updates the maintenance docs and threat-model guidance for the new operating contract
- adds integration and e2e coverage for the allow and deny paths

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

```sh
go test -tags=integration ./test/integration -run 'TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels|TestVAP_LockManagedRBAC_'
go test -tags=e2e ./test/e2e -run '^$'
make test-e2e E2E_FOCUS='prevents managed Pod deletion during maintenance without cluster maintenance permission|allows managed Pod deletion during maintenance with cluster maintenance permission' E2E_TIMEOUT=60m
make docs-build
```
