### PR TITLE
fix(helm): allow global values in chart schema

### DIFF
--- a/charts/openbao-operator/values.schema.json
+++ b/charts/openbao-operator/values.schema.json
@@ -4,6 +4,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global values shared by parent charts and subcharts"
+    },
     "nameOverride": {
       "type": "string",
       "description": "Override the chart name"


### PR DESCRIPTION
## Description

Allow the Helm chart values schema to accept the conventional top-level `global` object. Helm passes `.Values.global` through parent charts to subcharts, so the chart could fail schema validation when used as a dependency because root `additionalProperties: false` rejected `global` before templates rendered.

This keeps strict validation for OpenBao Operator chart values while allowing Helm's shared-values object.

## Related Issues

Closes #377

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. No comments were needed for this schema-only change.
- [x] I have made corresponding changes to the documentation. Documentation changes are not needed for this compatibility fix.
- [x] I have added tests that prove my fix is effective or that my feature works. Verified with Helm schema/render checks.
- [ ] New and existing unit tests pass locally with `make test`. Not run; this is a Helm chart schema-only change.
- [x] Any dependent changes have been merged and published in downstream modules. No dependent changes are required.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes. Not applicable.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions. Not applicable.

## Verification Process

```sh
make verify-helm
helm template openbao-operator charts/openbao-operator --namespace openbao-operator-system --set global.parentChart=true >/dev/null
```

The push also ran the repository pre-push hook, including `make lint-ci`, successfully.