### PR TITLE
refactor(resourceidentity): centralize managed resource identity

### DIFF
--- a/.ast-grep/policy/architecture-boundaries.yml
+++ b/.ast-grep/policy/architecture-boundaries.yml
@@ -45,6 +45,7 @@ layerCoverage:
       - platform/openbaotls
       - platform/predicates
       - platform/reconcile
+      - platform/resourceidentity
       - platform/statusapply
       - platform/statuspatch
       - platform/testutil

--- a/internal/platform/resourceidentity/names.go
+++ b/internal/platform/resourceidentity/names.go
@@ -1,0 +1,65 @@
+package resourceidentity
+
+import (
+	"fmt"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+const configInitMapSuffix = "-config-init"
+
+func Labels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
+	return map[string]string{
+		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
+		constants.LabelAppInstance:    cluster.Name,
+		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelOpenBaoCluster: cluster.Name,
+	}
+}
+
+func PodSelectorLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
+	return PodSelectorLabelsWithRevision(cluster, "")
+}
+
+func PodSelectorLabelsWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, revision string) map[string]string {
+	labels := Labels(cluster)
+	if revision != "" {
+		labels[constants.LabelOpenBaoRevision] = revision
+	}
+	return labels
+}
+
+func UnsealSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return cluster.Name + constants.SuffixUnsealKey
+}
+
+func ConfigMapName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return cluster.Name + constants.SuffixConfigMap
+}
+
+func ConfigMapNameWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, revision string) string {
+	if revision == "" {
+		return ConfigMapName(cluster)
+	}
+	return fmt.Sprintf("%s%s-%s", cluster.Name, constants.SuffixConfigMap, revision)
+}
+
+func ConfigInitMapName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return cluster.Name + configInitMapSuffix
+}
+
+func TLSServerSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return cluster.Name + constants.SuffixTLSServer
+}
+
+func HeadlessServiceName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return cluster.Name
+}
+
+func ServiceAccountName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	if cluster.Spec.ServiceAccount != nil && cluster.Spec.ServiceAccount.Name != "" {
+		return cluster.Spec.ServiceAccount.Name
+	}
+	return cluster.Name + constants.SuffixServiceAccount
+}

