### PR TITLE
feat(readreplicas): integrate read replicas with upgrade and restore workflows

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -2028,7 +2028,7 @@ type AdminOpsControllerStatus struct {
 }
 
 // BlueGreenPhase is a high-level summary of blue/green upgrade state.
-// +kubebuilder:validation:Enum=Idle;DeployingGreen;JoiningMesh;Syncing;Promoting;DemotingBlue;Cleanup;RollingBack;RollbackCleanup
+// +kubebuilder:validation:Enum=Idle;DeployingGreen;JoiningMesh;Syncing;Promoting;DemotingBlue;Cleanup;RestoringReadReplicas;RollingBack;RollbackCleanup
 type BlueGreenPhase string
 
 const (
@@ -2047,6 +2047,10 @@ const (
 	PhaseDemotingBlue BlueGreenPhase = "DemotingBlue"
 	// PhaseCleanup indicates Blue StatefulSet is being deleted.
 	PhaseCleanup BlueGreenPhase = "Cleanup"
+	// PhaseRestoringReadReplicas indicates the steady-state read-replica pool is
+	// being restored after cutover cleanup and must converge before the upgrade
+	// returns to Idle.
+	PhaseRestoringReadReplicas BlueGreenPhase = "RestoringReadReplicas"
 	// PhaseRollingBack indicates the upgrade is being rolled back.
 	// Blue nodes are re-promoted and Green nodes are demoted.
 	PhaseRollingBack BlueGreenPhase = "RollingBack"

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -4655,6 +4655,7 @@ spec:
                     - Promoting
                     - DemotingBlue
                     - Cleanup
+                    - RestoringReadReplicas
                     - RollingBack
                     - RollbackCleanup
                     type: string

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -4654,6 +4654,7 @@ spec:
                     - Promoting
                     - DemotingBlue
                     - Cleanup
+                    - RestoringReadReplicas
                     - RollingBack
                     - RollbackCleanup
                     type: string

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -358,7 +358,7 @@ _Underlying type:_ _string_
 BlueGreenPhase is a high-level summary of blue/green upgrade state.
 
 _Validation:_
-- Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RollingBack RollbackCleanup]
+- Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RestoringReadReplicas RollingBack RollbackCleanup]
 
 _Appears in:_
 - [BlueGreenStatus](#bluegreenstatus)
@@ -372,6 +372,7 @@ _Appears in:_
 | `Promoting` | PhasePromoting indicates Green nodes are being promoted to voters.<br /> |
 | `DemotingBlue` | PhaseDemotingBlue indicates Blue nodes are being demoted to non-voters.<br /> |
 | `Cleanup` | PhaseCleanup indicates Blue StatefulSet is being deleted.<br /> |
+| `RestoringReadReplicas` | PhaseRestoringReadReplicas indicates the steady-state read-replica pool is<br />being restored after cutover cleanup and must converge before the upgrade<br />returns to Idle.<br /> |
 | `RollingBack` | PhaseRollingBack indicates the upgrade is being rolled back.<br />Blue nodes are re-promoted and Green nodes are demoted.<br /> |
 | `RollbackCleanup` | PhaseRollbackCleanup indicates Green StatefulSet is being deleted after rollback.<br /> |
 
@@ -389,7 +390,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `phase` _[BlueGreenPhase](#bluegreenphase)_ | Phase is the current phase of the blue/green upgrade. |  | Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RollingBack RollbackCleanup] <br /> |
+| `phase` _[BlueGreenPhase](#bluegreenphase)_ | Phase is the current phase of the blue/green upgrade. |  | Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RestoringReadReplicas RollingBack RollbackCleanup] <br /> |
 | `blueRevision` _string_ | BlueRevision is the hash/name of the currently active cluster. |  |  |
 | `blueImage` _string_ | BlueImage is the container image used by the Blue cluster.<br />This ensures the Blue cluster is not actively upgraded when spec.image changes. |  |  |
 | `greenRevision` _string_ | GreenRevision is the hash/name of the next cluster (if upgrade in progress). |  |  |

--- a/internal/adapter/config/builder_fuzz_test.go
+++ b/internal/adapter/config/builder_fuzz_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -125,7 +126,10 @@ func FuzzRenderSelfInitHCL(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, name, path, operation string, allowFailure bool, data string, selfInitOn, bootstrapOn bool, clusterName, clusterNS, clusterVer string) {
-		if len(name) > 256 || len(path) > 512 || len(operation) > 64 || len(data) > 32*1024 || len(clusterName) > 128 || len(clusterNS) > 128 || len(clusterVer) > 64 {
+		if len(name) > 256 || len(path) > 512 || len(operation) > 64 || len(data) > 8*1024 || len(clusterName) > 128 || len(clusterNS) > 128 || len(clusterVer) > 64 {
+			t.Skip()
+		}
+		if strings.Count(data, "{")+strings.Count(data, "[") > 128 {
 			t.Skip()
 		}
 

--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -76,9 +76,7 @@ func Reconcile(
 	patchStatus StatusPatcher,
 	errorStatus ErrorStatusBuilder,
 ) (recon.Result, error) {
-	if cluster.Status.AdminOps == nil {
-		cluster.Status.AdminOps = &openbaov1alpha1.AdminOpsControllerStatus{}
-	}
+	ensureAdminOpsStatus(cluster)
 
 	if errorStatus == nil {
 		errorStatus = defaultErrorStatus
@@ -124,6 +122,7 @@ func Reconcile(
 	}
 
 	// Clear previous adminops error after a successful reconcile.
+	ensureAdminOpsStatus(cluster)
 	cluster.Status.AdminOps.LastError = nil
 	if patchStatus != nil {
 		if err := patchStatus(ctx, deps.Client, logger, original, cluster, "adminops-complete"); err != nil {
@@ -132,6 +131,15 @@ func Reconcile(
 	}
 
 	return recon.Result{}, nil
+}
+
+func ensureAdminOpsStatus(cluster *openbaov1alpha1.OpenBaoCluster) {
+	if cluster == nil {
+		return
+	}
+	if cluster.Status.AdminOps == nil {
+		cluster.Status.AdminOps = &openbaov1alpha1.AdminOpsControllerStatus{}
+	}
 }
 
 func buildReconcilers(deps Dependencies) []subReconciler {

--- a/internal/app/openbaocluster/adminops/reconcile_test.go
+++ b/internal/app/openbaocluster/adminops/reconcile_test.go
@@ -32,6 +32,19 @@ func (f fakeSubReconciler) Reconcile(_ context.Context, _ logr.Logger, _ *openba
 	return f.result, f.err
 }
 
+type fakeMutatingSubReconciler struct {
+	result recon.Result
+	err    error
+	mutate func(*openbaov1alpha1.OpenBaoCluster)
+}
+
+func (f fakeMutatingSubReconciler) Reconcile(_ context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
+	if f.mutate != nil {
+		f.mutate(cluster)
+	}
+	return f.result, f.err
+}
+
 func withAdminOpsReconcilers(t *testing.T, recs ...subReconciler) {
 	t.Helper()
 	orig := adminOpsReconcilersBuilder
@@ -213,6 +226,50 @@ func TestReconcile_AdminOpsRequeueAndSuccess(t *testing.T) {
 		}
 		if cluster.Status.AdminOps.LastError != nil {
 			t.Fatalf("expected LastError to be cleared after success")
+		}
+	})
+
+	t.Run("success recreates adminops status if a subreconciler refresh clears it", func(t *testing.T) {
+		withAdminOpsReconcilers(t, fakeMutatingSubReconciler{
+			mutate: func(cluster *openbaov1alpha1.OpenBaoCluster) {
+				cluster.Status.AdminOps = nil
+			},
+		})
+
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			Status: openbaov1alpha1.OpenBaoClusterStatus{
+				AdminOps: &openbaov1alpha1.AdminOpsControllerStatus{LastError: &openbaov1alpha1.ControllerErrorStatus{Reason: "old"}},
+			},
+		}
+		var patchReasons []string
+
+		result, err := Reconcile(
+			context.Background(),
+			logr.Discard(),
+			Dependencies{},
+			cluster.DeepCopy(),
+			cluster,
+			nil,
+			func(_ context.Context, _ client.Client, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, reason string) error {
+				patchReasons = append(patchReasons, reason)
+				return nil
+			},
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error on refreshed success path: %v", err)
+		}
+		if result != (recon.Result{}) {
+			t.Fatalf("result=%v, want zero result", result)
+		}
+		if cluster.Status.AdminOps == nil {
+			t.Fatalf("expected AdminOps status to be recreated")
+		}
+		if cluster.Status.AdminOps.LastError != nil {
+			t.Fatalf("expected recreated AdminOps status to have nil LastError")
+		}
+		if len(patchReasons) != 1 || patchReasons[0] != "adminops-complete" {
+			t.Fatalf("patch reasons=%v, want [adminops-complete]", patchReasons)
 		}
 	})
 }

--- a/internal/app/openbaocluster/infra.go
+++ b/internal/app/openbaocluster/infra.go
@@ -136,6 +136,7 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 	stagedScaleDown := false
 	stagedReadReplicaScaleDown := false
 	stagedRestartOrdering := false
+	applyOperationalReadReplicaStageDown(cluster, &readSpec)
 
 	currentSTS := &appsv1.StatefulSet{}
 	readCurrentSTS := &appsv1.StatefulSet{}

--- a/internal/app/openbaocluster/infra.go
+++ b/internal/app/openbaocluster/infra.go
@@ -135,9 +135,11 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 	readSpec := r.computeReadReplicaStatefulSetSpec(cluster, resolvedImages.mainImage, resolvedImages.initImage)
 	stagedScaleDown := false
 	stagedReadReplicaScaleDown := false
+	stagedRestartOrdering := false
 
 	currentSTS := &appsv1.StatefulSet{}
 	readCurrentSTS := &appsv1.StatefulSet{}
+	currentSTSFound := false
 	readCurrentSTSFound := false
 	reader := r.deps.Kubernetes.APIReader
 	if reader == nil {
@@ -147,6 +149,7 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 	err = reader.Get(ctx, client.ObjectKey{Name: spec.Name, Namespace: cluster.Namespace}, currentSTS)
 	switch {
 	case err == nil:
+		currentSTSFound = true
 		appliedReplicas, err := r.handleScaleDownSafety(ctx, cluster, spec.Replicas, currentSTS)
 		if err != nil {
 			if operatorerrors.IsPermanent(err) && errors.Is(err, operatorerrors.ErrPermanentPrerequisitesMissing) {
@@ -187,6 +190,8 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 	default:
 		return recon.Result{}, operatorerrors.WrapTransientKubernetesAPI(err)
 	}
+
+	stagedRestartOrdering = r.applyReadFirstRestartOrdering(cluster, &spec, &readSpec, currentSTS, currentSTSFound, readCurrentSTS, readCurrentSTSFound)
 
 	effectiveOIDC, err := r.resolveOIDC(ctx, cluster)
 	if err != nil {
@@ -238,6 +243,10 @@ func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, clu
 			"appliedStatefulSetReplicas", readSpec.Replicas,
 			"desiredReplicas", readCurrentDesiredReplicas(cluster),
 		)
+		return recon.Result{RequeueAfter: infraRequeueShort}, nil
+	}
+	if stagedRestartOrdering {
+		logger.Info("Read-pool restart ordering is still in progress; requeueing before voter restart rollout continues")
 		return recon.Result{RequeueAfter: infraRequeueShort}, nil
 	}
 

--- a/internal/app/openbaocluster/infra_operational_ordering_test.go
+++ b/internal/app/openbaocluster/infra_operational_ordering_test.go
@@ -1,0 +1,142 @@
+package openbaocluster
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
+)
+
+func TestApplyReadFirstRestartOrdering_StagesVoterRestartUntilReadPoolConverges(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+			Runtime: &openbaov1alpha1.RuntimeConfig{
+				RestartAt: "2026-04-19T12:00:00Z",
+			},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 2,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+
+	voterSpec := workloadsvc.StatefulSetSpec{Pool: constants.LabelValueOpenBaoWorkloadPoolVoter, Replicas: 3}
+	readSpec := workloadsvc.StatefulSetSpec{Pool: constants.LabelValueOpenBaoWorkloadPoolReadReplica, Replicas: 2}
+
+	currentVoter := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			Template: restartTemplate("2026-04-18T00:00:00Z"),
+		},
+	}
+	currentRead := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec: appsv1.StatefulSetSpec{
+			Template: restartTemplate("2026-04-19T12:00:00Z"),
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 2,
+			ReadyReplicas:      1,
+			UpdatedReplicas:    1,
+			CurrentReplicas:    1,
+			CurrentRevision:    "rev-a",
+			UpdateRevision:     "rev-b",
+		},
+	}
+
+	staged := (&infraReconciler{}).applyReadFirstRestartOrdering(cluster, &voterSpec, &readSpec, currentVoter, true, currentRead, true)
+	if !staged {
+		t.Fatal("expected voter restart to be staged behind read-pool convergence")
+	}
+	if voterSpec.RestartAt == nil || *voterSpec.RestartAt != "2026-04-18T00:00:00Z" {
+		t.Fatalf("voter restartAt = %v, want preserved current value", voterSpec.RestartAt)
+	}
+	if readSpec.RestartAt == nil || *readSpec.RestartAt != "2026-04-19T12:00:00Z" {
+		t.Fatalf("read restartAt = %v, want desired value", readSpec.RestartAt)
+	}
+}
+
+func TestApplyReadFirstRestartOrdering_AllowsVoterRestartAfterReadPoolConverges(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+			Runtime: &openbaov1alpha1.RuntimeConfig{
+				RestartAt: "2026-04-19T12:00:00Z",
+			},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 2,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+
+	voterSpec := workloadsvc.StatefulSetSpec{Pool: constants.LabelValueOpenBaoWorkloadPoolVoter, Replicas: 3}
+	readSpec := workloadsvc.StatefulSetSpec{Pool: constants.LabelValueOpenBaoWorkloadPoolReadReplica, Replicas: 2}
+
+	currentVoter := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			Template: restartTemplate("2026-04-18T00:00:00Z"),
+		},
+	}
+	currentRead := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec: appsv1.StatefulSetSpec{
+			Template: restartTemplate("2026-04-19T12:00:00Z"),
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 2,
+			ReadyReplicas:      2,
+			UpdatedReplicas:    2,
+			CurrentReplicas:    2,
+			CurrentRevision:    "rev-b",
+			UpdateRevision:     "rev-b",
+		},
+	}
+
+	staged := (&infraReconciler{}).applyReadFirstRestartOrdering(cluster, &voterSpec, &readSpec, currentVoter, true, currentRead, true)
+	if staged {
+		t.Fatal("expected voter restart ordering to be complete once read pool converges")
+	}
+	if voterSpec.RestartAt == nil || *voterSpec.RestartAt != "2026-04-19T12:00:00Z" {
+		t.Fatalf("voter restartAt = %v, want desired value", voterSpec.RestartAt)
+	}
+}
+
+func TestPVCRestartPoolPriority_PrefersReadReplicaPool(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+
+	readPod := resourceidentity.ReadReplicaStatefulSetName(cluster) + "-0"
+	voterPod := cluster.Name + "-0"
+	if got := pvcRestartPoolPriority(cluster, readPod); got != 0 {
+		t.Fatalf("read pool priority = %d, want 0", got)
+	}
+	if got := pvcRestartPoolPriority(cluster, voterPod); got != 1 {
+		t.Fatalf("voter pool priority = %d, want 1", got)
+	}
+}
+
+func restartTemplate(restartAt string) corev1.PodTemplateSpec {
+	annotations := map[string]string{}
+	if restartAt != "" {
+		annotations[constants.AnnotationRestartAt] = restartAt
+	}
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+	}
+}

--- a/internal/app/openbaocluster/infra_read_replica_operation.go
+++ b/internal/app/openbaocluster/infra_read_replica_operation.go
@@ -1,0 +1,46 @@
+package openbaocluster
+
+import (
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
+)
+
+func applyOperationalReadReplicaStageDown(cluster *openbaov1alpha1.OpenBaoCluster, readSpec *workloadsvc.StatefulSetSpec) bool {
+	if cluster == nil || readSpec == nil {
+		return false
+	}
+	if !shouldStageSteadyReadReplicasDown(cluster) {
+		return false
+	}
+	if readSpec.Replicas == 0 {
+		return false
+	}
+
+	readSpec.Replicas = 0
+	return true
+}
+
+func shouldStageSteadyReadReplicasDown(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if cluster == nil || cluster.Spec.ReadReplicas == nil || cluster.Spec.ReadReplicas.Replicas == 0 {
+		return false
+	}
+
+	if cluster.Status.BlueGreen != nil &&
+		cluster.Status.BlueGreen.Phase != "" &&
+		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle {
+		return true
+	}
+
+	if cluster.Status.OperationLock == nil {
+		return false
+	}
+
+	switch cluster.Status.OperationLock.Operation {
+	case openbaov1alpha1.ClusterOperationRestore:
+		return true
+	case openbaov1alpha1.ClusterOperationUpgrade:
+		return cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen
+	default:
+		return false
+	}
+}

--- a/internal/app/openbaocluster/infra_read_replica_operation.go
+++ b/internal/app/openbaocluster/infra_read_replica_operation.go
@@ -25,9 +25,12 @@ func shouldStageSteadyReadReplicasDown(cluster *openbaov1alpha1.OpenBaoCluster) 
 		return false
 	}
 
-	if cluster.Status.BlueGreen != nil &&
-		cluster.Status.BlueGreen.Phase != "" &&
-		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle {
+	phase := openbaov1alpha1.PhaseIdle
+	if cluster.Status.BlueGreen != nil {
+		phase = cluster.Status.BlueGreen.Phase
+	}
+
+	if blueGreenPhaseRequiresReadReplicaStageDown(phase) {
 		return true
 	}
 
@@ -39,7 +42,25 @@ func shouldStageSteadyReadReplicasDown(cluster *openbaov1alpha1.OpenBaoCluster) 
 	case openbaov1alpha1.ClusterOperationRestore:
 		return true
 	case openbaov1alpha1.ClusterOperationUpgrade:
-		return cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen
+		return cluster.Spec.Upgrade != nil &&
+			cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen &&
+			(phase == "" || phase == openbaov1alpha1.PhaseIdle)
+	default:
+		return false
+	}
+}
+
+func blueGreenPhaseRequiresReadReplicaStageDown(phase openbaov1alpha1.BlueGreenPhase) bool {
+	switch phase {
+	case openbaov1alpha1.PhaseDeployingGreen,
+		openbaov1alpha1.PhaseJoiningMesh,
+		openbaov1alpha1.PhaseSyncing,
+		openbaov1alpha1.PhasePromoting,
+		openbaov1alpha1.PhaseDemotingBlue,
+		openbaov1alpha1.PhaseCleanup,
+		openbaov1alpha1.PhaseRollingBack,
+		openbaov1alpha1.PhaseRollbackCleanup:
+		return true
 	default:
 		return false
 	}

--- a/internal/app/openbaocluster/infra_read_replica_operation_test.go
+++ b/internal/app/openbaocluster/infra_read_replica_operation_test.go
@@ -73,6 +73,26 @@ func TestShouldStageSteadyReadReplicasDown(t *testing.T) {
 
 		require.False(t, shouldStageSteadyReadReplicasDown(cluster))
 	})
