### PR TITLE
refactor(resourceapply): centralize owned apply helpers

### DIFF
--- a/.ast-grep/policy/architecture-boundaries.yml
+++ b/.ast-grep/policy/architecture-boundaries.yml
@@ -45,6 +45,7 @@ layerCoverage:
       - platform/openbaotls
       - platform/predicates
       - platform/reconcile
+      - platform/resourceapply
       - platform/resourceidentity
       - platform/statusapply
       - platform/statuspatch

--- a/internal/platform/resourceapply/apply.go
+++ b/internal/platform/resourceapply/apply.go
@@ -1,0 +1,53 @@
+package resourceapply
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+)
+
+const fieldOwner = "openbao-operator"
+
+func ApplyOwned(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj client.Object) error {
+	if err := PrepareOwned(obj, owner, scheme); err != nil {
+		return err
+	}
+	applyConfig, err := kube.ToApplyConfiguration(obj, c)
+	if err != nil {
+		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
+	}
+	return ApplyConfiguration(ctx, c, obj, applyConfig)
+}
+
+func ApplyUnowned(ctx context.Context, c client.Client, obj client.Object) error {
+	applyConfig, err := kube.ToApplyConfiguration(obj, c)
+	if err != nil {
+		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
+	}
+	return ApplyConfiguration(ctx, c, obj, applyConfig)
+}
+
+func PrepareOwned(obj client.Object, owner client.Object, scheme *runtime.Scheme) error {
+	if err := controllerutil.SetControllerReference(owner, obj, scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference: %w", err)
+	}
+	return nil
+}
+
+func ApplyConfiguration(ctx context.Context, c client.Client, obj client.Object, applyConfig runtime.ApplyConfiguration) error {
+	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner(fieldOwner)}
+	if err := c.Apply(ctx, applyConfig, applyOpts...); err != nil {
+		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
+			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+		}
+		return fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	return nil
+}

--- a/internal/platform/resourceapply/apply_test.go
+++ b/internal/platform/resourceapply/apply_test.go
@@ -1,0 +1,65 @@
+package resourceapply
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestApplyOwnedSetsOwnerReference(t *testing.T) {
+	scheme := newTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithReturnManagedFields().Build()
+
+	owner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "12345"}}
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+
+	if err := ApplyOwned(context.Background(), k8sClient, scheme, owner, obj); err != nil {
+		t.Fatalf("ApplyOwned() error = %v", err)
+	}
+
+	stored := &corev1.ConfigMap{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(stored.OwnerReferences) != 1 || stored.OwnerReferences[0].Name != owner.Name {
+		t.Fatalf("expected controller owner reference for %q, got %#v", owner.Name, stored.OwnerReferences)
+	}
+}
+
+func TestApplyUnownedDoesNotSetOwnerReference(t *testing.T) {
+	scheme := newTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithReturnManagedFields().Build()
+
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+
+	if err := ApplyUnowned(context.Background(), k8sClient, obj); err != nil {
+		t.Fatalf("ApplyUnowned() error = %v", err)
+	}
+
+	stored := &corev1.ConfigMap{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(stored.OwnerReferences) != 0 {
+		t.Fatalf("expected no owner references, got %#v", stored.OwnerReferences)
+	}
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1): %v", err)
+	}
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(openbaov1alpha1): %v", err)
+	}
+	return scheme
+}

--- a/internal/service/bootstrap/acme_cache.go
+++ b/internal/service/bootstrap/acme_cache.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
-	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
@@ -72,21 +70,5 @@ func buildManagedACMESharedCachePVC(cluster *openbaov1alpha1.OpenBaoCluster) (*c
 }
 
 func (m *Manager) applyResourceWithoutOwnerRef(ctx context.Context, obj client.Object) error {
-	applyConfig, err := kube.ToApplyConfiguration(obj, m.client)
-	if err != nil {
-		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
-	}
-
-	applyOpts := []client.ApplyOption{
-		client.ForceOwnership,
-		client.FieldOwner("openbao-operator"),
-	}
-
-	if err := m.client.Apply(ctx, applyConfig, applyOpts...); err != nil {
-		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		return fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
-	return nil
+	return resourceapply.ApplyUnowned(ctx, m.client, obj)
 }

--- a/internal/service/bootstrap/manager.go
+++ b/internal/service/bootstrap/manager.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
-	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	configurationservice "github.com/dc-tec/openbao-operator/internal/service/configuration"
 )
