### PR TITLE
fix(probe): stabilize openbao workload probes

### DIFF
--- a/cmd/bao-probe/main.go
+++ b/cmd/bao-probe/main.go
@@ -19,8 +19,9 @@ const (
 	portAPI          = 8200
 	pathTLSCACert    = "/etc/bao/tls/ca.crt"
 
-	livenessPath  = apiPathSysHealth + "?standbyok=true&sealedcode=204&uninitcode=204"
-	readinessPath = apiPathSysHealth + "?standbyok=true"
+	startupPath   = apiPathSysHealth + "?standbyok=true&perfstandbyok=true&sealedcode=204&uninitcode=204"
+	livenessPath  = apiPathSysHealth + "?standbyok=true&perfstandbyok=true&sealedcode=204&uninitcode=204"
+	readinessPath = apiPathSysHealth + "?standbyok=true&perfstandbyok=true"
 
 	loopbackHost = "localhost"
 
@@ -53,12 +54,11 @@ func run(ctx context.Context) error {
 			mode, modeStartup, modeLiveness, modeReadiness)
 	}
 
-	// Determine if we should allow insecure fallback for ACME mode
-	// For readiness probes in ACME mode, allow insecure loopback fallback during initial
-	// certificate acquisition. This handles the case where OpenBao is still obtaining the
-	// ACME certificate and using a temporary self-signed certificate.
+	// Determine if we should allow insecure fallback for ACME mode.
+	// ACME probes may run while OpenBao is still acquiring its serving certificate.
+	// The fallback is restricted to loopback by the prober implementation.
 	isACMEMode := serverName != "" && serverName != loopbackHost