+
+	t.Run("bluegreen restore phase allows steady read pool to come back", func(t *testing.T) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Upgrade:      &openbaov1alpha1.UpgradeConfig{Strategy: openbaov1alpha1.UpdateStrategyBlueGreen},
+				ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{
+				BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+					Phase: openbaov1alpha1.PhaseRestoringReadReplicas,
+				},
+				OperationLock: &openbaov1alpha1.OperationLockStatus{
+					Operation: openbaov1alpha1.ClusterOperationUpgrade,
+					Holder:    "upgrade",
+				},
+			},
+		}
+
+		require.False(t, shouldStageSteadyReadReplicasDown(cluster))
+	})
 }
 
 func TestApplyOperationalReadReplicaStageDown(t *testing.T) {

--- a/internal/app/openbaocluster/infra_read_replica_operation_test.go
+++ b/internal/app/openbaocluster/infra_read_replica_operation_test.go
@@ -1,0 +1,99 @@
+package openbaocluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
+)
+
+func TestShouldStageSteadyReadReplicasDown(t *testing.T) {
+	t.Run("restore lock forces read pool drain", func(t *testing.T) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{
+				OperationLock: &openbaov1alpha1.OperationLockStatus{
+					Operation: openbaov1alpha1.ClusterOperationRestore,
+					Holder:    "openbaorestore/example",
+				},
+			},
+		}
+
+		require.True(t, shouldStageSteadyReadReplicasDown(cluster))
+	})
+
+	t.Run("bluegreen phase forces read pool drain", func(t *testing.T) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{
+				BlueGreen: &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseSyncing},
+			},
+		}
+
+		require.True(t, shouldStageSteadyReadReplicasDown(cluster))
+	})
+
+	t.Run("bluegreen upgrade lock forces read pool drain before phase advances", func(t *testing.T) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Upgrade:      &openbaov1alpha1.UpgradeConfig{Strategy: openbaov1alpha1.UpdateStrategyBlueGreen},
+				ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{
+				OperationLock: &openbaov1alpha1.OperationLockStatus{
+					Operation: openbaov1alpha1.ClusterOperationUpgrade,
+					Holder:    "upgrade",
+				},
+			},
+		}
+
+		require.True(t, shouldStageSteadyReadReplicasDown(cluster))
+	})
+
+	t.Run("rolling upgrade lock does not force read pool drain", func(t *testing.T) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Upgrade:      &openbaov1alpha1.UpgradeConfig{Strategy: openbaov1alpha1.UpdateStrategyRollingUpdate},
+				ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{
+				OperationLock: &openbaov1alpha1.OperationLockStatus{
+					Operation: openbaov1alpha1.ClusterOperationUpgrade,
+					Holder:    "upgrade",
+				},
+			},
+		}
+
+		require.False(t, shouldStageSteadyReadReplicasDown(cluster))
+	})
+}
+
+func TestApplyOperationalReadReplicaStageDown(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			OperationLock: &openbaov1alpha1.OperationLockStatus{
+				Operation: openbaov1alpha1.ClusterOperationRestore,
+				Holder:    "openbaorestore/example",
+			},
+		},
+	}
+	spec := workloadsvc.StatefulSetSpec{
+		Pool:     constants.LabelValueOpenBaoWorkloadPoolReadReplica,
+		Replicas: 2,
+	}
+
+	changed := applyOperationalReadReplicaStageDown(cluster, &spec)
+
+	require.True(t, changed)
+	require.Zero(t, spec.Replicas)
+}

--- a/internal/app/openbaocluster/infra_restart_ordering.go
+++ b/internal/app/openbaocluster/infra_restart_ordering.go
@@ -1,0 +1,99 @@
+package openbaocluster
+
+import (
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
+)
+
+func (r *infraReconciler) applyReadFirstRestartOrdering(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	spec *workloadsvc.StatefulSetSpec,
+	readSpec *workloadsvc.StatefulSetSpec,
+	currentSTS *appsv1.StatefulSet,
+	currentSTSFound bool,
+	readCurrentSTS *appsv1.StatefulSet,
+	readCurrentSTSFound bool,
+) bool {
+	desiredRestartAt := clusterRestartAt(cluster)
+	if desiredRestartAt == "" || spec == nil {
+		return false
+	}
+
+	spec.RestartAt = stringPtr(desiredRestartAt)
+	if readSpec != nil {
+		readSpec.RestartAt = stringPtr(desiredRestartAt)
+	}
+
+	if cluster == nil || !cluster.Status.Initialized {
+		return false
+	}
+	if readSpec == nil || readSpec.SkipReconciliation || readSpec.Replicas == 0 || cluster.Spec.ReadReplicas == nil {
+		return false
+	}
+	if !currentSTSFound {
+		return false
+	}
+	if statefulSetRestartAtSettled(readCurrentSTS, readCurrentSTSFound, desiredRestartAt, readSpec.Replicas) {
+		return false
+	}
+
+	currentVoterRestartAt := currentStatefulSetRestartAt(currentSTS)
+	spec.RestartAt = stringPtr(currentVoterRestartAt)
+	return currentVoterRestartAt != desiredRestartAt
+}
+
+func clusterRestartAt(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	if cluster == nil {
+		return ""
+	}
+	if cluster.Spec.Runtime != nil {
+		if restartAt := strings.TrimSpace(cluster.Spec.Runtime.RestartAt); restartAt != "" {
+			return restartAt
+		}
+	}
+	if cluster.Spec.Maintenance != nil {
+		return strings.TrimSpace(cluster.Spec.Maintenance.RestartAt)
+	}
+	return ""
+}
+
+func currentStatefulSetRestartAt(sts *appsv1.StatefulSet) string {
+	if sts == nil || sts.Spec.Template.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(sts.Spec.Template.Annotations[constants.AnnotationRestartAt])
+}
+
+func statefulSetRestartAtSettled(sts *appsv1.StatefulSet, found bool, desiredRestartAt string, replicas int32) bool {
+	if !found || sts == nil {
+		return false
+	}
+	if currentStatefulSetRestartAt(sts) != strings.TrimSpace(desiredRestartAt) {
+		return false
+	}
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return false
+	}
+	if sts.Status.ReadyReplicas != replicas {
+		return false
+	}
+	if sts.Status.UpdatedReplicas != replicas {
+		return false
+	}
+	if sts.Status.CurrentReplicas != replicas {
+		return false
+	}
+	if sts.Status.CurrentRevision != "" && sts.Status.UpdateRevision != "" && sts.Status.CurrentRevision != sts.Status.UpdateRevision {
+		return false
+	}
+	return true
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/app/openbaocluster/statusops/versioning.go
+++ b/internal/app/openbaocluster/statusops/versioning.go
@@ -31,6 +31,17 @@ func ReconcileCurrentVersion(logger logr.Logger, cluster *openbaov1alpha1.OpenBa
 		return
 	}
 
+	if cluster.Status.CurrentVersion == "" {
+		fallbackVersion := strings.TrimSpace(cluster.Spec.Version)
+		if fallbackVersion == "" {
+			return
+		}
+
+		cluster.Status.CurrentVersion = fallbackVersion
+		logger.Info("Set initial CurrentVersion from cluster spec after initialization because pod version labels are unavailable", "version", fallbackVersion)
+		return
+	}
+
 	if observedVersion == "" || cluster.Status.CurrentVersion == "" || cluster.Status.CurrentVersion == observedVersion {
 		return
 	}

--- a/internal/app/openbaocluster/statusops/versioning_test.go
+++ b/internal/app/openbaocluster/statusops/versioning_test.go
@@ -151,6 +151,48 @@ func TestReconcileCurrentVersion_AdvancesAfterRollingUpgradeFinalization(t *test
 	assert.Equal(t, "2.4.4", cluster.Status.CurrentVersion)
 }
 
+func TestReconcileCurrentVersion_FallsBackToSpecVersionAfterInitialization(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version: "2.4.4",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized:    true,
+			CurrentVersion: "",
+		},
+	}
+
+	state := &StatusState{
+		RollingUpgradeInProgress: false,
+		BlueGreenInProgress:      false,
+		UpgradeInProgress:        false,
+	}
+
+	ReconcileCurrentVersion(logr.Discard(), cluster, state, "")
+	assert.Equal(t, "2.4.4", cluster.Status.CurrentVersion)
+}
+
+func TestReconcileCurrentVersion_DoesNotFallbackToSpecVersionDuringBlueGreenUpgrade(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version: "2.4.4",
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized:    true,
+			CurrentVersion: "",
+		},
+	}
+
+	state := &StatusState{
+		RollingUpgradeInProgress: false,
+		BlueGreenInProgress:      true,
+		UpgradeInProgress:        true,
+	}
+
+	ReconcileCurrentVersion(logr.Discard(), cluster, state, "")
+	assert.Equal(t, "", cluster.Status.CurrentVersion)
+}
+
 func TestMaybeAdvanceCurrentVersionForBlueGreen_AdvancesOnCompletion(t *testing.T) {
 	cluster := &openbaov1alpha1.OpenBaoCluster{
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{

--- a/internal/app/openbaocluster/storage.go
+++ b/internal/app/openbaocluster/storage.go
@@ -73,25 +73,44 @@ func ReconcileStorage(
 	if err != nil {
 		return recon.Result{}, err
 	}
+	readDesiredQty, readDesiredStorageClassName, readPoolConfigured, err := desiredReadReplicaStorageSpec(cluster, desiredQty, desiredStorageClassName)
+	if err != nil {
+		return recon.Result{}, err
+	}
 
 	pvcs, err := listClusterPVCs(ctx, deps.Resources.Client, cluster)
 	if err != nil {
 		return recon.Result{}, err
 	}
-	if len(pvcs) == 0 {
+	if len(pvcs.Voters) == 0 && len(pvcs.ReadReplicas) == 0 {
 		return recon.Result{}, nil
 	}
 
-	if err := validateStorageChangeAllowed(desiredQty, desiredStorageClassName, pvcs); err != nil {
+	if err := validateStorageChangeAllowed("spec.storage", desiredQty, desiredStorageClassName, pvcs.Voters); err != nil {
 		return recon.Result{}, err
 	}
+	if readPoolConfigured {
+		if err := validateStorageChangeAllowed("spec.readReplicas.storage", readDesiredQty, readDesiredStorageClassName, pvcs.ReadReplicas); err != nil {
+			return recon.Result{}, err
+		}
+	}
 
-	patched, err := expandPVCs(ctx, deps.Resources.Client, deps.Events.Recorder, cluster, logger, desiredQty, pvcs)
+	patched, err := expandPVCs(ctx, deps.Resources.Client, deps.Events.Recorder, cluster, logger, desiredQty, pvcs.Voters)
 	if err != nil {
 		return recon.Result{}, err
 	}
 	if patched > 0 {
-		logger.Info("Requested PVC storage expansion", "count", patched, "desired", desiredQty.String())
+		logger.Info("Requested voter PVC storage expansion", "count", patched, "desired", desiredQty.String())
+	}
+
+	if readPoolConfigured {
+		readPatched, err := expandPVCs(ctx, deps.Resources.Client, deps.Events.Recorder, cluster, logger, readDesiredQty, pvcs.ReadReplicas)
+		if err != nil {
+			return recon.Result{}, err
+		}
+		if readPatched > 0 {
+			logger.Info("Requested read-replica PVC storage expansion", "count", readPatched, "desired", readDesiredQty.String())
+		}
 	}
 
 	return recon.Result{}, nil

--- a/internal/app/openbaocluster/storage_pvc.go
+++ b/internal/app/openbaocluster/storage_pvc.go
@@ -15,6 +15,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 func desiredStorageSpec(cluster *openbaov1alpha1.OpenBaoCluster) (resource.Quantity, string, error) {
@@ -34,25 +35,67 @@ func desiredStorageSpec(cluster *openbaov1alpha1.OpenBaoCluster) (resource.Quant
 	return desiredQty, desiredStorageClassName, nil
 }
 
-func listClusterPVCs(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster) ([]corev1.PersistentVolumeClaim, error) {
+func desiredReadReplicaStorageSpec(cluster *openbaov1alpha1.OpenBaoCluster, voterQty resource.Quantity, voterStorageClassName string) (resource.Quantity, string, bool, error) {
+	if cluster == nil || cluster.Spec.ReadReplicas == nil || cluster.Spec.ReadReplicas.Replicas == 0 {
+		return resource.Quantity{}, "", false, nil
+	}
+
+	desiredQty := voterQty.DeepCopy()
+	desiredStorageClassName := voterStorageClassName
+
+	if cluster.Spec.ReadReplicas.Storage != nil {
+		if cluster.Spec.ReadReplicas.Storage.Size != nil {
+			desiredQty = cluster.Spec.ReadReplicas.Storage.Size.DeepCopy()
+		}
+		if cluster.Spec.ReadReplicas.Storage.StorageClassName != nil && *cluster.Spec.ReadReplicas.Storage.StorageClassName != "" {
+			desiredStorageClassName = *cluster.Spec.ReadReplicas.Storage.StorageClassName
+		}
+	}
+
+	if desiredQty.Cmp(voterQty) < 0 {
+		return resource.Quantity{}, "", false, operatorerrors.WithReason(
+			constants.ReasonStorageInvalidSize,
+			operatorerrors.WrapPermanentConfig(fmt.Errorf(
+				"spec.readReplicas.storage.size cannot be smaller than spec.storage.size (%s < %s)",
+				desiredQty.String(), voterQty.String(),
+			)),
+		)
+	}
+
+	return desiredQty, desiredStorageClassName, true, nil
+}
+
+type clusterDataPVCs struct {
+	Voters       []corev1.PersistentVolumeClaim
+	ReadReplicas []corev1.PersistentVolumeClaim
+}
+
+func listClusterPVCs(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster) (clusterDataPVCs, error) {
 	var pvcList corev1.PersistentVolumeClaimList
 	if err := c.List(ctx, &pvcList,
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabels(map[string]string{labelOpenBaoCluster: cluster.Name}),
 	); err != nil {
 		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
-			return nil, operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to list PVCs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err))
+			return clusterDataPVCs{}, operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to list PVCs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err))
 		}
-		return nil, fmt.Errorf("failed to list PVCs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+		return clusterDataPVCs{}, fmt.Errorf("failed to list PVCs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 	}
 
-	dataPVCs := make([]corev1.PersistentVolumeClaim, 0, len(pvcList.Items))
+	dataPVCs := clusterDataPVCs{
+		Voters:       make([]corev1.PersistentVolumeClaim, 0, len(pvcList.Items)),
+		ReadReplicas: make([]corev1.PersistentVolumeClaim, 0, len(pvcList.Items)),
+	}
 	for i := range pvcList.Items {
 		pvc := pvcList.Items[i]
 		if !isManagedDataPVC(cluster.Name, pvc.Name) {
 			continue
 		}
-		dataPVCs = append(dataPVCs, pvc)
+		if isReadReplicaDataPVC(cluster, pvc.Name) {
+			dataPVCs.ReadReplicas = append(dataPVCs.ReadReplicas, pvc)
+			continue
+		}
+		dataPVCs.Voters = append(dataPVCs.Voters, pvc)
 	}
 
 	return dataPVCs, nil
@@ -62,7 +105,11 @@ func isManagedDataPVC(clusterName, pvcName string) bool {
 	return strings.HasPrefix(pvcName, storageVolumeDataPrefix+clusterName+"-")
 }
 
-func validateStorageChangeAllowed(desiredQty resource.Quantity, desiredStorageClassName string, pvcs []corev1.PersistentVolumeClaim) error {
+func isReadReplicaDataPVC(cluster *openbaov1alpha1.OpenBaoCluster, pvcName string) bool {
+	return strings.HasPrefix(pvcName, storageVolumeDataPrefix+resourceidentity.ReadReplicaStatefulSetName(cluster)+"-")
+}
+
+func validateStorageChangeAllowed(fieldPath string, desiredQty resource.Quantity, desiredStorageClassName string, pvcs []corev1.PersistentVolumeClaim) error {
 	for i := range pvcs {
 		pvc := &pvcs[i]
 		currentStorageClassName := ""
@@ -74,8 +121,8 @@ func validateStorageChangeAllowed(desiredQty resource.Quantity, desiredStorageCl
 			return operatorerrors.WithReason(
 				constants.ReasonStorageClassChangeNotSupported,
 				operatorerrors.WrapPermanentConfig(fmt.Errorf(
-					"spec.storage.storageClassName cannot be changed for an existing cluster (PVC %s has %q, desired %q)",
-					pvc.Name, currentStorageClassName, desiredStorageClassName,
+					"%s.storageClassName cannot be changed for an existing cluster (PVC %s has %q, desired %q)",
+					fieldPath, pvc.Name, currentStorageClassName, desiredStorageClassName,
 				)),
 			)
 		}
@@ -88,8 +135,8 @@ func validateStorageChangeAllowed(desiredQty resource.Quantity, desiredStorageCl
 			return operatorerrors.WithReason(
 				constants.ReasonStorageShrinkNotSupported,
 				operatorerrors.WrapPermanentConfig(fmt.Errorf(
-					"spec.storage.size cannot be decreased (requested %s but PVC %s already requests %s); revert the change",
-					desiredQty.String(), pvc.Name, curr.String(),
+					"%s.size cannot be decreased (requested %s but PVC %s already requests %s); revert the change",
+					fieldPath, desiredQty.String(), pvc.Name, curr.String(),
 				)),
 			)
 		}

--- a/internal/app/openbaocluster/storage_resize_restart.go
+++ b/internal/app/openbaocluster/storage_resize_restart.go
@@ -13,6 +13,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
 )
@@ -69,6 +70,11 @@ func nextPodNeedingFSResizeRestart(
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
+		poolI := pvcRestartPoolPriority(cluster, candidates[i])
+		poolJ := pvcRestartPoolPriority(cluster, candidates[j])
+		if poolI != poolJ {
+			return poolI < poolJ
+		}
 		oi, okI := podOrdinal(candidates[i])
 		oj, okJ := podOrdinal(candidates[j])
 		if okI && okJ {
@@ -112,6 +118,16 @@ func nextPodNeedingFSResizeRestart(
 	}
 
 	return leaderCandidate, nil
+}
+
+func pvcRestartPoolPriority(cluster *openbaov1alpha1.OpenBaoCluster, podName string) int {
+	if cluster != nil {
+		readPrefix := resourceidentity.ReadReplicaStatefulSetName(cluster) + "-"
+		if strings.HasPrefix(strings.TrimSpace(podName), readPrefix) {
+			return 0
+		}
+	}
+	return 1
 }
 
 func clientForPod(

--- a/internal/app/openbaocluster/storage_test.go
+++ b/internal/app/openbaocluster/storage_test.go
@@ -18,6 +18,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	openbao "github.com/dc-tec/openbao-operator/internal/adapter/openbao"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -235,6 +236,121 @@ func TestStorageReconciler_IgnoresACMECachePVCForStorageClassValidation(t *testi
 	require.NoError(t, err)
 }
 
+func TestStorageReconciler_ExpandsReadReplicaPVCsUsingReadReplicaStorageSpec(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	readClass := "read-gp3"
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Storage: openbaov1alpha1.StorageConfig{
+				Size: "10Gi",
+			},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 2,
+				Storage: &openbaov1alpha1.ReadReplicaStorageConfig{
+					Size:             quantityPtr(resource.MustParse("20Gi")),
+					StorageClassName: &readClass,
+				},
+			},
+		},
+	}
+
+	voterPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-test-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelOpenBaoCluster: "test",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+	readPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-" + resourceidentity.ReadReplicaStatefulSetName(cluster) + "-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelOpenBaoCluster: "test",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &readClass,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(voterPVC, readPVC).Build()
+	r := NewStorageReconciler(
+		StorageDependencies{
+			Resources: StorageResourceRuntime{Client: c},
+			Events:    StorageEventRuntime{Recorder: events.NewFakeRecorder(10)},
+		},
+	)
+
+	_, err := r.Reconcile(context.Background(), logr.Discard(), cluster)
+	require.NoError(t, err)
+
+	gotRead := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(readPVC), gotRead))
+	require.Equal(t, resource.MustParse("20Gi"), gotRead.Spec.Resources.Requests[corev1.ResourceStorage])
+
+	gotVoter := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(voterPVC), gotVoter))
+	require.Equal(t, resource.MustParse("10Gi"), gotVoter.Spec.Resources.Requests[corev1.ResourceStorage])
+}
+
+func TestStorageReconciler_RejectsReadReplicaStorageSmallerThanVoterStorage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Storage: openbaov1alpha1.StorageConfig{
+				Size: "20Gi",
+			},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 1,
+				Storage: &openbaov1alpha1.ReadReplicaStorageConfig{
+					Size: quantityPtr(resource.MustParse("10Gi")),
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := NewStorageReconciler(
+		StorageDependencies{
+			Resources: StorageResourceRuntime{Client: c},
+			Events:    StorageEventRuntime{Recorder: events.NewFakeRecorder(10)},
+		},
+	)
+
+	_, err := r.Reconcile(context.Background(), logr.Discard(), cluster)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.readReplicas.storage.size cannot be smaller than spec.storage.size")
+}
+
 func TestStorageResizeRestartReconciler_RestartsFollowerPod(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
@@ -417,4 +533,90 @@ func TestStorageResizeRestartReconciler_RequiresMaintenance(t *testing.T) {
 	_, err := r.Reconcile(context.Background(), logr.Discard(), cluster)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), constants.ReasonStorageRestartRequired)
+}
+
+func TestStorageResizeRestartReconciler_PrefersReadReplicaPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Maintenance: &openbaov1alpha1.MaintenanceConfig{Enabled: true},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 1,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+
+	voterPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-test-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelOpenBaoCluster: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{
+				{Type: corev1.PersistentVolumeClaimFileSystemResizePending, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	readPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-" + resourceidentity.ReadReplicaStatefulSetName(cluster) + "-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelOpenBaoCluster: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{
+				{Type: corev1.PersistentVolumeClaimFileSystemResizePending, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	voterPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	readPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: resourceidentity.ReadReplicaStatefulSetName(cluster) + "-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, voterPVC, readPVC, voterPod, readPod).Build()
+	var selectedPod string
+	r := NewStorageResizeRestartReconciler(
+		StorageResizeRestartDependencies{
+			Resources: StorageResourceRuntime{Client: c, APIReader: c},
+			Events:    StorageEventRuntime{Recorder: events.NewFakeRecorder(10)},
+			Pods: StoragePodRuntime{
+				ClientForPodFunc: func(_ context.Context, _ *openbaov1alpha1.OpenBaoCluster, podName string) (StoragePodClient, error) {
+					selectedPod = podName
+					return &openbao.MockClusterActions{
+						IsLeaderFunc: func(ctx context.Context) (bool, error) { return false, nil },
+					}, nil
+				},
+			},
+		},
+	)
+
+	res, err := r.Reconcile(context.Background(), logr.Discard(), cluster)
+	require.NoError(t, err)
+	require.NotZero(t, res.RequeueAfter)
+	require.Equal(t, resourceidentity.ReadReplicaStatefulSetName(cluster)+"-0", selectedPod)
+}
+
+func quantityPtr(q resource.Quantity) *resource.Quantity {
+	return &q
 }

--- a/internal/controller/openbaocluster/setup.go
+++ b/internal/controller/openbaocluster/setup.go
@@ -53,6 +53,7 @@ func (r *OpenBaoClusterReconciler) setupSingleTenantMode(mgr ctrl.Manager) error
 		Owns(&corev1.ServiceAccount{}).
 		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
 			ReconcileOnBlueGreenStatus: true,
+			ReconcileOnOperationLock:   true,
 		})).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 2,
@@ -126,6 +127,7 @@ func (r *OpenBaoClusterReconciler) setupMultiTenantMode(mgr ctrl.Manager) error 
 		For(&openbaov1alpha1.OpenBaoCluster{}).
 		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
 			ReconcileOnBlueGreenStatus: true,
+			ReconcileOnOperationLock:   true,
 		})).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 2,

