### PR TITLE
fix(upgrade): harden bluegreen and rolling recovery flakes

### DIFF
--- a/internal/service/upgrade/raftops/actions.go
+++ b/internal/service/upgrade/raftops/actions.go
@@ -303,8 +303,13 @@ func RunBlueGreenRepairConsensus(ctx context.Context, logger logr.Logger, cfg *E
 		}
 
 		logger.Info("Promoting Blue peer to voter during consensus repair", "node_id", server.NodeID, "address", server.Address)
-		if err := client.PromoteRaftPeer(ctx, server.NodeID); err != nil {
+		alreadyVoter, err := promoteRaftPeerAndVerify(ctx, client, server.NodeID)
+		if err != nil {
 			return fmt.Errorf("failed to promote Blue peer %q to voter during consensus repair: %w", server.NodeID, err)
+		}
+		if alreadyVoter {
+			logger.V(1).Info("Blue peer already voter during consensus repair", "node_id", server.NodeID, "address", server.Address)
+			continue
 		}
 	}
 
@@ -387,8 +392,13 @@ func RunBlueGreenPromoteGreenVoters(ctx context.Context, logger logr.Logger, cfg
 		}
 
 		logger.V(1).Info("Promoting Green pod to voter", "pod_name", greenPodName)
-		if err := client.PromoteRaftPeer(ctx, greenPodName); err != nil {
+		alreadyVoter, err := promoteRaftPeerAndVerify(ctx, client, greenPodName)
+		if err != nil {
 			return fmt.Errorf("failed to promote Green pod %q to voter: %w", greenPodName, err)
+		}
+		if alreadyVoter {
+			logger.V(1).Info("Green pod is already a voter, skipping", "pod_name", greenPodName)
+			continue
 		}
 	}
 