-	allowInsecureFallback := mode == modeLiveness || (mode == modeReadiness && isACMEMode)
+	allowInsecureFallback := mode == modeLiveness || (isACMEMode && (mode == modeStartup || mode == modeReadiness))
 
 	prober, err := probe.NewProber(probe.ProberConfig{
 		Addr:                  addr,
@@ -66,7 +66,7 @@ func run(ctx context.Context) error {
 		ServerName:            serverName,
 		Timeout:               timeout,
 		AllowInsecureFallback: allowInsecureFallback,
-		StartupPath:           "",
+		StartupPath:           startupPath,
 		LivenessPath:          livenessPath,
 		ReadinessPath:         readinessPath,
 	})

--- a/internal/adapter/openbao/client_manager.go
+++ b/internal/adapter/openbao/client_manager.go
@@ -29,8 +29,9 @@ func NewClientManager(defaults portopenbao.ClientConfig) *ClientManager {
 //
 // The clusterKey should be a stable identifier for the cluster, typically
 // in the format "namespace/name". The caCert is the PEM-encoded CA certificate
-// for TLS verification.
-func (m *ClientManager) FactoryFor(clusterKey string, caCert []byte) *ClientFactory {
+// for TLS verification. tlsServerName optionally overrides the hostname used
+// for TLS verification when clients connect through a different Service name.
+func (m *ClientManager) FactoryFor(clusterKey string, caCert []byte, tlsServerName ...string) *ClientFactory {
 	if m == nil {
 		return nil
 	}
@@ -40,6 +41,9 @@ func (m *ClientManager) FactoryFor(clusterKey string, caCert []byte) *ClientFact
 	template := m.defaults
 	template.ClusterKey = clusterKey
 	template.CACert = caCert
+	if len(tlsServerName) > 0 {
+		template.TLSServerName = tlsServerName[0]
+	}
 
 	return newClientFactoryWithState(template, state)
 }

--- a/internal/adapter/openbao/client_manager_test.go
+++ b/internal/adapter/openbao/client_manager_test.go
@@ -51,6 +51,21 @@ func TestClientManager_FactoryFor_DifferentStateForDifferentClusters(t *testing.
 	}
 }
 
+func TestClientManager_FactoryFor_AppliesTLSServerNameOverride(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewClientManager(ClientConfig{})
+	defer mgr.Close()
+
+	factory := mgr.FactoryFor("ns/cluster", nil, "acme.example.com")
+	if factory == nil {
+		t.Fatal("expected factory")
+	}
+	if factory.template.TLSServerName != "acme.example.com" {
+		t.Fatalf("TLSServerName=%q, want acme.example.com", factory.template.TLSServerName)
+	}
+}
+
 func TestClientManager_ClusterCount(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/probe/prober.go
+++ b/internal/adapter/probe/prober.go
@@ -37,6 +37,7 @@ type HTTPProber struct {
 	addr          string
 	hostPort      string
 	isLoopback    bool
+	timeout       time.Duration
 }
 
 // ProberConfig holds configuration for creating a Prober.
@@ -53,6 +54,10 @@ type ProberConfig struct {
 
 // NewProber creates a new HTTPProber with the given configuration.
 func NewProber(cfg ProberConfig) (Prober, error) {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 4 * time.Second
+	}
+
 	parsedServerName, hostPort, isLoopback, err := parseAddr(cfg.Addr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid addr %q: %w", cfg.Addr, err)
@@ -86,12 +91,41 @@ func NewProber(cfg ProberConfig) (Prober, error) {
 		addr:          cfg.Addr,
 		hostPort:      hostPort,
 		isLoopback:    isLoopback,
+		timeout:       cfg.Timeout,
 	}, nil
 }
 
-// CheckStartup performs a TCP dial check to verify the service is listening.
+// CheckStartup verifies that OpenBao is serving its HTTP health endpoint.
+// The startup path accepts sealed and uninitialized states so bootstrap can
+// proceed without starting readiness checks while the listener is still coming up.
 func (p *HTTPProber) CheckStartup(ctx context.Context) error {
-	return tcpDial(ctx, p.hostPort)
+	base := strings.TrimRight(p.addr, "/")
+	probeURL := base + p.startupPath
+
+	reqCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	if resp.StatusCode == 429 || resp.StatusCode == 473 {
+		return nil
+	}
+	return fmt.Errorf("startup check failed with status %d", resp.StatusCode)
 }
 
 // CheckLiveness performs a liveness check.
@@ -100,7 +134,7 @@ func (p *HTTPProber) CheckLiveness(ctx context.Context) error {
 	probeURL := base + p.livenessPath
 
 	baseCtx := ctx
-	reqCtx, cancel := context.WithTimeout(baseCtx, 4*time.Second)
+	reqCtx, cancel := context.WithTimeout(baseCtx, p.timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, probeURL, nil)
@@ -160,7 +194,7 @@ func (p *HTTPProber) CheckReadiness(ctx context.Context) error {
 			}
 		}
 
-		reqCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+		reqCtx, cancel := context.WithTimeout(ctx, p.timeout)
 		req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodGet, probeURL, nil)
 		if reqErr != nil {
 			cancel()

--- a/internal/adapter/probe/prober_test.go
+++ b/internal/adapter/probe/prober_test.go
@@ -73,17 +73,101 @@ func TestHTTPProber_CheckStartup(t *testing.T) {
 		CAFile:        "",
 		ServerName:    "",
 		Timeout:       4 * time.Second,
+		StartupPath:   "/v1/sys/health?sealedcode=204&uninitcode=204",
 		LivenessPath:  "/v1/sys/health",
 		ReadinessPath: "/v1/sys/health",
 	})
 	if err != nil {
 		t.Fatalf("NewProber() error = %v", err)
 	}
+	httpProber := prober.(*HTTPProber)
+	httpProber.client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // #nosec G402 -- Test only
+			},
+		},
+	}
 
 	ctx := context.Background()
 	err = prober.CheckStartup(ctx)
 	if err != nil {
 		t.Fatalf("CheckStartup() error = %v", err)
+	}
+}
+
+func TestHTTPProber_CheckStartup_StatusCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "healthy",
+			statusCode: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "sealed remapped by startup path",
+			statusCode: http.StatusNoContent,
+			wantErr:    false,
+		},
+		{
+			name:       "standby",
+			statusCode: http.StatusTooManyRequests,
+			wantErr:    false,
+		},
+		{
+			name:       "performance standby",
+			statusCode: 473,
+			wantErr:    false,
+		},
+		{
+			name:       "unexpected server error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/sys/health" {
+					t.Fatalf("startup path=%q, want /v1/sys/health", r.URL.Path)
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			prober, err := NewProber(ProberConfig{
+				Addr:          server.URL,
+				Timeout:       4 * time.Second,
+				StartupPath:   "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204",
+				LivenessPath:  "/v1/sys/health",
+				ReadinessPath: "/v1/sys/health?standbyok=true",
+			})
+			if err != nil {
+				t.Fatalf("NewProber() error = %v", err)
+			}
+
+			httpProber := prober.(*HTTPProber)
+			httpProber.client = &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true, // #nosec G402 -- Test only
+					},
+				},
+			}
+
+			err = prober.CheckStartup(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CheckStartup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/adapter/raft/autopilot.go
+++ b/internal/adapter/raft/autopilot.go
@@ -15,6 +15,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/openbaotls"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
@@ -23,7 +24,6 @@ const (
 	// rootTokenSecretKey is the key used to store the root token in the Secret data.
 	rootTokenSecretKey = "token"
 	suffixRootToken    = "-root-token"
-	suffixTLSCA        = "-tls-ca"
 	roleNameOperator   = "openbao-operator"
 	portAPI            = 8200
 )
@@ -42,7 +42,7 @@ type ClientFactory interface {
 }
 
 type ClientFactoryProvider interface {
-	FactoryFor(clusterKey string, caCert []byte) ClientFactory
+	FactoryFor(clusterKey string, caCert []byte, tlsServerName string) ClientFactory
 }
 
 // Manager handles Raft Autopilot configuration for OpenBao clusters.
@@ -163,6 +163,11 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 	var err error
 
 	if selfInitEnabled {
+		if !portauth.OperatorJWTBootstrapEnabled(cluster) {
+			logger.V(1).Info("Skipping autopilot config reconciliation for self-init cluster without operator JWT bootstrap")
+			return nil
+		}
+
 		// Use ClientManager for JWT authentication (SelfInit)
 		client, err = m.newOpenBaoClient(ctx, logger, cluster)
 		if err != nil {
@@ -475,15 +480,14 @@ func (m *Manager) newOpenBaoClient(ctx context.Context, logger logr.Logger, clus
 
 	baseURL := autopilotBaseURL(cluster)
 
-	// Get TLS CA for validation
-	caCert, err := m.getTLSCACert(ctx, cluster)
+	trust, err := m.getClientTrustBundle(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get client factory
 	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
-	factory := m.clientFactory(clusterKey, caCert)
+	factory := m.clientFactory(clusterKey, trust.CACert, trust.TLSServerName)
 	if factory == nil {
 		return nil, fmt.Errorf("client factory provider returned nil factory for cluster %s", clusterKey)
 	}
@@ -531,24 +535,8 @@ func (m *Manager) newScaleDownClient(ctx context.Context, logger logr.Logger, cl
 	return client, nil
 }
 
-// getTLSCACert retrieves the CA certificate from the cluster's TLS CA secret.
-func (m *Manager) getTLSCACert(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) ([]byte, error) {
-	caSecretName := cluster.Name + suffixTLSCA
-	secret, err := m.clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, caSecretName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsForbidden(err) {
-			return nil, operatorerrors.WrapTransientKubernetesAPI(
-				fmt.Errorf("failed to get TLS CA Secret %s/%s: %w", cluster.Namespace, caSecretName, err),
-			)
-		}
-		return nil, fmt.Errorf("failed to get TLS CA Secret %s/%s: %w", cluster.Namespace, caSecretName, err)
-	}
-
-	caCert, ok := secret.Data["ca.crt"]
-	if !ok || len(caCert) == 0 {
-		return nil, fmt.Errorf("TLS CA Secret %s/%s missing 'ca.crt' key", cluster.Namespace, caSecretName)
-	}
-	return caCert, nil
+func (m *Manager) getClientTrustBundle(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) (openbaotls.ClientTrustBundle, error) {
+	return openbaotls.ReadClientTrustBundle(ctx, m.clientset, cluster)
 }
 
 // getJWTToken retrieves a JWT token for the operator from the projected volume.
@@ -619,25 +607,14 @@ func (m *Manager) newOpenBaoClientWithToken(ctx context.Context, cluster *openba
 
 	baseURL := autopilotBaseURL(cluster)
 
-	caSecretName := cluster.Name + suffixTLSCA
-	secret, err := m.clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, caSecretName, metav1.GetOptions{})
+	trust, err := m.getClientTrustBundle(ctx, cluster)
 	if err != nil {
-		if apierrors.IsForbidden(err) {
-			return nil, operatorerrors.WrapTransientKubernetesAPI(
-				fmt.Errorf("failed to get TLS CA Secret %s/%s: %w", cluster.Namespace, caSecretName, err),
-			)
-		}
-		return nil, fmt.Errorf("failed to get TLS CA Secret %s/%s: %w", cluster.Namespace, caSecretName, err)
-	}
-
-	caCert, ok := secret.Data["ca.crt"]
-	if !ok || len(caCert) == 0 {
-		return nil, fmt.Errorf("TLS CA Secret %s/%s missing 'ca.crt' key", cluster.Namespace, caSecretName)
+		return nil, err
 	}
 
 	// Create OpenBao client using the ClientManager for proper state isolation.
 	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
-	factory := m.clientFactory(clusterKey, caCert)
+	factory := m.clientFactory(clusterKey, trust.CACert, trust.TLSServerName)
 	if factory == nil {
 		return nil, fmt.Errorf("client factory provider returned nil factory for cluster %s", clusterKey)
 	}
@@ -650,11 +627,11 @@ func (m *Manager) newOpenBaoClientWithToken(ctx context.Context, cluster *openba
 	return client, nil
 }
 
-func (m *Manager) clientFactory(clusterKey string, caCert []byte) ClientFactory {
+func (m *Manager) clientFactory(clusterKey string, caCert []byte, tlsServerName string) ClientFactory {
 	if m == nil || m.clientFactoryProvider == nil {
 		return nil
 	}
-	return m.clientFactoryProvider.FactoryFor(clusterKey, caCert)
+	return m.clientFactoryProvider.FactoryFor(clusterKey, caCert, tlsServerName)
 }
 
 func findRaftServerForPod(config *portopenbao.RaftConfigurationResponse, podName string) (portopenbao.RaftServer, bool) {

--- a/internal/adapter/raft/autopilot_runtime_test.go
+++ b/internal/adapter/raft/autopilot_runtime_test.go
@@ -118,31 +118,73 @@ func TestHandleJWTAuthError(t *testing.T) {
 	}
 }
 
-func TestGetTLSCACert(t *testing.T) {
+func TestGetClientTrustBundle(t *testing.T) {
 	t.Parallel()
 
-	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "tenant-ns"}}
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "tenant-ns"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			TLS: openbaov1alpha1.TLSConfig{Enabled: true},
+		},
+	}
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("operator managed tls reads cluster ca secret", func(t *testing.T) {
 		clientset := k8sfake.NewClientset(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a-tls-ca", Namespace: "tenant-ns"},
 			Data:       map[string][]byte{"ca.crt": []byte("pem-data")},
 		})
 		mgr := NewManager(clientset, nil)
 
-		ca, err := mgr.getTLSCACert(context.Background(), cluster)
+		trust, err := mgr.getClientTrustBundle(context.Background(), cluster)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if string(ca) != "pem-data" {
-			t.Fatalf("ca=%q, want pem-data", string(ca))
+		if string(trust.CACert) != "pem-data" {
+			t.Fatalf("ca=%q, want pem-data", string(trust.CACert))
+		}
+		if trust.TLSServerName != "openbao-cluster-cluster-a.local" {
+			t.Fatalf("tlsServerName=%q, want openbao-cluster-cluster-a.local", trust.TLSServerName)
+		}
+	})
+
+	t.Run("private acme reads pki ca from unseal credentials secret", func(t *testing.T) {
+		acmeCluster := cluster.DeepCopy()
+		acmeCluster.Spec.TLS = openbaov1alpha1.TLSConfig{
+			Enabled: true,
+			Mode:    openbaov1alpha1.TLSModeACME,
+			ACME: &openbaov1alpha1.ACMEConfig{
+				Domains: []string{"cluster-a-acme.tenant-ns.svc"},
+			},
+		}
+		acmeCluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
+			ACMECARoot: "/etc/bao/seal-creds/ca.crt",
+		}
+		acmeCluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "seal-creds"},
+		}
+
+		clientset := k8sfake.NewClientset(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "seal-creds", Namespace: "tenant-ns"},
+			Data:       map[string][]byte{"pki-ca.crt": []byte("pki-ca-data")},
+		})
+		mgr := NewManager(clientset, nil)
+
+		trust, err := mgr.getClientTrustBundle(context.Background(), acmeCluster)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(trust.CACert) != "pki-ca-data" {
+			t.Fatalf("ca=%q, want pki-ca-data", string(trust.CACert))
+		}
+		if trust.TLSServerName != "cluster-a-acme.tenant-ns.svc" {
+			t.Fatalf("tlsServerName=%q, want ACME service name", trust.TLSServerName)
 		}
 	})
 
 	t.Run("missing secret", func(t *testing.T) {
 		mgr := NewManager(k8sfake.NewClientset(), nil)
-		_, err := mgr.getTLSCACert(context.Background(), cluster)
-		if err == nil || !strings.Contains(err.Error(), "failed to get TLS CA Secret") {
+		_, err := mgr.getClientTrustBundle(context.Background(), cluster)
+		if err == nil || !strings.Contains(err.Error(), "failed to get OpenBao trust Secret") {
 			t.Fatalf("expected missing secret error, got %v", err)
 		}
 	})
@@ -152,8 +194,8 @@ func TestGetTLSCACert(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a-tls-ca", Namespace: "tenant-ns"},
 		})
 		mgr := NewManager(clientset, nil)
