### PR TITLE
test(perf): harden performance scenario policies

### DIFF
--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -131,6 +131,8 @@ make test-e2e-existing E2E_LABEL_FILTER='openshift'`}
   ]}
 />
 
+Performance scenarios are declared in `hack/perf/scenarios.yaml`. Each scenario owns its Ginkgo label filter and the metric policies that are meaningful for that workflow. Keep those policies narrow: add a metric only when the scenario is expected to exercise that behavior, and use warning severity for broad diagnostic counters such as aggregate workqueue retries.
+
 <NextActions
   title="After test selection"
   items={[

--- a/hack/perf/scenarios.yaml
+++ b/hack/perf/scenarios.yaml
@@ -1,0 +1,61 @@
+version: v1
+scenarios:
+  - name: lifecycle
+    description: Core tenant lifecycle without disaster-recovery or upgrade workflows.
+    labelFilter: lifecycle && critical && tenant && !slow && !openshift && !pentest
+    metricPolicies:
+      reconcile_p95_seconds:
+        policy: upper_bound
+        multiplier: p95
+      reconcile_error_ratio:
+        policy: upper_bound
+        multiplier: max
+      workqueue_retries_delta:
+        policy: upper_bound
+        severity: warn
+        multiplier: max
+        floor: 100
+
+  - name: backup-restore
+    description: Disaster-recovery backup and restore lifecycle.
+    labelFilter: dr && backup && restore && !failure-injection
+    metricPolicies:
+      backup_last_duration_seconds_max:
+        policy: upper_bound
+        multiplier: max
+      restore_p95_seconds:
+        policy: upper_bound
+        multiplier: p95
+      reconcile_p95_seconds:
+        policy: upper_bound
+        multiplier: p95
+      reconcile_error_ratio:
+        policy: upper_bound
+        multiplier: max
+      workqueue_retries_delta:
+        policy: upper_bound
+        severity: warn
+        multiplier: max
+        floor: 500
+
+  - name: rolling-upgrade
+    description: Rolling upgrade steady path without snapshot-recovery coverage.
+    labelFilter: upgrade && rolling && !failure && !bluegreen && !snapshot && !recovery
+    metricPolicies:
+      upgrade_p95_seconds:
+        policy: upper_bound
+        multiplier: p95
+      upgrade_pod_p95_seconds:
+        policy: upper_bound
+        multiplier: p95
+      reconcile_p95_seconds:
+        policy: upper_bound
+        multiplier: p95
+      reconcile_error_ratio:
+        policy: upper_bound
+        multiplier: max
+      workqueue_retries_delta:
+        policy: upper_bound
+        severity: warn
+        multiplier: max
+        floor: 200

--- a/hack/perf/thresholds/kind-v1.34.3.yaml
+++ b/hack/perf/thresholds/kind-v1.34.3.yaml
@@ -15,31 +15,71 @@ metricSchema:
 scenarios:
     backup-restore:
         labelFilter: dr && backup && restore && !failure-injection
+        metricPolicies:
+            backup_last_duration_seconds_max:
+                policy: upper_bound
+                multiplier: max
+            reconcile_error_ratio:
+                policy: upper_bound
+                multiplier: max
+            reconcile_p95_seconds:
+                policy: upper_bound
+                multiplier: p95
+            restore_p95_seconds:
+                policy: upper_bound
+                multiplier: p95
+            workqueue_retries_delta:
+                policy: upper_bound
+                severity: warn
+                multiplier: max
+                floor: 500
         metrics:
             backup_last_duration_seconds_max: 6
             reconcile_error_ratio: 0.05
             reconcile_p95_seconds: 1
             restore_p95_seconds: 38
-            upgrade_p95_seconds: 0
-            upgrade_pod_p95_seconds: 0
-            workqueue_retries_delta: 426
+            workqueue_retries_delta: 500
     lifecycle:
         labelFilter: lifecycle && critical && tenant && !slow && !openshift && !pentest
+        metricPolicies:
+            reconcile_error_ratio:
+                policy: upper_bound
+                multiplier: max
+            reconcile_p95_seconds:
+                policy: upper_bound
+                multiplier: p95
+            workqueue_retries_delta:
+                policy: upper_bound
+                severity: warn
+                multiplier: max
+                floor: 100
         metrics:
-            backup_last_duration_seconds_max: 0
             reconcile_error_ratio: 0.46
             reconcile_p95_seconds: 1
-            restore_p95_seconds: 0
-            upgrade_p95_seconds: 0
-            upgrade_pod_p95_seconds: 0
-            workqueue_retries_delta: 75
+            workqueue_retries_delta: 100
     rolling-upgrade:
-        labelFilter: upgrade && rolling && !failure && !bluegreen
+        labelFilter: upgrade && rolling && !failure && !bluegreen && !snapshot && !recovery
+        metricPolicies:
+            reconcile_error_ratio:
+                policy: upper_bound
+                multiplier: max
+            reconcile_p95_seconds:
+                policy: upper_bound
+                multiplier: p95
+            upgrade_p95_seconds:
+                policy: upper_bound
+                multiplier: p95
+            upgrade_pod_p95_seconds:
+                policy: upper_bound
+                multiplier: p95
+            workqueue_retries_delta:
+                policy: upper_bound
+                severity: warn
+                multiplier: max
+                floor: 200
         metrics:
-            backup_last_duration_seconds_max: 0
             reconcile_error_ratio: 0.42
             reconcile_p95_seconds: 1
-            restore_p95_seconds: 0
             upgrade_p95_seconds: 75
             upgrade_pod_p95_seconds: 13
-            workqueue_retries_delta: 159
+            workqueue_retries_delta: 200

--- a/hack/perfcheck/main.go
+++ b/hack/perfcheck/main.go
@@ -59,11 +59,12 @@ func parseCaptureFlags(args []string) (options, error) {
 		scenarios = fs.String(
 			"scenarios",
 			"all",
-			"comma-separated scenarios (all|lifecycle|backup-restore|rolling-upgrade)",
+			"comma-separated scenarios from the scenario manifest, or all",
 		)
 		nodeImage       = fs.String("node-image", "kindest/node:v1.34.3", "kind node image")
 		kindBin         = fs.String("kind", "kind", "path to kind binary")
 		makeBin         = fs.String("make", "make", "path to make binary")
+		scenarioPath    = fs.String("scenario-manifest", defaultScenarioPath, "scenario manifest YAML path")
 		baselinePath    = fs.String("baseline-out", defaultBaselinePath, "output path for baseline JSON")
 		thresholdsPath  = fs.String("thresholds-out", defaultThresholdsPath, "output path for thresholds YAML")
 		scenarioTimeout = fs.Duration("scenario-timeout", 90*time.Minute, "per-scenario timeout")
@@ -92,6 +93,7 @@ func parseCaptureFlags(args []string) (options, error) {
 		*nodeImage,
 		*kindBin,
 		*makeBin,
+		*scenarioPath,
 		*scenarioTimeout,
 		*clusterTimeout,
 		*cleanupTimeout,
@@ -110,11 +112,12 @@ func parseVerifyFlags(args []string) (options, error) {
 		scenarios = fs.String(
 			"scenarios",
 			"all",
-			"comma-separated scenarios (all|lifecycle|backup-restore|rolling-upgrade)",
+			"comma-separated scenarios from the scenario manifest, or all",
 		)
 		nodeImage       = fs.String("node-image", "kindest/node:v1.34.3", "kind node image")
 		kindBin         = fs.String("kind", "kind", "path to kind binary")
 		makeBin         = fs.String("make", "make", "path to make binary")
+		scenarioPath    = fs.String("scenario-manifest", defaultScenarioPath, "scenario manifest YAML path")
 		thresholdsInput = fs.String("thresholds", defaultThresholdsPath, "input thresholds YAML path")
 		scenarioTimeout = fs.Duration("scenario-timeout", 90*time.Minute, "per-scenario timeout")
 		clusterTimeout  = fs.Duration("cluster-timeout", 20*time.Minute, "kind setup timeout")
@@ -134,6 +137,7 @@ func parseVerifyFlags(args []string) (options, error) {
 		*nodeImage,
 		*kindBin,
 		*makeBin,
+		*scenarioPath,
 		*scenarioTimeout,
 		*clusterTimeout,
 		*cleanupTimeout,
@@ -146,7 +150,7 @@ func parseVerifyFlags(args []string) (options, error) {
 }
 
 func baseOptions(
-	nodeImage, kindBin, makeBin string,
+	nodeImage, kindBin, makeBin, scenarioPath string,
 	scenarioTimeout, clusterTimeout, cleanupTimeout time.Duration,
 	keepOnFailure bool,
 ) options {
@@ -155,6 +159,7 @@ func baseOptions(
 		NodeImage:       nodeImage,
 		KindBin:         kindBin,
 		MakeBin:         makeBin,
+		ScenarioPath:    scenarioPath,
 		ScenarioTimeout: scenarioTimeout,
 		ClusterTimeout:  clusterTimeout,
 		CleanupTimeout:  cleanupTimeout,
@@ -198,9 +203,6 @@ func parseScenarioSelection(input string) ([]string, error) {
 		}
 		if name == "all" {
 			return nil, nil
-		}
-		if _, ok := scenarioByName[name]; !ok {
-			return nil, fmt.Errorf("unknown scenario %q", name)
 		}
 		if _, exists := seen[name]; exists {
 			continue

--- a/hack/perfcheck/main_test.go
+++ b/hack/perfcheck/main_test.go
@@ -17,7 +17,7 @@ func TestParseScenarioSelection(t *testing.T) {
 		{name: "single", input: "lifecycle", want: []string{"lifecycle"}},
 		{name: "multiple", input: "lifecycle, rolling-upgrade", want: []string{"lifecycle", "rolling-upgrade"}},
 		{name: "dedupe", input: "lifecycle,lifecycle", want: []string{"lifecycle"}},
-		{name: "unknown", input: "foo", wantErr: true},
+		{name: "unknown deferred to manifest validation", input: "foo", want: []string{"foo"}},
 	}
 
 	for _, tt := range tests {

--- a/hack/perfcheck/runner.go
+++ b/hack/perfcheck/runner.go
@@ -37,9 +37,10 @@ func runCapture(opts options) error {
 
 	for _, scenario := range scenarios {
 		base := scenarioBaseline{
-			LabelFilter: scenario.LabelFilter,
-			Runs:        make([]runResult, 0, opts.Runs),
-			MaxMetrics:  make(map[string]float64, len(metricKeys)),
+			LabelFilter:    scenario.LabelFilter,
+			MetricPolicies: scenario.MetricPolicies,
+			Runs:           make([]runResult, 0, opts.Runs),
+			MaxMetrics:     make(map[string]float64, len(metricKeys)),
 		}
 		for _, key := range metricKeys {
 			base.MaxMetrics[key] = 0
@@ -86,19 +87,33 @@ func runVerify(opts options) error {
 	}
 
 	var findings []string
+	var warnings []string
 	for _, scenario := range scenarios {
 		th, ok := thresholds.Scenarios[scenario.Name]
 		if !ok {
 			return fmt.Errorf("thresholds missing scenario %q", scenario.Name)
 		}
+		if err := validateScenarioThresholds(th, scenario); err != nil {
+			return err
+		}
+		th = applyScenarioPolicy(th, scenario)
 		res, runErr := executeScenarioRun(opts, scenario, 1)
 		if runErr != nil {
 			return runErr
 		}
-		scenarioFindings := compareScenarioMetrics(scenario.Name, res.Metrics, th)
-		findings = append(findings, scenarioFindings...)
+		scenarioResult := compareScenarioMetricsDetailed(scenario.Name, res.Metrics, th)
+		findings = append(findings, scenarioResult.Findings...)
+		warnings = append(warnings, scenarioResult.Warnings...)
 
 		fmt.Printf("scenario=%s metrics=%s\n", scenario.Name, formatMetrics(res.Metrics))
+	}
+
+	if len(warnings) > 0 {
+		sort.Strings(warnings)
+		fmt.Println("performance diagnostic warnings:")
+		for _, w := range warnings {
+			fmt.Printf("- %s\n", w)
+		}
 	}
 
 	if len(findings) > 0 {
@@ -115,15 +130,21 @@ func runVerify(opts options) error {
 }
 
 func selectedScenarios(opts options) ([]scenarioSpec, error) {
+	manifest, err := loadScenarioManifest(opts.ScenarioPath)
+	if err != nil {
+		return nil, err
+	}
 	if len(opts.ScenarioNames) == 0 {
-		return append([]scenarioSpec(nil), defaultScenarios...), nil
+		return append([]scenarioSpec(nil), manifest.Scenarios...), nil
 	}
 
+	byName := scenarioMap(manifest.Scenarios)
 	out := make([]scenarioSpec, 0, len(opts.ScenarioNames))
 	for _, name := range opts.ScenarioNames {
-		spec, ok := scenarioByName[name]
+		spec, ok := byName[name]
 		if !ok {
-			return nil, fmt.Errorf("unknown scenario %q", name)
+			available := strings.Join(sortedScenarioNames(manifest.Scenarios), ", ")
+			return nil, fmt.Errorf("unknown scenario %q (available: %s)", name, available)
 		}
 		out = append(out, spec)
 	}

--- a/hack/perfcheck/scenarios.go
+++ b/hack/perfcheck/scenarios.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const defaultScenarioPath = "hack/perf/scenarios.yaml"
+
+func loadScenarioManifest(path string) (scenarioManifest, error) {
+	if strings.TrimSpace(path) == "" {
+		path = defaultScenarioPath
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return scenarioManifest{}, fmt.Errorf("read scenario manifest: %w", err)
+	}
+
+	var manifest scenarioManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return scenarioManifest{}, fmt.Errorf("parse scenario manifest: %w", err)
+	}
+	if err := validateScenarioManifest(manifest); err != nil {
+		return scenarioManifest{}, err
+	}
+	return manifest, nil
+}
+
+func validateScenarioManifest(manifest scenarioManifest) error {
+	if manifest.Version == "" {
+		return fmt.Errorf("scenario manifest missing version")
+	}
+	if len(manifest.Scenarios) == 0 {
+		return fmt.Errorf("scenario manifest missing scenarios")
+	}
+
+	seen := make(map[string]struct{}, len(manifest.Scenarios))
+	for _, scenario := range manifest.Scenarios {
+		name := strings.TrimSpace(scenario.Name)
+		if name == "" {
+			return fmt.Errorf("scenario manifest contains scenario with empty name")
+		}
+		if _, exists := seen[name]; exists {
+			return fmt.Errorf("scenario manifest contains duplicate scenario %q", name)
+		}
+		seen[name] = struct{}{}
+
+		if strings.TrimSpace(scenario.LabelFilter) == "" {
+			return fmt.Errorf("scenario %q missing labelFilter", name)
+		}
+		if len(scenario.MetricPolicies) == 0 {
+			return fmt.Errorf("scenario %q missing metricPolicies", name)
+		}
+		for metric, policy := range scenario.MetricPolicies {
+			if err := validateMetricPolicy(metric, policy); err != nil {
+				return fmt.Errorf("scenario %q metric %q: %w", name, metric, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateMetricPolicy(metric string, policy metricPolicySpec) error {
+	if _, ok := metricKeySet()[metric]; !ok {
+		return fmt.Errorf("unknown metric")
+	}
+
+	normalized := normalizeMetricPolicy(metric, policy)
+	switch normalized.Policy {
+	case metricPolicyUpperBound, metricPolicyMustBeZero, metricPolicyIgnore:
+	default:
+		return fmt.Errorf("unknown policy %q", policy.Policy)
+	}
+
+	switch normalized.Severity {
+	case metricSeverityFail, metricSeverityWarn:
+	default:
+		return fmt.Errorf("unknown severity %q", policy.Severity)
+	}
+
+	switch normalized.Multiplier {
+	case metricMultiplierP95, metricMultiplierMax:
+	default:
+		return fmt.Errorf("unknown multiplier %q", policy.Multiplier)
+	}
+
+	if normalized.Floor != nil && *normalized.Floor < 0 {
+		return fmt.Errorf("floor must be >= 0")
+	}
+	if normalized.Threshold != nil && *normalized.Threshold < 0 {
+		return fmt.Errorf("threshold must be >= 0")
+	}
+	return nil
+}
+
+func normalizeMetricPolicy(metric string, policy metricPolicySpec) metricPolicySpec {
+	if strings.TrimSpace(policy.Policy) == "" {
+		policy.Policy = metricPolicyUpperBound
+	}
+	if strings.TrimSpace(policy.Severity) == "" {
+		policy.Severity = metricSeverityFail
+	}
+	if strings.TrimSpace(policy.Multiplier) == "" {
+		if _, ok := p95MetricSet[metric]; ok {
+			policy.Multiplier = metricMultiplierP95
+		} else {
+			policy.Multiplier = metricMultiplierMax
+		}
+	}
+	return policy
+}
+
+func metricKeySet() map[string]struct{} {
+	out := make(map[string]struct{}, len(metricKeys))
+	for _, key := range metricKeys {
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func defaultMetricPoliciesForKeys(keys []string) map[string]metricPolicySpec {
+	out := make(map[string]metricPolicySpec, len(keys))
+	for _, key := range keys {
+		out[key] = normalizeMetricPolicy(key, metricPolicySpec{})
+	}
+	return out
+}
+
+func scenarioMap(scenarios []scenarioSpec) map[string]scenarioSpec {
+	out := make(map[string]scenarioSpec, len(scenarios))
+	for _, scenario := range scenarios {
+		out[scenario.Name] = scenario
+	}
+	return out
+}
+
+func sortedScenarioNames(scenarios []scenarioSpec) []string {
+	names := make([]string, 0, len(scenarios))
+	for _, scenario := range scenarios {
+		names = append(names, scenario.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/hack/perfcheck/scenarios_test.go
+++ b/hack/perfcheck/scenarios_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadScenarioManifest(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := loadScenarioManifest("../perf/scenarios.yaml")
+	if err != nil {
+		t.Fatalf("loadScenarioManifest() error = %v", err)
+	}
+
+	byName := scenarioMap(manifest.Scenarios)
+	rolling, ok := byName["rolling-upgrade"]
+	if !ok {
+		t.Fatalf("rolling-upgrade scenario missing")
+	}
+	if !strings.Contains(rolling.LabelFilter, "!snapshot") {
+		t.Fatalf("rolling-upgrade label filter should exclude snapshot coverage: %q", rolling.LabelFilter)
+	}
+	if _, ok := rolling.MetricPolicies[metricBackupLastMax]; ok {
+		t.Fatalf("rolling-upgrade should not evaluate backup duration")
+	}
+	if rolling.MetricPolicies[metricWorkqueueRetries].Severity != metricSeverityWarn {
+		t.Fatalf("workqueue retries should be diagnostic warning signal")
+	}
+}
+
+func TestSelectedScenariosRejectsUnknownManifestScenario(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "scenarios.yaml")
+	if err := os.WriteFile(path, []byte(`
+version: v1
+scenarios:
+  - name: lifecycle
+    labelFilter: lifecycle
+    metricPolicies:
+      reconcile_p95_seconds:
+        policy: upper_bound
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	_, err := selectedScenarios(options{
+		ScenarioPath:  path,
+		ScenarioNames: []string{"missing"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `unknown scenario "missing"`) {
+		t.Fatalf("expected unknown scenario error, got %v", err)
+	}
+}

--- a/hack/perfcheck/thresholds.go
+++ b/hack/perfcheck/thresholds.go
@@ -23,26 +23,104 @@ func buildThresholds(baseline baselineDocument) thresholdDocument {
 	}
 
 	for scenarioName, scenario := range baseline.Scenarios {
-		thresholds := make(map[string]float64, len(metricKeys))
-		for _, key := range metricKeys {
+		policies := scenario.MetricPolicies
+		if len(policies) == 0 {
+			policies = defaultMetricPoliciesForKeys(metricKeys)
+		}
+
+		thresholds := make(map[string]float64, len(policies))
+		normalizedPolicies := make(map[string]metricPolicySpec, len(policies))
+		for key, policy := range policies {
+			normalized := normalizeMetricPolicy(key, policy)
+			normalizedPolicies[key] = normalized
+			if normalized.Policy == metricPolicyIgnore {
+				continue
+			}
+			if normalized.Policy == metricPolicyMustBeZero {
+				thresholds[key] = 0
+				if normalized.Threshold != nil {
+					thresholds[key] = *normalized.Threshold
+				}
+				continue
+			}
+			if normalized.Threshold != nil {
+				thresholds[key] = *normalized.Threshold
+				continue
+			}
+
 			maxVal := scenario.MaxMetrics[key]
 			multiplier := baseline.Multipliers.Max
-			if _, ok := p95MetricSet[key]; ok {
+			if normalized.Multiplier == metricMultiplierP95 {
 				multiplier = baseline.Multipliers.P95
 			}
-			thresholds[key] = math.Ceil(maxVal * multiplier)
+			threshold := math.Ceil(maxVal * multiplier)
+			if normalized.Floor != nil && threshold < *normalized.Floor {
+				threshold = *normalized.Floor
+			}
+			thresholds[key] = threshold
 		}
 		out.Scenarios[scenarioName] = scenarioThresholds{
-			LabelFilter: scenario.LabelFilter,
-			Metrics:     thresholds,
+			LabelFilter:    scenario.LabelFilter,
+			MetricPolicies: normalizedPolicies,
+			Metrics:        thresholds,
 		}
 	}
 
 	return out
 }
 
+type comparisonResult struct {
+	Findings []string
+	Warnings []string
+}
+
 func compareScenarioMetrics(scenarioName string, measured map[string]float64, thresholds scenarioThresholds) []string {
-	findings := make([]string, 0)
+	return compareScenarioMetricsDetailed(scenarioName, measured, thresholds).Findings
+}
+
+func applyScenarioPolicy(thresholds scenarioThresholds, scenario scenarioSpec) scenarioThresholds {
+	thresholds.LabelFilter = scenario.LabelFilter
+	if len(scenario.MetricPolicies) == 0 {
+		return thresholds
+	}
+
+	filteredMetrics := make(map[string]float64, len(scenario.MetricPolicies))
+	for metric, policy := range scenario.MetricPolicies {
+		normalized := normalizeMetricPolicy(metric, policy)
+		if normalized.Policy == metricPolicyIgnore {
+			continue
+		}
+		if threshold, ok := thresholds.Metrics[metric]; ok {
+			filteredMetrics[metric] = threshold
+		}
+	}
+	thresholds.Metrics = filteredMetrics
+	thresholds.MetricPolicies = scenario.MetricPolicies
+	return thresholds
+}
+
+func validateScenarioThresholds(thresholds scenarioThresholds, scenario scenarioSpec) error {
+	for metric, policy := range scenario.MetricPolicies {
+		normalized := normalizeMetricPolicy(metric, policy)
+		if normalized.Policy == metricPolicyIgnore {
+			continue
+		}
+		if _, ok := thresholds.Metrics[metric]; !ok {
+			return fmt.Errorf("thresholds missing metric %q for scenario %q", metric, scenario.Name)
+		}
+	}
+	return nil
+}
+
+func compareScenarioMetricsDetailed(
+	scenarioName string,
+	measured map[string]float64,
+	thresholds scenarioThresholds,
+) comparisonResult {
+	result := comparisonResult{
+		Findings: make([]string, 0),
+		Warnings: make([]string, 0),
+	}
 	keys := make([]string, 0, len(thresholds.Metrics))
 	for key := range thresholds.Metrics {
 		keys = append(keys, key)
@@ -51,22 +129,43 @@ func compareScenarioMetrics(scenarioName string, measured map[string]float64, th
 
 	for _, key := range keys {
 		threshold := thresholds.Metrics[key]
+		policy := normalizeMetricPolicy(key, thresholds.MetricPolicies[key])
+		if policy.Policy == metricPolicyIgnore {
+			continue
+		}
+
 		value, ok := measured[key]
 		if !ok {
-			findings = append(findings, fmt.Sprintf("%s: missing measured metric %q", scenarioName, key))
+			msg := fmt.Sprintf("%s: missing measured metric %q", scenarioName, key)
+			result = appendComparisonMessage(result, policy, msg)
 			continue
 		}
 		if value > threshold {
-			findings = append(findings, fmt.Sprintf(
-				"%s: metric %s exceeded threshold (value=%.3f threshold=%.3f)",
+			verb := "exceeded threshold"
+			if policy.Policy == metricPolicyMustBeZero {
+				verb = "must remain zero"
+			}
+			msg := fmt.Sprintf(
+				"%s: metric %s %s (value=%.3f threshold=%.3f)",
 				scenarioName,
 				key,
+				verb,
 				value,
 				threshold,
-			))
+			)
+			result = appendComparisonMessage(result, policy, msg)
 		}
 	}
-	return findings
+	return result
+}
+
+func appendComparisonMessage(result comparisonResult, policy metricPolicySpec, msg string) comparisonResult {
+	if policy.Severity == metricSeverityWarn {
+		result.Warnings = append(result.Warnings, msg)
+		return result
+	}
+	result.Findings = append(result.Findings, msg)
+	return result
 }
 
 func writeBaseline(path string, baseline baselineDocument) error {

--- a/hack/perfcheck/thresholds_test.go
+++ b/hack/perfcheck/thresholds_test.go
@@ -19,9 +19,26 @@ func TestBuildThresholdsFromBaseline(t *testing.T) {
 		Scenarios: map[string]scenarioBaseline{
 			"lifecycle": {
 				LabelFilter: "lifecycle && critical",
+				MetricPolicies: map[string]metricPolicySpec{
+					metricReconcileP95: {
+						Policy:     metricPolicyUpperBound,
+						Multiplier: metricMultiplierP95,
+					},
+					metricBackupLastMax: {
+						Policy:     metricPolicyUpperBound,
+						Multiplier: metricMultiplierMax,
+					},
+					metricWorkqueueRetries: {
+						Policy:     metricPolicyUpperBound,
+						Severity:   metricSeverityWarn,
+						Multiplier: metricMultiplierMax,
+						Floor:      ptrFloat64(20),
+					},
+				},
 				MaxMetrics: map[string]float64{
-					metricReconcileP95:  8,
-					metricBackupLastMax: 100,
+					metricReconcileP95:     8,
+					metricBackupLastMax:    100,
+					metricWorkqueueRetries: 7,
 				},
 			},
 		},
@@ -35,6 +52,12 @@ func TestBuildThresholdsFromBaseline(t *testing.T) {
 	}
 	if got := lifecycle.Metrics[metricBackupLastMax]; got != 140 {
 		t.Fatalf("backup threshold = %v, want 140", got)
+	}
+	if got := lifecycle.Metrics[metricWorkqueueRetries]; got != 20 {
+		t.Fatalf("workqueue threshold = %v, want 20", got)
+	}
+	if got := lifecycle.MetricPolicies[metricWorkqueueRetries].Severity; got != metricSeverityWarn {
+		t.Fatalf("workqueue severity = %q, want %q", got, metricSeverityWarn)
 	}
 }
 
@@ -57,4 +80,107 @@ func TestCompareScenarioMetricsFindings(t *testing.T) {
 	if !strings.Contains(findings[0], metricBackupLastMax) {
 		t.Fatalf("finding does not reference exceeded metric: %q", findings[0])
 	}
+}
+
+func TestCompareScenarioMetricsWarningSeverityDoesNotFail(t *testing.T) {
+	thresholds := scenarioThresholds{
+		MetricPolicies: map[string]metricPolicySpec{
+			metricWorkqueueRetries: {
+				Policy:   metricPolicyUpperBound,
+				Severity: metricSeverityWarn,
+			},
+		},
+		Metrics: map[string]float64{
+			metricWorkqueueRetries: 100,
+		},
+	}
+	measured := map[string]float64{
+		metricWorkqueueRetries: 120,
+	}
+
+	result := compareScenarioMetricsDetailed("rolling-upgrade", measured, thresholds)
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected warning-only comparison, got findings: %v", result.Findings)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("warnings len = %d, want 1 (%v)", len(result.Warnings), result.Warnings)
+	}
+}
+
+func TestApplyScenarioPolicyFiltersStaleThresholdMetrics(t *testing.T) {
+	scenario := scenarioSpec{
+		Name:        "rolling-upgrade",
+		LabelFilter: "upgrade && rolling && !snapshot",
+		MetricPolicies: map[string]metricPolicySpec{
+			metricUpgradeP95: {
+				Policy: metricPolicyUpperBound,
+			},
+		},
+	}
+	thresholds := scenarioThresholds{
+		LabelFilter: "upgrade && rolling",
+		Metrics: map[string]float64{
+			metricUpgradeP95:    75,
+			metricBackupLastMax: 0,
+		},
+	}
+
+	filtered := applyScenarioPolicy(thresholds, scenario)
+	if filtered.LabelFilter != scenario.LabelFilter {
+		t.Fatalf("labelFilter = %q, want %q", filtered.LabelFilter, scenario.LabelFilter)
+	}
+	if _, ok := filtered.Metrics[metricBackupLastMax]; ok {
+		t.Fatalf("stale backup metric should be filtered from rolling-upgrade thresholds")
+	}
+	if got := filtered.Metrics[metricUpgradeP95]; got != 75 {
+		t.Fatalf("upgrade threshold = %v, want 75", got)
+	}
+}
+
+func TestValidateScenarioThresholdsRequiresManagedMetrics(t *testing.T) {
+	scenario := scenarioSpec{
+		Name: "backup-restore",
+		MetricPolicies: map[string]metricPolicySpec{
+			metricRestoreP95: {
+				Policy: metricPolicyUpperBound,
+			},
+		},
+	}
+
+	err := validateScenarioThresholds(scenarioThresholds{Metrics: map[string]float64{}}, scenario)
+	if err == nil || !strings.Contains(err.Error(), metricRestoreP95) {
+		t.Fatalf("expected missing metric threshold error, got %v", err)
+	}
+}
+
+func TestBuildThresholdsMustBeZeroPolicy(t *testing.T) {
+	baseline := baselineDocument{
+		NodeImage:    "kindest/node:v1.34.3",
+		CapturedAt:   time.Unix(0, 0).UTC(),
+		RunsPerCase:  5,
+		Multipliers:  multiplierConfig{P95: 1.25, Max: 1.40},
+		MetricSchema: []string{metricBackupLastMax},
+		Scenarios: map[string]scenarioBaseline{
+			"rolling-upgrade": {
+				LabelFilter: "upgrade && rolling",
+				MetricPolicies: map[string]metricPolicySpec{
+					metricBackupLastMax: {
+						Policy: metricPolicyMustBeZero,
+					},
+				},
+				MaxMetrics: map[string]float64{
+					metricBackupLastMax: 3,
+				},
+			},
+		},
+	}
+
+	thresholds := buildThresholds(baseline)
+	if got := thresholds.Scenarios["rolling-upgrade"].Metrics[metricBackupLastMax]; got != 0 {
+		t.Fatalf("must_be_zero threshold = %v, want 0", got)
+	}
+}
+
+func ptrFloat64(v float64) *float64 {
+	return &v
 }

--- a/hack/perfcheck/types.go
+++ b/hack/perfcheck/types.go
@@ -29,30 +29,36 @@ var p95MetricSet = map[string]struct{}{
 	metricUpgradePodP95: {},
 }
 
+const (
+	metricPolicyUpperBound = "upper_bound"
+	metricPolicyMustBeZero = "must_be_zero"
+	metricPolicyIgnore     = "ignore"
+
+	metricSeverityFail = "fail"
+	metricSeverityWarn = "warn"
+
+	metricMultiplierP95 = "p95"
+	metricMultiplierMax = "max"
+)
+
 type scenarioSpec struct {
-	Name        string `json:"name" yaml:"name"`
-	LabelFilter string `json:"labelFilter" yaml:"labelFilter"`
+	Name           string                      `json:"name" yaml:"name"`
+	Description    string                      `json:"description,omitempty" yaml:"description,omitempty"`
+	LabelFilter    string                      `json:"labelFilter" yaml:"labelFilter"`
+	MetricPolicies map[string]metricPolicySpec `json:"metricPolicies" yaml:"metricPolicies"`
 }
 
-var defaultScenarios = []scenarioSpec{
-	{
-		Name:        "lifecycle",
-		LabelFilter: "lifecycle && critical && tenant && !slow && !openshift && !pentest",
-	},
-	{
-		Name:        "backup-restore",
-		LabelFilter: "dr && backup && restore && !failure-injection",
-	},
-	{
-		Name:        "rolling-upgrade",
-		LabelFilter: "upgrade && rolling && !failure && !bluegreen",
-	},
+type scenarioManifest struct {
+	Version   string         `json:"version" yaml:"version"`
+	Scenarios []scenarioSpec `json:"scenarios" yaml:"scenarios"`
 }
 
-var scenarioByName = map[string]scenarioSpec{
-	"lifecycle":       defaultScenarios[0],
-	"backup-restore":  defaultScenarios[1],
-	"rolling-upgrade": defaultScenarios[2],
+type metricPolicySpec struct {
+	Policy     string   `json:"policy" yaml:"policy"`
+	Severity   string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Multiplier string   `json:"multiplier,omitempty" yaml:"multiplier,omitempty"`
+	Floor      *float64 `json:"floor,omitempty" yaml:"floor,omitempty"`
+	Threshold  *float64 `json:"threshold,omitempty" yaml:"threshold,omitempty"`
 }
 
 type runResult struct {
@@ -67,9 +73,10 @@ type runResult struct {
 }
 
 type scenarioBaseline struct {
-	LabelFilter string             `json:"labelFilter"`
-	Runs        []runResult        `json:"runs"`
-	MaxMetrics  map[string]float64 `json:"maxMetrics"`
+	LabelFilter    string                      `json:"labelFilter"`
+	MetricPolicies map[string]metricPolicySpec `json:"metricPolicies,omitempty"`
+	Runs           []runResult                 `json:"runs"`
+	MaxMetrics     map[string]float64          `json:"maxMetrics"`
 }
 
 type baselineDocument struct {
@@ -97,14 +104,16 @@ type thresholdDocument struct {
 }
 
 type scenarioThresholds struct {
-	LabelFilter string             `json:"labelFilter" yaml:"labelFilter"`
-	Metrics     map[string]float64 `json:"metrics" yaml:"metrics"`
+	LabelFilter    string                      `json:"labelFilter" yaml:"labelFilter"`
+	MetricPolicies map[string]metricPolicySpec `json:"metricPolicies,omitempty" yaml:"metricPolicies,omitempty"`
+	Metrics        map[string]float64          `json:"metrics" yaml:"metrics"`
 }
 
 type options struct {
 	Mode            string
 	Runs            int
 	ScenarioNames   []string
+	ScenarioPath    string
 	NodeImage       string
 	KindBin         string
 	MakeBin         string

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -390,6 +390,7 @@ PERF_RUNS ?= 5
 PERF_SCENARIO_TIMEOUT ?= 90m
 PERF_SMOKE_SCENARIO_TIMEOUT ?= 45m
 PERF_SMOKE_SCENARIOS ?= lifecycle
+PERF_SCENARIOS_FILE ?= hack/perf/scenarios.yaml
 PERF_BASELINE_OUT ?= hack/perf/baseline/kind-v1.34.3-baseline.json
 PERF_THRESHOLDS_OUT ?= hack/perf/thresholds/kind-v1.34.3.yaml
 
@@ -505,6 +506,7 @@ perf-baseline: ## Capture performance baseline (5 runs/scenario by default) and 
 	go run ./hack/perfcheck capture \
 		--runs="$(PERF_RUNS)" \
 		--scenarios=all \
+		--scenario-manifest="$(PERF_SCENARIOS_FILE)" \
 		--kind="$(KIND)" \
 		--node-image="$(PERF_NODE_IMAGE)" \
 		--baseline-out="$(PERF_BASELINE_OUT)" \
@@ -515,6 +517,7 @@ perf-baseline: ## Capture performance baseline (5 runs/scenario by default) and 
 verify-perf: ## Run performance regression gate against committed thresholds.
 	go run ./hack/perfcheck verify \
 		--scenarios=all \
+		--scenario-manifest="$(PERF_SCENARIOS_FILE)" \
 		--kind="$(KIND)" \
 		--node-image="$(PERF_NODE_IMAGE)" \
 		--thresholds="$(PERF_THRESHOLDS_OUT)" \
@@ -524,6 +527,7 @@ verify-perf: ## Run performance regression gate against committed thresholds.
 verify-perf-smoke: ## Run a lightweight performance smoke gate (PR-focused).
 	go run ./hack/perfcheck verify \
 		--scenarios="$(PERF_SMOKE_SCENARIOS)" \
+		--scenario-manifest="$(PERF_SCENARIOS_FILE)" \
 		--kind="$(KIND)" \
 		--node-image="$(PERF_NODE_IMAGE)" \
 		--thresholds="$(PERF_THRESHOLDS_OUT)" \


### PR DESCRIPTION
## Description

This PR hardens the weekly performance regression harness so it measures explicit scenario contracts instead of broad E2E label drift.

It includes:

- a new `hack/perf/scenarios.yaml` manifest that owns perf scenario names, label filters, descriptions, and metric policies
- manifest loading and validation in `hack/perfcheck`
- per-scenario metric policy handling with `upper_bound`, `must_be_zero`, and `ignore` policy support
- warning-vs-failure severity, so broad diagnostic counters such as aggregate workqueue retries can be reported without making the weekly run fail by themselves
- threshold filtering through the scenario manifest so stale threshold metrics do not keep influencing a scenario after the scenario contract changes
- rolling upgrade perf scope narrowed to exclude snapshot/recovery coverage from the steady rolling-upgrade scenario
- updated perf thresholds to evaluate only scenario-owned metrics
- contributor testing docs noting the perf scenario manifest contract

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

Ran focused tests:

```sh
GOFLAGS=-mod=vendor go test ./hack/perfcheck
```

Checked scenario manifest validation behavior:

```sh
go run ./hack/perfcheck verify \
  --scenario-manifest=hack/perf/scenarios.yaml \
  --scenarios=missing \
  --thresholds=hack/perf/thresholds/kind-v1.34.3.yaml
```

This correctly fails early with the available scenario names.

Pre-push hook also ran:

```sh
make lint-ci
```