--- a/internal/service/upgrade/raftops/promote.go
+++ b/internal/service/upgrade/raftops/promote.go
@@ -1,0 +1,119 @@
+package raftops
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+const (
+	defaultPromoteVerifyMaxAttempts = 10
+	defaultPromoteVerifyInterval    = time.Second
+)
+
+type raftPeerPromoter interface {
+	raftConfigurationReader
+	PromoteRaftPeer(context.Context, string) error
+}
+
+type raftConfigurationReader interface {
+	ReadRaftConfiguration(context.Context) (*portopenbao.RaftConfigurationResponse, error)
+}
+
+func promoteRaftPeerAndVerify(ctx context.Context, client raftPeerPromoter, serverID string) (bool, error) {
+	return promoteRaftPeerAndVerifyWithPolicy(ctx, client, serverID, RetryPolicy{
+		MaxAttempts:     defaultPromoteVerifyMaxAttempts,
+		AttemptInterval: defaultPromoteVerifyInterval,
+	})
+}
+
+func promoteRaftPeerAndVerifyWithPolicy(
+	ctx context.Context,
+	client raftPeerPromoter,
+	serverID string,
+	policy RetryPolicy,
+) (bool, error) {
+	if err := client.PromoteRaftPeer(ctx, serverID); err != nil {
+		isVoter, verifyErr := waitForRaftServerVoter(ctx, client, serverID, policy)
+		if verifyErr == nil && isVoter {
+			return true, nil
+		}
+		if verifyErr != nil {
+			return false, fmt.Errorf("%w; failed to verify raft voter state after promote error: %v", err, verifyErr)
+		}
+
+		return false, err
+	}
+
+	return false, nil
+}
+
+func waitForRaftServerVoter(ctx context.Context, client raftConfigurationReader, serverID string, policy RetryPolicy) (bool, error) {
+	policy = NormalizeRetryPolicy(policy)
+
+	var lastErr error
+	lastReadFailed := false
+	for _, attempt := range AttemptOrdinals(policy.MaxAttempts) {
+		isVoter, err := raftServerIsVoter(ctx, client, serverID)
+		if err == nil && isVoter {
+			return true, nil
+		}
+		if err != nil {
+			lastErr = err
+			lastReadFailed = true
+		} else {
+			lastReadFailed = false
+		}
+
+		if attempt == policy.MaxAttempts-1 || policy.AttemptInterval <= 0 {
+			continue
+		}
+		if waitErr := waitForPromoteVerifyInterval(ctx, policy.AttemptInterval); waitErr != nil {
+			if lastErr != nil {
+				return false, fmt.Errorf("%v; %w", lastErr, waitErr)
+			}
+			return false, waitErr
+		}
+	}
+
+	if lastReadFailed && lastErr != nil {
+		return false, lastErr
+	}
+	return false, nil
+}
+
+func waitForPromoteVerifyInterval(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func raftServerIsVoter(ctx context.Context, client raftConfigurationReader, serverID string) (bool, error) {
+	config, err := client.ReadRaftConfiguration(ctx)
+	if err != nil {
+		return false, err
+	}
+	if config == nil {
+		return false, nil
+	}
+
+	for _, server := range config.Config.Servers {
+		if server.NodeID == serverID {
+			return server.Voter, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/service/upgrade/raftops/promote_test.go
+++ b/internal/service/upgrade/raftops/promote_test.go
@@ -1,0 +1,200 @@
+package raftops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+type raftPeerPromoterStub struct {
+	promoteErr  error
+	config      *portopenbao.RaftConfigurationResponse
+	configErr   error
+	readResults []raftConfigReadResult
+
+	promoteCalls int
+	readCalls    int
+}
+
+type raftConfigReadResult struct {
+	config *portopenbao.RaftConfigurationResponse
+	err    error
+}
+
+func (s *raftPeerPromoterStub) PromoteRaftPeer(context.Context, string) error {
+	s.promoteCalls++
+	return s.promoteErr
+}
+
+func (s *raftPeerPromoterStub) ReadRaftConfiguration(context.Context) (*portopenbao.RaftConfigurationResponse, error) {
+	index := s.readCalls
+	s.readCalls++
+	if index < len(s.readResults) {
+		return s.readResults[index].config, s.readResults[index].err
+	}
+	return s.config, s.configErr
+}
+
+func TestPromoteRaftPeerAndVerify(t *testing.T) {
+	t.Parallel()
+
+	promoteErr := errors.New("server is not a non-voter")
+	verifyPolicy := RetryPolicy{MaxAttempts: 3}
+
+	tests := []struct {
+		name              string
+		client            *raftPeerPromoterStub
+		wantAlreadyVoter  bool
+		wantErr           bool
+		wantErrContains   string
+		wantPromoteCalls  int
+		wantReadCalls     int
+		wantOriginalError bool
+	}{
+		{
+			name: "promote success does not re-read raft config",
+			client: &raftPeerPromoterStub{
+				config: raftConfigWithServer(true),
+			},
+			wantPromoteCalls: 1,
+		},
+		{
+			name: "promote error is benign when raft config confirms voter",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				config:     raftConfigWithServer(true),
+			},
+			wantAlreadyVoter: true,
+			wantPromoteCalls: 1,
+			wantReadCalls:    1,
+		},
+		{
+			name: "promote error is benign when raft config converges to voter after stale read",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				readResults: []raftConfigReadResult{
+					{config: raftConfigWithServer(false)},
+					{config: raftConfigWithServer(true)},
+				},
+			},
+			wantAlreadyVoter: true,
+			wantPromoteCalls: 1,
+			wantReadCalls:    2,
+		},
+		{
+			name: "promote error is benign when raft config read recovers and confirms voter",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				readResults: []raftConfigReadResult{
+					{err: errors.New("configuration unavailable")},
+					{config: raftConfigWithServer(true)},
+				},
+			},
+			wantAlreadyVoter: true,
+			wantPromoteCalls: 1,
+			wantReadCalls:    2,
+		},
+		{
+			name: "promote error is returned when raft config does not confirm voter",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				config:     raftConfigWithServer(false),
+			},
+			wantErr:           true,
+			wantPromoteCalls:  1,
+			wantReadCalls:     3,
+			wantOriginalError: true,
+		},
+		{
+			name: "promote error is returned when raft config read recovers but does not confirm voter",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				readResults: []raftConfigReadResult{
+					{err: errors.New("configuration unavailable")},
+					{config: raftConfigWithServer(false)},
+				},
+			},
+			wantErr:           true,
+			wantPromoteCalls:  1,
+			wantReadCalls:     3,
+			wantOriginalError: true,
+		},
+		{
+			name: "verification error preserves promote failure context",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				configErr:  errors.New("configuration unavailable"),
+			},
+			wantErr:           true,
+			wantErrContains:   "failed to verify raft voter state after promote error",
+			wantPromoteCalls:  1,
+			wantReadCalls:     3,
+			wantOriginalError: true,
+		},
+		{
+			name: "last verification error is returned when retries are exhausted",
+			client: &raftPeerPromoterStub{
+				promoteErr: promoteErr,
+				readResults: []raftConfigReadResult{
+					{err: errors.New("first read failed")},
+					{err: errors.New("middle read failed")},
+					{err: errors.New("last read failed")},
+				},
+			},
+			wantErr:           true,
+			wantErrContains:   "last read failed",
+			wantPromoteCalls:  1,
+			wantReadCalls:     3,
+			wantOriginalError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			alreadyVoter, err := promoteRaftPeerAndVerifyWithPolicy(context.Background(), tt.client, "node-1", verifyPolicy)
+
+			if alreadyVoter != tt.wantAlreadyVoter {
+				t.Fatalf("alreadyVoter = %t, want %t", alreadyVoter, tt.wantAlreadyVoter)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if tt.wantErrContains != "" {
+				gotErr := "<nil>"
+				if err != nil {
+					gotErr = err.Error()
+				}
+				if !strings.Contains(gotErr, tt.wantErrContains) {
+					t.Fatalf("error = %q, want contains %q", gotErr, tt.wantErrContains)
+				}
+			}
+			if tt.wantOriginalError && !errors.Is(err, promoteErr) {
+				t.Fatalf("error = %v, want original promote error", err)
+			}
+			if tt.client.promoteCalls != tt.wantPromoteCalls {
+				t.Fatalf("promoteCalls = %d, want %d", tt.client.promoteCalls, tt.wantPromoteCalls)
+			}
+			if tt.client.readCalls != tt.wantReadCalls {
+				t.Fatalf("readCalls = %d, want %d", tt.client.readCalls, tt.wantReadCalls)
+			}
+		})
+	}
+}
+
+func raftConfigWithServer(voter bool) *portopenbao.RaftConfigurationResponse {
+	return &portopenbao.RaftConfigurationResponse{
+		Config: portopenbao.RaftConfiguration{
+			Servers: []portopenbao.RaftServer{
+				{
+					NodeID: "node-1",
+					Voter:  voter,
+				},
+			},
+		},
+	}
+}