-		_, err := mgr.getTLSCACert(context.Background(), cluster)
-		if err == nil || !strings.Contains(err.Error(), "missing 'ca.crt' key") {
+		_, err := mgr.getClientTrustBundle(context.Background(), cluster)
+		if err == nil || !strings.Contains(err.Error(), `missing "ca.crt" key`) {
 			t.Fatalf("expected missing key error, got %v", err)
 		}
 	})
@@ -164,7 +206,7 @@ func TestGetTLSCACert(t *testing.T) {
 			return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "", Resource: "secrets"}, "cluster-a-tls-ca", errors.New("forbidden"))
 		})
 		mgr := NewManager(clientset, nil)
-		_, err := mgr.getTLSCACert(context.Background(), cluster)
+		_, err := mgr.getClientTrustBundle(context.Background(), cluster)
 		if err == nil {
 			t.Fatalf("expected forbidden error")
 		}
@@ -207,8 +249,11 @@ func TestReconcileAutopilotConfig_EarlyBranches(t *testing.T) {
 		mgr := NewManager(k8sfake.NewClientset(), nil)
 		cluster := &openbaov1alpha1.OpenBaoCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
-			Spec:       openbaov1alpha1.OpenBaoClusterSpec{Replicas: 3},
-			Status:     openbaov1alpha1.OpenBaoClusterStatus{Initialized: true},
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Replicas: 3,
+				TLS:      openbaov1alpha1.TLSConfig{Enabled: true},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{Initialized: true},
 		}
 		if err := mgr.ReconcileAutopilotConfig(context.Background(), logr.Discard(), cluster); err != nil {
 			t.Fatalf("expected nil error for missing root token secret, got %v", err)
@@ -225,6 +270,23 @@ func TestReconcileAutopilotConfig_EarlyBranches(t *testing.T) {
 		}
 		if err := mgr.ReconcileAutopilotConfig(context.Background(), logr.Discard(), cluster); err != nil {
 			t.Fatalf("expected nil error when root token is empty, got %v", err)
+		}
+	})
+
+	t.Run("self-init without operator jwt bootstrap is skipped", func(t *testing.T) {
+		mgr := NewManager(k8sfake.NewClientset(), nil)
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Replicas: 3,
+				SelfInit: &openbaov1alpha1.SelfInitConfig{
+					Enabled: true,
+				},
+			},
+			Status: openbaov1alpha1.OpenBaoClusterStatus{Initialized: true},
+		}
+		if err := mgr.ReconcileAutopilotConfig(context.Background(), logr.Discard(), cluster); err != nil {
+			t.Fatalf("expected nil error when operator JWT bootstrap is disabled, got %v", err)
 		}
 	})
 
