### PR TITLE
docs(readreplicas): document operations and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-OpenBao Operator is a Kubernetes operator for [OpenBao](https://openbao.org) that automates lifecycle management: provisioning, TLS, backups/restores, upgrades, and multi-tenancy controls.
+OpenBao Operator is a Kubernetes operator for [OpenBao](https://openbao.org) that automates lifecycle management: provisioning, TLS, backups/restores, upgrades, horizontal read scaling, and multi-tenancy controls.
 
 ## Documentation
 
@@ -64,6 +64,7 @@ For full details, see the [Compatibility Matrix](https://dc-tec.github.io/openba
 - **Streaming Raft Backups**: Snapshot streaming to S3/GCS/Azure with retention controls (no local staging).
 - **Declarative Restores**: Restore workflows via `OpenBaoRestore` with operation locking and safe overrides.
 - **Safe Upgrades**: Rolling and blue/green upgrade strategies, including pre-upgrade snapshots. `RollingUpdate` is the default recommended strategy.
+- **Horizontal Read Scaling**: Steady-state read replicas as non-voters, with a dedicated read Service and a shared primary endpoint that can include read replicas.
 - **Multi-Tenancy**: Namespace-scoped tenancy model with policy enforcement via `OpenBaoTenant`. Multi-tenant mode is the default and recommended production operating model.
 
 ## Security Model

--- a/config/grafana/README.md
+++ b/config/grafana/README.md
@@ -6,7 +6,7 @@ This directory contains sample Grafana dashboards for monitoring OpenBao Operato
 
 The dashboards provide monitoring of OpenBao Operator operations across several key areas:
 
-- `dashboards/overview.json` - Key cluster signals at a glance (upgrade, backup, replicas, TLS)
+- `dashboards/overview.json` - Key cluster signals at a glance (upgrade, backup, voter replicas, read replicas, TLS)
 - `dashboards/backup-restore.json` - Backups and restore operations
 - `dashboards/upgrades.json` - Upgrade progress and upgrade performance
 - `optional/controller-runtime/dashboard.json` - Operator controller-runtime health signals (workqueues, reconcile metrics) (optional)
@@ -94,6 +94,10 @@ The following metrics are implemented and will display data:
   - `openbao_restore_failure_total`
   - `openbao_restore_duration_seconds`
   - `openbao_cluster_ready_replicas`
+  - `openbao_cluster_read_replicas_desired`
+  - `openbao_cluster_read_replicas_ready`
+  - `openbao_cluster_read_replicas_registered`
+  - `openbao_cluster_read_replicas_healthy`
   - `openbao_cluster_phase`
   - `openbao_reconcile_duration_seconds`
   - `openbao_reconcile_errors_total`

--- a/config/grafana/dashboards/overview.json
+++ b/config/grafana/dashboards/overview.json
@@ -289,6 +289,222 @@
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 23,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(openbao_cluster_read_replicas_desired{exported_namespace=\"$namespace\", name=\"$cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Replicas Desired",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 24,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(openbao_cluster_read_replicas_ready{exported_namespace=\"$namespace\", name=\"$cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Replicas Ready",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 25,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(openbao_cluster_read_replicas_registered{exported_namespace=\"$namespace\", name=\"$cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Replicas Registered",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 26,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(openbao_cluster_read_replicas_healthy{exported_namespace=\"$namespace\", name=\"$cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Replicas Healthy",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
           "custom": {
             "spanNulls": true
           },
@@ -299,7 +515,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 4
+        "y": 8
       },
       "id": 5,
       "targets": [
@@ -341,7 +557,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 4
+        "y": 8
       },
       "id": 6,
       "targets": [
@@ -372,7 +588,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 16
       },
       "id": 16,
       "options": {
@@ -416,7 +632,7 @@
         "h": 4,
         "w": 12,
         "x": 12,
-        "y": 12
+        "y": 16
       },
       "id": 13,
       "options": {
@@ -489,7 +705,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 20
       },
       "id": 22,
       "options": {
@@ -596,5 +812,5 @@
   "timezone": "",
   "title": "OpenBao Operator - Overview",
   "uid": "openbao-operator-overview",
-  "version": 1
+  "version": 2
 }

--- a/docs/architecture/workload-managers.md
+++ b/docs/architecture/workload-managers.md
@@ -144,7 +144,7 @@ The bootstrap manager prepares everything the workload needs before the Stateful
 
 The networking manager owns how traffic and policy reach the cluster:
 
-- headless and external Services
+- headless and external Services, including the shared client Service and optional dedicated read Service
 - Ingress and Gateway API resources
 - gateway CA export and backend TLS policy resources
 - workload and job network policies
@@ -163,10 +163,18 @@ The identity manager owns the steady-state Kubernetes identity for the cluster w
 The workload manager owns the StatefulSet-facing contract:
 
 - StatefulSet render and apply
+- steady-state read-replica StatefulSet lifecycle and safe drain or delete behavior
 - PodDisruptionBudget reconciliation
 - rollout triggers from rendered config or certificate hash changes
 - single-replica bootstrap and later scale-out after initialization
 - revision-scoped workload resources used by blue/green and rollout-safe updates
+- read-first or restore-safe operational ordering delegated by the app layer for rolling upgrades, blue-green, and restore
+
+<Callout type="note" title="The shared client endpoint is intentional">
+
+The networking manager keeps the main client Service attached to the shared client-serving selector, which can include both voters and steady read replicas. The optional dedicated read Service remains a separate networking surface for explicit consumers, but the primary endpoint stays stable so OpenBao can handle standby reads and request forwarding itself.
+
+</Callout>
 
 ## Shared contracts on the workload path
 

--- a/docs/security/infrastructure/network-security.md
+++ b/docs/security/infrastructure/network-security.md
@@ -127,6 +127,12 @@ If you need additional ingress, use:
 - `spec.network.ingressRules` for additive peer rules
 - `spec.network.trustedIngressPeers` for user-managed ingress or passthrough proxies
 
+<Callout type="note" title="Read replicas are client-serving Pods">
+
+When steady read replicas are enabled, the main client Service can route to both voter and read-replica Pods. That does not create a separate ingress policy surface by itself; the same cluster ingress rules still govern the client listener, and the optional dedicated read Service remains only a second Service object selecting the same client-serving port on the read pool.
+
+</Callout>
+
 </TabItem>
 
 <TabItem value="egress" label="Egress">
@@ -171,6 +177,12 @@ If you need additional ingress, use:
 <Callout type="note" title="Lifecycle jobs use separate egress assumptions">
 
 Backup and restore do not rely on the main workload policy alone. They use separate job identities and separate network assumptions, which is why `BackupConfigurationReady` and `RestoreConfigurationReady` exist as distinct status signals.
+
+</Callout>
+
+<Callout type="note" title="Steady read replicas are staged out of destructive workflows">
+
+Blue-green promotion and restore intentionally drain the steady read pool before destructive membership or snapshot work starts, then restore it before the workflow completes. That is a network and safety boundary as much as a rollout detail: destructive workflows do not keep a second permanent client-serving non-voter tier online while peer removal or snapshot replacement is in progress.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/configuration/external-access.md
+++ b/docs/user-guide/openbaocluster/configuration/external-access.md
@@ -81,8 +81,8 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
   caption="The service boundary is a choice between where traffic enters, where TLS terminates, and how much of the edge behavior the operator is expected to own."
   code={`flowchart LR
     Client["Client"] --> Edge["Gateway / Ingress / L4 LB"]
-    Edge --> OpenBao["OpenBao public Service"]
-    OpenBao --> Pods["OpenBao Pods"]
+    Edge --> OpenBao["OpenBao client Service"]
+    OpenBao --> Pods["Voter and optional read-replica Pods"]
 
     classDef read fill:transparent,stroke:#79c0ab,stroke-width:2px,color:#e6f4ef;
     classDef process fill:transparent,stroke:#fdd0a4,stroke-width:2px,color:#e6f4ef;
@@ -92,6 +92,14 @@ description: Choose how clients reach OpenBao, decide where TLS terminates, and 
     class Edge process;
     class OpenBao,Pods write;`}
 />
+
+<Callout type="note" title="The default client endpoint is shared">
+
+When steady read replicas are enabled, the operator keeps the main external endpoint attached to the shared client Service. That Service can fan out to both voter and read-replica Pods, relying on OpenBao to serve read-only requests locally and forward write requests to the active leader.
+
+The dedicated read-replica Service remains available for explicit consumers, but the operator does not create a second Gateway or Ingress route for it automatically. Keep the primary hostname as the default client path, and treat the dedicated read Service as an opt-in endpoint for workloads that should land only on the steady read pool.
+
+</Callout>
 
 ## Representative configurations
 
@@ -215,6 +223,11 @@ If you use Traefik v3 with backend TLS validation, configure a `ServersTransport
       label: "Gateway API support",
       description: "Use the detailed Gateway API page when Gateway is the primary edge path.",
       docId: "user-guide/openbaocluster/configuration/gateway-api",
+    },
+    {
+      label: "Read replicas",
+      description: "See the steady-state read-pool contract, status conditions, and day-2 lifecycle before exposing a dedicated read Service.",
+      docId: "user-guide/openbaocluster/configuration/read-replicas",
     },
     {
       label: "Network configuration",

--- a/docs/user-guide/openbaocluster/configuration/gateway-api.md
+++ b/docs/user-guide/openbaocluster/configuration/gateway-api.md
@@ -202,7 +202,9 @@ When backend TLS is enabled, the operator creates a `BackendTLSPolicy` that pins
 
 <Callout type="note" title="Blue-green upgrades keep the route stable">
 
-During blue-green cutover, the operator keeps the Gateway route attached to the stable external Service and updates the Service selector behind it. That means the route object stays steady while the selected revision changes underneath.
+During blue-green cutover, the operator keeps the Gateway route attached to the stable external Service and updates the Service selector behind it. When steady read replicas are enabled, that same external Service can fan out to both voter and read-replica Pods during normal operation, relying on OpenBao to serve reads locally and forward writes to the active leader. During blue-green cutover the selector is temporarily narrowed to the active voter revision, so the route object stays steady while the selected backend set changes underneath.
+
+The operator does not create a second Gateway route for the dedicated read-replica Service yet. If you need an explicit read-only hostname, keep that as a separate edge concern for now.
 
 </Callout>
 
@@ -213,6 +215,11 @@ During blue-green cutover, the operator keeps the Gateway route attached to the 
       label: "Network configuration",
       description: "Align trusted ingress peers and external dependency egress with the Gateway path you just chose.",
       docId: "user-guide/openbaocluster/configuration/network",
+    },
+    {
+      label: "Read replicas",
+      description: "Review the shared client endpoint and optional dedicated read Service before exposing the cluster through a Gateway.",
+      docId: "user-guide/openbaocluster/configuration/read-replicas",
     },
     {
       label: "External access",

--- a/docs/user-guide/openbaocluster/configuration/index.mdx
+++ b/docs/user-guide/openbaocluster/configuration/index.mdx
@@ -57,6 +57,12 @@ description: Configure OpenBaoCluster profiles, bootstrap behavior, storage, exp
     },
     {
       eyebrow: '05',
+      title: 'Read scaling',
+      description: 'Add a steady-state read-replica pool when you need a second workload tier, explicit read offload, or separate read-pool storage and placement.',
+      docId: 'user-guide/openbaocluster/configuration/read-replicas',
+    },
+    {
+      eyebrow: '06',
       title: 'Platform readiness',
       description: 'Set storage, observability, and environment-specific constraints such as private registries early in the cluster design.',
       docId: 'user-guide/openbaocluster/configuration/resources-storage',

--- a/docs/user-guide/openbaocluster/configuration/observability.md
+++ b/docs/user-guide/openbaocluster/configuration/observability.md
@@ -182,6 +182,13 @@ spec:
     },
     {
       cells: [
+        "Steady read pool",
+        "`openbao_cluster_read_replicas_desired`, `_ready`, `_registered`, `_healthy`, plus read-replica conditions such as `ReadServingAvailable` and `ReadReplicasAutopilotHealthy`",
+        "This tells you whether the steady read tier exists, has actually joined, and is still healthy enough for the topology you placed it in.",
+      ],
+    },
+    {
+      cells: [
         "Backup freshness",
         "`openbao_backup_last_success_timestamp`, `openbao_backup_consecutive_failures`, and the backup status conditions",
         "These signals show whether the snapshots you plan to restore are current and successful.",
@@ -222,11 +229,17 @@ spec:
         - alert: OpenBaoBackupStale
           expr: time() - openbao_backup_last_success_timestamp > 86400
           for: 15m
+        - alert: OpenBaoReadReplicaPoolDegraded
+          expr: openbao_cluster_read_replicas_desired > openbao_cluster_read_replicas_healthy
+          for: 10m
+        - alert: OpenBaoReadReplicaPoolNotRegistered
+          expr: openbao_cluster_read_replicas_desired > openbao_cluster_read_replicas_registered
+          for: 10m
         - alert: OpenBaoReconcileErrors
           expr: rate(openbao_reconcile_errors_total[5m]) > 0.1
           for: 10m`}
 >
-  Keep the first alert set small. Availability, backup freshness, and sustained reconcile failure are the highest-value starting signals.
+  Keep the first alert set small. Availability, backup freshness, sustained read-pool degradation, and sustained reconcile failure are the highest-value starting signals.
 </CommandBlock>
 
 ## Dashboards, logs, and health
@@ -255,6 +268,12 @@ spec:
 <Callout type="tip" title="Keep operator metrics and workload telemetry separate in your dashboards">
 
 Build dashboards that show both surfaces together and still make it obvious whether a failure is in the operator control plane or in the OpenBao workload itself.
+
+</Callout>
+
+<Callout type="note" title="The overview dashboard now includes the steady read pool">
+
+`config/grafana/dashboards/overview.json` now shows desired, ready, registered, and Autopilot-healthy read-replica counts next to the existing cluster-level signals. Use that view for the first operational pass, then build more topology-specific dashboards if your placement strategy needs them.
 
 </Callout>
 

--- a/docs/user-guide/openbaocluster/configuration/read-replicas.md
+++ b/docs/user-guide/openbaocluster/configuration/read-replicas.md
@@ -1,0 +1,307 @@
+---
+title: Read Replicas
+slug: /configure/read-replicas
+hide_title: true
+pageType: task
+journey: configure
+description: Configure steady-state non-voter read replicas, their endpoint model, and the status and lifecycle signals that keep the pool operationally safe.
+---
+
+<PageHeader
+  title="Configure read replicas"
+  lede="Read replicas add a steady-state non-voter pool for read scaling and placement isolation. The operator keeps the main client endpoint stable, can create a dedicated read Service, and stages the pool deliberately during destructive workflows."
+/>
+
+<DecisionTable
+  title="What enabling read replicas changes"
+  columns={["Surface", "Operator behavior", "Why it matters"]}
+  rows={[
+    {
+      cells: [
+        "Workload topology",
+        "Creates a second StatefulSet for the steady-state non-voter read pool.",
+        "The read pool becomes a first-class workload tier with its own lifecycle, storage, and template overrides.",
+      ],
+      emphasis: "recommended",
+    },
+    {
+      cells: [
+        "Primary client endpoint",
+        "Keeps the main client Service shared across voter and read-replica Pods.",
+        "Clients can stay on one hostname while OpenBao handles standby or non-voter read traffic and forwards leader-only operations as needed.",
+      ],
+    },
+    {
+      cells: [
+        "Dedicated read endpoint",
+        "Optionally creates a separate read Service that selects only steady read replicas.",
+        "Use it when a workload should opt into explicit read offload instead of relying on the shared primary endpoint.",
+      ],
+    },
+    {
+      cells: [
+        "Destructive workflows",
+        "Stages the steady read pool down for restore and blue-green cutover, then restores it before the workflow completes.",
+        "This keeps peer removal, promotion, and restore semantics deterministic instead of mixing steady non-voters into destructive phases.",
+      ],
+    },
+  ]}
+/>
+
+<DiagramFrame
+  title="Endpoint model for read replicas"
+  caption="The main endpoint stays stable and can reach any client-serving Pod. The optional read Service exists for explicit consumers that want only the read pool."
+  code={`flowchart LR
+    Client["Client"] --> Main["<cluster>-public"]
+    Client --> Read["<cluster>-read (optional)"]
+    Main --> Voters["Voter Pods"]
+    Main --> Reads["Read-replica Pods"]
+    Read --> Reads
+    Reads --> Leader["OpenBao forwards writes to the leader"]
+
+    classDef read fill:transparent,stroke:#79c0ab,stroke-width:2px,color:#e6f4ef;
+    classDef process fill:transparent,stroke:#fdd0a4,stroke-width:2px,color:#e6f4ef;
+    classDef write fill:transparent,stroke:#87d6be,stroke-width:2px,color:#e6f4ef;
+
+    class Client read;
+    class Main,Read process;
+    class Voters,Reads,Leader write;`}
+/>
+
+<Callout type="note" title="The primary endpoint stays shared by default">
+
+OpenBao `2.5.x` supports standby and non-voter read scaling together with request forwarding. The operator follows that contract by keeping the primary endpoint attached to the shared client Service instead of trying to classify requests at the edge. A separate read Service is still available when you want an explicit read-pool consumer path.
+
+</Callout>
+
+## Configure the read pool
+
+<CommandBlock
+  language="yaml"
+  label="configure"
+  title="Add a steady-state read-replica pool"
+  code={`spec:
+  replicas: 3
+  readReplicas:
+    replicas: 2
+    service:
+      enabled: true
+      type: ClusterIP
+    template:
+      metadata:
+        labels:
+          workload.openbao.org/tier: read
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
+      scheduling:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                openbao.org/cluster: prod-cluster
+        tolerations:
+          - key: "workload"
+            operator: "Equal"
+            value: "read"
+            effect: "NoSchedule"
+    storage:
+      size: 2Gi
+      storageClassName: fast-ssd`}
+>
+  Use the read pool when you want a steady non-voter tier. `template` and `storage` overrides apply only to the read StatefulSet. Cluster-wide concerns such as TLS, unseal, plugins, and audit remain shared with the voter pool.
+</CommandBlock>
+
+<Callout type="warning" title="Read-pool storage stays validated against the voter pool">
+
+Read-replica storage is intentionally narrower than a full second cluster spec. The operator rejects a read-pool PVC request that is smaller than the voter storage request, and an effective read `storageClassName` becomes immutable once read PVCs exist.
+
+</Callout>
+
+## Decide how clients should use the endpoints
+
+<DecisionTable
+  kind="reference"
+  title="Client endpoint choices"
+  columns={["Endpoint", "Use it when", "What to expect"]}
+  rows={[
+    {
+      cells: [
+        "Primary endpoint",
+        "Most clients should keep using the existing cluster address.",
+        "Requests can land on voters or read replicas. OpenBao then decides whether to serve the request on the target node or forward it to the active leader.",
+      ],
+      emphasis: "recommended",
+    },
+    {
+      cells: [
+        "Dedicated read Service",
+        "You want explicit read offload, separate SLOs, or an endpoint that must never land on the voter pool directly.",
+        "Traffic reaches only the steady read StatefulSet. Write-class requests still rely on OpenBao forwarding semantics rather than Kubernetes request inspection.",
+      ],
+    },
+  ]}
+/>
+
+<Callout type="tip" title="Do not try to split reads and writes at the edge">
+
+The operator does not inspect HTTP methods or paths to decide which Pod should receive a request. Gateway API, Ingress, or a load balancer should send traffic to the chosen Service, and OpenBao should handle standby-read and request-forwarding behavior itself.
+
+</Callout>
+
+## Watch the read-pool status separately
+
+<DecisionTable
+  kind="reference"
+  title="Read-replica conditions"
+  columns={["Condition", "What it proves", "Typical next move"]}
+  rows={[
+    {
+      cells: [
+        "`ReadReplicasReady`",
+        "The read StatefulSet has the expected number of Ready Pods.",
+        "If false, inspect the read StatefulSet, read Pod events, and any template or storage overrides.",
+      ],
+      emphasis: "recommended",
+    },
+    {
+      cells: [
+        "`ReadServingAvailable`",
+        "At least one Ready read replica is actually serving reads.",
+        "If false, inspect `/sys/health` on the read Pods and verify the pool is unsealed and has joined correctly.",
+      ],
+    },
+    {
+      cells: [
+        "`RaftMembershipReady`",
+        "The expected steady non-voter peers are registered in Raft membership.",
+        "If false, inspect membership and safe scale-down behavior before assuming the topology is stable.",
+      ],
+    },
+    {
+      cells: [
+        "`ReadReplicasAutopilotHealthy`",
+        "Autopilot considers the steady read-replica peers healthy from the integrated-storage timing perspective.",
+        "If false, inspect Autopilot state, inter-node latency, and the read pool placement before assuming the pool is a good fit for that topology. If `Unknown`, confirm the `openbao-operator` policy can `read` `sys/storage/raft/autopilot/state`.",
+      ],
+    },
+    {
+      cells: [
+        "`ReadReplicaStorageConfigured`",
+        "The read-pool PVC surface matches the declared storage contract.",
+        "If false, inspect read PVC provisioning, binding, and the effective storage class or size.",
+      ],
+    },
+  ]}
+/>
+
+<Callout type="note" title="Storage status is pool-aware">
+
+`status.readReplicas.storage` records the read-pool PVC state separately from the voter pool. The existing top-level storage condition remains voter-scoped so its meaning does not change under existing automation.
+
+</Callout>
+
+<Callout type="note" title="Read-pool health and read-pool usefulness are different questions">
+
+`ReadReplicasReady`, `ReadServingAvailable`, and `RaftMembershipReady` prove that the operator-created
+topology converged. `ReadReplicasAutopilotHealthy` adds a stricter integrated-storage view of whether
+those non-voters are healthy under the current timing and replication conditions.
+
+</Callout>
+
+<Callout type="warning" title="There is no published RTT limit for read replicas">
+
+OpenBao does not publish a hard maximum network-latency number for steady non-voters. Cross-zone or
+cross-region placement can work, but it is an environment-specific validation question rather than a
+fixed supported RTT budget. Validate the actual placement with your own latency, replication, and
+Autopilot checks instead of relying on a generic rule of thumb.
+
+</Callout>
+
+<Callout type="tip" title="Healthy-cluster request behavior may still rely on forwarding">
+
+In local validation, healthy-cluster reads against read replicas still relied on OpenBao request-forwarding
+behavior for the tested KV path. Treat the shared primary endpoint and dedicated read Service as endpoint
+selection choices, not as a promise that every read is served locally from the target Pod.
+
+</Callout>
+
+<Callout type="warning" title="Do not assume no-quorum read continuity">
+
+Local validation under a stricter leader-voter partition plus added cross-node latency produced
+request stalls and timeouts rather than a clean “reads continue locally” outcome. Treat no-quorum
+read behavior as environment-specific and validate it directly in the failure topology you care
+about before you rely on it for continuity planning.
+
+</Callout>
+
+## Know the day-2 behavior before enabling the pool
+
+<DecisionTable
+  kind="reference"
+  title="Operational behavior"
+  columns={["Workflow", "What the operator does", "Why it is deliberate"]}
+  rows={[
+    {
+      cells: [
+        "Scale up or change template",
+        "Reconciles the read StatefulSet independently from the voter StatefulSet.",
+        "Read-pool rollout and voter rollout do not need to mutate together.",
+      ],
+      emphasis: "recommended",
+    },
+    {
+      cells: [
+        "Disable `spec.readReplicas`",
+        "Removes steady non-voters safely, scales the read StatefulSet to zero, then deletes the read StatefulSet, read Service, and read ConfigMap.",
+        "The topology change is non-destructive to retained PVCs, so disabling the feature does not silently delete storage.",
+      ],
+    },
+    {
+      cells: [
+        "Rolling upgrade",
+        "Upgrades the read pool before allowing voter partition rollout to proceed.",
+        "This preserves read continuity and keeps voter-side disruption behind a converged read pool.",
+      ],
+    },
+    {
+      cells: [
+        "Blue-green upgrade or restore",
+        "Stages steady read replicas down first, performs the destructive work, restores the read pool, and only then marks the workflow complete.",
+        "Steady non-voters are kept out of promotion and restore-critical phases so membership cleanup and completion semantics remain deterministic.",
+      ],
+    },
+  ]}
+/>
+
+<NextActions
+  title="Continue the rollout design"
+  items={[
+    {
+      label: "External access",
+      description: "See how the shared primary endpoint and optional read Service fit Gateway, Ingress, and direct Service exposure.",
+      docId: "user-guide/openbaocluster/configuration/external-access",
+    },
+    {
+      label: "Gateway API",
+      description: "Review how the current Gateway integration keeps one route on the shared client Service.",
+      docId: "user-guide/openbaocluster/configuration/gateway-api",
+    },
+    {
+      label: "Plan upgrades",
+      description: "Understand how rolling and blue-green workflows stage or restore the steady read pool.",
+      docId: "user-guide/openbaocluster/operations/upgrades",
+    },
+    {
+      label: "Restore from backup",
+      description: "See how restore drains the steady read pool before the restore Job and restores it before completion.",
+      docId: "user-guide/openbaorestore/restore",
+    },
+  ]}
+/>

--- a/docs/user-guide/openbaocluster/operations/upgrades.md
+++ b/docs/user-guide/openbaocluster/operations/upgrades.md
@@ -161,6 +161,12 @@ If leadership moves while the rollout is in progress, you may see multiple step-
 
 </Callout>
 
+<Callout type="note" title="Read replicas change the rollout ordering">
+
+When steady read replicas are configured, the operator upgrades the read pool first and only then starts the voter partition rollout. For blue-green, the operator stages the steady read pool down before cutover, restores it afterward, and only then returns the workflow to `Idle`.
+
+</Callout>
+
 ## Use blue-green when you need a controlled cutover
 
 Choose `BlueGreen` when you need parallel validation, a manual promotion point, or stronger rollback boundaries before the new revision takes over production traffic.

--- a/docs/user-guide/openbaorestore/restore.md
+++ b/docs/user-guide/openbaorestore/restore.md
@@ -120,6 +120,12 @@ That keeps the restore path aligned with the backup path you have already proven
 
 </Callout>
 
+<Callout type="note" title="Restore drains and restores steady read replicas deliberately">
+
+When the target cluster has steady read replicas enabled, restore first drains that pool to zero, then launches the restore Job. After the snapshot is forced into the cluster, the operator restores the steady read pool and only marks the `OpenBaoRestore` as `Completed` once the read-replica conditions are healthy again.
+
+</Callout>
+
 ## Configure the snapshot source
 
 <Tabs groupId="restore-source-provider">

--- a/docs/user-guide/operator/authn.md
+++ b/docs/user-guide/operator/authn.md
@@ -75,6 +75,15 @@ If you use self-init, create human access in the same bootstrap contract through
 
 </Callout>
 
+<Callout type="warning" title="Bootstrap does not mean ongoing policy reconciliation">
+
+`spec.selfInit.oidc.enabled: true` bootstraps the controller JWT auth method, policy, and role.
+After bootstrap, the operator uses that auth surface but does not continue mutating OpenBao
+policies on its own. When a later operator release needs an additional controller capability,
+the human operator must update the `openbao-operator` policy explicitly.
+
+</Callout>
+
 <DecisionTable
   title="Bootstrap authentication surfaces"
   columns={['Surface', 'Where it is defined', 'Why it exists']}
@@ -124,6 +133,29 @@ If you use self-init, create human access in the same bootstrap contract through
   ]}
 />
 
+<DecisionTable
+  kind="reference"
+  title="Who owns policy changes after bootstrap"
+  columns={['Install shape', 'Who creates the initial policy', 'Who updates it later']}
+  rows={[
+    {
+      cells: [
+        'Self-init with OIDC',
+        'The bootstrap contract created by the operator during self-init.',
+        'The human operator. Self-init does not keep mutating OpenBao policies after the cluster is initialized.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'Manual JWT configuration',
+        'The cluster administrator.',
+        'The cluster administrator.',
+      ],
+    },
+  ]}
+/>
+
 <CommandBlock
   language="hcl"
   label="configure"
@@ -136,8 +168,20 @@ path "sys/step-down" {
   capabilities = ["sudo", "update"]
 }
 
+path "sys/storage/raft/configuration" {
+  capabilities = ["read"]
+}
+
+path "sys/storage/raft/remove-peer" {
+  capabilities = ["update"]
+}
+
 path "sys/storage/raft/autopilot/configuration" {
   capabilities = ["read", "update"]
+}
+
+path "sys/storage/raft/autopilot/state" {
+  capabilities = ["read"]
 }`}
 >
   Keep the controller policy focused on maintenance work. Backup, restore, and upgrade jobs authenticate through their own roles instead of inheriting the controller scope.

--- a/docs/user-guide/operator/authz.md
+++ b/docs/user-guide/operator/authz.md
@@ -118,12 +118,33 @@ path "sys/step-down" {
   capabilities = ["sudo", "update"]
 }
 
+path "sys/storage/raft/configuration" {
+  capabilities = ["read"]
+}
+
+path "sys/storage/raft/remove-peer" {
+  capabilities = ["update"]
+}
+
 path "sys/storage/raft/autopilot/configuration" {
   capabilities = ["read", "update"]
+}
+
+path "sys/storage/raft/autopilot/state" {
+  capabilities = ["read"]
 }`}
 >
   This is the steady-state controller scope. Keep backup, restore, and blue-green peer management in separate roles unless you are intentionally changing the model.
 </CommandBlock>
+
+<Callout type="warning" title="Existing clusters must update the controller policy manually">
+
+The operator does not rewrite OpenBao policies after bootstrap. If an operator upgrade adds a new
+controller-side capability, such as `read` on `sys/storage/raft/autopilot/state`, update the
+`openbao-operator` policy manually on existing clusters. Until that policy includes the new path,
+features that depend on it will report `Unknown` rather than a concrete health state.
+
+</Callout>
 
 </TabItem>
 
@@ -203,6 +224,38 @@ path "sys/storage/raft/demote" {
 </TabItem>
 
 </Tabs>
+
+## Policy upgrade notes
+
+<DecisionTable
+  kind="reference"
+  title="When the controller policy surface changes"
+  columns={['Situation', 'What the operator does', 'What you must do']}
+  rows={[
+    {
+      cells: [
+        'A new operator release adds a controller-side capability',
+        'Uses the new capability if the `openbao-operator` policy already includes it, otherwise reports `Unknown` or a permission error for the dependent feature.',
+        'Update the `openbao-operator` policy manually on existing clusters. The operator does not rewrite OpenBao policies after bootstrap.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'A cluster was bootstrapped with self-init in an earlier release',
+        'Keeps using the already-created JWT role and policy.',
+        'Treat the policy as cluster security configuration that you own after bootstrap. Review release notes and add any newly required paths deliberately.',
+      ],
+    },
+    {
+      cells: [
+        'JWT auth and policies are fully manually managed',
+        'Never mutates that auth surface.',
+        'Carry the full policy diff yourself as part of operator upgrades.',
+      ],
+    },
+  ]}
+/>
 
 <DecisionTable
   kind="reference"


### PR DESCRIPTION
## Description

This PR adds the documentation and dashboard updates for horizontal read scaling.

It documents the steady-state and operational behavior introduced in the earlier PRs and extends the OpenBaoCluster overview dashboard with read-replica visibility.

This is PR `3/3` in the horizontal-read-scaling stack.

Included in this PR:

- dedicated user guide page for read replicas
- external access and Gateway API docs for:
  - shared primary endpoint behavior
  - dedicated read Service behavior
- upgrade and restore docs for read-pool drain and restore behavior
- operator authn/authz docs for the manual policy update required for Autopilot-health reporting on existing clusters
- architecture and security docs for the new steady-state topology
- overview dashboard panels for:
  - desired read replicas
  - ready read replicas
  - registered read replicas
  - healthy read replicas
- observability guidance and alert examples for read-replica degradation
- top-level README update to mention horizontal read scaling

## Related Issues

- Builds on #362

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

Passed locally:

- `make lint-ci`
- `make test-ci`
- `make docs-build`

Reviewer path:

1. Review the user-guide, architecture, and security docs under `docs/`.
2. Review the overview dashboard changes in `config/grafana/dashboards/overview.json`.
3. Run `make docs-build`.