--- a/internal/controller/openbaocluster/status_requeue.go
+++ b/internal/controller/openbaocluster/status_requeue.go
@@ -15,6 +15,15 @@ func (r *OpenBaoClusterReconciler) determineStatusRequeue(logger logr.Logger, st
 
 	previousReadyReplicas := original.Status.ReadyReplicas
 	readyReplicasChanged := state.ReadyReplicas != previousReadyReplicas
+	desiredReadReplicas := desiredReadReplicaCount(cluster)
+	previousReadReadyReplicas := int32(0)
+	previousReadRegisteredReplicas := int32(0)
+	if original.Status.ReadReplicas != nil {
+		previousReadReadyReplicas = original.Status.ReadReplicas.ReadyReplicas
+		previousReadRegisteredReplicas = original.Status.ReadReplicas.RegisteredReplicas
+	}
+	readReadyReplicasChanged := state.ReadReplicaReadyReplicas != previousReadReadyReplicas
+	readRegisteredReplicasChanged := state.ReadReplicaRegisteredReplicas != previousReadRegisteredReplicas
 
 	if state.StatusStale {
 		logger.V(1).Info("StatefulSet status may be stale; requeuing to check status")
@@ -32,6 +41,39 @@ func (r *OpenBaoClusterReconciler) determineStatusRequeue(logger logr.Logger, st
 		logger.V(1).Info("All replicas became ready; requeuing once to ensure status is persisted",
 			"readyReplicas", state.ReadyReplicas,
 			"previousReadyReplicas", previousReadyReplicas)
+		return ctrl.Result{RequeueAfter: constants.RequeueShort}
+	}
+
+	if desiredReadReplicas > 0 && state.ReadReplicaReadyReplicas != desiredReadReplicas {
+		logger.V(1).Info("Read replica pool is still converging; requeuing to refresh status",
+			"readReplicaReadyReplicas", state.ReadReplicaReadyReplicas,
+			"desiredReadReplicas", desiredReadReplicas)
+		return ctrl.Result{RequeueAfter: constants.RequeueShort}
+	}
+
+	if desiredReadReplicas > 0 && state.ReadReplicaReadyReplicas == desiredReadReplicas {
+		if !state.ReadServingKnown || !state.ReadServingAvailable {
+			logger.V(1).Info("Read replica serving state has not fully converged; requeuing to refresh status",
+				"readServingKnown", state.ReadServingKnown,
+				"readServingAvailable", state.ReadServingAvailable,
+				"desiredReadReplicas", desiredReadReplicas)
+			return ctrl.Result{RequeueAfter: constants.RequeueShort}
+		}
+		if !state.ReadReplicaMembershipKnown || state.ReadReplicaRegisteredReplicas != desiredReadReplicas {
+			logger.V(1).Info("Read replica raft membership has not fully converged; requeuing to refresh status",
+				"readReplicaMembershipKnown", state.ReadReplicaMembershipKnown,
+				"readReplicaRegisteredReplicas", state.ReadReplicaRegisteredReplicas,
+				"desiredReadReplicas", desiredReadReplicas)
+			return ctrl.Result{RequeueAfter: constants.RequeueShort}
+		}
+	}
+
+	if desiredReadReplicas > 0 && (readReadyReplicasChanged || readRegisteredReplicasChanged) {
+		logger.V(1).Info("Read replica status changed; requeuing once to ensure status is persisted",
+			"readReplicaReadyReplicas", state.ReadReplicaReadyReplicas,
+			"previousReadReplicaReadyReplicas", previousReadReadyReplicas,
+			"readReplicaRegisteredReplicas", state.ReadReplicaRegisteredReplicas,
+			"previousReadReplicaRegisteredReplicas", previousReadRegisteredReplicas)
 		return ctrl.Result{RequeueAfter: constants.RequeueShort}
 	}
 

--- a/internal/controller/openbaocluster/status_requeue.go
+++ b/internal/controller/openbaocluster/status_requeue.go
@@ -18,12 +18,15 @@ func (r *OpenBaoClusterReconciler) determineStatusRequeue(logger logr.Logger, st
 	desiredReadReplicas := desiredReadReplicaCount(cluster)
 	previousReadReadyReplicas := int32(0)
 	previousReadRegisteredReplicas := int32(0)
+	previousReadHealthyReplicas := int32(0)
 	if original.Status.ReadReplicas != nil {
 		previousReadReadyReplicas = original.Status.ReadReplicas.ReadyReplicas
 		previousReadRegisteredReplicas = original.Status.ReadReplicas.RegisteredReplicas
+		previousReadHealthyReplicas = original.Status.ReadReplicas.HealthyReplicas
 	}
 	readReadyReplicasChanged := state.ReadReplicaReadyReplicas != previousReadReadyReplicas
 	readRegisteredReplicasChanged := state.ReadReplicaRegisteredReplicas != previousReadRegisteredReplicas
+	readHealthyReplicasChanged := state.ReadReplicaHealthyReplicas != previousReadHealthyReplicas
 
 	if state.StatusStale {
 		logger.V(1).Info("StatefulSet status may be stale; requeuing to check status")
@@ -66,14 +69,21 @@ func (r *OpenBaoClusterReconciler) determineStatusRequeue(logger logr.Logger, st
 				"desiredReadReplicas", desiredReadReplicas)
 			return ctrl.Result{RequeueAfter: constants.RequeueShort}
 		}
+		if !state.ReadReplicaAutopilotKnown {
+			logger.V(1).Info("Read replica Autopilot health has not been observed yet; requeuing to refresh status",
+				"desiredReadReplicas", desiredReadReplicas)
+			return ctrl.Result{RequeueAfter: constants.RequeueShort}
+		}
 	}
 
-	if desiredReadReplicas > 0 && (readReadyReplicasChanged || readRegisteredReplicasChanged) {
+	if desiredReadReplicas > 0 && (readReadyReplicasChanged || readRegisteredReplicasChanged || readHealthyReplicasChanged) {
 		logger.V(1).Info("Read replica status changed; requeuing once to ensure status is persisted",
 			"readReplicaReadyReplicas", state.ReadReplicaReadyReplicas,
 			"previousReadReplicaReadyReplicas", previousReadReadyReplicas,
 			"readReplicaRegisteredReplicas", state.ReadReplicaRegisteredReplicas,
-			"previousReadReplicaRegisteredReplicas", previousReadRegisteredReplicas)
+			"previousReadReplicaRegisteredReplicas", previousReadRegisteredReplicas,
+			"readReplicaHealthyReplicas", state.ReadReplicaHealthyReplicas,
+			"previousReadReplicaHealthyReplicas", previousReadHealthyReplicas)
 		return ctrl.Result{RequeueAfter: constants.RequeueShort}
 	}
 

--- a/internal/controller/openbaocluster/status_requeue_test.go
+++ b/internal/controller/openbaocluster/status_requeue_test.go
@@ -77,6 +77,123 @@ func TestDetermineStatusRequeue(t *testing.T) {
 			cluster:  &openbaov1alpha1.OpenBaoCluster{},
 			want:     0,
 		},
+		{
+			name: "read replicas partially ready requeue short",
+			state: &clusterState{
+				Available:                true,
+				ReadyReplicas:            3,
+				ReadReplicaReadyReplicas: 1,
+			},
+			original: &openbaov1alpha1.OpenBaoCluster{},
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 2,
+					},
+				},
+			},
+			want: int64(constants.RequeueShort),
+		},
+		{
+			name: "read replicas ready but serving unknown requeue short",
+			state: &clusterState{
+				Available:                true,
+				ReadyReplicas:            3,
+				ReadReplicaReadyReplicas: 2,
+			},
+			original: &openbaov1alpha1.OpenBaoCluster{},
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 2,
+					},
+				},
+			},
+			want: int64(constants.RequeueShort),
+		},
+		{
+			name: "read replicas ready and serving but membership pending requeue short",
+			state: &clusterState{
+				Available:                  true,
+				ReadyReplicas:              3,
+				ReadReplicaReadyReplicas:   2,
+				ReadServingKnown:           true,
+				ReadServingAvailable:       true,
+				ReadReplicaMembershipKnown: false,
+			},
+			original: &openbaov1alpha1.OpenBaoCluster{},
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 2,
+					},
+				},
+			},
+			want: int64(constants.RequeueShort),
+		},
+		{
+			name: "read replica convergence persists with one extra short requeue",
+			state: &clusterState{
+				Available:                     true,
+				ReadyReplicas:                 3,
+				ReadReplicaReadyReplicas:      2,
+				ReadReplicaRegisteredReplicas: 2,
+				ReadServingKnown:              true,
+				ReadServingAvailable:          true,
+				ReadReplicaMembershipKnown:    true,
+			},
+			original: &openbaov1alpha1.OpenBaoCluster{
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					ReadyReplicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaStatus{
+						ReadyReplicas:      1,
+						RegisteredReplicas: 1,
+					},
+				},
+			},
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 2,
+					},
+				},
+			},
+			want: int64(constants.RequeueShort),
+		},
+		{
+			name: "fully converged read replicas keep zero result",
+			state: &clusterState{
+				Available:                     true,
+				ReadyReplicas:                 3,
+				ReadReplicaReadyReplicas:      2,
+				ReadReplicaRegisteredReplicas: 2,
+				ReadServingKnown:              true,
+				ReadServingAvailable:          true,
+				ReadReplicaMembershipKnown:    true,
+			},
+			original: &openbaov1alpha1.OpenBaoCluster{
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					ReadyReplicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaStatus{
+						ReadyReplicas:      2,
+						RegisteredReplicas: 2,
+					},
+				},
+			},
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 2,
+					},
+				},
+			},
+			want: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/openbaocluster/status_requeue_test.go
+++ b/internal/controller/openbaocluster/status_requeue_test.go
@@ -141,9 +141,11 @@ func TestDetermineStatusRequeue(t *testing.T) {
 				ReadyReplicas:                 3,
 				ReadReplicaReadyReplicas:      2,
 				ReadReplicaRegisteredReplicas: 2,
+				ReadReplicaHealthyReplicas:    2,
 				ReadServingKnown:              true,
 				ReadServingAvailable:          true,
 				ReadReplicaMembershipKnown:    true,
+				ReadReplicaAutopilotKnown:     true,
 			},
 			original: &openbaov1alpha1.OpenBaoCluster{
 				Status: openbaov1alpha1.OpenBaoClusterStatus{
@@ -151,6 +153,7 @@ func TestDetermineStatusRequeue(t *testing.T) {
 					ReadReplicas: &openbaov1alpha1.ReadReplicaStatus{
 						ReadyReplicas:      1,
 						RegisteredReplicas: 1,
+						HealthyReplicas:    1,
 					},
 				},
 			},
@@ -171,9 +174,11 @@ func TestDetermineStatusRequeue(t *testing.T) {
 				ReadyReplicas:                 3,
 				ReadReplicaReadyReplicas:      2,
 				ReadReplicaRegisteredReplicas: 2,
+				ReadReplicaHealthyReplicas:    2,
 				ReadServingKnown:              true,
 				ReadServingAvailable:          true,
 				ReadReplicaMembershipKnown:    true,
+				ReadReplicaAutopilotKnown:     true,
 			},
 			original: &openbaov1alpha1.OpenBaoCluster{
 				Status: openbaov1alpha1.OpenBaoClusterStatus{
@@ -181,6 +186,7 @@ func TestDetermineStatusRequeue(t *testing.T) {
 					ReadReplicas: &openbaov1alpha1.ReadReplicaStatus{
 						ReadyReplicas:      2,
 						RegisteredReplicas: 2,
+						HealthyReplicas:    2,
 					},
 				},
 			},
@@ -193,6 +199,30 @@ func TestDetermineStatusRequeue(t *testing.T) {
 				},
 			},
 			want: 0,
+		},
+		{
+			name: "read replicas healthy but autopilot unknown requeues short",
+			state: &clusterState{
+				Available:                     true,
+				ReadyReplicas:                 3,
+				ReadReplicaReadyReplicas:      2,
+				ReadReplicaRegisteredReplicas: 2,
+				ReadReplicaHealthyReplicas:    2,
+				ReadServingKnown:              true,
+				ReadServingAvailable:          true,
+				ReadReplicaMembershipKnown:    true,
+				ReadReplicaAutopilotKnown:     false,
+			},
+			original: &openbaov1alpha1.OpenBaoCluster{},
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 2,
+					},
+				},
+			},
+			want: int64(constants.RequeueShort),
 		},
 	}
 

--- a/internal/controller/openbaocluster/status_upgrade_helpers.go
+++ b/internal/controller/openbaocluster/status_upgrade_helpers.go
@@ -144,6 +144,11 @@ func buildBlueGreenUpgradeMessage(cluster *openbaov1alpha1.OpenBaoCluster) strin
 		return fmt.Sprintf("Blue/green upgrade from %s to %s is demoting Blue revision %s after promoting Green revision %s.", from, to, blueRevision, greenRevision)
 	case openbaov1alpha1.PhaseCleanup:
 		return fmt.Sprintf("Blue/green upgrade from %s to %s is cleaning up Blue revision %s after promoting Green revision %s.", from, to, blueRevision, greenRevision)
+	case openbaov1alpha1.PhaseRestoringReadReplicas:
+		if status.RollbackStartTime != nil {
+			return "Blue/green rollback is restoring steady read replicas before marking the rollback complete."
+		}
+		return "Blue/green upgrade is restoring steady read replicas before marking the rollout complete."
 	case openbaov1alpha1.PhaseRollingBack:
 		return fmt.Sprintf(
 			"Blue/green upgrade from %s to %s is rolling back to Blue revision %s. %s",

--- a/internal/platform/predicates/predicates.go
+++ b/internal/platform/predicates/predicates.go
@@ -40,6 +40,8 @@ type OpenBaoClusterPredicateOptions struct {
 	ReconcileOnWorkloadError bool
 	// ReconcileOnAdminOpsError enables reconciliation when status.adminOps.lastError changes.
 	ReconcileOnAdminOpsError bool
+	// ReconcileOnOperationLock enables reconciliation when status.operationLock changes.
+	ReconcileOnOperationLock bool
 }
 
 // OpenBaoClusterPredicate filters OpenBaoCluster events to only reconcile on
@@ -111,6 +113,9 @@ func shouldReconcileOpenBaoClusterUpdate(
 		return true
 	}
 	if opts.ReconcileOnAdminOpsError && !equality.Semantic.DeepEqual(adminOpsLastError(oldCluster), adminOpsLastError(newCluster)) {
+		return true
+	}
+	if opts.ReconcileOnOperationLock && !equality.Semantic.DeepEqual(oldCluster.Status.OperationLock, newCluster.Status.OperationLock) {
 		return true
 	}
 

--- a/internal/platform/predicates/predicates_test.go
+++ b/internal/platform/predicates/predicates_test.go
@@ -26,6 +26,11 @@ func baseClusterForPredicate() *openbaov1alpha1.OpenBaoCluster {
 			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
 				Phase: openbaov1alpha1.PhaseSyncing,
 			},
+			OperationLock: &openbaov1alpha1.OperationLockStatus{
+				Operation: openbaov1alpha1.ClusterOperationUpgrade,
+				Holder:    "holder-a",
+				Message:   "in progress",
+			},
 			BreakGlass: &openbaov1alpha1.BreakGlassStatus{Active: false},
 			Workload:   &openbaov1alpha1.WorkloadControllerStatus{LastError: &openbaov1alpha1.ControllerErrorStatus{Reason: "X", Message: "Y"}},
 			AdminOps:   &openbaov1alpha1.AdminOpsControllerStatus{LastError: &openbaov1alpha1.ControllerErrorStatus{Reason: "A", Message: "B"}},
@@ -156,6 +161,18 @@ func TestShouldReconcileOpenBaoClusterUpdate_StatusOptions(t *testing.T) {
 			opts: OpenBaoClusterPredicateOptions{ReconcileOnAdminOpsError: true},
 			mutate: func(newC *openbaov1alpha1.OpenBaoCluster) {
 				newC.Status.AdminOps.LastError = &openbaov1alpha1.ControllerErrorStatus{Reason: "Changed", Message: "changed"}
+			},
+			want: true,
+		},
+		{
+			name: "operation lock change with option enabled",
+			opts: OpenBaoClusterPredicateOptions{ReconcileOnOperationLock: true},
+			mutate: func(newC *openbaov1alpha1.OpenBaoCluster) {
+				newC.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+					Operation: openbaov1alpha1.ClusterOperationRestore,
+					Holder:    "holder-b",
+					Message:   "restore running",
+				}
 			},
 			want: true,
 		},