@@ -302,14 +364,16 @@ func (f *fakeScaleDownFactory) NewWithToken(string, string) (Client, error) {
 }
 
 type fakeScaleDownFactoryProvider struct {
-	factory    ClientFactory
-	clusterKey string
-	caCert     []byte
+	factory       ClientFactory
+	clusterKey    string
+	caCert        []byte
+	tlsServerName string
 }
 
-func (p *fakeScaleDownFactoryProvider) FactoryFor(clusterKey string, caCert []byte) ClientFactory {
+func (p *fakeScaleDownFactoryProvider) FactoryFor(clusterKey string, caCert []byte, tlsServerName string) ClientFactory {
 	p.clusterKey = clusterKey
 	p.caCert = append([]byte(nil), caCert...)
+	p.tlsServerName = tlsServerName
 	return p.factory
 }
 
@@ -321,6 +385,7 @@ func TestPrepareScaleDown_RemovesFollowerAndUpdatesAutopilot(t *testing.T) {
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile:  openbaov1alpha1.ProfileDevelopment,
 			Replicas: 3,
+			TLS:      openbaov1alpha1.TLSConfig{Enabled: true},
 		},
 		Status: openbaov1alpha1.OpenBaoClusterStatus{Initialized: true},
 	}
@@ -379,6 +444,9 @@ func TestPrepareScaleDown_RemovesFollowerAndUpdatesAutopilot(t *testing.T) {
 	}
 	if string(provider.caCert) != "pem-data" {
 		t.Fatalf("caCert = %q, want pem-data", string(provider.caCert))
+	}
+	if provider.tlsServerName != "openbao-cluster-cluster.local" {
+		t.Fatalf("tlsServerName = %q, want openbao-cluster-cluster.local", provider.tlsServerName)
 	}
 }
 