--- a/internal/platform/resourceidentity/names_test.go
+++ b/internal/platform/resourceidentity/names_test.go
@@ -1,0 +1,79 @@
+package resourceidentity
+
+import (
+	"testing"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLabels(t *testing.T) {
+	cluster := newTestCluster()
+
+	got := Labels(cluster)
+
+	if got[constants.LabelAppName] != constants.LabelValueAppNameOpenBao {
+		t.Fatalf("expected app name label, got %#v", got)
+	}
+	if got[constants.LabelAppInstance] != cluster.Name {
+		t.Fatalf("expected app instance label %q, got %#v", cluster.Name, got)
+	}
+	if got[constants.LabelOpenBaoCluster] != cluster.Name {
+		t.Fatalf("expected cluster label %q, got %#v", cluster.Name, got)
+	}
+}
+
+func TestPodSelectorLabelsWithRevision(t *testing.T) {
+	cluster := newTestCluster()
+
+	got := PodSelectorLabelsWithRevision(cluster, "blue123")
+
+	if got[constants.LabelOpenBaoRevision] != "blue123" {
+		t.Fatalf("expected revision label, got %#v", got)
+	}
+	if got[constants.LabelOpenBaoCluster] != cluster.Name {
+		t.Fatalf("expected cluster label, got %#v", got)
+	}
+}
+
+func TestServiceAccountName(t *testing.T) {
+	cluster := newTestCluster()
+	if got := ServiceAccountName(cluster); got != cluster.Name+constants.SuffixServiceAccount {
+		t.Fatalf("expected default service account name, got %q", got)
+	}
+
+	cluster.Spec.ServiceAccount = &openbaov1alpha1.ServiceAccountConfig{Name: "custom-sa"}
+	if got := ServiceAccountName(cluster); got != "custom-sa" {
+		t.Fatalf("expected explicit service account name, got %q", got)
+	}
+}
+
+func TestSharedNames(t *testing.T) {
+	cluster := newTestCluster()
+
+	if got := HeadlessServiceName(cluster); got != cluster.Name {
+		t.Fatalf("expected headless service name %q, got %q", cluster.Name, got)
+	}
+	if got := ConfigMapName(cluster); got != cluster.Name+constants.SuffixConfigMap {
+		t.Fatalf("expected config map name, got %q", got)
+	}
+	if got := ConfigMapNameWithRevision(cluster, "green123"); got != cluster.Name+constants.SuffixConfigMap+"-green123" {
+		t.Fatalf("expected revision config map name, got %q", got)
+	}
+	if got := ConfigInitMapName(cluster); got != cluster.Name+"-config-init" {
+		t.Fatalf("expected config init map name, got %q", got)
+	}
+	if got := UnsealSecretName(cluster); got != cluster.Name+constants.SuffixUnsealKey {
+		t.Fatalf("expected unseal secret name, got %q", got)
+	}
+	if got := TLSServerSecretName(cluster); got != cluster.Name+constants.SuffixTLSServer {
+		t.Fatalf("expected tls server secret name, got %q", got)
+	}
+}
+
+func newTestCluster() *openbaov1alpha1.OpenBaoCluster {
+	return &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+}

--- a/internal/service/bootstrap/acme_cache.go
+++ b/internal/service/bootstrap/acme_cache.go
@@ -14,6 +14,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -45,7 +46,7 @@ func buildManagedACMESharedCachePVC(cluster *openbaov1alpha1.OpenBaoCluster) (*c
 		return nil, fmt.Errorf("invalid ACME shared cache size %q: %w", cluster.Spec.TLS.ACME.SharedCache.Size, err)
 	}
 
-	labels := infraLabels(cluster)
+	labels := resourceidentity.Labels(cluster)
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      portopenbao.ManagedACMESharedCachePVCName(cluster),

--- a/internal/service/bootstrap/config.go
+++ b/internal/service/bootstrap/config.go
@@ -18,6 +18,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/auth"
 	configbuilder "github.com/dc-tec/openbao-operator/internal/adapter/config"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
 
@@ -39,7 +40,7 @@ func usesStaticSeal(cluster *openbaov1alpha1.OpenBaoCluster) bool {
 // the operator never needs GET permission on the unseal key Secret after creation,
 // improving security by preventing the operator from reading root keys.
 func (m *Manager) ensureUnsealSecret(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	secretName := unsealSecretName(cluster)
+	secretName := resourceidentity.UnsealSecretName(cluster)
 
 	// Generate key in memory
 	key, genErr := generateUnsealKey()
@@ -51,7 +52,7 @@ func (m *Manager) ensureUnsealSecret(ctx context.Context, logger logr.Logger, cl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Type:      corev1.SecretTypeOpaque,
 		Immutable: ptr.To(true), // Secure by default: prevent accidental overwrites
@@ -94,7 +95,7 @@ func generateUnsealKey() ([]byte, error) {
 
 // ensureConfigMap manages the config.hcl ConfigMap for the OpenBaoCluster using Server-Side Apply.
 func (m *Manager) ensureConfigMap(ctx context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, configContent string) error {
-	return m.ensureConfigMapWithName(ctx, cluster, configMapName(cluster), configContent)
+	return m.ensureConfigMapWithName(ctx, cluster, resourceidentity.ConfigMapName(cluster), configContent)
 }
 
 func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, cmName string, configContent string) error {
@@ -110,7 +111,7 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Data: map[string]string{
 			configFileName: configContent,
@@ -128,7 +129,7 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 // self-initialization stanzas. This ConfigMap is only mounted for pod-0, since
 // only the first pod needs to execute initialization requests.
 func (m *Manager) ensureSelfInitConfigMap(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	cmName := configInitMapName(cluster)
+	cmName := resourceidentity.ConfigInitMapName(cluster)
 
 	// If self-init is not enabled, delete the ConfigMap if it exists
 	if cluster.Spec.SelfInit == nil || !cluster.Spec.SelfInit.Enabled {
@@ -231,7 +232,7 @@ func (m *Manager) ensureSelfInitConfigMap(ctx context.Context, logger logr.Logge
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Data: map[string]string{
 			configFileName: initConfigContent,

--- a/internal/service/bootstrap/config_test.go
+++ b/internal/service/bootstrap/config_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
 
@@ -119,7 +120,7 @@ func TestEnsureUnsealSecret_CreatesSecret(t *testing.T) {
 	}
 
 	// Verify Secret was created
-	secretName := unsealSecretName(cluster)
+	secretName := resourceidentity.UnsealSecretName(cluster)
 	secret := &corev1.Secret{}
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
@@ -145,7 +146,7 @@ func TestEnsureUnsealSecret_CreatesSecret(t *testing.T) {
 
 func TestEnsureUnsealSecret_HandlesAlreadyExists(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
-	secretName := unsealSecretName(cluster)
+	secretName := resourceidentity.UnsealSecretName(cluster)
 
 	existingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -185,7 +186,7 @@ func TestEnsureConfigMap_CreatesConfigMap(t *testing.T) {
 	}
 
 	// Verify ConfigMap was created
-	cmName := configMapName(cluster)
+	cmName := resourceidentity.ConfigMapName(cluster)
 	configMap := &corev1.ConfigMap{}
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
@@ -203,7 +204,7 @@ func TestEnsureConfigMap_CreatesConfigMap(t *testing.T) {
 
 func TestEnsureConfigMap_UpdatesConfigMap(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
-	cmName := configMapName(cluster)
+	cmName := resourceidentity.ConfigMapName(cluster)
 
 	existingConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -244,7 +245,7 @@ func TestEnsureConfigMap_UpdatesConfigMap(t *testing.T) {
 
 func TestEnsureConfigMap_IsIdempotent(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
-	cmName := configMapName(cluster)
+	cmName := resourceidentity.ConfigMapName(cluster)
 	configContent := "test config content"
 
 	existingConfigMap := &corev1.ConfigMap{
@@ -294,7 +295,7 @@ func TestEnsureSelfInitConfigMap_Disabled(t *testing.T) {
 	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
 		Enabled: false,
 	}
-	cmName := configInitMapName(cluster)
+	cmName := resourceidentity.ConfigInitMapName(cluster)
 
 	existingConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -382,7 +383,7 @@ func TestEnsureSelfInitConfigMap_HardenedProfileWithBootstrap(t *testing.T) {
 	}
 
 	// Verify ConfigMap was created
-	cmName := configInitMapName(cluster)
+	cmName := resourceidentity.ConfigInitMapName(cluster)
 	configMap := &corev1.ConfigMap{}
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
@@ -466,7 +467,7 @@ func TestEnsureSelfInitConfigMap_DevelopmentProfileWithBackupJWTAuthBootstraps(t
 		t.Fatalf("ensureSelfInitConfigMap() error = %v", err)
 	}
 
-	cmName := configInitMapName(cluster)
+	cmName := resourceidentity.ConfigInitMapName(cluster)
 	configMap := &corev1.ConfigMap{}
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
@@ -528,7 +529,7 @@ func TestEnsureSelfInitConfigMap_RejectsBootstrapAudienceMismatch(t *testing.T) 
 
 func TestDeleteConfigMap(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
-	cmName := configMapName(cluster)
+	cmName := resourceidentity.ConfigMapName(cluster)
 
 	existingConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -578,7 +579,7 @@ func TestDeleteSecrets(t *testing.T) {
 
 	unsealSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      unsealSecretName(cluster),
+			Name:      resourceidentity.UnsealSecretName(cluster),
 			Namespace: cluster.Namespace,
 		},
 	}
@@ -592,7 +593,7 @@ func TestDeleteSecrets(t *testing.T) {
 
 	tlsServerSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tlsServerSecretName(cluster),
+			Name:      resourceidentity.TLSServerSecretName(cluster),
 			Namespace: cluster.Namespace,
 		},
 	}
@@ -607,9 +608,9 @@ func TestDeleteSecrets(t *testing.T) {
 
 	// Verify all secrets were deleted
 	secrets := []string{
-		unsealSecretName(cluster),
+		resourceidentity.UnsealSecretName(cluster),
 		tlsCASecretName(cluster),
-		tlsServerSecretName(cluster),
+		resourceidentity.TLSServerSecretName(cluster),
 	}
 
 	for _, secretName := range secrets {
@@ -631,7 +632,7 @@ func TestDeleteSecrets_PartialMissing(t *testing.T) {
 	// Only create one secret
 	unsealSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      unsealSecretName(cluster),
+			Name:      resourceidentity.UnsealSecretName(cluster),
 			Namespace: cluster.Namespace,
 		},
 	}

--- a/internal/service/bootstrap/helpers_integration_test.go
+++ b/internal/service/bootstrap/helpers_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 func newTestClientWithObjects(t interface{ Helper() }, objs ...client.Object) client.Client {
@@ -33,15 +34,11 @@ func tlsCASecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
 	return cluster.Name + constants.SuffixTLSCA
 }
 
-func tlsServerSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixTLSServer
-}
-
 func deleteConfigMap(ctx context.Context, k8sClient client.Client, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	configMap := &corev1.ConfigMap{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      configMapName(cluster),
+		Name:      resourceidentity.ConfigMapName(cluster),
 	}, configMap)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -69,12 +66,12 @@ func deleteSecrets(ctx context.Context, k8sClient client.Client, cluster *openba
 		mode = openbaov1alpha1.TLSModeOperatorManaged
 	}
 	if cluster.Spec.TLS.Enabled && mode == openbaov1alpha1.TLSModeOperatorManaged {
-		secretNames = append(secretNames, tlsServerSecretName(cluster), tlsCASecretName(cluster))
+		secretNames = append(secretNames, resourceidentity.TLSServerSecretName(cluster), tlsCASecretName(cluster))
 	}
 
 	staticUnseal := cluster.Spec.Unseal == nil || cluster.Spec.Unseal.Type == "" || cluster.Spec.Unseal.Type == "static"
 	if staticUnseal {
-		secretNames = append(secretNames, unsealSecretName(cluster))
+		secretNames = append(secretNames, resourceidentity.UnsealSecretName(cluster))
 	}
 
 	for _, name := range secretNames {

--- a/internal/service/bootstrap/manager.go
+++ b/internal/service/bootstrap/manager.go
@@ -12,18 +12,16 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
-	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	configurationservice "github.com/dc-tec/openbao-operator/internal/service/configuration"
 )
 
 const (
-	configInitMapSuffix = "-config-init"
-	unsealSecretKey     = "key"
-	unsealKeyBytes      = 32
-	configFileName      = "config.hcl"
-	unsealTypeTransit   = "transit"
+	unsealSecretKey   = "key"
+	unsealKeyBytes    = 32
+	configFileName    = "config.hcl"
+	unsealTypeTransit = "transit"
 )
 
 // Manager reconciles bootstrap/configuration resources for an OpenBaoCluster.
@@ -140,25 +138,4 @@ func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster 
 	}
 
 	return nil
-}
-
-func infraLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	return map[string]string{
-		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
-		constants.LabelAppInstance:    cluster.Name,
-		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
-		constants.LabelOpenBaoCluster: cluster.Name,
-	}
-}
-
-func unsealSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixUnsealKey
-}
-
-func configMapName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixConfigMap
-}
-
-func configInitMapName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + configInitMapSuffix
 }

--- a/internal/service/identity/manager.go
+++ b/internal/service/identity/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/revision"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // Manager reconciles ServiceAccount and RBAC resources for an OpenBaoCluster.
@@ -46,7 +47,7 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 }
 
 func (m *Manager) ensureServiceAccount(ctx context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	saName := serviceAccountName(cluster)
+	saName := resourceidentity.ServiceAccountName(cluster)
 
 	sa := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
@@ -73,13 +74,13 @@ func (m *Manager) ensureServiceAccount(ctx context.Context, _ logr.Logger, clust
 }
 
 func serviceAccountLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	labels := resourceLabels(cluster)
+	labels := resourceidentity.Labels(cluster)
 	labels[constants.LabelOpenBaoServiceAccountRole] = constants.ServiceAccountRoleMain
 	return labels
 }
 
 func (m *Manager) ensureRBAC(ctx context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	saName := serviceAccountName(cluster)
+	saName := resourceidentity.ServiceAccountName(cluster)
 	roleName := saName + "-role"
 	roleBindingName := saName + "-rolebinding"
 
@@ -93,7 +94,7 @@ func (m *Manager) ensureRBAC(ctx context.Context, _ logr.Logger, cluster *openba
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
 			Namespace: cluster.Namespace,
-			Labels:    resourceLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -122,7 +123,7 @@ func (m *Manager) ensureRBAC(ctx context.Context, _ logr.Logger, cluster *openba
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleBindingName,
 			Namespace: cluster.Namespace,
-			Labels:    resourceLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -171,22 +172,6 @@ func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster 
 	}
 
 	return nil
-}
-
-func resourceLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	return map[string]string{
-		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
-		constants.LabelAppInstance:    cluster.Name,
-		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
-		constants.LabelOpenBaoCluster: cluster.Name,
-	}
-}
-
-func serviceAccountName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	if cluster.Spec.ServiceAccount != nil && cluster.Spec.ServiceAccount.Name != "" {
-		return cluster.Spec.ServiceAccount.Name
-	}
-	return cluster.Name + constants.SuffixServiceAccount
 }
 
 func openBaoPodResourceNames(cluster *openbaov1alpha1.OpenBaoCluster) []string {

--- a/internal/service/identity/manager_test.go
+++ b/internal/service/identity/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 const (
@@ -37,7 +38,7 @@ func TestEnsureServiceAccountCreatesAndUpdates(t *testing.T) {
 	sa := &corev1.ServiceAccount{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      serviceAccountName(cluster),
+		Name:      resourceidentity.ServiceAccountName(cluster),
 	}, sa)
 	if err != nil {
 		t.Fatalf("expected ServiceAccount to exist: %v", err)
@@ -71,7 +72,7 @@ func TestEnsureServiceAccount_IsIdempotent(t *testing.T) {
 	sa1 := &corev1.ServiceAccount{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      serviceAccountName(cluster),
+		Name:      resourceidentity.ServiceAccountName(cluster),
 	}, sa1)
 	if err != nil {
 		t.Fatalf("expected ServiceAccount to exist after first reconcile: %v", err)
@@ -86,7 +87,7 @@ func TestEnsureServiceAccount_IsIdempotent(t *testing.T) {
 	sa2 := &corev1.ServiceAccount{}
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      serviceAccountName(cluster),
+		Name:      resourceidentity.ServiceAccountName(cluster),
 	}, sa2)
 	if err != nil {
 		t.Fatalf("expected ServiceAccount to exist after second reconcile: %v", err)
@@ -117,7 +118,7 @@ func TestEnsureRBACCreatesRoleAndRoleBinding(t *testing.T) {
 
 	// Verify Role exists
 	role := &rbacv1.Role{}
-	roleName := serviceAccountName(cluster) + "-role"
+	roleName := resourceidentity.ServiceAccountName(cluster) + "-role"
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      roleName,
@@ -208,7 +209,7 @@ func TestEnsureRBACCreatesRoleAndRoleBinding(t *testing.T) {
 
 	// Verify RoleBinding exists
 	roleBinding := &rbacv1.RoleBinding{}
-	roleBindingName := serviceAccountName(cluster) + "-rolebinding"
+	roleBindingName := resourceidentity.ServiceAccountName(cluster) + "-rolebinding"
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      roleBindingName,
@@ -227,7 +228,7 @@ func TestEnsureRBACCreatesRoleAndRoleBinding(t *testing.T) {
 		t.Fatalf("expected RoleBinding to have subjects")
 	}
 
-	saName := serviceAccountName(cluster)
+	saName := resourceidentity.ServiceAccountName(cluster)
 	foundSubject := false
 	for _, subject := range roleBinding.Subjects {
 		if subject.Kind == "ServiceAccount" && subject.Name == saName && subject.Namespace == cluster.Namespace {
@@ -261,7 +262,7 @@ func TestEnsureRBAC_IncludesBlueGreenPodResourceNames(t *testing.T) {
 	}
 
 	role := &rbacv1.Role{}
-	roleName := serviceAccountName(cluster) + "-role"
+	roleName := resourceidentity.ServiceAccountName(cluster) + "-role"
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      roleName,
@@ -325,7 +326,7 @@ func TestEnsureRBAC_IsIdempotent(t *testing.T) {
 
 	// Verify RoleBinding still references correct ServiceAccount
 	roleBinding := &rbacv1.RoleBinding{}
-	roleBindingName := serviceAccountName(cluster) + "-rolebinding"
+	roleBindingName := resourceidentity.ServiceAccountName(cluster) + "-rolebinding"
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      roleBindingName,
@@ -334,14 +335,14 @@ func TestEnsureRBAC_IsIdempotent(t *testing.T) {
 		t.Fatalf("expected RoleBinding to exist after idempotent applies: %v", err)
 	}
 
-	saName := serviceAccountName(cluster)
+	saName := resourceidentity.ServiceAccountName(cluster)
 	if len(roleBinding.Subjects) == 0 || roleBinding.Subjects[0].Name != saName {
 		t.Fatalf("expected RoleBinding to reference ServiceAccount %q after idempotent applies", saName)
 	}
 
 	// Verify Role still exists and has correct rules
 	role := &rbacv1.Role{}
-	roleName := serviceAccountName(cluster) + "-role"
+	roleName := resourceidentity.ServiceAccountName(cluster) + "-role"
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      roleName,
@@ -378,7 +379,7 @@ func TestServiceAccountHasOwnerReferenceForGC(t *testing.T) {
 	sa := &corev1.ServiceAccount{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      serviceAccountName(cluster),
+		Name:      resourceidentity.ServiceAccountName(cluster),
 	}, sa)
 	if err != nil {
 		t.Fatalf("expected ServiceAccount to exist: %v", err)
@@ -418,7 +419,7 @@ func TestRBACHasOwnerReferenceForGC(t *testing.T) {
 	}
 
 	// Verify RoleBinding has OwnerReference (for GC)
-	roleBindingName := serviceAccountName(cluster) + "-rolebinding"
+	roleBindingName := resourceidentity.ServiceAccountName(cluster) + "-rolebinding"
 	roleBinding := &rbacv1.RoleBinding{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
@@ -440,7 +441,7 @@ func TestRBACHasOwnerReferenceForGC(t *testing.T) {
 	}
 
 	// Verify Role has OwnerReference (for GC)
-	roleName := serviceAccountName(cluster) + "-role"
+	roleName := resourceidentity.ServiceAccountName(cluster) + "-role"
 	role := &rbacv1.Role{}
 	err = k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,

--- a/internal/service/networking/backend_tls_policy.go
+++ b/internal/service/networking/backend_tls_policy.go
@@ -16,6 +16,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // ensureBackendTLSPolicy manages the Gateway API BackendTLSPolicy for the OpenBaoCluster.
@@ -122,7 +123,7 @@ func buildBackendTLSPolicy(cluster *openbaov1alpha1.OpenBaoCluster) *gatewayv1.B
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backendTLSPolicyName(cluster),
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Spec: gatewayv1.BackendTLSPolicySpec{
 			TargetRefs: targetRefs,
@@ -199,7 +200,7 @@ func (m *Manager) ensureGatewayCAConfigMap(ctx context.Context, logger logr.Logg
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Data: map[string]string{
 			"ca.crt": string(caCertPEM),

--- a/internal/service/networking/http_route.go
+++ b/internal/service/networking/http_route.go
@@ -12,6 +12,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // ensureHTTPRoute manages the Gateway API HTTPRoute for the OpenBaoCluster.
@@ -81,7 +82,7 @@ func buildHTTPRoute(cluster *openbaov1alpha1.OpenBaoCluster) *gatewayv1.HTTPRout
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        httpRouteName(cluster),
 			Namespace:   cluster.Namespace,
-			Labels:      infraLabels(cluster),
+			Labels:      resourceidentity.Labels(cluster),
 			Annotations: gw.Annotations,
 		},
 		Spec: gatewayv1.HTTPRouteSpec{

--- a/internal/service/networking/ingress.go
+++ b/internal/service/networking/ingress.go
@@ -12,6 +12,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 func (m *Manager) ensureIngress(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
@@ -87,14 +88,14 @@ func buildIngress(cluster *openbaov1alpha1.OpenBaoCluster) *networkingv1.Ingress
 
 	secretName := ing.TLSSecretName
 	if strings.TrimSpace(secretName) == "" {
-		secretName = tlsServerSecretName(cluster)
+		secretName = resourceidentity.TLSServerSecretName(cluster)
 	}
 
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cluster.Name,
 			Namespace:   cluster.Namespace,
-			Labels:      infraLabels(cluster),
+			Labels:      resourceidentity.Labels(cluster),
 			Annotations: ing.Annotations,
 		},
 		Spec: networkingv1.IngressSpec{

--- a/internal/service/networking/names.go
+++ b/internal/service/networking/names.go
@@ -2,37 +2,7 @@ package networking
 
 import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
-
-func infraLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	return map[string]string{
-		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
-		constants.LabelAppInstance:    cluster.Name,
-		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
-		constants.LabelOpenBaoCluster: cluster.Name,
-	}
-}
-
-func podSelectorLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	return podSelectorLabelsWithRevision(cluster, "")
-}
-
-func podSelectorLabelsWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, rev string) map[string]string {
-	labels := infraLabels(cluster)
-	if rev != "" {
-		labels[constants.LabelOpenBaoRevision] = rev
-	}
-	return labels
-}
-
-func headlessServiceName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name
-}
-
-func tlsServerSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixTLSServer
-}
 
 func externalServiceName(cluster *openbaov1alpha1.OpenBaoCluster) string {
 	return cluster.Name + publicServiceSuffix

--- a/internal/service/networking/policy_build.go
+++ b/internal/service/networking/policy_build.go
@@ -10,12 +10,13 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // buildNetworkPolicy constructs a NetworkPolicy for the given OpenBaoCluster.
 func buildNetworkPolicy(cluster *openbaov1alpha1.OpenBaoCluster, apiServerInfo *apiServerInfo, operatorNamespace string) (*networkingv1.NetworkPolicy, error) {
-	labels := infraLabels(cluster)
-	podSelector := podSelectorLabels(cluster)
+	labels := resourceidentity.Labels(cluster)
+	podSelector := resourceidentity.PodSelectorLabels(cluster)
 
 	clusterPeer := networkingv1.NetworkPolicyPeer{
 		PodSelector: &metav1.LabelSelector{
@@ -152,7 +153,7 @@ func buildNetworkPolicy(cluster *openbaov1alpha1.OpenBaoCluster, apiServerInfo *
 }
 
 func buildJobNetworkPolicy(cluster *openbaov1alpha1.OpenBaoCluster, apiServerInfo *apiServerInfo) (*networkingv1.NetworkPolicy, error) {
-	labels := infraLabels(cluster)
+	labels := resourceidentity.Labels(cluster)
 
 	kubernetesAPIPort443 := intstr.FromInt(443)
 	kubernetesAPIPort6443 := intstr.FromInt(6443)
@@ -160,7 +161,7 @@ func buildJobNetworkPolicy(cluster *openbaov1alpha1.OpenBaoCluster, apiServerInf
 
 	openBaoPeer := networkingv1.NetworkPolicyPeer{
 		PodSelector: &metav1.LabelSelector{
-			MatchLabels: infraLabels(cluster),
+			MatchLabels: resourceidentity.Labels(cluster),
 		},
 	}
 

--- a/internal/service/networking/services.go
+++ b/internal/service/networking/services.go
@@ -14,10 +14,11 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 func (m *Manager) ensureHeadlessService(ctx context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	svcName := headlessServiceName(cluster)
+	svcName := resourceidentity.HeadlessServiceName(cluster)
 
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -27,12 +28,12 @@ func (m *Manager) ensureHeadlessService(ctx context.Context, _ logr.Logger, clus
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      svcName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP:                corev1.ClusterIPNone,
 			PublishNotReadyAddresses: true,
-			Selector:                 podSelectorLabels(cluster),
+			Selector:                 resourceidentity.PodSelectorLabels(cluster),
 			Ports: []corev1.ServicePort{
 				{
 					Name:     "api",
@@ -89,7 +90,7 @@ func (m *Manager) ensureExternalService(ctx context.Context, _ logr.Logger, clus
 		}
 	}
 
-	selectorLabels := podSelectorLabels(cluster)
+	selectorLabels := resourceidentity.PodSelectorLabels(cluster)
 	if activeRevision := activeServiceRevision(cluster); activeRevision != "" {
 		selectorLabels[constants.LabelOpenBaoRevision] = activeRevision
 	}
@@ -102,7 +103,7 @@ func (m *Manager) ensureExternalService(ctx context.Context, _ logr.Logger, clus
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
 			Namespace:   cluster.Namespace,
-			Labels:      infraLabels(cluster),
+			Labels:      resourceidentity.Labels(cluster),
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
@@ -154,7 +155,7 @@ func (m *Manager) ensureACMEChallengeService(ctx context.Context, _ logr.Logger,
 		return nil
 	}
 
-	selectorLabels := podSelectorLabels(cluster)
+	selectorLabels := resourceidentity.PodSelectorLabels(cluster)
 	if activeRevision := activeServiceRevision(cluster); activeRevision != "" {
 		selectorLabels[constants.LabelOpenBaoRevision] = activeRevision
 	}
@@ -167,7 +168,7 @@ func (m *Manager) ensureACMEChallengeService(ctx context.Context, _ logr.Logger,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      svcName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                     corev1.ServiceTypeClusterIP,

--- a/internal/service/networking/tls_route.go
+++ b/internal/service/networking/tls_route.go
@@ -12,6 +12,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // ensureTLSRoute manages the Gateway API TLSRoute for the OpenBaoCluster using Server-Side Apply.
@@ -80,7 +81,7 @@ func buildTLSRoute(cluster *openbaov1alpha1.OpenBaoCluster) *gatewayv1alpha2.TLS
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        tlsRouteName(cluster),
 			Namespace:   cluster.Namespace,
-			Labels:      infraLabels(cluster),
+			Labels:      resourceidentity.Labels(cluster),
 			Annotations: gw.Annotations,
 		},
 		Spec: gatewayv1alpha2.TLSRouteSpec{

--- a/internal/service/workload/compute.go
+++ b/internal/service/workload/compute.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -28,7 +29,7 @@ var ErrStatefulSetPrerequisitesMissing = errors.New("StatefulSet prerequisites m
 // by setting a condition and requeuing). Returns other errors for unexpected failures.
 func (m *Manager) checkStatefulSetPrerequisites(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, revision string) error {
 	// Always check for the config ConfigMap
-	configMapName := configMapNameWithRevision(cluster, revision)
+	configMapName := resourceidentity.ConfigMapNameWithRevision(cluster, revision)
 	configMap := &corev1.ConfigMap{}
 	if err := m.client.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
@@ -43,7 +44,7 @@ func (m *Manager) checkStatefulSetPrerequisites(ctx context.Context, cluster *op
 	// Check for TLS secret if TLS is enabled and not in ACME mode
 	// In ACME mode, OpenBao manages certificates internally, so no secret is needed
 	if cluster.Spec.TLS.Enabled && !usesACMEMode(cluster) {
-		tlsSecretName := tlsServerSecretName(cluster)
+		tlsSecretName := resourceidentity.TLSServerSecretName(cluster)
 		tlsSecret := &corev1.Secret{}
 		if err := m.client.Get(ctx, types.NamespacedName{
 			Namespace: cluster.Namespace,

--- a/internal/service/workload/constants.go
+++ b/internal/service/workload/constants.go
@@ -3,7 +3,6 @@ package workload
 import "github.com/dc-tec/openbao-operator/internal/platform/constants"
 
 const (
-	configInitMapSuffix      = "-config-init"
 	dataVolumeName           = constants.VolumeData
 	tlsVolumeName            = constants.VolumeTLS
 	configVolumeName         = constants.VolumeConfig

--- a/internal/service/workload/maintenance.go
+++ b/internal/service/workload/maintenance.go
@@ -11,6 +11,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 const maintenanceAnnotationEnabledValue = "true"
@@ -25,7 +26,7 @@ func (m *Manager) reconcileMaintenanceAnnotationsForPods(ctx context.Context, lo
 	var pods corev1.PodList
 	if err := m.client.List(ctx, &pods,
 		client.InNamespace(cluster.Namespace),
-		client.MatchingLabels(podSelectorLabelsWithRevision(cluster, revision)),
+		client.MatchingLabels(resourceidentity.PodSelectorLabelsWithRevision(cluster, revision)),
 	); err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}

--- a/internal/service/workload/manager.go
+++ b/internal/service/workload/manager.go
@@ -16,6 +16,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // Manager reconciles workload-owned resources for an OpenBaoCluster.
@@ -83,7 +84,7 @@ func (m *Manager) ensureConfigMapWithRevision(ctx context.Context, cluster *open
 		return nil
 	}
 
-	return m.ensureConfigMapWithName(ctx, cluster, configMapNameWithRevision(cluster, revision), configContent)
+	return m.ensureConfigMapWithName(ctx, cluster, resourceidentity.ConfigMapNameWithRevision(cluster, revision), configContent)
 }
 
 func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, cmName string, configContent string) error {
@@ -92,7 +93,7 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 	}
 
 	configMap := corev1apply.ConfigMap(cmName, cluster.Namespace).
-		WithLabels(infraLabels(cluster)).
+		WithLabels(resourceidentity.Labels(cluster)).
 		WithData(map[string]string{configFileName: configContent})
 	configMap.Kind = ptrTo("ConfigMap")
 	configMap.APIVersion = ptrTo("v1")

--- a/internal/service/workload/names.go
+++ b/internal/service/workload/names.go
@@ -4,69 +4,13 @@ import (
 	"fmt"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
-
-func infraLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	return map[string]string{
-		constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
-		constants.LabelAppInstance:    cluster.Name,
-		constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
-		constants.LabelOpenBaoCluster: cluster.Name,
-	}
-}
-
-func podSelectorLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	return podSelectorLabelsWithRevision(cluster, "")
-}
-
-func podSelectorLabelsWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, rev string) map[string]string {
-	labels := infraLabels(cluster)
-	if rev != "" {
-		labels[constants.LabelOpenBaoRevision] = rev
-	}
-	return labels
-}
-
-func unsealSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixUnsealKey
-}
-
-func configMapName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixConfigMap
-}
-
-func configMapNameWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, rev string) string {
-	if rev == "" {
-		return configMapName(cluster)
-	}
-	return fmt.Sprintf("%s%s-%s", cluster.Name, constants.SuffixConfigMap, rev)
-}
-
-func configInitMapName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + configInitMapSuffix
-}
-
-func tlsServerSecretName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name + constants.SuffixTLSServer
-}
-
-func headlessServiceName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	return cluster.Name
-}
 
 func statefulSetNameWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, rev string) string {
 	if rev == "" {
 		return cluster.Name
 	}
 	return fmt.Sprintf("%s-%s", cluster.Name, rev)
-}
-
-func serviceAccountName(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	if cluster.Spec.ServiceAccount != nil && cluster.Spec.ServiceAccount.Name != "" {
-		return cluster.Spec.ServiceAccount.Name
-	}
-	return cluster.Name + constants.SuffixServiceAccount
 }
 
 func usesStaticSeal(cluster *openbaov1alpha1.OpenBaoCluster) bool {

--- a/internal/service/workload/pdb.go
+++ b/internal/service/workload/pdb.go
@@ -11,6 +11,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 // ensurePodDisruptionBudget creates or updates a PodDisruptionBudget for the OpenBaoCluster.
@@ -48,12 +49,12 @@ func (m *Manager) ensurePodDisruptionBudget(ctx context.Context, logger logr.Log
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pdbName,
 			Namespace: cluster.Namespace,
-			Labels:    infraLabels(cluster),
+			Labels:    resourceidentity.Labels(cluster),
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: podSelectorLabels(cluster),
+				MatchLabels: resourceidentity.PodSelectorLabels(cluster),
 				// Exclude Job pods (backup, restore, upgrade-snapshot) which don't
 				// support the scale subresource required by PDBs.
 				MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/internal/service/workload/seal_wiring.go
+++ b/internal/service/workload/seal_wiring.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 const (
@@ -84,7 +85,7 @@ func (p *staticSealWiringProvider) Volumes() []corev1.Volume {
 			Name: unsealVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  unsealSecretName(p.cluster),
+					SecretName:  resourceidentity.UnsealSecretName(p.cluster),
 					DefaultMode: ptr.To(secretFileMode),
 				},
 			},

--- a/internal/service/workload/seal_wiring_test.go
+++ b/internal/service/workload/seal_wiring_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 func TestSealWiring_StaticDefault_MountsUnseal(t *testing.T) {
@@ -31,8 +32,8 @@ func TestSealWiring_StaticDefault_MountsUnseal(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected %q volume to be present for static seal", unsealVolumeName)
 	}
-	if unsealVol.Secret == nil || unsealVol.Secret.SecretName != unsealSecretName(cluster) {
-		t.Fatalf("expected %q volume to use secret %q", unsealVolumeName, unsealSecretName(cluster))
+	if unsealVol.Secret == nil || unsealVol.Secret.SecretName != resourceidentity.UnsealSecretName(cluster) {
+		t.Fatalf("expected %q volume to use secret %q", unsealVolumeName, resourceidentity.UnsealSecretName(cluster))
 	}
 	if !hasVolumeMountWithPath(mounts, unsealVolumeName, openBaoUnsealMountPath) {
 		t.Fatalf("expected %q volume mount at %q for static seal", unsealVolumeName, openBaoUnsealMountPath)

--- a/internal/service/workload/statefulset_builder.go
+++ b/internal/service/workload/statefulset_builder.go
@@ -11,6 +11,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/security"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 // revision is an optional revision identifier for blue/green deployments.
 // disableSelfInit prevents adding self-init logic (used for Green pods).
 func buildStatefulSetWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, configContent string, initialized bool, verifiedImageDigest string, verifiedInitContainerDigest string, revision string, disableSelfInit bool, platform string) (*appsv1.StatefulSet, error) {
-	labels := podSelectorLabelsWithRevision(cluster, revision)
+	labels := resourceidentity.PodSelectorLabelsWithRevision(cluster, revision)
 
 	replicas := desiredStatefulSetReplicas(cluster, initialized)
 
@@ -58,11 +59,11 @@ func buildStatefulSetWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, confi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        statefulSetName,
 			Namespace:   cluster.Namespace,
-			Labels:      infraLabels(cluster),
+			Labels:      resourceidentity.Labels(cluster),
 			Annotations: statefulSetAnnotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName: headlessServiceName(cluster),
+			ServiceName: resourceidentity.HeadlessServiceName(cluster),
 			Replicas:    int32Ptr(replicas),
 			// Scale-down removes the departing Raft peer before shrinking the StatefulSet.
 			// Reusing that ordinal's old data directory on a later scale-up resurrects
@@ -89,7 +90,7 @@ func buildStatefulSetWithRevision(cluster *openbaov1alpha1.OpenBaoCluster, confi
 					// SECURITY: Explicitly disable automount for all containers, then mount
 					// ServiceAccount token only where needed (OpenBao container for Kubernetes Auth)
 					AutomountServiceAccountToken: ptr.To(false),
-					ServiceAccountName:           serviceAccountName(cluster),
+					ServiceAccountName:           resourceidentity.ServiceAccountName(cluster),
 					SecurityContext:              buildStatefulSetPodSecurityContext(cluster, platform),
 					InitContainers:               initContainers,
 					Containers:                   buildContainers(cluster, verifiedImageDigest, renderedConfigDir, probes),
@@ -158,7 +159,7 @@ func buildStatefulSetTopologySpreadConstraints(cluster *openbaov1alpha1.OpenBaoC
 }
 
 func statefulSetPlacementLabels(cluster *openbaov1alpha1.OpenBaoCluster) map[string]string {
-	labels := podSelectorLabels(cluster)
+	labels := resourceidentity.PodSelectorLabels(cluster)
 	if labels == nil {
 		labels = make(map[string]string)
 	}

--- a/internal/service/workload/statefulset_builder_probe_volumes.go
+++ b/internal/service/workload/statefulset_builder_probe_volumes.go
@@ -8,6 +8,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -99,7 +100,7 @@ func buildStatefulSetVolumes(cluster *openbaov1alpha1.OpenBaoCluster, revision s
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: configMapNameWithRevision(cluster, revision),
+						Name: resourceidentity.ConfigMapNameWithRevision(cluster, revision),
 					},
 				},
 			},
@@ -172,7 +173,7 @@ func buildStatefulSetVolumes(cluster *openbaov1alpha1.OpenBaoCluster, revision s
 			Name: tlsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  tlsServerSecretName(cluster),
+					SecretName:  resourceidentity.TLSServerSecretName(cluster),
 					DefaultMode: ptr.To(secretFileMode),
 				},
 			},
@@ -199,7 +200,7 @@ func buildStatefulSetVolumes(cluster *openbaov1alpha1.OpenBaoCluster, revision s
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: configInitMapName(cluster),
+						Name: resourceidentity.ConfigInitMapName(cluster),
 					},
 				},
 			},

--- a/internal/service/workload/statefulset_builder_spec.go
+++ b/internal/service/workload/statefulset_builder_spec.go
@@ -12,6 +12,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 func desiredStatefulSetReplicas(cluster *openbaov1alpha1.OpenBaoCluster, initialized bool) int32 {
@@ -110,7 +111,7 @@ func buildStatefulSetPVC(cluster *openbaov1alpha1.OpenBaoCluster) (corev1.Persis
 	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   dataVolumeName,
-			Labels: infraLabels(cluster),
+			Labels: resourceidentity.Labels(cluster),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
@@ -133,7 +134,7 @@ func buildStatefulSetPVC(cluster *openbaov1alpha1.OpenBaoCluster) (corev1.Persis
 }
 
 func buildStatefulSetPodLabelsAndAnnotations(cluster *openbaov1alpha1.OpenBaoCluster, revision string, configContent string) (map[string]string, map[string]string) {
-	podLabels := podSelectorLabelsWithRevision(cluster, revision)
+	podLabels := resourceidentity.PodSelectorLabelsWithRevision(cluster, revision)
 
 	if podLabels == nil {
 		podLabels = make(map[string]string)


### PR DESCRIPTION
## Description

This change centralizes shared managed-resource identity under `internal/platform/resourceidentity` and moves workload-side services onto that shared contract.

It removes duplicated names, labels, and selector helpers from `bootstrap`, `networking`, `identity`, and `workload`, and updates the architecture policy so `platform/resourceidentity` is treated as a first-class platform package.

### Dependency report delta and boundary-risk notes

- The dependency graph remains acyclic.
- This slice replaces repeated local naming and labeling logic with a single shared contract instead of adding a new convergence bucket.
- No policy exceptions were added.

## Related Issues

- N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

```sh
make test-ci
make verify-arch-policy
make test-ast
make lint-ast
make report-internal-deps
git diff --check
```