--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -665,6 +665,80 @@ func TestValidateUpgrade_ResumeHealthBlocksNonTargetUnavailableReplica(t *testin
 	}
 }
 
+func TestValidateUpgrade_ResumeHealthMarksTimedOutNonTargetAsPodNotReady(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme()
+	startedAt := metav1.NewTime(time.Now().Add(-(upgrade.DefaultPodReadyTimeout + time.Minute)))
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version:  "2.5.0",
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			CurrentVersion: "2.4.4",
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				FromVersion:      "2.4.4",
+				TargetVersion:    "2.5.0",
+				CurrentPartition: 2,
+				CompletedPods:    []int32{2},
+				StartedAt:        &startedAt,
+			},
+		},
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: cluster.Name, Namespace: cluster.Namespace},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:      3,
+			ReadyReplicas: 2,
+		},
+	}
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + constants.SuffixTLSCA,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			"ca.crt": []byte("fake-ca"),
+		},
+	}
+
+	pod0 := pendingRollingTestPod(cluster, 0)
+	pod1 := readyRollingTestPod(cluster, 1, false)
+	pod2 := readyRollingTestPod(cluster, 2, true)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts, caSecret, pod0, pod1, pod2).Build()
+	mgr := NewManagerWithClientFactory(
+		k8sClient,
+		scheme,
+		nil,
+		rollingTestClientFactory(),
+		portopenbao.ClientConfig{},
+		nil,
+		"",
+	)
+
+	err := mgr.validateUpgrade(context.Background(), testLogger(), cluster)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "non-target pod test-cluster-0 is not ready") {
+		t.Fatalf("validateUpgrade() error = %v, want non-target readiness failure", err)
+	}
+	if cluster.Status.Upgrade == nil {
+		t.Fatal("expected rolling upgrade status to remain present")
+	}
+	if cluster.Status.Upgrade.LastErrorReason != upgrade.ReasonPodNotReady {
+		t.Fatalf("LastErrorReason=%q, want %q", cluster.Status.Upgrade.LastErrorReason, upgrade.ReasonPodNotReady)
+	}
+	if !strings.Contains(cluster.Status.Upgrade.LastErrorMessage, "test-cluster-0") {
+		t.Fatalf("LastErrorMessage=%q, want non-target pod name", cluster.Status.Upgrade.LastErrorMessage)
+	}
+}
+
 func TestIsPodReady(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -46,7 +46,7 @@ func (m *Manager) prepareFailedUpgradeRetry(ctx context.Context, logger logr.Log
 	if err := m.cleanupStepDownJobForRetry(ctx, logger, cluster); err != nil {
 		return false, err
 	}
-	if err := m.resetTargetPodForRetry(ctx, logger, cluster); err != nil {
+	if err := m.resetRolloutPodsForRetry(ctx, logger, cluster); err != nil {
 		return false, err
 	}
 
@@ -125,17 +125,13 @@ func (m *Manager) cleanupStepDownJobForRetry(ctx context.Context, logger logr.Lo
 	return nil
 }
 
-func (m *Manager) resetTargetPodForRetry(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
+func (m *Manager) resetRolloutPodsForRetry(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	if cluster == nil || cluster.Status.Upgrade == nil {
 		return nil
 	}
 	if cluster.Status.Upgrade.CurrentPartition <= 0 {
 		return nil
 	}
-
-	targetOrdinal := cluster.Status.Upgrade.CurrentPartition - 1
-	targetPod := fmt.Sprintf("%s-%d", cluster.Name, targetOrdinal)
-	podKey := types.NamespacedName{Namespace: cluster.Namespace, Name: targetPod}
 
 	sts := &appsv1.StatefulSet{}
 	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, sts); err != nil {
@@ -145,12 +141,44 @@ func (m *Manager) resetTargetPodForRetry(ctx context.Context, logger logr.Logger
 		return fmt.Errorf("failed to get StatefulSet %s/%s for retry pod reset: %w", cluster.Namespace, cluster.Name, err)
 	}
 
+	desiredImage := strings.TrimSpace(baoContainerImage(sts.Spec.Template.Spec.Containers))
+	specImage := strings.TrimSpace(cluster.Spec.Image)
+	if specImage != "" && desiredImage != specImage {
+		logger.Info("Waiting for StatefulSet template to reflect retry target image before resetting failed pods",
+			"statefulSetImage", desiredImage,
+			"specImage", specImage)
+		return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf(
+			"StatefulSet template still references %q while retry target image is %q",
+			desiredImage,
+			specImage,
+		))
+	}
+
+	for _, ordinal := range retryResetOrdinals(cluster) {
+		if err := m.resetRolloutPodForRetry(ctx, logger, cluster, sts, ordinal); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) resetRolloutPodForRetry(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	sts *appsv1.StatefulSet,
+	ordinal int32,
+) error {
+	targetPod := fmt.Sprintf("%s-%d", cluster.Name, ordinal)
+	podKey := types.NamespacedName{Namespace: cluster.Namespace, Name: targetPod}
+
 	pod := &corev1.Pod{}
 	if err := m.client.Get(ctx, podKey, pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get target pod %s/%s for retry reset: %w", cluster.Namespace, targetPod, err)
+		return fmt.Errorf("failed to get rollout pod %s/%s for retry reset: %w", cluster.Namespace, targetPod, err)
 	}
 
 	podRevision := ""
@@ -160,19 +188,6 @@ func (m *Manager) resetTargetPodForRetry(ctx context.Context, logger logr.Logger
 	desiredRevision := strings.TrimSpace(sts.Status.UpdateRevision)
 	podImage := strings.TrimSpace(baoContainerImage(pod.Spec.Containers))
 	desiredImage := strings.TrimSpace(baoContainerImage(sts.Spec.Template.Spec.Containers))
-	specImage := strings.TrimSpace(cluster.Spec.Image)
-
-	if specImage != "" && desiredImage != specImage {
-		logger.Info("Waiting for StatefulSet template to reflect retry target image before resetting failed pod",
-			"pod", targetPod,
-			"statefulSetImage", desiredImage,
-			"specImage", specImage)
-		return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf(
-			"StatefulSet template still references %q while retry target image is %q",
-			desiredImage,
-			specImage,
-		))
-	}
 
 	needsDelete := !isPodReady(pod)
 	if desiredRevision != "" && podRevision != desiredRevision {
@@ -186,16 +201,46 @@ func (m *Manager) resetTargetPodForRetry(ctx context.Context, logger logr.Logger
 	}
 
 	if err := m.client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete target pod %s/%s for retry reset: %w", cluster.Namespace, targetPod, err)
+		return fmt.Errorf("failed to delete rollout pod %s/%s for retry reset: %w", cluster.Namespace, targetPod, err)
 	}
 
-	logger.Info("Deleted target pod before retry to force a fresh rollout attempt",
+	logger.Info("Deleted rollout pod before retry to force a fresh rollout attempt",
 		"pod", targetPod,
+		"ordinal", ordinal,
 		"podRevision", podRevision,
 		"targetRevision", desiredRevision,
 		"podImage", podImage,
 		"desiredImage", desiredImage)
 	return nil
+}
+
+func retryResetOrdinals(cluster *openbaov1alpha1.OpenBaoCluster) []int32 {
+	if cluster == nil || cluster.Status.Upgrade == nil || cluster.Status.Upgrade.CurrentPartition <= 0 {
+		return nil
+	}
+
+	seen := make(map[int32]struct{})
+	ordinals := make([]int32, 0, 1+len(cluster.Status.Upgrade.CompletedPods))
+	add := func(ordinal int32) {
+		if ordinal < 0 {
+			return
+		}
+		if cluster.Spec.Replicas > 0 && ordinal >= cluster.Spec.Replicas {
+			return
+		}
+		if _, ok := seen[ordinal]; ok {
+			return
+		}
+		seen[ordinal] = struct{}{}
+		ordinals = append(ordinals, ordinal)
+	}
+
+	add(cluster.Status.Upgrade.CurrentPartition - 1)
+	for _, ordinal := range cluster.Status.Upgrade.CompletedPods {
+		add(ordinal)
+	}
+
+	return ordinals
 }
 
 func baoContainerImage(containers []corev1.Container) string {

--- a/internal/service/upgrade/rolling/retry_test.go
+++ b/internal/service/upgrade/rolling/retry_test.go
@@ -418,6 +418,140 @@ func TestPatchRetryStatusSSA_ApplyPayloadOmitsClearedFailureFields(t *testing.T)
 	}
 }
 
+func TestPrepareFailedUpgradeRetry_DeletesStaleCompletedPod(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add openbao scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batchv1 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	now := metav1.Now()
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "retry-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version:  "2.5.0",
+			Image:    "openbao/openbao:2.5.0",
+			Replicas: 3,
+			Upgrade: &openbaov1alpha1.UpgradeConfig{
+				Requests: &openbaov1alpha1.UpgradeRequestConfig{
+					Retry: "retry-now",
+				},
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				TargetVersion:    "2.5.0",
+				FromVersion:      "2.4.4",
+				CurrentPartition: 2,
+				CompletedPods:    []int32{2},
+				LastErrorReason:  upgrade.ReasonPodNotReady,
+				LastErrorMessage: "Pod retry-cluster-2 failed to become ready within 10m0s",
+				LastErrorAt:      &now,
+			},
+		},
+	}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: "rev-good",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.ContainerBao,
+							Image: "openbao/openbao:2.5.0",
+						},
+					},
+				},
+			},
+		},
+	}
+	currentTargetPod := retryPodForResetTest(cluster.Namespace, "retry-cluster-1", "rev-good", "openbao/openbao:2.5.0", true)
+	staleCompletedPod := retryPodForResetTest(cluster.Namespace, "retry-cluster-2", "rev-bad", "openbao/openbao:retry-image-does-not-exist", false)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+		WithObjects(cluster, sts, currentTargetPod, staleCompletedPod).
+		Build()
+	manager := &Manager{
+		client:          k8sClient,
+		reader:          k8sClient,
+		scheme:          scheme,
+		adminOpsMutator: testAdminOpsMutator(k8sClient),
+	}
+
+	resumed, err := manager.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("prepareFailedUpgradeRetry() error = %v, want nil", err)
+	}
+	if !resumed {
+		t.Fatal("prepareFailedUpgradeRetry() resumed=false, want true")
+	}
+
+	remainingTargetPod := &corev1.Pod{}
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: currentTargetPod.Name, Namespace: cluster.Namespace}, remainingTargetPod); err != nil {
+		t.Fatalf("current target pod was deleted unexpectedly: %v", err)
+	}
+
+	deletedCompletedPod := &corev1.Pod{}
+	err = k8sClient.Get(context.Background(), types.NamespacedName{Name: staleCompletedPod.Name, Namespace: cluster.Namespace}, deletedCompletedPod)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stale completed pod to be deleted, got err=%v", err)
+	}
+}
+
+func retryPodForResetTest(namespace, name, revision, image string, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				appsv1.StatefulSetRevisionLabel: revision,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  constants.ContainerBao,
+					Image: image,
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+	if ready {
+		pod.Status.Phase = corev1.PodRunning
+		pod.Status.Conditions = []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			},
+		}
+	}
+	return pod
+}
+
 func TestPrepareFailedUpgradeRetry_GuardConditions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/upgrade/rolling/validate_health.go