--- a/internal/platform/openbaotls/client_trust.go
+++ b/internal/platform/openbaotls/client_trust.go
@@ -1,0 +1,62 @@
+package openbaotls
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+// ClientTrustBundle describes the TLS trust inputs for controller-side OpenBao clients.
+type ClientTrustBundle struct {
+	CACert        []byte
+	TLSServerName string
+}
+
+// ReadClientTrustBundle resolves and reads the trust bundle needed by controller-side
+// OpenBao clients. ACME clusters do not have operator-managed TLS Secrets, so this
+// follows the shared OpenBao trust contract instead of assuming <cluster>-tls-ca.
+func ReadClientTrustBundle(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (ClientTrustBundle, error) {
+	if clientset == nil {
+		return ClientTrustBundle{}, fmt.Errorf("kubernetes clientset is required")
+	}
+
+	source, err := portopenbao.ResolveClientTrustBundle(cluster)
+	if err != nil {
+		return ClientTrustBundle{}, err
+	}
+
+	trust := ClientTrustBundle{
+		TLSServerName: portopenbao.ComputeTLSServerName(cluster),
+	}
+	if source.UseSystemRoots {
+		return trust, nil
+	}
+
+	secret, err := clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, source.SecretName, metav1.GetOptions{})
+	if err != nil {
+		msg := fmt.Errorf("failed to get OpenBao trust Secret %s/%s key %q: %w", cluster.Namespace, source.SecretName, source.SecretKey, err)
+		if apierrors.IsForbidden(err) {
+			return ClientTrustBundle{}, operatorerrors.WrapTransientKubernetesAPI(msg)
+		}
+		return ClientTrustBundle{}, msg
+	}
+
+	caCert, ok := secret.Data[source.SecretKey]
+	if !ok || len(caCert) == 0 {
+		return ClientTrustBundle{}, fmt.Errorf("OpenBao trust Secret %s/%s missing %q key", cluster.Namespace, source.SecretName, source.SecretKey)
+	}
+
+	trust.CACert = caCert
+	return trust, nil
+}

