### PR TITLE
fix(provisioner): reduce release reconciliation log noise

### DIFF
--- a/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
@@ -41,6 +41,21 @@ rules:
       - watch
 
   - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - validatingadmissionpolicies

--- a/config/rbac/provisioner_minimal_role.yaml
+++ b/config/rbac/provisioner_minimal_role.yaml
@@ -49,7 +49,24 @@ rules:
       - list
       - watch
 
-  # 2c. Admission policy dependency checks (get only)
+  # 2c. Kubernetes event emission in tenant namespaces.
+  # Required when recording OpenBaoTenant reconciliation events outside the operator namespace.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+  # 2d. Admission policy dependency checks (get only)
   # Required for fail-closed startup validation that ValidatingAdmissionPolicies are present and enforced.
   - apiGroups:
       - admissionregistration.k8s.io
@@ -59,7 +76,7 @@ rules:
     verbs:
       - get
 
-  # 2d. Tenant quota/limits management (namespaced)
+  # 2e. Tenant quota/limits management (namespaced)
   # NOTE: Server-Side Apply may create objects when they don't exist yet, which requires 'create' permission.
   - apiGroups:
       - ""

--- a/internal/adapter/openbao/transport.go
+++ b/internal/adapter/openbao/transport.go
@@ -255,7 +255,11 @@ func (c *Client) doAndReadAll(req *http.Request, httpClient *http.Client, op str
 		if c.state != nil {
 			c.state.after(req, false)
 		}
-		return nil, nil, fmt.Errorf("%s: failed to read response body: %w", op, err)
+		wrapped := fmt.Errorf("%s: failed to read response body: %w", op, err)
+		if operatorerrors.IsTransientConnection(err) {
+			return nil, nil, operatorerrors.WrapTransientConnection(wrapped)
+		}
+		return nil, nil, wrapped
 	}
 
 	// The health endpoint encodes state in HTTP status codes (sealed, standby, etc.),