--- a/internal/service/restore/manager_running.go
+++ b/internal/service/restore/manager_running.go
@@ -31,37 +31,6 @@ func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore
 		return ctrl.Result{}, fmt.Errorf("failed to get target cluster: %w", err)
 	}
 
-	lock := restoreOperationLock(restore)
-	lockHeldByUs := lock.IsHeldBy(cluster.Status.OperationLock)
-	if err := opslifecycle.AcquireWithReader(ctx, m.reader, m.client, cluster, lock, opslifecycle.AcquireOptions{
-		Message: restoreLockMessage(restore),
-	}); err != nil {
-		if opslifecycle.IsLockHeld(err) {
-			logging.LogAuditEvent(logger, logging.EventRestoreLockLost, map[string]string{
-				"cluster_namespace": restore.Namespace,
-				"cluster_name":      restore.Spec.Cluster,
-				"restore_name":      restore.Name,
-			})
-			m.emitWarningEvent(restore, ReasonOperationLockLost, "Restore lost the cluster operation lock while running")
-			return m.failRestore(
-				ctx,
-				logger,
-				restore,
-				"Restore stopped because another operation took the cluster operation lock while the restore Job was running. Check concurrent backup or upgrade activity, then create a new OpenBaoRestore to retry.",
-			)
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to renew cluster operation lock: %w", err)
-	}
-	if !lockHeldByUs {
-		logging.LogAuditEvent(logger, logging.EventOperationLockAcquired, map[string]string{
-			"cluster_namespace": restore.Namespace,
-			"cluster_name":      restore.Spec.Cluster,
-			"restore_name":      restore.Name,
-			"operation":         string(openbaov1alpha1.ClusterOperationRestore),
-			"holder":            lock.Holder,
-		})
-	}
-
 	// Check if job already exists
 	jobName := restoreJobName(restore)
 	job := &batchv1.Job{}
@@ -71,6 +40,13 @@ func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore
 	}, job)
 
 	if apierrors.IsNotFound(err) {
+		done, err := m.renewRunningRestoreLock(ctx, logger, restore, cluster)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if done {
+			return ctrl.Result{}, nil
+		}
 		return m.createRestoreJob(ctx, logger, restore, cluster, jobName)
 	} else if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get restore job: %w", err)
@@ -78,9 +54,20 @@ func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore
 
 	// Check job status
 	if job.Status.Succeeded > 0 {
-		if err := m.completeRestore(ctx, logger, restore, "Restore completed successfully"); err != nil {
+		if err := m.handleSucceededRestoreJob(ctx, logger, restore, cluster); err != nil {
 			return ctrl.Result{}, err
 		}
+		if restore.Status.Phase == openbaov1alpha1.RestorePhaseCompleted {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{RequeueAfter: restoreRequeueImmediately}, nil
+	}
+
+	done, err := m.renewRunningRestoreLock(ctx, logger, restore, cluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if done {
 		return ctrl.Result{}, nil
 	}
 
@@ -96,6 +83,89 @@ func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore
 	}
 
 	return ctrl.Result{RequeueAfter: restoreRequeueJobPoll}, nil
+}
+
+func (m *Manager) renewRunningRestoreLock(
+	ctx context.Context,
+	logger logr.Logger,
+	restore *openbaov1alpha1.OpenBaoRestore,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (bool, error) {
+	lock := restoreOperationLock(restore)
+	lockHeldByUs := lock.IsHeldBy(cluster.Status.OperationLock)
+	if err := opslifecycle.AcquireWithReader(ctx, m.reader, m.client, cluster, lock, opslifecycle.AcquireOptions{
+		Message: restoreLockMessage(restore),
+	}); err != nil {
+		if opslifecycle.IsLockHeld(err) {
+			logging.LogAuditEvent(logger, logging.EventRestoreLockLost, map[string]string{
+				"cluster_namespace": restore.Namespace,
+				"cluster_name":      restore.Spec.Cluster,
+				"restore_name":      restore.Name,
+			})
+			m.emitWarningEvent(restore, ReasonOperationLockLost, "Restore lost the cluster operation lock while running")
+			_, failErr := m.failRestore(
+				ctx,
+				logger,
+				restore,
+				"Restore stopped because another operation took the cluster operation lock while the restore Job was running. Check concurrent backup or upgrade activity, then create a new OpenBaoRestore to retry.",
+			)
+			return true, failErr
+		}
+		return false, fmt.Errorf("failed to renew cluster operation lock: %w", err)
+	}
+	if !lockHeldByUs {
+		logging.LogAuditEvent(logger, logging.EventOperationLockAcquired, map[string]string{
+			"cluster_namespace": restore.Namespace,
+			"cluster_name":      restore.Spec.Cluster,
+			"restore_name":      restore.Name,
+			"operation":         string(openbaov1alpha1.ClusterOperationRestore),
+			"holder":            lock.Holder,
+		})
+	}
+
+	return false, nil
+}
+
+func (m *Manager) handleSucceededRestoreJob(
+	ctx context.Context,
+	logger logr.Logger,
+	restore *openbaov1alpha1.OpenBaoRestore,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) error {
+	if !shouldWaitForSteadyReadReplicaRestore(cluster) {
+		return m.completeRestore(ctx, logger, restore, "Restore completed successfully")
+	}
+
+	if err := m.releaseClusterLock(ctx, logger, restore); err != nil {
+		return fmt.Errorf("failed to release cluster operation lock while waiting for steady read replicas to restore: %w", err)
+	}
+
+	if steadyReadReplicaRestoreComplete(cluster) {
+		return m.completeRestore(ctx, logger, restore, "Restore completed successfully")
+	}
+
+	readyReplicas := int32(0)
+	registeredReplicas := int32(0)
+	if cluster.Status.ReadReplicas != nil {
+		readyReplicas = cluster.Status.ReadReplicas.ReadyReplicas
+		registeredReplicas = cluster.Status.ReadReplicas.RegisteredReplicas
+	}
+
+	original := restore.DeepCopy()
+	restore.Status.Message = fmt.Sprintf(
+		"Waiting for steady read replicas to restore before marking restore complete: desiredReadReplicas=%d readyReadReplicas=%d registeredReadReplicas=%d readReplicasReady=%t readServingAvailable=%t raftMembershipReady=%t",
+		cluster.Spec.ReadReplicas.Replicas,
+		readyReplicas,
+		registeredReplicas,
+		restoreConditionTrue(cluster, openbaov1alpha1.ConditionReadReplicasReady),
+		restoreConditionTrue(cluster, openbaov1alpha1.ConditionReadServingAvailable),
+		restoreConditionTrue(cluster, openbaov1alpha1.ConditionRaftMembershipReady),
+	)
+	if err := m.patchStatus(ctx, restore, original); err != nil {
+		return fmt.Errorf("failed to patch restore status while waiting for steady read replicas to restore: %w", err)
+	}
+
+	return nil
 }
 
 func (m *Manager) createRestoreJob(

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -281,6 +282,76 @@ func TestReconcilePhaseRouting(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateClusterState_WaitsForSteadyReadReplicaDrain(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cluster",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{Replicas: 2},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+
+	replicas := int32(1)
+	readSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-cluster-read",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           1,
+			ReadyReplicas:      1,
+			CurrentReplicas:    1,
+		},
+	}
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-restore",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "test-cluster",
+		},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseValidating,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, readSTS, restore).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
+		WithReturnManagedFields().
+		Build()
+
+	mgr := NewManager(k8sClient, scheme, nil, security.NewImageVerifier(testLogger(), k8sClient, nil), "")
+	result, err := mgr.validateClusterState(context.Background(), testLogger(), restore, cluster)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, restoreRequeueImmediately, result.RequeueAfter)
+
+	updated := &openbaov1alpha1.OpenBaoRestore{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, updated))
+	assert.Contains(t, updated.Status.Message, "Waiting for steady read replicas to scale down before restore starts")
 }
 
 func TestReconcileTerminalPhase_ReleasesOperationLock(t *testing.T) {

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -785,6 +785,166 @@ func TestHandleRunning_FailedJobSetsActionableMessage(t *testing.T) {
 	assert.Contains(t, updated.Status.Message, "create a new OpenBaoRestore to retry")
 }
 
+func TestHandleRunning_SucceededJobWaitsForSteadyReadReplicaRestore(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 2,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			OperationLock: &openbaov1alpha1.OperationLockStatus{
+				Operation: openbaov1alpha1.ClusterOperationRestore,
+				Holder:    constants.ControllerNameOpenBaoRestore + "/test-restore",
+				Message:   "restore default/test-restore",
+			},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaStatus{
+				DesiredReplicas:    2,
+				ReadyReplicas:      1,
+				RegisteredReplicas: 1,
+			},
+		},
+	}
+	setTestResourceVersion(cluster)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "test-cluster",
+			Source: openbaov1alpha1.RestoreSource{
+				Key: "snapshot-key",
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseRunning,
+		},
+	}
+	setTestResourceVersion(restore)
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      restoreJobName(restore),
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: 1,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, job).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
+		WithReturnManagedFields().
+		Build()
+
+	mgr := NewManager(k8sClient, scheme, nil, security.NewImageVerifier(testLogger(), k8sClient, nil), "")
+
+	result, err := mgr.handleRunning(context.Background(), testLogger(), restore)
+	require.NoError(t, err)
+	assert.Equal(t, restoreRequeueImmediately, result.RequeueAfter)
+
+	updatedRestore := &openbaov1alpha1.OpenBaoRestore{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, updatedRestore))
+	assert.Equal(t, openbaov1alpha1.RestorePhaseRunning, updatedRestore.Status.Phase)
+	assert.Nil(t, updatedRestore.Status.CompletionTime)
+	assert.Contains(t, updatedRestore.Status.Message, "Waiting for steady read replicas to restore before marking restore complete")
+
+}
+
+func TestHandleRunning_SucceededJobCompletesAfterSteadyReadReplicaRestore(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: 2,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			OperationLock: &openbaov1alpha1.OperationLockStatus{
+				Operation: openbaov1alpha1.ClusterOperationRestore,
+				Holder:    constants.ControllerNameOpenBaoRestore + "/test-restore",
+				Message:   "restore default/test-restore",
+			},
+			ReadReplicas: &openbaov1alpha1.ReadReplicaStatus{
+				DesiredReplicas:    2,
+				ReadyReplicas:      2,
+				RegisteredReplicas: 2,
+			},
+			Conditions: []metav1.Condition{
+				{Type: string(openbaov1alpha1.ConditionReadReplicasReady), Status: metav1.ConditionTrue},
+				{Type: string(openbaov1alpha1.ConditionReadServingAvailable), Status: metav1.ConditionTrue},
+				{Type: string(openbaov1alpha1.ConditionRaftMembershipReady), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	setTestResourceVersion(cluster)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "test-cluster",
+			Source: openbaov1alpha1.RestoreSource{
+				Key: "snapshot-key",
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseRunning,
+		},
+	}
+	setTestResourceVersion(restore)
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      restoreJobName(restore),
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: 1,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, job).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
+		WithReturnManagedFields().
+		Build()
+
+	mgr := NewManager(k8sClient, scheme, nil, security.NewImageVerifier(testLogger(), k8sClient, nil), "")
+
+	result, err := mgr.handleRunning(context.Background(), testLogger(), restore)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), result.RequeueAfter)
+
+	updatedRestore := &openbaov1alpha1.OpenBaoRestore{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, updatedRestore))
+	assert.Equal(t, openbaov1alpha1.RestorePhaseCompleted, updatedRestore.Status.Phase)
+	assert.NotNil(t, updatedRestore.Status.CompletionTime)
+
+}
+
 func TestReconcilePending_AddsFinalizerThenPatchesStatus(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))

--- a/internal/service/restore/manager_validation.go
+++ b/internal/service/restore/manager_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -15,6 +16,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/workloadidentity"
 )
@@ -129,22 +131,61 @@ func (m *Manager) handleLockOverride(restore *openbaov1alpha1.OpenBaoRestore, lo
 // validateClusterState validates that the cluster is in a valid state for restore.
 // Returns (result, error) where result is non-nil if validation failed and should return early.
 func (m *Manager) validateClusterState(ctx context.Context, logger logr.Logger, restore *openbaov1alpha1.OpenBaoRestore, cluster *openbaov1alpha1.OpenBaoCluster) (*ctrl.Result, error) {
-	if restore.Spec.Force {
-		return nil, nil
+	if !restore.Spec.Force {
+		if !cluster.Status.Initialized {
+			result, err := m.failRestore(ctx, logger, restore, "target cluster is not initialized (use force: true to override)")
+			return &result, err
+		}
+
+		upgradingCond := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionUpgrading))
+		if upgradingCond != nil && upgradingCond.Status == metav1.ConditionTrue {
+			result, err := m.failRestore(ctx, logger, restore, "cannot restore while cluster is upgrading")
+			return &result, err
+		}
 	}
 
-	if !cluster.Status.Initialized {
-		result, err := m.failRestore(ctx, logger, restore, "target cluster is not initialized (use force: true to override)")
-		return &result, err
-	}
-
-	upgradingCond := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionUpgrading))
-	if upgradingCond != nil && upgradingCond.Status == metav1.ConditionTrue {
-		result, err := m.failRestore(ctx, logger, restore, "cannot restore while cluster is upgrading")
-		return &result, err
+	if result, err := m.waitForSteadyReadReplicasScaledDown(ctx, restore, cluster); result != nil || err != nil {
+		return result, err
 	}
 
 	return nil, nil
+}
+
+func (m *Manager) waitForSteadyReadReplicasScaledDown(ctx context.Context, restore *openbaov1alpha1.OpenBaoRestore, cluster *openbaov1alpha1.OpenBaoCluster) (*ctrl.Result, error) {
+	if cluster == nil || cluster.Spec.ReadReplicas == nil || cluster.Spec.ReadReplicas.Replicas == 0 {
+		return nil, nil
+	}
+
+	readStatefulSet := &appsv1.StatefulSet{}
+	key := types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      resourceidentity.ReadReplicaStatefulSetName(cluster),
+	}
+	if err := m.reader.Get(ctx, key, readStatefulSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get steady read-replica StatefulSet %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	if readReplicaStatefulSetScaledDown(readStatefulSet) {
+		return nil, nil
+	}
+
+	original := restore.DeepCopy()
+	restore.Status.Message = fmt.Sprintf(
+		"Waiting for steady read replicas to scale down before restore starts: statefulSet=%s specReplicas=%d statusReplicas=%d readyReplicas=%d",
+		readStatefulSet.Name,
+		derefReplicas(readStatefulSet.Spec.Replicas),
+		readStatefulSet.Status.Replicas,
+		readStatefulSet.Status.ReadyReplicas,
+	)
+	if err := m.patchStatus(ctx, restore, original); err != nil {
+		return nil, fmt.Errorf("failed to patch restore status while waiting for steady read replicas to scale down: %w", err)
+	}
+
+	result := ctrl.Result{RequeueAfter: restoreRequeueImmediately}
+	return &result, nil
 }
 
 // validateExecutionReadiness validates restore auth, storage, and hardened-profile
@@ -194,4 +235,24 @@ func (m *Manager) ensureRestoreServiceAccount(
 // The restore job needs permission to list pods for leader discovery.
 func (m *Manager) ensureRestoreRBAC(ctx context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoRestore, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	return EnsureRestoreRBAC(ctx, m.client, m.scheme, cluster)
+}
+
+func readReplicaStatefulSetScaledDown(sts *appsv1.StatefulSet) bool {
+	if sts == nil {
+		return true
+	}
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return false
+	}
+	if derefReplicas(sts.Spec.Replicas) != 0 {
+		return false
+	}
+	return sts.Status.Replicas == 0 && sts.Status.ReadyReplicas == 0 && sts.Status.CurrentReplicas == 0
+}
+
+func derefReplicas(replicas *int32) int32 {
+	if replicas == nil {
+		return 0
+	}
+	return *replicas
 }

--- a/internal/service/restore/read_replica_restore.go
+++ b/internal/service/restore/read_replica_restore.go
@@ -1,0 +1,41 @@
+package restore
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func shouldWaitForSteadyReadReplicaRestore(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return cluster != nil &&
+		cluster.Spec.ReadReplicas != nil &&
+		cluster.Spec.ReadReplicas.Replicas > 0
+}
+
+func steadyReadReplicaRestoreComplete(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if !shouldWaitForSteadyReadReplicaRestore(cluster) {
+		return true
+	}
+	if cluster == nil || cluster.Status.ReadReplicas == nil {
+		return false
+	}
+
+	desired := cluster.Spec.ReadReplicas.Replicas
+	if cluster.Status.ReadReplicas.ReadyReplicas != desired ||
+		cluster.Status.ReadReplicas.RegisteredReplicas != desired {
+		return false
+	}
+
+	return restoreConditionTrue(cluster, openbaov1alpha1.ConditionReadReplicasReady) &&
+		restoreConditionTrue(cluster, openbaov1alpha1.ConditionReadServingAvailable) &&
+		restoreConditionTrue(cluster, openbaov1alpha1.ConditionRaftMembershipReady)
+}
+
+func restoreConditionTrue(cluster *openbaov1alpha1.OpenBaoCluster, condType openbaov1alpha1.ConditionType) bool {
+	if cluster == nil {
+		return false
+	}
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, string(condType))
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}

--- a/internal/service/upgrade/bluegreen/lifecycle.go
+++ b/internal/service/upgrade/bluegreen/lifecycle.go
@@ -118,7 +118,22 @@ func (m *Manager) completeBlueGreenUpgrade(
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 ) (phaseOutcome, error) {
-	if err := m.finalizeUpgradeTerminalState(ctx, logger, cluster, true); err != nil {
+	if shouldRestoreSteadyReadReplicas(cluster) {
+		beginSteadyReadReplicaRestore(logger, cluster)
+		m.transitionToPhase(logger, cluster, openbaov1alpha1.PhaseRestoringReadReplicas)
+		return requeueAfterOutcome(constants.RequeueShort), nil
+	}
+
+	return m.finalizeCompletedBlueGreenUpgrade(ctx, logger, cluster, true)
+}
+
+func (m *Manager) finalizeCompletedBlueGreenUpgrade(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	promoteGreenToBlue bool,
+) (phaseOutcome, error) {
+	if err := m.finalizeUpgradeTerminalState(ctx, logger, cluster, promoteGreenToBlue); err != nil {
 		logger.Error(err, "Failed to finalize blue/green terminal state")
 		return phaseOutcome{}, err
 	}

--- a/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
+++ b/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
@@ -667,6 +667,53 @@ func TestHandlePhaseCleanup_Branches(t *testing.T) {
 			t.Fatal("expected operation lock to be released")
 		}
 	})