+++ b/internal/service/upgrade/rolling/validate_health.go
@@ -222,28 +222,44 @@ func (m *Manager) verifyNonTargetPodsReadyAndHealthy(
 
 		pod := podsByName[podName]
 		if pod == nil {
-			return fmt.Errorf("rolling upgrade cannot continue while non-target pod %s is missing; current target is %s", podName, targetPodName)
+			return resumePodReadyBlocker(cluster, podName, "rolling upgrade cannot continue while non-target pod %s is missing; current target is %s", podName, targetPodName)
 		}
 		if !isPodReady(pod) {
-			return fmt.Errorf("rolling upgrade cannot continue while non-target pod %s is not ready; current target is %s", podName, targetPodName)
+			return resumePodReadyBlocker(cluster, podName, "rolling upgrade cannot continue while non-target pod %s is not ready; current target is %s", podName, targetPodName)
 		}
 
 		apiClient, err := raftops.NewClusterPodClient(cluster, podName, caCert, m.clientFactory, raftops.ClusterPodClientOptions{})
 		if err != nil {
-			return fmt.Errorf("rolling upgrade cannot continue while non-target pod %s is unavailable: %w", podName, err)
+			return resumePodReadyBlocker(cluster, podName, "rolling upgrade cannot continue while non-target pod %s is unavailable: %w", podName, err)
 		}
 
 		healthy, err := apiClient.IsHealthy(ctx)
 		if err != nil {
 			logger.V(1).Info("Non-target pod health check failed during rolling resume validation", "pod", podName, "error", err)
-			return fmt.Errorf("rolling upgrade cannot continue while non-target pod %s is unhealthy: %w", podName, err)
+			return resumePodHealthBlocker(cluster, podName, "rolling upgrade cannot continue while non-target pod %s is unhealthy: %w", podName, err)
 		}
 		if !healthy {
-			return fmt.Errorf("rolling upgrade cannot continue while non-target pod %s is unhealthy; current target is %s", podName, targetPodName)
+			return resumePodHealthBlocker(cluster, podName, "rolling upgrade cannot continue while non-target pod %s is unhealthy; current target is %s", podName, targetPodName)
 		}
 	}
 
 	return nil