--- a/internal/adapter/raft/autopilot.go
+++ b/internal/adapter/raft/autopilot.go
@@ -204,8 +204,7 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 	defer cancel()
 
 	if err := client.ConfigureRaftAutopilot(autopilotCtx, desiredConfig); err != nil {
-		// Don't fail reconciliation on autopilot config errors - log and continue
-		logger.Error(err, "Failed to update Raft Autopilot configuration; will retry on next reconcile")
+		logger.V(1).Info("Raft Autopilot configuration not ready; will retry on next reconcile", "error", err)
 		return operatorerrors.WrapTransientConnection(
 			fmt.Errorf("failed to configure Raft Autopilot: %w", err),
 		)
@@ -456,7 +455,7 @@ func (m *Manager) configureAutopilotWithClient(ctx context.Context, logger logr.
 	defer cancel()
 
 	if err := client.ConfigureRaftAutopilot(autopilotCtx, desiredConfig); err != nil {
-		logger.Error(err, "Failed to update Raft Autopilot configuration; will retry on next reconcile")
+		logger.V(1).Info("Raft Autopilot configuration not ready; will retry on next reconcile", "error", err)
 		return operatorerrors.WrapTransientConnection(
 			fmt.Errorf("failed to configure Raft Autopilot: %w", err),
 		)

--- a/internal/app/openbaocluster/adminops/reconcile_test.go
+++ b/internal/app/openbaocluster/adminops/reconcile_test.go
@@ -79,6 +79,12 @@ func TestReconcile_AdminOpsErrorPaths(t *testing.T) {
 			wantPatchReason:  "adminops-error",
 		},
 		{
+			name:             "transient cluster state error requeues with delay",
+			reconcilerErr:    operatorerrors.WrapTransientClusterState(errors.New("no leader found in cluster")),
+			wantRequeueAfter: 5 * time.Second,
+			wantPatchReason:  "adminops-error",
+		},
+		{
 			name:            "patch failure takes precedence",
 			reconcilerErr:   operatorerrors.WrapPermanentConfig(errors.New("bad config")),
 			patchErr:        errors.New("status patch failed"),

--- a/internal/app/openbaocluster/deletion_facade.go
+++ b/internal/app/openbaocluster/deletion_facade.go
@@ -13,25 +13,20 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/deletionops"
 )
 
-const (
-	deletionSecretSuffixUnsealKey = "-unseal-key"
-	deletionSecretSuffixRootToken = "-root-token"
-)
-
 // DeletionDependencies defines dependencies for OpenBaoCluster deletion orchestration.
 type DeletionDependencies = deletionops.Dependencies
 
 // HandleDeletion applies deletion policy side effects.
 func HandleDeletion(ctx context.Context, logger logr.Logger, deps DeletionDependencies, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	if len(deps.RetentionSecrets) == 0 {
-		deps.RetentionSecrets = defaultRetentionSecrets(cluster)
+		deps.RetentionSecrets = deletionops.DefaultRetentionSecrets(cluster)
 	}
 	return deletionops.Handle(ctx, logger, deps, cluster)
 }
 
 // OrphanRetentionSecrets removes owner references from retention secrets.
 func OrphanRetentionSecrets(ctx context.Context, logger logr.Logger, kubeClient client.Client, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	return deletionops.OrphanRetentionSecrets(ctx, logger, kubeClient, cluster, defaultRetentionSecrets(cluster))
+	return deletionops.OrphanRetentionSecrets(ctx, logger, kubeClient, cluster, deletionops.DefaultRetentionSecrets(cluster))
 }
 
 // HasOwnerReference reports whether object has an owner reference with uid.
@@ -42,11 +37,4 @@ func HasOwnerReference(obj metav1.Object, uid types.UID) bool {
 // RemoveOwnerReferences removes all owner references from a Secret.
 func RemoveOwnerReferences(ctx context.Context, logger logr.Logger, kubeClient client.Client, secret *corev1.Secret) error {
 	return deletionops.RemoveOwnerReferences(ctx, logger, kubeClient, secret)
-}
-
-func defaultRetentionSecrets(cluster *openbaov1alpha1.OpenBaoCluster) []string {
-	return []string{
-		cluster.Name + deletionSecretSuffixUnsealKey,
-		cluster.Name + deletionSecretSuffixRootToken,
-	}
 }

--- a/internal/app/openbaocluster/deletionops/handler.go
+++ b/internal/app/openbaocluster/deletionops/handler.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/observability"
 )
 
@@ -28,7 +29,11 @@ func Handle(ctx context.Context, logger logr.Logger, deps Dependencies, cluster 
 
 	// CRITICAL: When DeletionPolicy is Retain, orphan required secrets before finalizer removal.
 	if policy == openbaov1alpha1.DeletionPolicyRetain {
-		if err := OrphanRetentionSecrets(ctx, logger, deps.Client, cluster, deps.RetentionSecrets); err != nil {
+		retentionSecrets := deps.RetentionSecrets
+		if len(retentionSecrets) == 0 {
+			retentionSecrets = DefaultRetentionSecrets(cluster)
+		}
+		if err := OrphanRetentionSecrets(ctx, logger, deps.Client, cluster, retentionSecrets); err != nil {
 			return fmt.Errorf("failed to orphan retention secrets: %w", err)
 		}
 	}
@@ -43,4 +48,12 @@ func Handle(ctx context.Context, logger logr.Logger, deps Dependencies, cluster 
 
 	// Backup deletion for DeletionPolicyDeleteAll will be implemented alongside BackupManager data path.
 	return nil
+}
+
+// DefaultRetentionSecrets returns the generated secrets that must survive a retained cluster deletion.
+func DefaultRetentionSecrets(cluster *openbaov1alpha1.OpenBaoCluster) []string {
+	return []string{
+		cluster.Name + constants.SuffixUnsealKey,
+		cluster.Name + constants.SuffixRootToken,
+	}
 }

--- a/internal/app/openbaocluster/deletionops/handler_test.go
+++ b/internal/app/openbaocluster/deletionops/handler_test.go
@@ -1,0 +1,59 @@
+package deletionops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+func TestHandleDefaultsRetentionSecrets(t *testing.T) {
+	t.Parallel()
+
+	cluster := newCleanupTestCluster("retain-defaults")
+	cluster.UID = types.UID("retain-defaults-uid")
+	cluster.Spec.DeletionPolicy = openbaov1alpha1.DeletionPolicyRetain
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: ptrBool(true),
+	}
+	unsealSecret := newRetentionTestSecret(cluster, cluster.Name+constants.SuffixUnsealKey, ownerRef)
+	rootTokenSecret := newRetentionTestSecret(cluster, cluster.Name+constants.SuffixRootToken, ownerRef)
+	kubeClient := newCleanupTestClient(t, cluster, unsealSecret, rootTokenSecret)
+
+	if err := Handle(context.Background(), logr.Discard(), Dependencies{Client: kubeClient}, cluster); err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+
+	for _, secretName := range []string{unsealSecret.Name, rootTokenSecret.Name} {
+		secret := &corev1.Secret{}
+		if err := kubeClient.Get(context.Background(), client.ObjectKey{Namespace: cluster.Namespace, Name: secretName}, secret); err != nil {
+			t.Fatalf("Get(%s) error = %v", secretName, err)
+		}
+		if len(secret.OwnerReferences) != 0 {
+			t.Fatalf("secret %s ownerReferences = %#v, want empty", secretName, secret.OwnerReferences)
+		}
+	}
+}
+
+func newRetentionTestSecret(cluster *openbaov1alpha1.OpenBaoCluster, name string, ownerRef metav1.OwnerReference) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Data: map[string][]byte{"value": []byte("redacted")},
+	}
+}

--- a/internal/app/openbaocluster/patch.go
+++ b/internal/app/openbaocluster/patch.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -65,6 +66,10 @@ func PatchWorkloadOwnedFields(
 	}
 
 	if err := c.Status().Apply(ctx, applyConfig, client.FieldOwner(workloadFieldOwner)); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("Skipping workload status patch because OpenBaoCluster no longer exists", "reason", reason)
+			return nil
+		}
 		return fmt.Errorf("failed to patch workload status (%s) for OpenBaoCluster %s/%s: %w", reason, cluster.Namespace, cluster.Name, err)
 	}
 	logger.V(1).Info("Patched OpenBaoCluster workload status (SSA)", "reason", reason, "fieldOwner", workloadFieldOwner)