+
+	t.Run("transitions to read replica restore before idle when steady reads are configured", func(t *testing.T) {
+		t.Parallel()
+
+		scheme := newBlueGreenTestScheme(t)
+		cluster := newPhaseMachineCluster()
+		cluster.Spec.Replicas = 1
+		cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
+		cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseCleanup
+		cluster.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+			Operation: openbaov1alpha1.ClusterOperationUpgrade,
+			Holder:    core.UpgradeOperationLockHolder,
+			Message:   "blue/green upgrade phase Cleanup",
+		}
+		greenPod := newRevisionPod(cluster, cluster.Status.BlueGreen.GreenRevision, "green-0")
+		markPodReadyUnsealed(greenPod)
+		greenPod.Labels[portopenbao.LabelActive] = testBoolTrue
+		job := succeededExecutorJob(cluster, ActionRemoveBluePeers)
+		manager := &Manager{
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+				WithObjects(cluster, greenPod, job).
+				Build(),
+			scheme: scheme,
+		}
+
+		outcome, err := manager.handlePhaseCleanup(context.Background(), logr.Discard(), cluster)
+		if err != nil {
+			t.Fatalf("handlePhaseCleanup() error = %v", err)
+		}
+		if outcome.kind != phaseOutcomeRequeueAfter || outcome.after != constants.RequeueShort {
+			t.Fatalf("handlePhaseCleanup() outcome = %+v, want short requeue", outcome)
+		}
+		if cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseRestoringReadReplicas {
+			t.Fatalf("phase = %s, want %s", cluster.Status.BlueGreen.Phase, openbaov1alpha1.PhaseRestoringReadReplicas)
+		}
+		if cluster.Status.BlueGreen.BlueRevision == "" {
+			t.Fatal("expected active revision to be promoted before read replica restore")
+		}
+		if cluster.Status.BlueGreen.GreenRevision != "" {
+			t.Fatalf("green revision = %q, want empty", cluster.Status.BlueGreen.GreenRevision)
+		}
+		if cluster.Status.OperationLock == nil {
+			t.Fatal("expected operation lock to stay held until steady reads are restored")
+		}
+	})
 }
 
 func TestHandlePhaseRollingBack_AdvancesWhenConsensusIsRepaired(t *testing.T) {

--- a/internal/service/upgrade/bluegreen/manager_state_machine.go
+++ b/internal/service/upgrade/bluegreen/manager_state_machine.go
@@ -55,13 +55,14 @@ func (m *Manager) executeStateMachine(ctx context.Context, logger logr.Logger, c
 		openbaov1alpha1.PhaseDeployingGreen: func(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (phaseOutcome, error) {
 			return m.handlePhaseDeployingGreen(ctx, logger, cluster, verifiedImageDigest)
 		},
-		openbaov1alpha1.PhaseJoiningMesh:     m.handlePhaseJoiningMesh,
-		openbaov1alpha1.PhaseSyncing:         m.handlePhaseSyncing,
-		openbaov1alpha1.PhasePromoting:       m.handlePhasePromoting,
-		openbaov1alpha1.PhaseDemotingBlue:    m.handlePhaseDemotingBlue,
-		openbaov1alpha1.PhaseCleanup:         m.handlePhaseCleanup,
-		openbaov1alpha1.PhaseRollingBack:     m.handlePhaseRollingBack,
-		openbaov1alpha1.PhaseRollbackCleanup: m.handlePhaseRollbackCleanup,
+		openbaov1alpha1.PhaseJoiningMesh:           m.handlePhaseJoiningMesh,
+		openbaov1alpha1.PhaseSyncing:               m.handlePhaseSyncing,
+		openbaov1alpha1.PhasePromoting:             m.handlePhasePromoting,
+		openbaov1alpha1.PhaseDemotingBlue:          m.handlePhaseDemotingBlue,
+		openbaov1alpha1.PhaseCleanup:               m.handlePhaseCleanup,
+		openbaov1alpha1.PhaseRestoringReadReplicas: m.handlePhaseRestoringReadReplicas,
+		openbaov1alpha1.PhaseRollingBack:           m.handlePhaseRollingBack,
+		openbaov1alpha1.PhaseRollbackCleanup:       m.handlePhaseRollbackCleanup,
 	}
 
 	handler, ok := handlers[phase]

--- a/internal/service/upgrade/bluegreen/read_replica_restore.go
+++ b/internal/service/upgrade/bluegreen/read_replica_restore.go
@@ -1,0 +1,114 @@
+package bluegreen
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+func shouldRestoreSteadyReadReplicas(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return cluster != nil &&
+		cluster.Spec.ReadReplicas != nil &&
+		cluster.Spec.ReadReplicas.Replicas > 0
+}
+
+func beginSteadyReadReplicaRestore(
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) {
+	if cluster == nil || cluster.Status.BlueGreen == nil {
+		return
+	}
+
+	if greenRevision := cluster.Status.BlueGreen.GreenRevision; greenRevision != "" {
+		cluster.Status.BlueGreen.BlueRevision = greenRevision
+	}
+	if cluster.Spec.Image != "" {
+		cluster.Status.BlueGreen.BlueImage = cluster.Spec.Image
+	}
+	cluster.Status.BlueGreen.GreenRevision = ""
+	cluster.Status.BlueGreen.ManualPromotionRequired = false
+	maybeResetBlueGreenRollbackState(cluster)
+	cluster.Status.BlueGreen.LastJobFailure = ""
+	cluster.Status.BlueGreen.JobFailureCount = 0
+
+	logger.Info("Blue/green cleanup complete; restoring steady read replicas before finalizing upgrade")
+}
+
+func maybeResetBlueGreenRollbackState(cluster *openbaov1alpha1.OpenBaoCluster) {
+	if cluster == nil || cluster.Status.BlueGreen == nil || cluster.Status.BlueGreen.RollbackStartTime == nil {
+		return
+	}
+
+	cluster.Status.BlueGreen.RollbackReason = ""
+	cluster.Status.BlueGreen.RollbackStartTime = nil
+	cluster.Status.BlueGreen.RollbackAttempt = 0
+}
+
+func readReplicaRestoreComplete(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if !shouldRestoreSteadyReadReplicas(cluster) {
+		return true
+	}
+	if cluster == nil || cluster.Status.ReadReplicas == nil {
+		return false
+	}
+
+	desired := cluster.Spec.ReadReplicas.Replicas
+	if cluster.Status.ReadReplicas.ReadyReplicas != desired ||
+		cluster.Status.ReadReplicas.RegisteredReplicas != desired {
+		return false
+	}
+
+	return conditionTrue(cluster, openbaov1alpha1.ConditionReadReplicasReady) &&
+		conditionTrue(cluster, openbaov1alpha1.ConditionReadServingAvailable) &&
+		conditionTrue(cluster, openbaov1alpha1.ConditionRaftMembershipReady)
+}
+
+func conditionTrue(cluster *openbaov1alpha1.OpenBaoCluster, condType openbaov1alpha1.ConditionType) bool {
+	if cluster == nil {
+		return false
+	}
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, string(condType))
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}
+
+func (m *Manager) handlePhaseRestoringReadReplicas(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (phaseOutcome, error) {
+	if cluster.Status.BlueGreen == nil {
+		return phaseOutcome{}, nil
+	}
+
+	if !shouldRestoreSteadyReadReplicas(cluster) {
+		return m.finalizeCompletedBlueGreenUpgrade(ctx, logger, cluster, false)
+	}
+
+	if !readReplicaRestoreComplete(cluster) {
+		readyReplicas := int32(0)
+		registeredReplicas := int32(0)
+		if cluster.Status.ReadReplicas != nil {
+			readyReplicas = cluster.Status.ReadReplicas.ReadyReplicas
+			registeredReplicas = cluster.Status.ReadReplicas.RegisteredReplicas
+		}
+
+		logger.Info(
+			"Waiting for steady read replicas to restore before finalizing blue/green upgrade",
+			"desiredReadReplicas", cluster.Spec.ReadReplicas.Replicas,
+			"readyReadReplicas", readyReplicas,
+			"registeredReadReplicas", registeredReplicas,
+			"readReplicasReady", conditionTrue(cluster, openbaov1alpha1.ConditionReadReplicasReady),
+			"readServingAvailable", conditionTrue(cluster, openbaov1alpha1.ConditionReadServingAvailable),
+			"raftMembershipReady", conditionTrue(cluster, openbaov1alpha1.ConditionRaftMembershipReady),
+		)
+		return requeueAfterOutcome(constants.RequeueShort), nil
+	}
+
+	return m.finalizeCompletedBlueGreenUpgrade(ctx, logger, cluster, false)
+}

--- a/internal/service/upgrade/bluegreen/read_replicas.go
+++ b/internal/service/upgrade/bluegreen/read_replicas.go
@@ -1,0 +1,73 @@
+package bluegreen
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+)
+
+func (m *Manager) ensureSteadyReadReplicasScaledDown(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, bool, error) {
+	if cluster == nil || cluster.Spec.ReadReplicas == nil || cluster.Spec.ReadReplicas.Replicas == 0 {
+		return recon.Result{}, false, nil
+	}
+
+	reader := m.reader
+	if reader == nil {
+		reader = m.client
+	}
+
+	readStatefulSet := &appsv1.StatefulSet{}
+	key := client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      resourceidentity.ReadReplicaStatefulSetName(cluster),
+	}
+	if err := reader.Get(ctx, key, readStatefulSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			return recon.Result{}, false, nil
+		}
+		return recon.Result{}, true, fmt.Errorf("failed to get steady read-replica StatefulSet %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	if readReplicaStatefulSetScaledDown(readStatefulSet) {
+		return recon.Result{}, false, nil
+	}
+
+	logger.Info(
+		"Waiting for steady read replicas to scale down before blue/green continues",
+		"statefulSet", readStatefulSet.Name,
+		"specReplicas", derefReplicas(readStatefulSet.Spec.Replicas),
+		"statusReplicas", readStatefulSet.Status.Replicas,
+		"readyReplicas", readStatefulSet.Status.ReadyReplicas,
+		"currentReplicas", readStatefulSet.Status.CurrentReplicas,
+	)
+	return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+}
+
+func readReplicaStatefulSetScaledDown(sts *appsv1.StatefulSet) bool {
+	if sts == nil {
+		return true
+	}
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return false
+	}
+	if derefReplicas(sts.Spec.Replicas) != 0 {
+		return false
+	}
+	return sts.Status.Replicas == 0 && sts.Status.ReadyReplicas == 0 && sts.Status.CurrentReplicas == 0
+}
+
+func derefReplicas(replicas *int32) int32 {
+	if replicas == nil {
+		return 0
+	}
+	return *replicas
+}

--- a/internal/service/upgrade/bluegreen/read_replicas_test.go
+++ b/internal/service/upgrade/bluegreen/read_replicas_test.go
@@ -165,3 +165,18 @@ func TestHandlePhaseRestoringReadReplicas_FinalizesWhenHealthy(t *testing.T) {
 		t.Fatal("expected operation lock to be released")
 	}
 }
+
+func TestShouldWaitForSteadyReadReplicaDrain(t *testing.T) {
+	t.Parallel()
+
+	cluster := newBlueGreenCluster()
+	cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseCleanup
+	if !shouldWaitForSteadyReadReplicaDrain(cluster) {
+		t.Fatal("expected cleanup phase to keep waiting for steady read replica drain")
+	}
+
+	cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseRestoringReadReplicas
+	if shouldWaitForSteadyReadReplicaDrain(cluster) {
+		t.Fatal("expected restoring-read-replicas phase to stop waiting for steady read replica drain")
+	}
+}

--- a/internal/service/upgrade/bluegreen/read_replicas_test.go
+++ b/internal/service/upgrade/bluegreen/read_replicas_test.go
@@ -1,0 +1,89 @@
+package bluegreen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+)
+
+func TestEnsureSteadyReadReplicasScaledDown_WaitsForDrain(t *testing.T) {
+	scheme := newBlueGreenTestScheme(t)
+	cluster := newBlueGreenCluster()
+	cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
+
+	replicas := int32(2)
+	readSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       resourceidentity.ReadReplicaStatefulSetName(cluster),
+			Namespace:  cluster.Namespace,
+			Generation: 1,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           2,
+			ReadyReplicas:      2,
+			CurrentReplicas:    2,
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readSTS).Build()
+	manager := &Manager{client: client, reader: client, scheme: scheme}
+
+	result, waiting, err := manager.ensureSteadyReadReplicasScaledDown(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("ensureSteadyReadReplicasScaledDown() error = %v", err)
+	}
+	if !waiting {
+		t.Fatal("ensureSteadyReadReplicasScaledDown() waiting = false, want true")
+	}
+	if result.RequeueAfter != constants.RequeueShort {
+		t.Fatalf("requeueAfter = %s, want %s", result.RequeueAfter, constants.RequeueShort)
+	}
+}
+
+func TestEnsureSteadyReadReplicasScaledDown_AllowsProgressWhenScaledDown(t *testing.T) {
+	scheme := newBlueGreenTestScheme(t)
+	cluster := newBlueGreenCluster()
+	cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
+
+	replicas := int32(0)
+	readSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       resourceidentity.ReadReplicaStatefulSetName(cluster),
+			Namespace:  cluster.Namespace,
+			Generation: 1,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readSTS).Build()
+	manager := &Manager{client: client, reader: client, scheme: scheme}
+
+	result, waiting, err := manager.ensureSteadyReadReplicasScaledDown(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("ensureSteadyReadReplicasScaledDown() error = %v", err)
+	}
+	if waiting {
+		t.Fatal("ensureSteadyReadReplicasScaledDown() waiting = true, want false")
+	}
+	if result != (recon.Result{}) {
+		t.Fatalf("result = %+v, want empty", result)
+	}
+}

--- a/internal/service/upgrade/bluegreen/read_replicas_test.go
+++ b/internal/service/upgrade/bluegreen/read_replicas_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade/core"
 )
 
 func TestEnsureSteadyReadReplicasScaledDown_WaitsForDrain(t *testing.T) {
@@ -85,5 +87,81 @@ func TestEnsureSteadyReadReplicasScaledDown_AllowsProgressWhenScaledDown(t *test
 	}
 	if result != (recon.Result{}) {
 		t.Fatalf("result = %+v, want empty", result)
+	}
+}
+
+func TestHandlePhaseRestoringReadReplicas_WaitsForConvergence(t *testing.T) {
+	scheme := newBlueGreenTestScheme(t)
+	cluster := newBlueGreenCluster()
+	cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
+	cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseRestoringReadReplicas
+	cluster.Status.ReadReplicas = &openbaov1alpha1.ReadReplicaStatus{
+		DesiredReplicas:    2,
+		ReadyReplicas:      1,
+		RegisteredReplicas: 1,
+	}
+
+	manager := &Manager{client: fake.NewClientBuilder().WithScheme(scheme).Build(), scheme: scheme}
+
+	outcome, err := manager.handlePhaseRestoringReadReplicas(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("handlePhaseRestoringReadReplicas() error = %v", err)
+	}
+	if outcome.kind != phaseOutcomeRequeueAfter || outcome.after != constants.RequeueShort {
+		t.Fatalf("handlePhaseRestoringReadReplicas() outcome = %+v, want short requeue", outcome)
+	}
+	if cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseRestoringReadReplicas {
+		t.Fatalf("phase = %s, want %s", cluster.Status.BlueGreen.Phase, openbaov1alpha1.PhaseRestoringReadReplicas)
+	}
+}
+
+func TestHandlePhaseRestoringReadReplicas_FinalizesWhenHealthy(t *testing.T) {
+	scheme := newBlueGreenTestScheme(t)
+	cluster := newBlueGreenCluster()
+	cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
+	cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseRestoringReadReplicas
+	cluster.Status.ReadReplicas = &openbaov1alpha1.ReadReplicaStatus{
+		DesiredReplicas:    2,
+		ReadyReplicas:      2,
+		RegisteredReplicas: 2,
+	}
+	cluster.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+		Operation: openbaov1alpha1.ClusterOperationUpgrade,
+		Holder:    core.UpgradeOperationLockHolder,
+	}
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:   string(openbaov1alpha1.ConditionReadReplicasReady),
+		Status: metav1.ConditionTrue,
+	})
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:   string(openbaov1alpha1.ConditionReadServingAvailable),
+		Status: metav1.ConditionTrue,
+	})
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:   string(openbaov1alpha1.ConditionRaftMembershipReady),
+		Status: metav1.ConditionTrue,
+	})
+
+	manager := &Manager{
+		client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+			WithObjects(cluster).
+			Build(),
+		scheme: scheme,
+	}
+
+	outcome, err := manager.handlePhaseRestoringReadReplicas(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("handlePhaseRestoringReadReplicas() error = %v", err)
+	}
+	if outcome.kind != phaseOutcomeRequeueAfter || outcome.after != constants.RequeueShort {
+		t.Fatalf("handlePhaseRestoringReadReplicas() outcome = %+v, want short requeue", outcome)
+	}
+	if cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle {
+		t.Fatalf("phase = %s, want %s", cluster.Status.BlueGreen.Phase, openbaov1alpha1.PhaseIdle)
+	}
+	if cluster.Status.OperationLock != nil {
+		t.Fatal("expected operation lock to be released")
 	}
 }

--- a/internal/service/upgrade/bluegreen/workflow_preflight.go
+++ b/internal/service/upgrade/bluegreen/workflow_preflight.go
@@ -85,11 +85,17 @@ func (m *Manager) prepareBlueGreenReconcile(
 		return res, true, err
 	}
 
-	if result, waiting, err := m.ensureSteadyReadReplicasScaledDown(ctx, logger, cluster); waiting || err != nil {
-		return result, true, err
+	if shouldWaitForSteadyReadReplicaDrain(cluster) {
+		if result, waiting, err := m.ensureSteadyReadReplicasScaledDown(ctx, logger, cluster); waiting || err != nil {
+			return result, true, err
+		}
 	}
 
 	return recon.Result{}, false, nil
+}
+
+func shouldWaitForSteadyReadReplicaDrain(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return core.CurrentBlueGreenPhase(cluster) != openbaov1alpha1.PhaseRestoringReadReplicas
 }
 
 func (m *Manager) handleUnexpectedPromoteRequest(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) {

--- a/internal/service/upgrade/bluegreen/workflow_preflight.go
+++ b/internal/service/upgrade/bluegreen/workflow_preflight.go
@@ -85,6 +85,10 @@ func (m *Manager) prepareBlueGreenReconcile(
 		return res, true, err
 	}
 
+	if result, waiting, err := m.ensureSteadyReadReplicasScaledDown(ctx, logger, cluster); waiting || err != nil {
+		return result, true, err
+	}
+
 	return recon.Result{}, false, nil
 }
 

