### PR TITLE
docs(readreplicas): add nav entry

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -154,6 +154,17 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Read Scaling',
+          items: [
+            {
+              type: 'doc',
+              id: 'user-guide/openbaocluster/configuration/read-replicas',
+              label: 'Read replicas',
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Platform Readiness',
           items: [
             {


### PR DESCRIPTION
## Description

Add the missing sidebar entry for the read replicas page so the published documentation navigation exposes the new guide.

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- Run `make docs-build`
- Confirm the `Configure` sidebar includes `Read Scaling -> Read replicas`