--- a/internal/platform/openbaotls/client_trust_test.go
+++ b/internal/platform/openbaotls/client_trust_test.go
@@ -1,0 +1,71 @@
+package openbaotls
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestReadClientTrustBundle_PrivateACME(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao", Namespace: "tenant"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			TLS: openbaov1alpha1.TLSConfig{
+				Enabled: true,
+				Mode:    openbaov1alpha1.TLSModeACME,
+				ACME: &openbaov1alpha1.ACMEConfig{
+					Domains: []string{"bao-acme.tenant.svc"},
+				},
+			},
+			Configuration: &openbaov1alpha1.OpenBaoConfiguration{
+				ACMECARoot: "/etc/bao/seal-creds/ca.crt",
+			},
+			Unseal: &openbaov1alpha1.UnsealConfig{
+				CredentialsSecretRef: &corev1.LocalObjectReference{Name: "seal-creds"},
+			},
+		},
+	}
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "seal-creds", Namespace: "tenant"},
+		Data:       map[string][]byte{"pki-ca.crt": []byte("pki-ca")},
+	})
+
+	trust, err := ReadClientTrustBundle(context.Background(), clientset, cluster)
+	if err != nil {
+		t.Fatalf("ReadClientTrustBundle() error = %v", err)
+	}
+	if string(trust.CACert) != "pki-ca" {
+		t.Fatalf("CACert=%q, want pki-ca", string(trust.CACert))
+	}
+	if trust.TLSServerName != "bao-acme.tenant.svc" {
+		t.Fatalf("TLSServerName=%q, want bao-acme.tenant.svc", trust.TLSServerName)
+	}
+}
+
+func TestReadClientTrustBundle_MissingKey(t *testing.T) {
+	t.Parallel()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao", Namespace: "tenant"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			TLS: openbaov1alpha1.TLSConfig{Enabled: true},
+		},
+	}
+	clientset := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao-tls-ca", Namespace: "tenant"},
+		Data:       map[string][]byte{},
+	})
+
+	_, err := ReadClientTrustBundle(context.Background(), clientset, cluster)
+	if err == nil || !strings.Contains(err.Error(), `missing "ca.crt" key`) {
+		t.Fatalf("expected missing key error, got %v", err)
+	}
+}

--- a/internal/service/init/manager.go
+++ b/internal/service/init/manager.go
@@ -63,12 +63,12 @@ func NewManager(config *rest.Config, clientset kubernetes.Interface, clientMgr *
 	}
 }
 