--- a/internal/service/upgrade/bluegreen/workflow_preflight.go
+++ b/internal/service/upgrade/bluegreen/workflow_preflight.go
@@ -145,6 +145,10 @@ func (m *Manager) maybeAcquireUpgradeLock(ctx context.Context, logger logr.Logge
 }
 
 func (m *Manager) handleNoUpgradeNeeded(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (bool, recon.Result, error) {
+	if core.CurrentBlueGreenPhase(cluster) != openbaov1alpha1.PhaseIdle {
+		return false, recon.Result{}, nil
+	}
+
 	if cluster.Status.CurrentVersion == "" {
 		logger.Info("CurrentVersion not yet set; waiting for initial version to be established")
 		if err := m.ensureIdleAndCleanupGreen(ctx, logger, cluster); err != nil {

--- a/internal/service/upgrade/raftops/actions.go
+++ b/internal/service/upgrade/raftops/actions.go
@@ -13,35 +13,82 @@ import (
 
 // RunRollingStepDownLeader steps down the current cluster leader.
 func RunRollingStepDownLeader(ctx context.Context, logger logr.Logger, cfg *ExecutorConfig) error {
-	leaderURL, err := FindLeader(ctx, cfg, "")
-	if err != nil {
-		return fmt.Errorf("failed to find leader: %w", err)
-	}
-	logger.Info("Leader found", "leader_url", leaderURL)
-
-	token, err := LoginJWT(ctx, cfg, leaderURL)
-	if err != nil {
-		return fmt.Errorf("failed to authenticate: %w", err)
-	}
-
 	factory, cleanup, err := NewOpenBaoClientFactory(cfg)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	client, err := factory.NewWithToken(leaderURL, token)
-	if err != nil {
-		return fmt.Errorf("failed to create OpenBao client: %w", err)
+	resolveClient := func(ctx context.Context, leaderURL string) (LeaderTransferClient, error) {
+		token, err := LoginJWT(ctx, cfg, leaderURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to authenticate: %w", err)
+		}
+
+		client, err := factory.NewWithToken(leaderURL, token)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OpenBao client: %w", err)
+		}
+
+		return client, nil
 	}
 
-	logger.Info("Stepping down leader")
-	if err := client.StepDown(ctx); err != nil {
-		return fmt.Errorf("failed to step down leader: %w", err)
+	return runRollingStepDownLeaderWithFuncs(ctx, logger, cfg, RetryPolicy{MaxAttempts: defaultLeaderTransferMaxRetries}, FindLeader, resolveClient, WaitForNewLeaderURL)
+}
+
+func runRollingStepDownLeaderWithFuncs(
+	ctx context.Context,
+	logger logr.Logger,
+	cfg *ExecutorConfig,
+	policy RetryPolicy,
+	findLeader func(context.Context, *ExecutorConfig, string) (string, error),
+	resolveClient LeaderTransferClientResolver,
+	waitForLeader LeaderTransferWaitFunc,
+) error {
+	policy = NormalizeLeaderTransferRetryPolicy(policy)
+
+	for _, attempt := range AttemptOrdinals(policy.MaxAttempts) {
+		attemptNumber := attempt + 1
+
+		leaderURL, err := findLeader(ctx, cfg, "")
+		if err != nil {
+			return fmt.Errorf("failed to find leader: %w", err)
+		}
+		logger.Info("Leader found", "leader_url", leaderURL, "attempt", attemptNumber, "max_attempts", policy.MaxAttempts)
+
+		client, err := resolveClient(ctx, leaderURL)
+		if err != nil {
+			return err
+		}
+
+		logger.Info("Stepping down leader", "attempt", attemptNumber, "max_attempts", policy.MaxAttempts)
+		classification, err := StepDownLeader(ctx, logger, client)
+		if err != nil {
+			if classification == BenignErrorClassificationFatal {
+				return fmt.Errorf("failed to step down leader: %w", err)
+			}
+			logger.Info("Retryable leader step-down error observed; retrying", "attempt", attemptNumber, "max_attempts", policy.MaxAttempts, "error", err.Error())
+			continue
+		}
+
+		nextLeaderURL, err := waitForLeader(ctx, logger, cfg, leaderURL)
+		if err != nil {
+			return fmt.Errorf("failed to wait for a new leader after step-down: %w", err)
+		}
+		if strings.TrimSpace(nextLeaderURL) == "" {
+			logger.Info("Leader transfer did not surface a leader URL yet; retrying step-down", "attempt", attemptNumber, "max_attempts", policy.MaxAttempts)
+			continue
+		}
+		if nextLeaderURL == leaderURL {
+			logger.Info("Leader transferred back to the same node after step-down; retrying", "leader_url", leaderURL, "attempt", attemptNumber, "max_attempts", policy.MaxAttempts)
+			continue
+		}
+
+		logger.Info("Leader transferred successfully", "previous_leader_url", leaderURL, "new_leader_url", nextLeaderURL, "attempt", attemptNumber, "max_attempts", policy.MaxAttempts)
+		return nil
 	}
 
-	logger.Info("Leader stepped down")
-	return nil
+	return fmt.Errorf("leader step-down did not transfer leadership after %d attempts", policy.MaxAttempts)
 }
 
 // RunBlueGreenJoinGreenNonVoters joins Green peers as non-voters under the Blue

--- a/internal/service/upgrade/raftops/actions_test.go
+++ b/internal/service/upgrade/raftops/actions_test.go
@@ -1,0 +1,134 @@
+package raftops
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	"github.com/go-logr/logr"
+)
+
+const testRollingLeaderURL0 = "https://vault-0"
+
+type rollingStepDownStubClient struct {
+	stepDownCalls int
+	stepDownErr   error
+}
+
+func (c *rollingStepDownStubClient) ReadRaftConfiguration(context.Context) (*portopenbao.RaftConfigurationResponse, error) {
+	return nil, nil
+}
+
+func (c *rollingStepDownStubClient) DemoteRaftPeer(context.Context, string) error {
+	return nil
+}
+
+func (c *rollingStepDownStubClient) StepDown(ctx context.Context) error {
+	c.stepDownCalls++
+	return c.stepDownErr
+}
+
+func TestRunRollingStepDownLeaderWithFuncs_RetriesUntilLeaderChanges(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ExecutorConfig{
+		ClusterName:     "vault",
+		ClusterReplicas: 3,
+	}
+	client := &rollingStepDownStubClient{}
+
+	err := runRollingStepDownLeaderWithFuncs(
+		context.Background(),
+		logr.Discard(),
+		cfg,
+		RetryPolicy{MaxAttempts: 3},
+		func(context.Context, *ExecutorConfig, string) (string, error) {
+			return testRollingLeaderURL0, nil
+		},
+		func(context.Context, string) (LeaderTransferClient, error) {
+			return client, nil
+		},
+		func(context.Context, logr.Logger, *ExecutorConfig, string) (string, error) {
+			if client.stepDownCalls == 1 {
+				return testRollingLeaderURL0, nil
+			}
+			return "https://vault-1", nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runRollingStepDownLeaderWithFuncs() error = %v, want nil", err)
+	}
+	if client.stepDownCalls != 2 {
+		t.Fatalf("stepDownCalls = %d, want 2", client.stepDownCalls)
+	}
+}
+
+func TestRunRollingStepDownLeaderWithFuncs_FailsAfterBoundedSameLeaderRetries(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ExecutorConfig{
+		ClusterName:     "vault",
+		ClusterReplicas: 3,
+	}
+	client := &rollingStepDownStubClient{}
+
+	err := runRollingStepDownLeaderWithFuncs(
+		context.Background(),
+		logr.Discard(),
+		cfg,
+		RetryPolicy{MaxAttempts: 3},
+		func(context.Context, *ExecutorConfig, string) (string, error) {
+			return testRollingLeaderURL0, nil
+		},
+		func(context.Context, string) (LeaderTransferClient, error) {
+			return client, nil
+		},
+		func(context.Context, logr.Logger, *ExecutorConfig, string) (string, error) {
+			return testRollingLeaderURL0, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("runRollingStepDownLeaderWithFuncs() error = nil, want retry exhaustion")
+	}
+	if client.stepDownCalls != 3 {
+		t.Fatalf("stepDownCalls = %d, want 3", client.stepDownCalls)
+	}
+	if got, want := err.Error(), "leader step-down did not transfer leadership after 3 attempts"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestRunRollingStepDownLeaderWithFuncs_StopsOnFatalStepDownError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ExecutorConfig{
+		ClusterName:     "vault",
+		ClusterReplicas: 3,
+	}
+	client := &rollingStepDownStubClient{
+		stepDownErr: portopenbao.NewAPIError("step-down forbidden", http.StatusForbidden, nil),
+	}
+
+	err := runRollingStepDownLeaderWithFuncs(
+		context.Background(),
+		logr.Discard(),
+		cfg,
+		RetryPolicy{MaxAttempts: 3},
+		func(context.Context, *ExecutorConfig, string) (string, error) {
+			return testRollingLeaderURL0, nil
+		},
+		func(context.Context, string) (LeaderTransferClient, error) {
+			return client, nil
+		},
+		func(context.Context, logr.Logger, *ExecutorConfig, string) (string, error) {
+			return "https://vault-1", nil
+		},
+	)
+	if err == nil {
+		t.Fatal("runRollingStepDownLeaderWithFuncs() error = nil, want fatal step-down error")
+	}
+	if client.stepDownCalls != 1 {
+		t.Fatalf("stepDownCalls = %d, want 1", client.stepDownCalls)
+	}
+}

--- a/internal/service/upgrade/rolling/lifecycle.go
+++ b/internal/service/upgrade/rolling/lifecycle.go
@@ -62,11 +62,20 @@ func (m *Manager) waitForFinalizationConverged(ctx context.Context, logger logr.
 		partition = *sts.Spec.UpdateStrategy.RollingUpdate.Partition
 	}
 
-	rolloutComplete := sts.Status.ReadyReplicas == cluster.Spec.Replicas &&
+	statefulSetRevisionsConverged := sts.Status.ReadyReplicas == cluster.Spec.Replicas &&
 		sts.Status.UpdatedReplicas == cluster.Spec.Replicas &&
 		sts.Status.CurrentRevision != "" &&
-		sts.Status.CurrentRevision == sts.Status.UpdateRevision &&
-		partition == 0
+		sts.Status.CurrentRevision == sts.Status.UpdateRevision
+	if statefulSetRevisionsConverged && partition != 0 && cluster.Status.Upgrade != nil && cluster.Status.Upgrade.CurrentPartition == 0 {
+		logger.Info("Repairing stale StatefulSet partition before finalizing rolling upgrade",
+			"partition", partition)
+		if err := m.setStatefulSetPartition(ctx, cluster, 0); err != nil {
+			return false, fmt.Errorf("failed to repair stale StatefulSet partition before finalization: %w", err)
+		}
+		return false, nil
+	}
+
+	rolloutComplete := statefulSetRevisionsConverged && partition == 0
 	if !rolloutComplete {
 		logger.Info("Waiting for StatefulSet convergence before finalizing rolling upgrade",
 			"readyReplicas", sts.Status.ReadyReplicas,

--- a/internal/service/upgrade/rolling/lifecycle_test.go
+++ b/internal/service/upgrade/rolling/lifecycle_test.go
@@ -219,6 +219,73 @@ func TestWaitForFinalizationConverged_SucceedsWhenStatefulSetPodsAndHealthConver
 	}
 }
 
+func TestWaitForFinalizationConverged_RepairsStalePartitionWhenStatusIsAlreadyComplete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = openbaov1alpha1.AddToScheme(scheme)
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-cluster",
+			Namespace: "ns1",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				CurrentPartition: 0,
+			},
+		},
+	}
+
+	partition := int32(3)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					Partition: &partition,
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:   3,
+			UpdatedReplicas: 3,
+			CurrentRevision: "rev-new",
+			UpdateRevision:  "rev-new",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts).Build()
+	mgr := NewManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
+		return &openbaoapi.MockClusterActions{}, nil
+	}, portopenbao.ClientConfig{}, nil, "")
+
+	converged, err := mgr.waitForFinalizationConverged(context.Background(), testr.New(t), cluster)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if converged {
+		t.Fatalf("expected convergence check to requeue after repairing stale partition")
+	}
+
+	updated := &appsv1.StatefulSet{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(sts), updated); err != nil {
+		t.Fatalf("failed to reload StatefulSet: %v", err)
+	}
+	if updated.Spec.UpdateStrategy.RollingUpdate == nil || updated.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+		t.Fatalf("expected rolling update partition to be set")
+	}
+	if *updated.Spec.UpdateStrategy.RollingUpdate.Partition != 0 {
+		t.Fatalf("partition=%d, want 0", *updated.Spec.UpdateStrategy.RollingUpdate.Partition)
+	}
+}
+
 func TestPatchFinalizedUpgradeStatus_ClearsUpgradeWithoutTouchingCurrentVersion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = openbaov1alpha1.AddToScheme(scheme)

--- a/internal/service/upgrade/rolling/read_replicas.go
+++ b/internal/service/upgrade/rolling/read_replicas.go
@@ -1,0 +1,130 @@
+package rolling
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+)
+
+func (m *Manager) ensureReadReplicaPoolReadyForRollingUpgrade(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (recon.Result, bool, error) {
+	desiredReplicas := desiredReadReplicaReplicas(cluster)
+	if desiredReplicas == 0 {
+		return recon.Result{}, false, nil
+	}
+
+	sts, err := m.getReadReplicaStatefulSet(ctx, cluster)
+	if err != nil {
+		return recon.Result{}, false, err
+	}
+
+	if sts.Generation > 0 && sts.Status.ObservedGeneration < sts.Generation {
+		logger.Info("Waiting for read-replica StatefulSet generation to be observed before rolling voter upgrade",
+			"statefulSet", sts.Name,
+			"generation", sts.Generation,
+			"observedGeneration", sts.Status.ObservedGeneration)
+		return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+	}
+
+	if sts.Status.ReadyReplicas != desiredReplicas ||
+		sts.Status.UpdatedReplicas != desiredReplicas ||
+		sts.Status.CurrentRevision == "" ||
+		sts.Status.CurrentRevision != sts.Status.UpdateRevision {
+		logger.Info("Waiting for read-replica StatefulSet convergence before rolling voter upgrade",
+			"statefulSet", sts.Name,
+			"readyReplicas", sts.Status.ReadyReplicas,
+			"updatedReplicas", sts.Status.UpdatedReplicas,
+			"desiredReplicas", desiredReplicas,
+			"currentRevision", sts.Status.CurrentRevision,
+			"updateRevision", sts.Status.UpdateRevision)
+		return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+	}
+
+	pods, err := m.getReadReplicaPods(ctx, cluster)
+	if err != nil {
+		return recon.Result{}, false, err
+	}
+	if len(pods) != int(desiredReplicas) {
+		logger.Info("Waiting for expected number of read-replica pods before rolling voter upgrade",
+			"foundPods", len(pods),
+			"desiredReplicas", desiredReplicas)
+		return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+	}
+
+	for i := range pods {
+		pod := &pods[i]
+		if !isPodReady(pod) {
+			logger.Info("Waiting for read-replica pod readiness before rolling voter upgrade",
+				"pod", pod.Name,
+				"phase", pod.Status.Phase)
+			return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+		}
+		if pod.Labels[appsv1.StatefulSetRevisionLabel] != sts.Status.UpdateRevision {
+			logger.Info("Waiting for read-replica pod revision convergence before rolling voter upgrade",
+				"pod", pod.Name,
+				"podRevision", pod.Labels[appsv1.StatefulSetRevisionLabel],
+				"targetRevision", sts.Status.UpdateRevision)
+			return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+		}
+
+		healthy, err := m.isPodHealthyForFinalization(ctx, logger, cluster, pod.Name)
+		if err != nil {
+			return recon.Result{}, false, err
+		}
+		if !healthy {
+			logger.Info("Waiting for read-replica pod health before rolling voter upgrade", "pod", pod.Name)
+			return recon.Result{RequeueAfter: constants.RequeueShort}, true, nil
+		}
+	}
+
+	return recon.Result{}, false, nil
+}
+
+func desiredReadReplicaReplicas(cluster *openbaov1alpha1.OpenBaoCluster) int32 {
+	if cluster == nil || cluster.Spec.ReadReplicas == nil || cluster.Spec.ReadReplicas.Replicas <= 0 {
+		return 0
+	}
+	return cluster.Spec.ReadReplicas.Replicas
+}
+
+func (m *Manager) getReadReplicaStatefulSet(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) (*appsv1.StatefulSet, error) {
+	sts := &appsv1.StatefulSet{}
+	stsKey := types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      resourceidentity.ReadReplicaStatefulSetName(cluster),
+	}
+	if err := m.client.Get(ctx, stsKey, sts); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("read-replica StatefulSet not found while preparing rolling upgrade")
+		}
+		return nil, fmt.Errorf("failed to get read-replica StatefulSet: %w", err)
+	}
+	return sts, nil
+}
+
+func (m *Manager) getReadReplicaPods(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	labelSelector := labels.SelectorFromSet(resourceidentity.ReadReplicaPodSelectorLabels(cluster))
+	if err := m.client.List(ctx, podList,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list read-replica pods: %w", err)
+	}
+	return podList.Items, nil
+}

