### PR TITLE
ci(ci): pass changelog to channel chart packaging

### DIFF
--- a/.github/workflows/reusable-channel-hardening.yml
+++ b/.github/workflows/reusable-channel-hardening.yml
@@ -222,7 +222,11 @@ jobs:
           set -euo pipefail
           work_dir="$(mktemp -d)"
           cp -a source-under-test/charts/openbao-operator "${work_dir}/openbao-operator"
-          CHART_DIR="${work_dir}/openbao-operator" CHART_VERSION="${CHART_VERSION}" OWNER="${OWNER}" bash .github-workflow-src/hack/ci/prepare-release-chart.sh
+          CHANGELOG_FILE="${GITHUB_WORKSPACE}/source-under-test/CHANGELOG.md" \
+            CHART_DIR="${work_dir}/openbao-operator" \
+            CHART_VERSION="${CHART_VERSION}" \
+            OWNER="${OWNER}" \
+            bash .github-workflow-src/hack/ci/prepare-release-chart.sh
           find "${work_dir}/openbao-operator" -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
           helm package "${work_dir}/openbao-operator" -d dist/primary
           test -f "dist/primary/openbao-operator-${CHART_VERSION}.tgz"
@@ -236,7 +240,11 @@ jobs:
           set -euo pipefail
           work_dir="$(mktemp -d)"
           cp -a source-under-test/charts/openbao-operator "${work_dir}/openbao-operator"
-          CHART_DIR="${work_dir}/openbao-operator" CHART_VERSION="${CHART_VERSION}" OWNER="${OWNER}" bash .github-workflow-src/hack/ci/prepare-release-chart.sh
+          CHANGELOG_FILE="${GITHUB_WORKSPACE}/source-under-test/CHANGELOG.md" \
+            CHART_DIR="${work_dir}/openbao-operator" \
+            CHART_VERSION="${CHART_VERSION}" \
+            OWNER="${OWNER}" \
+            bash .github-workflow-src/hack/ci/prepare-release-chart.sh
           find "${work_dir}/openbao-operator" -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
           helm package "${work_dir}/openbao-operator" -d dist/rebuild
           test -f "dist/rebuild/openbao-operator-${CHART_VERSION}.tgz"


### PR DESCRIPTION
## Description

Fix edge and nightly channel candidate packaging after the Helm chart changelog sync change.

The channel hardening workflow checks out the source repository under `source-under-test` and workflow helper scripts under `.github-workflow-src`. `prepare-release-chart.sh` now needs `CHANGELOG.md` to sync Artifact Hub chart changes, but the byte-reproducibility Helm packaging steps were still invoking it with the default `CHANGELOG_FILE=CHANGELOG.md` from the workflow workspace root. That path does not exist in the split checkout layout, so both edge and nightly failed with `changelog file not found: CHANGELOG.md`.

This PR passes `CHANGELOG_FILE=${GITHUB_WORKSPACE}/source-under-test/CHANGELOG.md` explicitly for both primary and rebuild chart packaging.

## Related Issues

- Fixes latest failing edge channel hardening run.
- Fixes latest failing nightly channel hardening run.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`. Not run directly; this is a workflow-only fix.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `bin/actionlint .github/workflows/*.yml`
- split-checkout chart package reproduction with explicit `CHANGELOG_FILE`
- `git diff --check`
- `make lint-ci` via pre-push hook

Failure evidence checked:
- Nightly run `24921431699` failed in `Build + Verify Nightly Candidate / Verify Byte Reproducibility` at `Package Helm chart (primary)` with `changelog file not found: CHANGELOG.md`.
- Main CI run `24908711884` failed in `Build + Verify Edge Candidate / Verify Byte Reproducibility` with the same error, which caused the Publish Edge workflow to skip.