-func (p raftClientFactoryProvider) FactoryFor(clusterKey string, caCert []byte) raft.ClientFactory {
+func (p raftClientFactoryProvider) FactoryFor(clusterKey string, caCert []byte, tlsServerName string) raft.ClientFactory {
 	if p.clientMgr == nil {
 		return nil
 	}
 
-	factory := p.clientMgr.FactoryFor(clusterKey, caCert)
+	factory := p.clientMgr.FactoryFor(clusterKey, caCert, tlsServerName)
 	if factory == nil {
 		return nil
 	}

--- a/internal/service/init/manager_client.go
+++ b/internal/service/init/manager_client.go
@@ -5,17 +5,14 @@ import (
 	"fmt"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
-	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/openbaotls"
 )
 
 // newOpenBaoClient constructs a minimal OpenBao client for talking to the pod-0 instance
-// of the StatefulSet using the per-cluster TLS CA bundle.
+// of the StatefulSet using the cluster's client trust contract.
 func (m *Manager) newOpenBaoClient(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) (*openbao.Client, error) {
 	if strings.TrimSpace(cluster.Name) == "" || strings.TrimSpace(cluster.Namespace) == "" {
 		return nil, fmt.Errorf("cluster name and namespace are required to build OpenBao client")
@@ -23,27 +20,13 @@ func (m *Manager) newOpenBaoClient(ctx context.Context, cluster *openbaov1alpha1
 
 	baseURL := fmt.Sprintf("https://%s-0.%s.%s.svc:%d", cluster.Name, cluster.Name, cluster.Namespace, constants.PortAPI)
 
-	caSecretName := cluster.Name + constants.SuffixTLSCA
-	secret, err := m.clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, caSecretName, metav1.GetOptions{})
+	trust, err := openbaotls.ReadClientTrustBundle(ctx, m.clientset, cluster)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("TLS CA Secret %s/%s not found", cluster.Namespace, caSecretName)
-		}
-		if apierrors.IsForbidden(err) {
-			return nil, operatorerrors.WrapTransientKubernetesAPI(
-				fmt.Errorf("failed to get TLS CA Secret %s/%s: %w", cluster.Namespace, caSecretName, err),
-			)
-		}
-		return nil, fmt.Errorf("failed to get TLS CA Secret %s/%s: %w", cluster.Namespace, caSecretName, err)
-	}
-
-	caCert, ok := secret.Data["ca.crt"]
-	if !ok || len(caCert) == 0 {
-		return nil, fmt.Errorf("TLS CA Secret %s/%s missing 'ca.crt' key", cluster.Namespace, caSecretName)
+		return nil, err
 	}
 
 	clusterKey := fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
-	factory := m.clientMgr.FactoryFor(clusterKey, caCert)
+	factory := m.clientMgr.FactoryFor(clusterKey, trust.CACert, trust.TLSServerName)
 	if factory == nil {
 		return nil, fmt.Errorf("client manager returned nil factory for cluster %s", clusterKey)
 	}

--- a/internal/service/init/manager_test.go
+++ b/internal/service/init/manager_test.go
@@ -193,6 +193,9 @@ func TestReconcileOperatorInitFailure_EmitsInitFailedEvent(t *testing.T) {
 			Name:      "cluster",
 			Namespace: "default",
 		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			TLS: openbaov1alpha1.TLSConfig{Enabled: true},
+		},
 	}
 
 	started := true

--- a/internal/service/workload/statefulset_acme_test.go
+++ b/internal/service/workload/statefulset_acme_test.go
@@ -1,6 +1,7 @@
 package workload
 
 import (
+	"slices"
 	"testing"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -79,6 +80,70 @@ func TestStatefulSet_ACMEMode_WithSharedCacheMount(t *testing.T) {
 	}
 	if !hasVolumeMountWithPath(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, acmeCacheVolumeName, "/bao/acme-cache") {
 		t.Fatal("expected OpenBao container to mount ACME shared cache volume at /bao/acme-cache")
+	}
+}
+
+func TestStatefulSet_ProbeDefaults(t *testing.T) {
+	cluster := newMinimalCluster("probe-cluster", "default")
+	cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeExternal
+
+	statefulSet, err := buildStatefulSet(cluster, "test-config", true, "", "", "")
+	if err != nil {
+		t.Fatalf("buildStatefulSet() error = %v", err)
+	}
+
+	openBaoContainer := statefulSet.Spec.Template.Spec.Containers[0]
+	if openBaoContainer.StartupProbe == nil || openBaoContainer.StartupProbe.Exec == nil {
+		t.Fatal("expected startup probe exec action")
+	}
+	if !slices.Contains(openBaoContainer.StartupProbe.Exec.Command, "-mode=startup") {
+		t.Fatalf("startup probe command=%v, want -mode=startup", openBaoContainer.StartupProbe.Exec.Command)
+	}
+	if !slices.Contains(openBaoContainer.StartupProbe.Exec.Command, "-ca-file="+constants.PathTLSCACert) {
+		t.Fatalf("startup probe command=%v, want TLS CA file", openBaoContainer.StartupProbe.Exec.Command)
+	}
+	if openBaoContainer.StartupProbe.InitialDelaySeconds != 10 {
+		t.Fatalf("startup initial delay=%d, want 10", openBaoContainer.StartupProbe.InitialDelaySeconds)
+	}
+	if openBaoContainer.ReadinessProbe == nil {
+		t.Fatal("expected readiness probe")
+	}
+	if openBaoContainer.ReadinessProbe.InitialDelaySeconds != 20 {
+		t.Fatalf("readiness initial delay=%d, want 20", openBaoContainer.ReadinessProbe.InitialDelaySeconds)
+	}
+}
+
+func TestStatefulSet_ACMEMode_ProbeTrustUsesACMEPKICA(t *testing.T) {
+	cluster := newMinimalCluster("acme-cluster", "default")
+	cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeACME
+	cluster.Spec.TLS.ACME = &openbaov1alpha1.ACMEConfig{
+		DirectoryURL: "https://acme-v02.api.letsencrypt.org/directory",
+		Domain:       "example.com",
+	}
+	cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
+		ACMECARoot: "/etc/bao/seal-creds/ca.crt",
+	}
+
+	statefulSet, err := buildStatefulSet(cluster, "test-config", true, "", "", "")
+	if err != nil {
+		t.Fatalf("buildStatefulSet() error = %v", err)
+	}
+
+	openBaoContainer := statefulSet.Spec.Template.Spec.Containers[0]
+	startupCommand := openBaoContainer.StartupProbe.Exec.Command
+	if !slices.Contains(startupCommand, "-servername=example.com") {
+		t.Fatalf("startup probe command=%v, want ACME server name", startupCommand)
+	}
+	if !slices.Contains(startupCommand, "-ca-file=/etc/bao/seal-creds/pki-ca.crt") {
+		t.Fatalf("startup probe command=%v, want ACME PKI CA file", startupCommand)
+	}
+
+	readinessCommand := openBaoContainer.ReadinessProbe.Exec.Command
+	if !slices.Contains(readinessCommand, "-servername=example.com") {
+		t.Fatalf("readiness probe command=%v, want ACME server name", readinessCommand)
+	}
+	if !slices.Contains(readinessCommand, "-ca-file=/etc/bao/seal-creds/pki-ca.crt") {
+		t.Fatalf("readiness probe command=%v, want ACME PKI CA file", readinessCommand)
 	}
 }
 