--- a/internal/service/upgrade/rolling/read_replicas_test.go
+++ b/internal/service/upgrade/rolling/read_replicas_test.go
@@ -1,0 +1,200 @@
+package rolling
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	openbaoapi "github.com/dc-tec/openbao-operator/internal/adapter/openbao"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	"github.com/dc-tec/openbao-operator/internal/service/backup"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
+	"github.com/go-logr/logr/testr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	readReplicaTargetRevision = "rev-read-new"
+	readReplicaOldRevision    = "rev-read-old"
+)
+
+func TestEnsureReadReplicaPoolReadyForRollingUpgrade_SkipsWhenReadReplicasAreNotConfigured(t *testing.T) {
+	scheme := newScheme()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "upgrade-cluster", Namespace: "ns1"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	mgr := NewManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), rollingTestClientFactory(), portopenbao.ClientConfig{}, nil, "")
+
+	result, waiting, err := mgr.ensureReadReplicaPoolReadyForRollingUpgrade(context.Background(), testr.New(t), cluster)
+	if err != nil {
+		t.Fatalf("ensureReadReplicaPoolReadyForRollingUpgrade() error = %v", err)
+	}
+	if waiting {
+		t.Fatalf("waiting = true, want false")
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want 0", result.RequeueAfter)
+	}
+}
+
+func TestEnsureReadReplicaPoolReadyForRollingUpgrade_WaitsForStatefulSetConvergence(t *testing.T) {
+	scheme := newScheme()
+	cluster := readReplicaRollingTestCluster(2)
+	readSTS := convergedReadReplicaStatefulSet(cluster)
+	readSTS.Status.UpdatedReplicas = 1
+	readSTS.Status.CurrentRevision = readReplicaOldRevision
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readSTS).Build()
+	mgr := NewManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), rollingTestClientFactory(), portopenbao.ClientConfig{}, nil, "")
+
+	result, waiting, err := mgr.ensureReadReplicaPoolReadyForRollingUpgrade(context.Background(), testr.New(t), cluster)
+	if err != nil {
+		t.Fatalf("ensureReadReplicaPoolReadyForRollingUpgrade() error = %v", err)
+	}
+	if !waiting {
+		t.Fatalf("waiting = false, want true")
+	}
+	if result.RequeueAfter != constants.RequeueShort {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, constants.RequeueShort)
+	}
+}
+
+func TestEnsureReadReplicaPoolReadyForRollingUpgrade_WaitsForPodHealth(t *testing.T) {
+	scheme := newScheme()
+	cluster := readReplicaRollingTestCluster(2)
+	readSTS := convergedReadReplicaStatefulSet(cluster)
+	pod0 := readyReadReplicaTestPod(cluster, 0)
+	pod1 := readyReadReplicaTestPod(cluster, 1)
+	caSecret := testClusterCASecret(cluster)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readSTS, pod0, pod1, caSecret).Build()
+	mgr := NewManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), unhealthyReadReplicaClientFactory(), portopenbao.ClientConfig{}, nil, "")
+
+	result, waiting, err := mgr.ensureReadReplicaPoolReadyForRollingUpgrade(context.Background(), testr.New(t), cluster)
+	if err != nil {
+		t.Fatalf("ensureReadReplicaPoolReadyForRollingUpgrade() error = %v", err)
+	}
+	if !waiting {
+		t.Fatalf("waiting = false, want true")
+	}
+	if result.RequeueAfter != constants.RequeueShort {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, constants.RequeueShort)
+	}
+}
+
+func TestEnsureReadReplicaPoolReadyForRollingUpgrade_SucceedsWhenReadPoolConverged(t *testing.T) {
+	scheme := newScheme()
+	cluster := readReplicaRollingTestCluster(2)
+	readSTS := convergedReadReplicaStatefulSet(cluster)
+	pod0 := readyReadReplicaTestPod(cluster, 0)
+	pod1 := readyReadReplicaTestPod(cluster, 1)
+	caSecret := testClusterCASecret(cluster)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readSTS, pod0, pod1, caSecret).Build()
+	mgr := NewManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), rollingTestClientFactory(), portopenbao.ClientConfig{}, nil, "")
+
+	result, waiting, err := mgr.ensureReadReplicaPoolReadyForRollingUpgrade(context.Background(), testr.New(t), cluster)
+	if err != nil {
+		t.Fatalf("ensureReadReplicaPoolReadyForRollingUpgrade() error = %v", err)
+	}
+	if waiting {
+		t.Fatalf("waiting = true, want false")
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want 0", result.RequeueAfter)
+	}
+}
+
+func readReplicaRollingTestCluster(replicas int32) *openbaov1alpha1.OpenBaoCluster {
+	return &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-cluster",
+			Namespace: "ns1",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+			ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+				Replicas: replicas,
+			},
+		},
+	}
+}
+
+func convergedReadReplicaStatefulSet(cluster *openbaov1alpha1.OpenBaoCluster) *appsv1.StatefulSet {
+	replicas := cluster.Spec.ReadReplicas.Replicas
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       resourceidentity.ReadReplicaStatefulSetName(cluster),
+			Namespace:  cluster.Namespace,
+			Generation: 2,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 2,
+			ReadyReplicas:      replicas,
+			UpdatedReplicas:    replicas,
+			CurrentRevision:    readReplicaTargetRevision,
+			UpdateRevision:     readReplicaTargetRevision,
+		},
+	}
+}
+
+func readyReadReplicaTestPod(cluster *openbaov1alpha1.OpenBaoCluster, ordinal int) *corev1.Pod {
+	labels := resourceidentity.ReadReplicaPodSelectorLabels(cluster)
+	labels[appsv1.StatefulSetRevisionLabel] = readReplicaTargetRevision
+	labels["statefulset.kubernetes.io/pod-name"] = readReplicaPodName(cluster, ordinal)
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      readReplicaPodName(cluster, ordinal),
+			Namespace: cluster.Namespace,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func readReplicaPodName(cluster *openbaov1alpha1.OpenBaoCluster, ordinal int) string {
+	return resourceidentity.ReadReplicaStatefulSetName(cluster) + "-" + strconv.Itoa(ordinal)
+}
+
+func testClusterCASecret(cluster *openbaov1alpha1.OpenBaoCluster) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + constants.SuffixTLSCA,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			"ca.crt": []byte("fake-ca"),
+		},
+	}
+}
+
+func unhealthyReadReplicaClientFactory() raftops.OpenBaoClientFactory {
+	return func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
+		return &openbaoapi.MockClusterActions{
+			IsHealthyFunc: func(ctx context.Context) (bool, error) {
+				return !strings.Contains(config.BaseURL, "-read-1."), nil
+			},
+		}, nil
+	}
+}

--- a/internal/service/upgrade/rolling/rollout.go
+++ b/internal/service/upgrade/rolling/rollout.go
@@ -37,6 +37,9 @@ func (m *Manager) performPodByPodUpgrade(ctx context.Context, logger logr.Logger
 		return false, err
 	}
 	if alreadyRolledOut {
+		if err := m.setStatefulSetPartition(ctx, cluster, target.NextPartition); err != nil {
+			return false, fmt.Errorf("failed to advance partition while resuming rolled-out target: %w", err)
+		}
 		recordCompletedTargetPodUpgrade(logger, cluster, metrics, target, podStartTime)
 		return target.NextPartition == 0, nil
 	}

--- a/internal/service/upgrade/rolling/rollout.go
+++ b/internal/service/upgrade/rolling/rollout.go
@@ -32,6 +32,15 @@ func (m *Manager) performPodByPodUpgrade(ctx context.Context, logger logr.Logger
 
 	podStartTime := time.Now()
 
+	alreadyRolledOut, err := m.targetPodAlreadyRolledOut(ctx, logger, cluster, target)
+	if err != nil {
+		return false, err
+	}
+	if alreadyRolledOut {
+		recordCompletedTargetPodUpgrade(logger, cluster, metrics, target, podStartTime)
+		return target.NextPartition == 0, nil
+	}
+
 	stepDownComplete, err := m.ensureTargetPodLeadershipTransferred(ctx, logger, cluster, target, metrics)
 	if err != nil {
 		return false, err
@@ -54,6 +63,29 @@ func (m *Manager) performPodByPodUpgrade(ctx context.Context, logger logr.Logger
 
 	recordCompletedTargetPodUpgrade(logger, cluster, metrics, target, podStartTime)
 	return target.NextPartition == 0, nil
+}
+
+func (m *Manager) targetPodAlreadyRolledOut(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	target rolloutTargetPod,
+) (bool, error) {
+	revisionUpdated, err := m.waitForPodRevisionUpdated(ctx, logger, cluster, target.Name)
+	if err != nil || !revisionUpdated {
+		return false, err
+	}
+
+	podReady, err := m.waitForPodReady(ctx, logger, cluster, target.Name)
+	if err != nil || !podReady {
+		return false, err
+	}
+
+	logger.Info("Target pod is already updated and ready; resuming rolling-upgrade progress and deferring full health verification to finalization",
+		"pod", target.Name,
+		"partition", target.CurrentPartition,
+		"nextPartition", target.NextPartition)
+	return true, nil
 }
 
 type rolloutTargetPod struct {

--- a/internal/service/upgrade/rolling/rollout_leader.go
+++ b/internal/service/upgrade/rolling/rollout_leader.go
@@ -3,13 +3,11 @@ package rolling
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -184,27 +182,14 @@ func (m *Manager) stepDownLeader(ctx context.Context, logger logr.Logger, cluste
 		return true, nil
 	}
 
-	// The step-down Job can succeed while leadership quickly returns to the same pod.
-	// If that persisted longer than the step-down timeout window, recycle the Job so
-	// the next reconcile performs another step-down attempt for this pod.
+	// A succeeded step-down Job that still leaves the target pod as leader should
+	// not be retried forever. If the target remains leader beyond the timeout
+	// window, fail the upgrade and require an explicit retry after operator/user
+	// intervention.
 	if jobExists && !stepDownJob.CreationTimestamp.IsZero() {
-		elapsed := time.Since(stepDownJob.CreationTimestamp.Time)
-		if elapsed > upgrade.DefaultStepDownTimeout {
-			// Use foreground deletion so the old Job pod is removed before a new
-			// retry Job with the same deterministic name is created.
-			propagationPolicy := metav1.DeletePropagationForeground
-			if err := m.client.Delete(
-				ctx,
-				stepDownJob,
-				&client.DeleteOptions{PropagationPolicy: &propagationPolicy},
-			); err != nil && !apierrors.IsNotFound(err) {
-				return false, fmt.Errorf("failed to delete stale step-down Job %s/%s for retry: %w", cluster.Namespace, stepDownJob.Name, err)
-			}
-			logger.Info("Step-down job succeeded but target pod is still leader; deleting job to retry",
-				"pod", podName,
-				"job", stepDownJob.Name,
-				"elapsed", elapsed)
-			return false, nil
+		if err := failUpgradeIfTimestampTimeout(cluster, &stepDownJob.CreationTimestamp, stepDownTimeout(podName)); err != nil {
+			metrics.IncrementStepDownFailures()
+			return false, err
 		}
 	}
 

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -142,7 +142,7 @@ func TestStepDownLeader_TimesOutBasedOnJobAge(t *testing.T) {
 	}
 }
 
-func TestStepDownLeader_DeletesStaleSucceededJobWhenTargetStillLeader(t *testing.T) {
+func TestStepDownLeader_FailsWhenSucceededJobStillLeavesTargetAsLeader(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = batchv1.AddToScheme(scheme)
@@ -210,23 +210,17 @@ func TestStepDownLeader_DeletesStaleSucceededJobWhenTargetStillLeader(t *testing
 	}, portopenbao.ClientConfig{}, nil, "")
 
 	ok, err := mgr.stepDownLeader(context.Background(), testr.New(t), cluster, podName, upgrade.NewMetrics(ns, name))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if err == nil {
+		t.Fatal("expected step-down timeout error")
 	}
 	if ok {
-		t.Fatalf("expected step-down to remain in progress while leader transfer is not yet observed")
+		t.Fatalf("expected step-down to remain incomplete after timeout")
 	}
-	if cluster.Status.Upgrade.LastErrorReason != "" {
-		t.Fatalf("expected LastErrorReason to remain empty, got %q", cluster.Status.Upgrade.LastErrorReason)
+	if cluster.Status.Upgrade.LastErrorReason != upgrade.ReasonStepDownTimeout {
+		t.Fatalf("LastErrorReason=%q, want %q", cluster.Status.Upgrade.LastErrorReason, upgrade.ReasonStepDownTimeout)
 	}
-
-	gotJob := &batchv1.Job{}
-	getErr := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: jobName}, gotJob)
-	if getErr == nil {
-		t.Fatalf("expected stale succeeded step-down job to be deleted for retry")
-	}
-	if !apierrors.IsNotFound(getErr) {
-		t.Fatalf("expected NotFound after deleting stale step-down job, got %v", getErr)
+	if cluster.Status.Upgrade.LastErrorMessage != "Leader step-down timed out for pod "+podName {
+		t.Fatalf("LastErrorMessage=%q, want %q", cluster.Status.Upgrade.LastErrorMessage, "Leader step-down timed out for pod "+podName)
 	}
 }
 

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -482,6 +482,16 @@ func TestPerformPodByPodUpgrade_ResumesWhenTargetAlreadyRolledOut(t *testing.T) 
 	if len(cluster.Status.Upgrade.CompletedPods) != 3 || cluster.Status.Upgrade.CompletedPods[2] != 0 {
 		t.Fatalf("CompletedPods=%v, want [2 1 0]", cluster.Status.Upgrade.CompletedPods)
 	}
+	updatedSTS := &appsv1.StatefulSet{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(sts), updatedSTS); err != nil {
+		t.Fatalf("expected to reload StatefulSet, got %v", err)
+	}
+	if updatedSTS.Spec.UpdateStrategy.RollingUpdate == nil || updatedSTS.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+		t.Fatalf("expected StatefulSet partition to be set")
+	}
+	if *updatedSTS.Spec.UpdateStrategy.RollingUpdate.Partition != 0 {
+		t.Fatalf("partition=%d, want 0", *updatedSTS.Spec.UpdateStrategy.RollingUpdate.Partition)
+	}
 
 	jobList := &batchv1.JobList{}
 	if err := c.List(context.Background(), jobList); err != nil {

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -371,6 +371,127 @@ func TestStepDownLeader_SkipsJobWhenTargetPodIsNotLeader(t *testing.T) {
 	}
 }
 
+func TestPerformPodByPodUpgrade_ResumesWhenTargetAlreadyRolledOut(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = openbaov1alpha1.AddToScheme(scheme)
+
+	ns := testNamespace
+	name := "c1"
+	podName := name + "-0"
+	startedAt := metav1.Now()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+			TLS: openbaov1alpha1.TLSConfig{
+				Enabled: true,
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				StartedAt:        &startedAt,
+				TargetVersion:    "2.5.2",
+				FromVersion:      "2.5.1",
+				CurrentPartition: 1,
+				CompletedPods:    []int32{2, 1},
+			},
+		},
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.ContainerBao,
+							Image: "openbao/openbao:2.5.2",
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "rev-new",
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			Labels: map[string]string{
+				appsv1.StatefulSetRevisionLabel: "rev-new",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  constants.ContainerBao,
+					Image: "openbao/openbao:2.5.2",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + constants.SuffixTLSCA,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{
+			"ca.crt": []byte("fake-ca"),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts, pod, caSecret).Build()
+	mgr := NewManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
+		return &openbaoapi.MockClusterActions{
+			IsHealthyFunc: func(ctx context.Context) (bool, error) {
+				return true, nil
+			},
+		}, nil
+	}, portopenbao.ClientConfig{}, nil, "")
+
+	completed, err := mgr.performPodByPodUpgrade(context.Background(), testr.New(t), cluster, upgrade.NewMetrics(ns, name))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !completed {
+		t.Fatalf("expected upgrade to be treated as completed")
+	}
+	if cluster.Status.Upgrade.CurrentPartition != 0 {
+		t.Fatalf("CurrentPartition=%d, want 0", cluster.Status.Upgrade.CurrentPartition)
+	}
+	if len(cluster.Status.Upgrade.CompletedPods) != 3 || cluster.Status.Upgrade.CompletedPods[2] != 0 {
+		t.Fatalf("CompletedPods=%v, want [2 1 0]", cluster.Status.Upgrade.CompletedPods)
+	}
+
+	jobList := &batchv1.JobList{}
+	if err := c.List(context.Background(), jobList); err != nil {
+		t.Fatalf("expected listing jobs to succeed, got %v", err)
+	}
+	if len(jobList.Items) != 0 {
+		t.Fatalf("expected no step-down jobs to be created, got %d", len(jobList.Items))
+	}
+}
+
 func TestWaitForPodRevisionUpdated_WaitsUntilRevisionMatches(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme)

--- a/internal/service/upgrade/rolling/workflow_prepare.go
+++ b/internal/service/upgrade/rolling/workflow_prepare.go
@@ -37,6 +37,13 @@ func (m *Manager) prepareUpgradeExecution(
 		return recon.Result{}, false, err
 	}
 
+	if result, waiting, err := m.ensureReadReplicaPoolReadyForRollingUpgrade(ctx, logger, cluster); waiting || err != nil {
+		if waiting && err == nil {
+			m.recordInProgressMetrics(metrics, cluster)
+		}
+		return result, waiting, err
+	}
+
 	m.recordInProgressMetrics(metrics, cluster)
 	return recon.Result{}, false, nil
 }