+}
+
+func resumePodReadyBlocker(cluster *openbaov1alpha1.OpenBaoCluster, podName string, format string, args ...any) error {
+	err := fmt.Errorf(format, args...)
+	if timeoutErr := markResumeUpgradeTimeout(cluster, podName); timeoutErr != nil {
+		return fmt.Errorf("%v: %w", err, timeoutErr)
+	}
+	return err
+}
+
+func resumePodHealthBlocker(cluster *openbaov1alpha1.OpenBaoCluster, podName string, format string, args ...any) error {
+	err := fmt.Errorf(format, args...)
+	if timeoutErr := failUpgradeIfStartedTimeout(cluster, podHealthTimeout(podName)); timeoutErr != nil {
+		return fmt.Errorf("%v: %w", err, timeoutErr)
+	}
+	return err
 }
 
 func transientClusterStatef(reason string, format string, args ...any) error {

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -435,11 +435,11 @@ func newStaleRollingStepDownJob(namespace, clusterName, podName, image string) *
 
 // === Tests ===
 
-var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "slow"), Ordered, func() {
+var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "slow"), func() {
 	ctx := context.Background()
 
 	// --- Rolling Upgrade ---
-	Context("Rolling Upgrade", Label("rolling"), func() {
+	Context("Rolling Upgrade", Label("rolling"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -856,7 +856,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Rolling Snapshot Recovery", Label("rolling", "snapshot", "recovery"), func() {
+	Context("Rolling Snapshot Recovery", Label("rolling", "snapshot", "recovery"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -1168,7 +1168,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Rolling Failure Recovery", Label("rolling", "recovery"), func() {
+	Context("Rolling Failure Recovery", Label("rolling", "recovery"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -1359,7 +1359,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Validation Guardrails", Label("guardrails", "validation"), func() {
+	Context("Validation Guardrails", Label("guardrails", "validation"), Ordered, func() {
 		var (
 			tenantNamespace  string
 			tenantFW         *framework.Framework
@@ -1532,7 +1532,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 	})
 
 	// --- Blue/Green Upgrade ---
-	Context("Blue/Green Upgrade", Label("bluegreen"), func() {
+	Context("Blue/Green Upgrade", Label("bluegreen"), Ordered, func() {
 		var (
 			tenantNamespace   string
 			tenantFW          *framework.Framework
@@ -2051,7 +2051,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Blue/Green Syncing Gates", Label("bluegreen", "verification"), func() {
+	Context("Blue/Green Syncing Gates", Label("bluegreen", "verification"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -2223,7 +2223,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Blue/Green Validation Hook Failure", Label("bluegreen", "verification", "failure"), func() {
+	Context("Blue/Green Validation Hook Failure", Label("bluegreen", "verification", "failure"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -2419,7 +2419,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 	})
 
 	// --- Failure Scenarios ---
-	Context("Failure Scenarios", Label("failure", "bluegreen"), func() {
+	Context("Failure Scenarios", Label("failure", "bluegreen"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -2611,7 +2611,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Late-Phase Rollback Scenarios", Label("failure", "bluegreen", "rollback"), func() {
+	Context("Late-Phase Rollback Scenarios", Label("failure", "bluegreen", "rollback"), Ordered, func() {
 		var (
 			tenantNamespace     string
 			tenantFW            *framework.Framework
@@ -2825,7 +2825,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 	})
 
 	// --- Safe Mode (Chaos) ---
-	Context("Safe Mode (chaos)", Label("chaos", "bluegreen"), func() {
+	Context("Safe Mode (chaos)", Label("chaos", "bluegreen"), Ordered, func() {
 		var (
 			tenantNamespace string
 			tenantFW        *framework.Framework
@@ -3065,8 +3065,6 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 			// Secret should still be there as we are technically still on the Blue cluster (or the active one)
 			// even if we are in safe mode/break glass state.
 			secretPath = "secret/safemode-test"
-			// bypassLabels is in scope from the beginning of the It block
-			// bypassLabels is in scope from the beginning of the It block
 			Eventually(func(g Gomega) {
 				baoAddr, err := e2ehelpers.ResolveActiveOpenBaoAddress(ctx, admin, tenantNamespace, chaosCluster.Name)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -3108,7 +3106,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 					policyWriteCommand("openbao-operator-upgrade", `path "*" { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }`),
 				)
 				g.Expect(err).NotTo(HaveOccurred())
-			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 
 			By("Acknowledging break glass with the current nonce")
 			Eventually(func(g Gomega) {
@@ -3122,6 +3120,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				updated.Spec.BreakGlassAck = updated.Status.BreakGlass.Nonce
 				g.Expect(admin.Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
 			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+			Expect(tenantFW.TriggerReconcile(ctx, chaosCluster.Name)).To(Succeed())
 
 			By("Verifying break glass deactivates and rollback resumes")
 			Eventually(func(g Gomega) {
@@ -3149,7 +3148,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 	})
 
 	// --- Gateway Integration ---
-	Context("Gateway Integration", Label("gateway", "requires-gateway-api", "bluegreen"), func() {
+	Context("Gateway Integration", Label("gateway", "requires-gateway-api", "bluegreen"), Ordered, func() {
 		var (
 			tenantNamespace  string
 			tenantFW         *framework.Framework
@@ -3424,7 +3423,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		})
 	})
 
-	Context("Gateway TLS Passthrough", Label("gateway", "requires-gateway-api", "tls-passthrough"), func() {
+	Context("Gateway TLS Passthrough", Label("gateway", "requires-gateway-api", "tls-passthrough"), Ordered, func() {
 		var (
 			tenantNamespace     string
 			tenantFW            *framework.Framework


### PR DESCRIPTION
## Description

Hardens upgrade recovery paths that showed up as flaky in edge/nightly runs.

This change fixes two failure modes:

- Blue/green safe-mode rollback consensus repair no longer depends on OpenBao's undocumented promote error text for an already-voter peer. Promote failures are now verified against the Raft configuration, and only treated as benign when the peer is observed as `voter=true`.
- Rolling upgrade retry validation now reports stale/non-target pod readiness blockers through upgrade status so the recovery test can observe the expected timeout state instead of waiting indefinitely.

The e2e upgrade spec was also adjusted so ordering is scoped to each strategy context, and the safe-mode test nudges reconciliation after break-glass policy repair.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. (No additional comments required.)
- [x] I have made corresponding changes to the documentation. (Not applicable: no user-facing/API documentation change.)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with `make test`.
- [x] Any dependent changes have been merged and published in downstream modules. (Not applicable: no dependent changes.)
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes. (Not applicable.)
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions. (Not applicable.)

## Verification Process

- `make test`
- pre-push hook: `make lint-ci`
- `go test ./internal/adapter/openbao ./internal/service/upgrade/raftops ./internal/service/upgrade/rolling`
- `go test ./internal/service/upgrade/...`
- `go test -tags=e2e ./test/e2e -run TestE2E -count=0`
- `git diff --check`