--- a/internal/app/openbaocluster/patch_test.go
+++ b/internal/app/openbaocluster/patch_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -153,6 +155,41 @@ func TestPatchAdminOpsOwnedFields_IgnoresBackupOnlyChanges(t *testing.T) {
 	}
 	if !reflect.DeepEqual(stored.Status.Backup, original.Status.Backup) {
 		t.Fatalf("stored backup = %#v, want original %#v", stored.Status.Backup, original.Status.Backup)
+	}
+}
+
+func TestPatchWorkloadOwnedFields_IgnoresDeletedCluster(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workload-deleted",
+			Namespace: "default",
+		},
+	}
+	original := cluster.DeepCopy()
+	desired := cluster.DeepCopy()
+	desired.Status.Workload = &openbaov1alpha1.WorkloadControllerStatus{
+		LastError: &openbaov1alpha1.ControllerErrorStatus{
+			Reason:  "Test",
+			Message: "status update raced with deletion",
+		},
+	}
+
+	scheme := newPatchTestScheme(t)
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster.DeepCopy()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(context.Context, client.Client, string, runtime.ApplyConfiguration, ...client.SubResourceApplyOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: openbaov1alpha1.GroupVersion.Group, Resource: "openbaoclusters"}, cluster.Name)
+			},
+		}).
+		Build()
+
+	if err := PatchWorkloadOwnedFields(context.Background(), k8sClient, logr.Discard(), original, desired, "workload-deleted"); err != nil {
+		t.Fatalf("PatchWorkloadOwnedFields() error = %v", err)
 	}
 }
 

--- a/internal/platform/errors/errors.go
+++ b/internal/platform/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -73,6 +74,11 @@ var ErrTransientConnection = errors.New("transient connection error")
 // OpenBao (excluding endpoints like /sys/health where status codes represent state rather than failure).
 var ErrTransientRemoteOverloaded = errors.New("transient remote overloaded")
 
+// ErrTransientClusterState indicates a cluster is temporarily not in the state
+// required for the requested operation. This covers externally observable
+// convergence states such as leader election or readiness settling.
+var ErrTransientClusterState = errors.New("transient cluster state")
+
 // ErrTransientKubernetesAPI indicates a transient Kubernetes API error that should be retried.
 // This includes rate limiting, temporary server errors, and network issues.
 var ErrTransientKubernetesAPI = errors.New("transient Kubernetes API error")
