### PR TITLE
ci(ci): avoid github context shell interpolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,51 +843,62 @@ jobs:
 
       - name: Determine E2E Filter
         id: filter
+        env:
+          HAS_E2E_CHANGES: ${{ needs.changes.outputs.e2e == 'true' }}
+          FULL_E2E: >-
+            ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_full_e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}
+          PR_BACKUP: >-
+            ${{ needs.changes.outputs.manual_backup_e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'backup')) }}
+          PR_UPGRADE: >-
+            ${{ needs.changes.outputs.manual_upgrade_e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'upgrades')) }}
+          PR_HARDENED: >-
+            ${{ needs.changes.outputs.manual_hardened_e2e == 'true' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller'))) }}
+          E2E_BACKUP_CHANGED: ${{ needs.changes.outputs.e2e_backup }}
+          E2E_UPGRADE_CHANGED: ${{ needs.changes.outputs.e2e_upgrade }}
+          E2E_HARDENED_CHANGED: ${{ needs.changes.outputs.e2e_hardened }}
+          EXCLUDE_PENTEST_ON_DEFAULT_PR: ${{ matrix.exclude_pentest_on_default_pr }}
+          LABEL_FILTER: ${{ matrix.label_filter }}
+          PR_SCOPE: ${{ matrix.pr_scope }}
+          SHARD_NAME: ${{ matrix.name }}
         run: |
           set -euo pipefail
 
-          HAS_E2E_CHANGES="${{ needs.changes.outputs.e2e == 'true' }}"
-          FULL_E2E="${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_full_e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}"
-          PR_BACKUP="${{ needs.changes.outputs.manual_backup_e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'backup')) }}"
-          PR_UPGRADE="${{ needs.changes.outputs.manual_upgrade_e2e == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'upgrades')) }}"
-          PR_HARDENED="${{ needs.changes.outputs.manual_hardened_e2e == 'true' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller'))) }}"
-
-          FILTER='${{ matrix.label_filter }}'
+          FILTER="${LABEL_FILTER}"
           SHOULD_RUN="false"
 
-          case "${{ matrix.pr_scope }}" in
+          case "${PR_SCOPE}" in
             always)
               if [[ "${FULL_E2E}" == "true" ]] || [[ "${HAS_E2E_CHANGES}" == "true" ]]; then
                 SHOULD_RUN="true"
               fi
               ;;
             backup)
-              if [[ "${FULL_E2E}" == "true" ]] || [[ "${PR_BACKUP}" == "true" ]] || [[ "${{ needs.changes.outputs.e2e_backup }}" == "true" ]]; then
+              if [[ "${FULL_E2E}" == "true" ]] || [[ "${PR_BACKUP}" == "true" ]] || [[ "${E2E_BACKUP_CHANGED}" == "true" ]]; then
                 SHOULD_RUN="true"
               fi
               ;;
             upgrade)
-              if [[ "${FULL_E2E}" == "true" ]] || [[ "${PR_UPGRADE}" == "true" ]] || [[ "${{ needs.changes.outputs.e2e_upgrade }}" == "true" ]]; then
+              if [[ "${FULL_E2E}" == "true" ]] || [[ "${PR_UPGRADE}" == "true" ]] || [[ "${E2E_UPGRADE_CHANGED}" == "true" ]]; then
                 SHOULD_RUN="true"
               fi
               ;;
             hardened)
-              if [[ "${FULL_E2E}" == "true" ]] || [[ "${PR_HARDENED}" == "true" ]] || [[ "${{ needs.changes.outputs.e2e_hardened }}" == "true" ]]; then
+              if [[ "${FULL_E2E}" == "true" ]] || [[ "${PR_HARDENED}" == "true" ]] || [[ "${E2E_HARDENED_CHANGED}" == "true" ]]; then
                 SHOULD_RUN="true"
               fi
               ;;
           esac
 
-          if [[ "${FULL_E2E}" != "true" ]] && [[ "${{ matrix.exclude_pentest_on_default_pr }}" == "true" ]] && [[ "${PR_HARDENED}" != "true" ]]; then
+          if [[ "${FULL_E2E}" != "true" ]] && [[ "${EXCLUDE_PENTEST_ON_DEFAULT_PR}" == "true" ]] && [[ "${PR_HARDENED}" != "true" ]]; then
             FILTER="(${FILTER}) && !pentest"
           fi
 
           echo "E2E_LABEL_FILTER=$FILTER" >> "${GITHUB_ENV}"
           echo "SHOULD_RUN=$SHOULD_RUN" >> "${GITHUB_ENV}"
           if [[ "$SHOULD_RUN" == "false" ]]; then
-            echo "::notice::Skipping ${{ matrix.name }} shard (routing optimization)"
+            echo "::notice::Skipping ${SHARD_NAME} shard (routing optimization)"
           else
-            echo "::notice::Running ${{ matrix.name }} with filter: $FILTER"
+            echo "::notice::Running ${SHARD_NAME} with filter: $FILTER"
           fi
 
       - name: Setup repo tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,11 @@ jobs:
 
       - name: Compute release variables
         id: vars
+        env:
+          RELEASE_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          version="${{ github.ref_name }}"
+          version="${RELEASE_REF_NAME}"
           if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
             echo "version must be a semver tag (e.g., 0.1.0 or 0.1.0-rc.1)" >&2
             exit 1


### PR DESCRIPTION
## Description

Move GitHub context expressions out of shell scripts in the CI and release workflows. The Semgrep GitHub Actions rule `yaml.github-actions.security.run-shell-injection.run-shell-injection` flags direct `${{ github.* }}` interpolation inside `run:` blocks because GitHub context values can contain attacker-controlled input on pull request events.

The workflow logic is unchanged: values are now passed through step-level `env:` entries and read as quoted shell variables inside the scripts.

## Related Issues

Unblocks #378

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. No comments were needed for this workflow-only change.
- [x] I have made corresponding changes to the documentation. Documentation changes are not needed for this CI security fix.
- [x] I have added tests that prove my fix is effective or that my feature works. Verified with Semgrep and actionlint.
- [ ] New and existing unit tests pass locally with `make test`. Not run; this changes GitHub Actions workflow scripts only.
- [x] Any dependent changes have been merged and published in downstream modules. No dependent changes are required.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes. Not applicable.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions. Not applicable.

## Verification Process

```sh
make semgrep-ci
mkdir -p bin && GOBIN="$PWD/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 && "$PWD/bin/actionlint" .github/workflows/*.yml
```

The push also ran the repository pre-push hook, including `make lint-ci`, successfully.