--- a/internal/service/workload/spec.go
+++ b/internal/service/workload/spec.go
@@ -25,6 +25,11 @@ type StatefulSetSpec struct {
 	// ConfigHash is used for pod annotations to trigger restarts on config changes
 	ConfigHash string
 
+	// RestartAt overrides the effective pod-template restart annotation for this
+	// workload pool. Nil falls back to the cluster-level runtime or deprecated
+	// maintenance restart request.
+	RestartAt *string
+
 	// DisableSelfInit prevents pod self-initialization (used for Green pods in BlueGreen)
 	DisableSelfInit bool
 

--- a/internal/service/workload/statefulset_builder_spec.go
+++ b/internal/service/workload/statefulset_builder_spec.go
@@ -212,6 +212,19 @@ func buildStatefulSetPodLabelsAndAnnotations(cluster *openbaov1alpha1.OpenBaoClu
 	// Compute config hash and add to annotations to trigger rollout on config changes
 	annotations[configHashAnnotation] = computeConfigHash(configContent)
 
+	restartAt := effectiveRestartAt(cluster, spec)
+	if restartAt != "" {
+		annotations[constants.AnnotationRestartAt] = restartAt
+	}
+
+	return podLabels, annotations
+}
+
+func effectiveRestartAt(cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSpec) string {
+	if spec.RestartAt != nil {
+		return strings.TrimSpace(*spec.RestartAt)
+	}
+
 	restartAt := ""
 	if cluster.Spec.Runtime != nil {
 		restartAt = strings.TrimSpace(cluster.Spec.Runtime.RestartAt)
@@ -219,9 +232,5 @@ func buildStatefulSetPodLabelsAndAnnotations(cluster *openbaov1alpha1.OpenBaoClu
 	if restartAt == "" && cluster.Spec.Maintenance != nil {
 		restartAt = strings.TrimSpace(cluster.Spec.Maintenance.RestartAt)
 	}
-	if restartAt != "" {
-		annotations[constants.AnnotationRestartAt] = restartAt
-	}
-
-	return podLabels, annotations
+	return restartAt
 }

--- a/internal/service/workload/statefulset_builder_test.go
+++ b/internal/service/workload/statefulset_builder_test.go
@@ -180,6 +180,28 @@ func TestBuildStatefulSet_DeprecatedMaintenanceRestartAtFallback(t *testing.T) {
 	}
 }
 
+func TestBuildStatefulSetForSpec_UsesPoolSpecificRestartOverride(t *testing.T) {
+	cluster := newMinimalCluster("read-restart-override-cluster", "default")
+	cluster.Spec.Runtime = &openbaov1alpha1.RuntimeConfig{
+		RestartAt: testRuntimeRestartAt,
+	}
+
+	override := "2026-01-20T00:00:00Z"
+	statefulSet, err := buildStatefulSetForSpec(cluster, "test-config", true, StatefulSetSpec{
+		Name:      "read-restart-override-cluster-read",
+		Pool:      constants.LabelValueOpenBaoWorkloadPoolReadReplica,
+		Replicas:  1,
+		RestartAt: &override,
+	}, constants.PlatformKubernetes)
+	if err != nil {
+		t.Fatalf("buildStatefulSetForSpec() error = %v", err)
+	}
+
+	if got := statefulSet.Spec.Template.Annotations[constants.AnnotationRestartAt]; got != override {
+		t.Fatalf("expected pool-specific restart override %q, got %q", override, got)
+	}
+}
+
 func TestBuildStatefulSet_DeletesPVCsOnlyWhenScaledDown(t *testing.T) {
 	cluster := newMinimalCluster("scaledown-pvc-cluster", "default")
 

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -108,7 +108,7 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	mkdir -p dist; \
 	cp -R config "$$tmp/config"; \
 	for f in "$$tmp/config/manager/controller.yaml" "$$tmp/config/manager/provisioner.yaml"; do \
-		python3 -c 'import pathlib,re,sys; p=pathlib.Path(sys.argv[1]); v=sys.argv[2]; q=chr(34); s=p.read_text(encoding="utf-8"); s=re.sub(r"(\\n\\s*-\\s*name:\\s*OPERATOR_VERSION\\s*\\n\\s*value:\\s*)(\\\"[^\\\"]*\\\"|[^\\n#]+)", lambda m: m.group(1)+q+v+q, s, count=1); p.write_text(s, encoding="utf-8")' "$$f" "$(OPERATOR_VERSION)"; \
+		python3 -c 'import pathlib,re,sys; p=pathlib.Path(sys.argv[1]); v=sys.argv[2]; q=chr(34); s=p.read_text(encoding="utf-8"); s=re.sub(r"(\n\s*-\s*name:\s*OPERATOR_VERSION\s*\n\s*value:\s*)(\"[^\"]*\"|[^\n#]+)", lambda m: m.group(1)+q+v+q, s, count=1); p.write_text(s, encoding="utf-8")' "$$f" "$(OPERATOR_VERSION)"; \
 	done; \
 		( cd "$$tmp/config/manager" && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
 		"$(KUSTOMIZE)" build "$$tmp/config/default" > "$$out"

--- a/mk/deploy.mk
+++ b/mk/deploy.mk
@@ -24,7 +24,7 @@ deploy: manifests kustomize ## Deploy both provisioner and controller to the K8s
 	trap 'rm -rf "$$tmp"' EXIT; \
 	cp -R config "$$tmp/config"; \
 	for f in "$$tmp/config/manager/controller.yaml" "$$tmp/config/manager/provisioner.yaml"; do \
-		python3 -c 'import pathlib,re,sys; p=pathlib.Path(sys.argv[1]); v=sys.argv[2]; q=chr(34); s=p.read_text(encoding="utf-8"); s=re.sub(r"(\\n\\s*-\\s*name:\\s*OPERATOR_VERSION\\s*\\n\\s*value:\\s*)(\\\"[^\\\"]*\\\"|[^\\n#]+)", lambda m: m.group(1)+q+v+q, s, count=1); p.write_text(s, encoding="utf-8")' "$$f" "$(OPERATOR_VERSION)"; \
+		python3 -c 'import pathlib,re,sys; p=pathlib.Path(sys.argv[1]); v=sys.argv[2]; q=chr(34); s=p.read_text(encoding="utf-8"); s=re.sub(r"(\n\s*-\s*name:\s*OPERATOR_VERSION\s*\n\s*value:\s*)(\"[^\"]*\"|[^\n#]+)", lambda m: m.group(1)+q+v+q, s, count=1); p.write_text(s, encoding="utf-8")' "$$f" "$(OPERATOR_VERSION)"; \
 	done; \
 	( cd "$$tmp/config/manager" && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
 	"$(KUSTOMIZE)" build "$$tmp/config/default" | "$(KUBECTL)" apply -f -
@@ -32,9 +32,15 @@ deploy: manifests kustomize ## Deploy both provisioner and controller to the K8s
 .PHONY: deploy-dev
 deploy-dev: ## Build, push, and deploy the manager image (avoids stale local tags).
 	@dev_img="$${IMG:-k3d-registry.localhost:5000/openbao-operator:dev-$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"; \
+	if [ "$(OPERATOR_VERSION)" = "0.0.0" ]; then \
+		dev_operator_version=edge; \
+	else \
+		dev_operator_version="$(OPERATOR_VERSION)"; \
+	fi; \
 	echo "Deploying dev image: $$dev_img"; \
+	echo "Using OPERATOR_VERSION=$$dev_operator_version for dev helper images"; \
 	$(MAKE) docker-build docker-push IMG="$$dev_img"; \
-	$(MAKE) deploy IMG="$$dev_img"
+	$(MAKE) deploy IMG="$$dev_img" OPERATOR_VERSION="$$dev_operator_version"
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy both provisioner and controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion. Call with wait=false to avoid waiting for finalizers.

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -32,7 +32,9 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/bluegreen"
 	"github.com/dc-tec/openbao-operator/test/e2e/framework"
@@ -475,6 +477,12 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 					Version:  initialVersion,
 					Image:    initialImage,
 					Replicas: 3,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 1,
+						Service: &openbaov1alpha1.ReadReplicaServiceConfig{
+							Enabled: true,
+						},
+					},
 					InitContainer: &openbaov1alpha1.InitContainerConfig{
 						Enabled: true,
 						Image:   configInitImage,
@@ -516,6 +524,38 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				g.Expect(available.Status).To(Equal(metav1.ConditionTrue))
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 			tenantFW.WaitForStatefulSetReady(ctx, upgradeCluster.Name, 3, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval)
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: upgradeCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
+				g.Expect(updated.Status.ReadReplicas).NotTo(BeNil())
+				g.Expect(updated.Status.ReadReplicas.DesiredReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.ReadyReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.RegisteredReplicas).To(Equal(int32(1)))
+
+				for _, condType := range []openbaov1alpha1.ConditionType{
+					openbaov1alpha1.ConditionReadReplicasReady,
+					openbaov1alpha1.ConditionReadServingAvailable,
+					openbaov1alpha1.ConditionRaftMembershipReady,
+					openbaov1alpha1.ConditionReadReplicaStorageConfigured,
+				} {
+					cond := meta.FindStatusCondition(updated.Status.Conditions, string(condType))
+					g.Expect(cond).NotTo(BeNil(), "expected read-replica condition %s", condType)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "expected read-replica condition %s to be true", condType)
+				}
+
+				readSts := &appsv1.StatefulSet{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      resourceidentity.ReadReplicaStatefulSetName(upgradeCluster),
+					Namespace: tenantNamespace,
+				}, readSts)).To(Succeed())
+				g.Expect(readSts.Status.ReadyReplicas).To(Equal(int32(1)))
+
+				readSvc := &corev1.Service{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      resourceidentity.ReadReplicaServiceName(upgradeCluster),
+					Namespace: tenantNamespace,
+				}, readSvc)).To(Succeed())
+			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 		})
 
 		AfterAll(func() {
@@ -536,7 +576,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 			dumpRollingUpgradeDiagnostics(ctx, admin, tenantNamespace, upgradeCluster.Name)
 		})
 
-		It("performs rolling upgrade", func() {
+		It("performs rolling upgrade", Label("read-replicas", "read-replicas-rolling"), func() {
 			cfg, err := ctrlconfig.GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -580,6 +620,63 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				g.Expect(updated.Status.Upgrade.TargetVersion).To(Equal(targetVersion))
 				g.Expect(updated.Status.Upgrade.FromVersion).To(Equal(initialVersion))
 			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+			By("Verifying the steady read pool converges before voter rollout starts")
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: upgradeCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
+				g.Expect(updated.Status.ReadReplicas).NotTo(BeNil())
+				g.Expect(updated.Status.ReadReplicas.ReadyReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.RegisteredReplicas).To(Equal(int32(1)))
+				for _, condType := range []openbaov1alpha1.ConditionType{
+					openbaov1alpha1.ConditionReadReplicasReady,
+					openbaov1alpha1.ConditionReadServingAvailable,
+					openbaov1alpha1.ConditionRaftMembershipReady,
+				} {
+					cond := meta.FindStatusCondition(updated.Status.Conditions, string(condType))
+					g.Expect(cond).NotTo(BeNil(), "expected read-replica condition %s", condType)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "expected read-replica condition %s to be true", condType)
+				}
+
+				readSts := &appsv1.StatefulSet{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      resourceidentity.ReadReplicaStatefulSetName(upgradeCluster),
+					Namespace: tenantNamespace,
+				}, readSts)).To(Succeed())
+				g.Expect(readSts.Status.ReadyReplicas).To(Equal(int32(1)))
+
+				readPods := &corev1.PodList{}
+				g.Expect(admin.List(ctx, readPods,
+					client.InNamespace(tenantNamespace),
+					client.MatchingLabels{
+						constants.LabelOpenBaoCluster:      upgradeCluster.Name,
+						constants.LabelOpenBaoWorkloadPool: constants.LabelValueOpenBaoWorkloadPoolReadReplica,
+					},
+				)).To(Succeed())
+				g.Expect(readPods.Items).To(HaveLen(1))
+				for _, pod := range readPods.Items {
+					e2ehelpers.ExpectOpenBaoPodVersion(g, pod, targetVersion)
+				}
+
+				voterPods := &corev1.PodList{}
+				g.Expect(admin.List(ctx, voterPods,
+					client.InNamespace(tenantNamespace),
+					client.MatchingLabels{
+						constants.LabelOpenBaoCluster:      upgradeCluster.Name,
+						constants.LabelOpenBaoWorkloadPool: constants.LabelValueOpenBaoWorkloadPoolVoter,
+					},
+				)).To(Succeed())
+				g.Expect(voterPods.Items).To(HaveLen(int(upgradeCluster.Spec.Replicas)))
+
+				voterRolloutStarted := false
+				for _, pod := range voterPods.Items {
+					if pod.Labels[portopenbao.LabelVersion] == targetVersion {
+						voterRolloutStarted = true
+						break
+					}
+				}
+				g.Expect(voterRolloutStarted).To(BeTrue(), "expected voter rollout to start after the steady read pool converged")
+			}, 20*time.Minute, 5*time.Second).Should(Succeed())
 
 			By("Monitoring rolling invariants during upgrade")
 			var (
@@ -672,6 +769,20 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				g.Expect(updated.Status.Upgrade).To(BeNil(), "Status.Upgrade should be cleared when upgrade completes")
 				g.Expect(updated.Status.CurrentVersion).To(Equal(targetVersion))
 				g.Expect(updated.Status.Phase).To(Equal(openbaov1alpha1.ClusterPhaseRunning))
+				g.Expect(updated.Status.ReadReplicas).NotTo(BeNil())
+				g.Expect(updated.Status.ReadReplicas.DesiredReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.ReadyReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.RegisteredReplicas).To(Equal(int32(1)))
+				for _, condType := range []openbaov1alpha1.ConditionType{
+					openbaov1alpha1.ConditionReadReplicasReady,
+					openbaov1alpha1.ConditionReadServingAvailable,
+					openbaov1alpha1.ConditionRaftMembershipReady,
+					openbaov1alpha1.ConditionReadReplicaStorageConfigured,
+				} {
+					cond := meta.FindStatusCondition(updated.Status.Conditions, string(condType))
+					g.Expect(cond).NotTo(BeNil(), "expected read-replica condition %s", condType)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "expected read-replica condition %s to be true", condType)
+				}
 
 				// Strict verification: Check that all pods are running the target image
 				podList := &corev1.PodList{}
@@ -684,6 +795,13 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				for _, pod := range podList.Items {
 					e2ehelpers.ExpectOpenBaoPodVersion(g, pod, targetVersion)
 				}
+
+				readSts := &appsv1.StatefulSet{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      resourceidentity.ReadReplicaStatefulSetName(upgradeCluster),
+					Namespace: tenantNamespace,
+				}, readSts)).To(Succeed())
+				g.Expect(readSts.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, 20*time.Minute, 10*time.Second).Should(Succeed())
 
 			By("Verifying rolling step-down jobs are deterministic and successful")

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -2508,6 +2508,9 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				updated := &openbaov1alpha1.OpenBaoCluster{}
 				g.Expect(admin.Get(ctx, types.NamespacedName{Name: failureCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
 				g.Expect(updated.Status.Initialized).To(BeTrue())
+				g.Expect(updated.Status.CurrentVersion).To(Equal(initialVersion))
+				g.Expect(updated.Status.BlueGreen).NotTo(BeNil())
+				g.Expect(updated.Status.BlueGreen.Phase).To(Equal(openbaov1alpha1.PhaseIdle))
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 		})
 

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -27,6 +27,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	restoresvc "github.com/dc-tec/openbao-operator/internal/service/restore"
 	"github.com/dc-tec/openbao-operator/test/e2e/framework"
 	e2ehelpers "github.com/dc-tec/openbao-operator/test/e2e/helpers"
@@ -281,6 +282,9 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 					Version:  openBaoVersion,
 					Image:    openBaoImage,
 					Replicas: 1,
+					ReadReplicas: &openbaov1alpha1.ReadReplicaConfig{
+						Replicas: 1,
+					},
 					InitContainer: &openbaov1alpha1.InitContainerConfig{
 						Enabled: true,
 						Image:   configInitImage,
@@ -441,6 +445,33 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 				g.Expect(available.Status).To(Equal(metav1.ConditionTrue))
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: drCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
+				g.Expect(updated.Status.ReadReplicas).NotTo(BeNil())
+				g.Expect(updated.Status.ReadReplicas.DesiredReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.ReadyReplicas).To(Equal(int32(1)))
+				g.Expect(updated.Status.ReadReplicas.RegisteredReplicas).To(Equal(int32(1)))
+
+				for _, condType := range []openbaov1alpha1.ConditionType{
+					openbaov1alpha1.ConditionReadReplicasReady,
+					openbaov1alpha1.ConditionReadServingAvailable,
+					openbaov1alpha1.ConditionRaftMembershipReady,
+					openbaov1alpha1.ConditionReadReplicaStorageConfigured,
+				} {
+					cond := meta.FindStatusCondition(updated.Status.Conditions, string(condType))
+					g.Expect(cond).NotTo(BeNil(), "expected read-replica condition %s", condType)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "expected read-replica condition %s to be true", condType)
+				}
+
+				readSts := &appsv1.StatefulSet{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      resourceidentity.ReadReplicaStatefulSetName(drCluster),
+					Namespace: tenantNamespace,
+				}, readSts)).To(Succeed())
+				g.Expect(readSts.Status.ReadyReplicas).To(Equal(int32(1)))
+			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
 			Expect(tenantFW.TriggerReconcile(ctx, drCluster.Name)).To(Succeed())
 			tenantFW.WaitForConditionReason(drCluster.Name, openbaov1alpha1.ConditionBackupConfigurationReady, metav1.ConditionTrue, "Ready")
 		})
@@ -454,7 +485,7 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 			_ = tenantFW.Cleanup(cleanupCtx)
 		})
 
-		It("triggers manual backup to S3", func() {
+		It("triggers manual backup to S3", Label("read-replicas", "read-replicas-restore"), func() {
 			By("Writing a secret before backup")
 			secretPath := "secret/backup-test"
 			secretData := map[string]string{"foo": "bar", "version": "v1"}
@@ -500,7 +531,7 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 		})
 
-		It("executes backup job successfully to S3", func() {
+		It("executes backup job successfully to S3", Label("read-replicas", "read-replicas-restore"), func() {
 			By("waiting for the S3 backup job to complete successfully")
 			Eventually(func(g Gomega) {
 				var jobs batchv1.JobList
@@ -533,7 +564,7 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 			}, framework.DefaultLongWaitTimeout, 5*time.Second).Should(Succeed())
 		})
 
-		It("restores from S3 backup using OpenBaoRestore CR", func() {
+		It("restores from S3 backup using OpenBaoRestore CR", Label("read-replicas", "read-replicas-restore"), func() {
 			Expect(backupKey).NotTo(BeEmpty(), "backup key should have been set by previous test")
 
 			restore := &openbaov1alpha1.OpenBaoRestore{
@@ -576,11 +607,71 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 				g.Expect(configuration.Reason).To(Equal("Ready"))
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 
+			By("waiting for restore to drain steady read replicas before execution continues")
+			Eventually(func(g Gomega) {
+				updatedRestore := &openbaov1alpha1.OpenBaoRestore{}
+				err := admin.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: tenantNamespace}, updatedRestore)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(updatedRestore.Status.Phase).NotTo(Equal(openbaov1alpha1.RestorePhaseFailed))
+
+				cluster := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: drCluster.Name, Namespace: tenantNamespace}, cluster)).To(Succeed())
+				g.Expect(cluster.Status.ReadReplicas).NotTo(BeNil())
+				g.Expect(cluster.Status.ReadReplicas.DesiredReplicas).To(Equal(int32(1)))
+				if updatedRestore.Status.Phase == openbaov1alpha1.RestorePhaseRunning {
+					g.Expect(cluster.Status.ReadReplicas.ReadyReplicas).To(Equal(int32(0)))
+
+					readReady := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionReadReplicasReady))
+					g.Expect(readReady).NotTo(BeNil())
+					g.Expect(readReady.Status).To(Equal(metav1.ConditionFalse))
+
+					readServing := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionReadServingAvailable))
+					g.Expect(readServing).NotTo(BeNil())
+					g.Expect(readServing.Status).To(Equal(metav1.ConditionFalse))
+
+					raftMembership := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionRaftMembershipReady))
+					g.Expect(raftMembership).NotTo(BeNil())
+					g.Expect(raftMembership.Status).To(Equal(metav1.ConditionFalse))
+
+					readSts := &appsv1.StatefulSet{}
+					g.Expect(admin.Get(ctx, types.NamespacedName{
+						Name:      resourceidentity.ReadReplicaStatefulSetName(drCluster),
+						Namespace: tenantNamespace,
+					}, readSts)).To(Succeed())
+					g.Expect(readSts.Spec.Replicas).NotTo(BeNil())
+					g.Expect(*readSts.Spec.Replicas).To(Equal(int32(0)))
+					g.Expect(readSts.Status.ReadyReplicas).To(Equal(int32(0)))
+				}
+			}, framework.DefaultLongWaitTimeout, 5*time.Second).Should(Succeed())
+
 			Eventually(func(g Gomega) {
 				updated := &openbaov1alpha1.OpenBaoRestore{}
 				err := admin.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: tenantNamespace}, updated)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(updated.Status.Phase).To(Equal(openbaov1alpha1.RestorePhaseCompleted))
+
+				cluster := &openbaov1alpha1.OpenBaoCluster{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{Name: drCluster.Name, Namespace: tenantNamespace}, cluster)).To(Succeed())
+				g.Expect(cluster.Status.ReadReplicas).NotTo(BeNil())
+				g.Expect(cluster.Status.ReadReplicas.DesiredReplicas).To(Equal(int32(1)))
+				g.Expect(cluster.Status.ReadReplicas.ReadyReplicas).To(Equal(int32(1)))
+				g.Expect(cluster.Status.ReadReplicas.RegisteredReplicas).To(Equal(int32(1)))
+				for _, condType := range []openbaov1alpha1.ConditionType{
+					openbaov1alpha1.ConditionReadReplicasReady,
+					openbaov1alpha1.ConditionReadServingAvailable,
+					openbaov1alpha1.ConditionRaftMembershipReady,
+				} {
+					cond := meta.FindStatusCondition(cluster.Status.Conditions, string(condType))
+					g.Expect(cond).NotTo(BeNil(), "expected read-replica condition %s", condType)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "expected read-replica condition %s to be true", condType)
+				}
+
+				readSts := &appsv1.StatefulSet{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      resourceidentity.ReadReplicaStatefulSetName(drCluster),
+					Namespace: tenantNamespace,
+				}, readSts)).To(Succeed())
+				g.Expect(readSts.Status.ReadyReplicas).To(Equal(int32(1)))
 			}, 15*time.Minute, 30*time.Second).Should(Succeed())
 
 			By("Verifying secret persists after restore")


### PR DESCRIPTION
## Description

This PR integrates steady-state read replicas with the operator's disruptive workflows.

It makes rolling upgrades, BlueGreen upgrades, restore, and restart/storage ordering read-pool aware, and adds focused E2E coverage for those lifecycle paths.

This is PR `2/3` in the horizontal-read-scaling stack and builds on the steady-state foundation from PR `1/3`.

Included in this PR:

- read-first restart and storage-resize ordering
- rolling-upgrade gating on read-pool convergence
- rolling-upgrade recovery/finalization fixes for resumed upgrades
- BlueGreen drain and restore integration for the steady read pool
- BlueGreen terminal state held until the read pool is restored and healthy
- restore drain and restore integration for the steady read pool
- restore completion held until the read pool is restored and healthy
- upgrade/adminops stabilization fixes discovered during manual validation
- `deploy-dev` helper-image version propagation fix for local upgrade testing
- focused E2E coverage for:
  - rolling upgrades with read replicas
  - restore with read replicas

Follow-up docs and Grafana updates land in PR `3/3`.

## Related Issues

- Builds on #361

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

Passed locally:

- `make lint-ci`
- `make test-ci`
- `make test-e2e E2E_LABEL_FILTER='read-replicas'`

Reviewer path:

1. Review the operational integration logic under `internal/service/upgrade`, `internal/service/restore`, and related app/controller glue.
2. Run `make test-ci`.
3. Run `make test-e2e E2E_LABEL_FILTER='read-replicas'`.