@@ -102,6 +108,9 @@ func IsTransientConnection(err error) bool {
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 
@@ -164,6 +173,16 @@ func IsTransientRemoteOverloaded(err error) bool {
 	return errors.Is(err, ErrTransientRemoteOverloaded)
 }
 
+// IsTransientClusterState checks if an error indicates the target cluster is
+// temporarily not ready for the requested operation.
+func IsTransientClusterState(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, ErrTransientClusterState)
+}
+
 // WrapTransientConnection wraps an error as a transient connection error.
 // If the error is already a transient connection error, it is returned as-is.
 func WrapTransientConnection(err error) error {
@@ -190,6 +209,20 @@ func WrapTransientRemoteOverloaded(err error) error {
 	}
 
 	return fmt.Errorf("%w: %w", ErrTransientRemoteOverloaded, err)
+}
+
+// WrapTransientClusterState wraps an error as a transient cluster state error.
+// If the error is already a transient cluster state error, it is returned as-is.
+func WrapTransientClusterState(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if IsTransientClusterState(err) {
+		return err
+	}
+
+	return fmt.Errorf("%w: %w", ErrTransientClusterState, err)
 }
 
 // WrapTransientKubernetesAPI wraps an error as a transient Kubernetes API error.
@@ -224,9 +257,11 @@ func WrapPermanentPrerequisitesMissing(err error) error {
 }
 
 // IsTransient checks if an error is transient (should be retried).
-// Returns true for transient connection or Kubernetes API errors.
 func IsTransient(err error) bool {
-	return IsTransientConnection(err) || IsTransientRemoteOverloaded(err) || IsTransientKubernetesAPI(err)
+	return IsTransientConnection(err) ||
+		IsTransientRemoteOverloaded(err) ||
+		IsTransientClusterState(err) ||
+		IsTransientKubernetesAPI(err)
 }
 
 // IsPermanent checks if an error is permanent (requires user intervention).