@@ -117,25 +114,5 @@ func (m *Manager) reconcilePreStatefulSet(ctx context.Context, logger logr.Logge
 }
 
 func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	if err := controllerutil.SetControllerReference(cluster, obj, m.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %w", err)
-	}
-
-	applyConfig, err := kube.ToApplyConfiguration(obj, m.client)
-	if err != nil {
-		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
-	}
-
-	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner("openbao-operator")}
-	if err := m.client.Apply(ctx, applyConfig, applyOpts...); err != nil {
-		if operatorerrors.IsTransientKubernetesAPI(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		if apierrors.IsConflict(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		return fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
-
-	return nil
+	return resourceapply.ApplyOwned(ctx, m.client, m.scheme, cluster, obj)
 }

--- a/internal/service/identity/manager.go
+++ b/internal/service/identity/manager.go
@@ -8,17 +8,14 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/adapter/revision"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
-	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
@@ -147,31 +144,7 @@ func (m *Manager) ensureRBAC(ctx context.Context, _ logr.Logger, cluster *openba
 }
 
 func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	if err := controllerutil.SetControllerReference(cluster, obj, m.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %w", err)
-	}
-
-	applyConfig, err := kube.ToApplyConfiguration(obj, m.client)
-	if err != nil {
-		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
-	}
-
-	applyOpts := []client.ApplyOption{
-		client.ForceOwnership,
-		client.FieldOwner("openbao-operator"),
-	}
-
-	if err := m.client.Apply(ctx, applyConfig, applyOpts...); err != nil {
-		if operatorerrors.IsTransientKubernetesAPI(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		if apierrors.IsConflict(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		return fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
-
-	return nil
+	return resourceapply.ApplyOwned(ctx, m.client, m.scheme, cluster, obj)
 }
 
 func openBaoPodResourceNames(cluster *openbaov1alpha1.OpenBaoCluster) []string {

--- a/internal/service/networking/manager.go
+++ b/internal/service/networking/manager.go
@@ -2,19 +2,13 @@ package networking
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
-	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 )
 
 // Manager reconciles network-owned resources and validations for an OpenBaoCluster.
@@ -83,46 +77,5 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 }
 
 func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	if err := controllerutil.SetControllerReference(cluster, obj, m.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %w", err)
-	}
-
-	applyConfig, err := kube.ToApplyConfiguration(obj, m.client)
-	if err != nil {
-		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
-	}
-
-	if sts, ok := obj.(*appsv1.StatefulSet); ok &&
-		(cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen) {
-		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sts)
-		if err != nil {
-			return fmt.Errorf("failed to convert StatefulSet to unstructured: %w", err)
-		}
-		if spec, ok := u["spec"].(map[string]any); ok {
-			delete(spec, "updateStrategy")
-		}
-		unstructuredObj := &unstructured.Unstructured{Object: u}
-		gvk := sts.GetObjectKind().GroupVersionKind()
-		if gvk.Empty() {
-			gvk, err = m.client.GroupVersionKindFor(sts)
-			if err != nil {
-				return fmt.Errorf("failed to resolve GVK for StatefulSet: %w", err)
-			}
-		}
-		unstructuredObj.SetGroupVersionKind(gvk)
-		applyConfig = client.ApplyConfigurationFromUnstructured(unstructuredObj)
-	}
-
-	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner("openbao-operator")}
-	if err := m.client.Apply(ctx, applyConfig, applyOpts...); err != nil {
-		if operatorerrors.IsTransientKubernetesAPI(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		if apierrors.IsConflict(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		return fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
-
-	return nil
+	return resourceapply.ApplyOwned(ctx, m.client, m.scheme, cluster, obj)
 }

--- a/internal/service/workload/manager.go
+++ b/internal/service/workload/manager.go
@@ -11,11 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
@@ -110,17 +109,11 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 }
 
 func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	if err := controllerutil.SetControllerReference(cluster, obj, m.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %w", err)
-	}
-
-	applyConfig, err := kube.ToApplyConfiguration(obj, m.client)
-	if err != nil {
-		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
-	}
-
 	if sts, ok := obj.(*appsv1.StatefulSet); ok &&
 		(cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen) {
+		if err := resourceapply.PrepareOwned(obj, cluster, m.scheme); err != nil {
+			return err
+		}
 		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sts)
 		if err != nil {
 			return fmt.Errorf("failed to convert StatefulSet to unstructured: %w", err)
@@ -137,18 +130,10 @@ func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster 
 			}
 		}
 		unstructuredObj.SetGroupVersionKind(gvk)
-		applyConfig = client.ApplyConfigurationFromUnstructured(unstructuredObj)
+		return resourceapply.ApplyConfiguration(ctx, m.client, obj, client.ApplyConfigurationFromUnstructured(unstructuredObj))
 	}
 
-	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner("openbao-operator")}
-	if err := m.client.Apply(ctx, applyConfig, applyOpts...); err != nil {
-		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
-		}
-		return fmt.Errorf("failed to apply resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
-
-	return nil
+	return resourceapply.ApplyOwned(ctx, m.client, m.scheme, cluster, obj)
 }
 
 func ptrTo[T any](v T) *T { return &v }

--- a/internal/service/workload/statefulset_builder_spec.go
+++ b/internal/service/workload/statefulset_builder_spec.go
@@ -90,8 +90,8 @@ func buildStatefulSetUpdateStrategy(cluster *openbaov1alpha1.OpenBaoCluster) app
 	// For standard rolling upgrades, use RollingUpdate (the Kubernetes default behavior).
 	//
 	// Important: The rolling upgrade manager controls the RollingUpdate.Partition field to
-	// orchestrate upgrades. The infra Manager strips updateStrategy from SSA patches for
-	// non-BlueGreen clusters to avoid clearing/overriding that partition value.
+	// orchestrate upgrades. The workload manager strips updateStrategy from StatefulSet
+	// SSA patches for non-BlueGreen clusters to avoid clearing/overriding that partition value.
 	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
 		return appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.OnDeleteStatefulSetStrategyType,


### PR DESCRIPTION
## Description

Centralizes the shared server-side apply ownership path into `internal/platform/resourceapply` and rewires the workload-side services to use it instead of carrying duplicated owner-ref/apply/error-wrapping logic.

This keeps generic owned-apply mechanics in one platform package, removes the stray StatefulSet-specific branch from `internal/service/networking`, and leaves the workload package owning the only remaining object-specific exception.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `make test`
- `make test-ci`
- `make verify-arch-policy`
- `make test-ast`
- `make lint-ast`
- `make report-internal-deps`

Dependency report delta and boundary-risk notes:
- Runtime dependency graph remains acyclic after the rebase and extraction.
- No intentional policy exceptions were introduced.
- `internal/platform/resourceapply` is now the shared owned-apply seam.
- `internal/service/networking` no longer carries the previous stray StatefulSet-specific apply branch; object-specific apply handling remains in `internal/service/workload`.