--- a/internal/service/workload/statefulset_builder_containers.go
+++ b/internal/service/workload/statefulset_builder_containers.go
@@ -291,9 +291,10 @@ func buildContainers(cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSp
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: probes.startup,
 				},
-				TimeoutSeconds:   10,
-				PeriodSeconds:    5,
-				FailureThreshold: 60,
+				InitialDelaySeconds: 10,
+				TimeoutSeconds:      10,
+				PeriodSeconds:       5,
+				FailureThreshold:    60,
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -307,7 +308,7 @@ func buildContainers(cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSp
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: probes.readiness,
 				},
-				InitialDelaySeconds: 5,
+				InitialDelaySeconds: 20,
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 				FailureThreshold:    6,

--- a/internal/service/workload/statefulset_builder_probe_volumes.go
+++ b/internal/service/workload/statefulset_builder_probe_volumes.go
@@ -37,18 +37,17 @@ func buildStatefulSetProbeExecActions(cluster *openbaov1alpha1.OpenBaoCluster) p
 		}
 	}
 
-	// Startup probe only does TCP dial, so it doesn't need a CA file.
-	// In ACME mode, the default CA file (/etc/bao/tls/ca.crt) doesn't exist, so
-	// explicitly set -ca-file="" to avoid trying to read it.
 	startupProbeCmd := []string{
 		constants.PathProbeBinary,
 		"-mode=startup",
 		"-addr=" + probeAddr,
 		"-timeout=" + openBaoStartupProbeTimeout,
 	}
-	// Only set empty CA file for ACME mode where the default CA file won't exist
-	if usesACMEMode(cluster) {
-		startupProbeCmd = append(startupProbeCmd, "-ca-file=")
+	if probeServerName != "" {
+		startupProbeCmd = append(startupProbeCmd, "-servername="+probeServerName)
+	}
+	if probeCAFile != "" {
+		startupProbeCmd = append(startupProbeCmd, "-ca-file="+probeCAFile)
 	}
 	startupProbeExec := &corev1.ExecAction{
 		Command: startupProbeCmd,


### PR DESCRIPTION
## Description

This PR stabilizes OpenBao workload probes and fixes the ACME/private PKI trust path used by controller-side OpenBao clients.

It includes:

- startup probes using the OpenBao health endpoint instead of raw TCP
- startup/liveness/readiness health checks that include `perfstandbyok=true`
- less aggressive startup/readiness timing defaults
- ACME startup/readiness probe trust using the same server name and CA inputs as the workload TLS path
- controller-side OpenBao clients resolving trust through the shared OpenBao trust contract instead of assuming `<cluster>-tls-ca`
- autopilot reconciliation skipping JWT bootstrap work when operator JWT bootstrap is disabled

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

Ran focused tests:

```sh
go test ./cmd/bao-probe ./internal/adapter/probe ./internal/service/workload ./internal/platform/openbaotls ./internal/adapter/openbao ./internal/adapter/raft ./internal/service/init ./internal/app/openbaocluster ./internal/controller/openbaocluster
```

Ran focused E2E before splitting the branch:

```sh
E2E_FOCUS='ACME TLS' make test-e2e
E2E_FOCUS='creates a cluster with 1 replica|scales up to 3 replicas|scales down to 1 replica' make test-e2e
```

Observed results:

- hardened ACME E2E: 2/2 passed
- scale lifecycle E2E: 3/3 passed
- controller/provisioner log scans were clean for new warning/error patterns; remaining warnings were Kind bootstrap/control-plane noise and expected development/static-unseal warnings

Pre-push hook also ran:

```sh
make lint-ci
```