@@ -255,6 +290,10 @@ func ShouldRequeue(err error) (bool, time.Duration) {
 		// For remote overloaded errors, requeue with a longer delay to reduce pressure
 		if IsTransientRemoteOverloaded(err) {
 			return true, 15 * time.Second
+		}
+		// For transient cluster convergence states, requeue with a short delay
+		if IsTransientClusterState(err) {
+			return true, 5 * time.Second
 		}
 		// For transient Kubernetes API errors, requeue with a short delay
 		if IsTransientKubernetesAPI(err) {

--- a/internal/platform/errors/errors_test.go
+++ b/internal/platform/errors/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"reflect"
@@ -179,6 +180,16 @@ func TestIsTransientConnection(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "response body EOF",
+			err:  io.EOF,
+			want: true,
+		},
+		{
+			name: "response body unexpected EOF",
+			err:  fmt.Errorf("read failed: %w", io.ErrUnexpectedEOF),
+			want: true,
+		},
+		{
 			name: "no such host",
 			err:  newDNSError(),
 			want: true,
@@ -346,6 +357,44 @@ func TestIsTransientRemoteOverloaded(t *testing.T) {
 	}
 }
 
+func TestIsTransientClusterState(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "well-known error",
+			err:  ErrTransientClusterState,
+			want: true,
+		},
+		{
+			name: "wrapped well-known error",
+			err:  fmt.Errorf("context: %w", ErrTransientClusterState),
+			want: true,
+		},
+		{
+			name: "non-transient error",
+			err:  errors.New("invalid configuration"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTransientClusterState(tt.err)
+			if got != tt.want {
+				t.Errorf("IsTransientClusterState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsCRDMissingError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -489,6 +538,38 @@ func TestWrapTransientRemoteOverloaded(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWrapTransientClusterState(t *testing.T) {
+	tests := []transientWrapTestCase{
+		{
+			name:            "nil error",
+			err:             nil,
+			wantWrapped:     false,
+			wantIsTransient: false,
+		},
+		{
+			name:            "already transient cluster state error",
+			err:             ErrTransientClusterState,
+			wantWrapped:     false,
+			wantIsTransient: true,
+		},
+		{
+			name:            "non-transient error",
+			err:             errors.New("leader election has not settled"),
+			wantWrapped:     true,
+			wantIsTransient: true,
+		},
+	}
+
+	runTransientWrapTests(
+		t,
+		"WrapTransientClusterState",
+		ErrTransientClusterState,
+		WrapTransientClusterState,
+		IsTransientClusterState,
+		tests,
+	)
 }
 
 func TestWrapTransientKubernetesAPI(t *testing.T) {
@@ -666,6 +747,11 @@ func TestIsTransient(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "transient cluster state",
+			err:  ErrTransientClusterState,
+			want: true,
+		},
+		{
 			name: "connection refused",
 			err:  newConnectionRefusedError(),
 			want: true,
@@ -767,6 +853,12 @@ func TestShouldRequeue(t *testing.T) {
 		{
 			name:        "transient K8s API",
 			err:         ErrTransientKubernetesAPI,
+			wantRequeue: true,
+			wantAfter:   5 * time.Second,
+		},
+		{
+			name:        "transient cluster state",
+			err:         ErrTransientClusterState,
 			wantRequeue: true,
 			wantAfter:   5 * time.Second,
 		},

--- a/internal/service/init/manager_reconcile.go
+++ b/internal/service/init/manager_reconcile.go
@@ -147,7 +147,11 @@ func (m *Manager) markSelfInitComplete(ctx context.Context, logger logr.Logger, 
 	cluster.Status.SelfInitialized = true
 
 	if err := m.raftManager.ReconcileAutopilotConfig(ctx, logger, cluster); err != nil {
-		logger.Error(err, "Failed to configure Raft Autopilot for self-init cluster; will retry via reconciler")
+		if operatorerrors.IsTransient(err) {
+			logger.V(1).Info("Raft Autopilot configuration not ready for self-init cluster; will retry via reconciler", "error", err)
+		} else {
+			logger.Error(err, "Failed to configure Raft Autopilot for self-init cluster; will retry via reconciler")
+		}
 	}
 	emitNormalEvent(m.recorder, cluster, ReasonInitCompleted, "Self-initialization completed for cluster %s", cluster.Name)
 }

--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -285,6 +285,69 @@ func TestValidateUpgrade_BlocksInvalidVersionSelection(t *testing.T) {
 	}
 }
 
+func TestValidateUpgrade_LeaderUnknownIsTransientClusterState(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version:  "2.5.0",
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			CurrentVersion: "2.4.4",
+		},
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: cluster.Name, Namespace: cluster.Namespace},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      3,
+			ReadyReplicas: 3,
+		},
+	}
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + constants.SuffixTLSCA,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{"ca.crt": []byte("fake-ca")},
+	}
+	pod0 := readyRollingTestPod(cluster, 0, false)
+	pod1 := readyRollingTestPod(cluster, 1, false)
+	pod2 := readyRollingTestPod(cluster, 2, false)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts, caSecret, pod0, pod1, pod2).Build()
+	mgr := NewManagerWithClientFactory(
+		k8sClient,
+		scheme,
+		nil,
+		rollingTestClientFactory(),
+		portopenbao.ClientConfig{},
+		nil,
+		"",
+	).WithReader(k8sClient).WithAdminOpsStatusMutator(testAdminOpsMutator(k8sClient))
+
+	err := mgr.validateUpgrade(context.Background(), testLogger(), cluster)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !operatorerrors.IsTransientClusterState(err) {
+		t.Fatalf("expected transient cluster state error, got %v", err)
+	}
+	reason, ok := operatorerrors.Reason(err)
+	if !ok {
+		t.Fatalf("expected reasoned error, got %v", err)
+	}
+	if reason != upgrade.ReasonLeaderUnknown {
+		t.Fatalf("reason=%q, want %q", reason, upgrade.ReasonLeaderUnknown)
+	}
+	if !strings.Contains(err.Error(), "no leader found in cluster") {
+		t.Fatalf("error=%q, want no leader detail", err.Error())
+	}
+}
+
 func TestValidateUpgrade_ResumeHealthAllowsOneUnavailableTarget(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/upgrade/rolling/validate_health.go
+++ b/internal/service/upgrade/rolling/validate_health.go
@@ -11,7 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
 )
 
@@ -28,7 +30,12 @@ func (m *Manager) verifyClusterHealth(ctx context.Context, logger logr.Logger, c
 	}
 
 	if sts.Status.ReadyReplicas != cluster.Spec.Replicas {
-		return fmt.Errorf("not all replicas are ready (%d/%d)", sts.Status.ReadyReplicas, cluster.Spec.Replicas)
+		return transientClusterStatef(
+			upgrade.ReasonClusterNotReady,
+			"not all replicas are ready (%d/%d)",
+			sts.Status.ReadyReplicas,
+			cluster.Spec.Replicas,
+		)
 	}
 
 	podList, err := m.getClusterPods(ctx, cluster)
@@ -36,7 +43,12 @@ func (m *Manager) verifyClusterHealth(ctx context.Context, logger logr.Logger, c
 		return fmt.Errorf("failed to list cluster pods: %w", err)
 	}
 	if len(podList) != int(cluster.Spec.Replicas) {
-		return fmt.Errorf("unexpected number of pods (%d/%d)", len(podList), cluster.Spec.Replicas)
+		return transientClusterStatef(
+			upgrade.ReasonClusterNotReady,
+			"unexpected number of pods (%d/%d)",
+			len(podList),
+			cluster.Spec.Replicas,
+		)
 	}
 
 	counts, err := m.requireHealthyLeaderQuorum(ctx, logger, cluster, podList)
@@ -103,7 +115,7 @@ func (m *Manager) getUpgradeStatefulSet(ctx context.Context, cluster *openbaov1a
 	}
 	if err := m.client.Get(ctx, stsName, sts); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("StatefulSet not found; cluster may not be fully initialized")
+			return nil, transientClusterStatef(upgrade.ReasonClusterNotReady, "StatefulSet not found; cluster may not be fully initialized")
 		}
 		return nil, fmt.Errorf("failed to get StatefulSet: %w", err)
 	}
@@ -156,11 +168,16 @@ func (m *Manager) requireHealthyLeaderQuorum(
 
 	quorumRequired := requiredQuorum(cluster.Spec.Replicas)
 	if counts.healthyPods < quorumRequired {
-		return clusterHealthCounts{}, fmt.Errorf("cluster has lost quorum (%d/%d healthy, need %d)",
-			counts.healthyPods, cluster.Spec.Replicas, quorumRequired)
+		return clusterHealthCounts{}, transientClusterStatef(
+			upgrade.ReasonQuorumLost,
+			"cluster has lost quorum (%d/%d healthy, need %d)",
+			counts.healthyPods,
+			cluster.Spec.Replicas,
+			quorumRequired,
+		)
 	}
 	if counts.leaderCount == 0 {
-		return clusterHealthCounts{}, fmt.Errorf("no leader found in cluster")
+		return clusterHealthCounts{}, transientClusterStatef(upgrade.ReasonLeaderUnknown, "no leader found in cluster")
 	}
 	if counts.leaderCount > 1 {
 		return clusterHealthCounts{}, fmt.Errorf("multiple leaders detected (%d); possible split-brain", counts.leaderCount)
@@ -227,6 +244,13 @@ func (m *Manager) verifyNonTargetPodsReadyAndHealthy(
 	}
 
 	return nil
+}
+
+func transientClusterStatef(reason string, format string, args ...any) error {
+	return operatorerrors.WithReason(
+		reason,
+		operatorerrors.WrapTransientClusterState(fmt.Errorf(format, args...)),
+	)
 }
 
 // checkPodHealth queries each pod's health status and returns counts.


### PR DESCRIPTION
## Description

This PR reduces avoidable error-level log noise in release-critical reconciliation paths.

It includes:

- provisioner RBAC for recording Kubernetes Events in tenant namespaces
- safer deletion cleanup when retention secrets are absent
- classification of transient lifecycle retry states so controller logs distinguish retryable OpenBao/API conditions from hard failures
- focused tests for deletion cleanup, patch behavior, lifecycle retry classification, and rolling upgrade health validation

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

Ran focused tests:

```sh
go test ./internal/app/openbaocluster ./internal/platform/errors ./internal/service/init ./internal/service/upgrade/rolling ./internal/adapter/openbao ./internal/adapter/raft
```

Pre-push hook also ran:

```sh
make lint-ci
```
