### PR TITLE
test(ci): stabilize post-merge e2e lanes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -439,7 +439,9 @@ jobs:
       - name: Summarize E2E report
         if: always()
         env:
+          E2E_LABEL_FILTER: ${{ matrix.label_filter }}
           GOFLAGS: -mod=vendor
+          KIND_NODE_IMAGE: ${{ matrix.kind_node_image }}
         run: |
           set -euo pipefail
           if [[ -z "${E2E_JSON_REPORT:-}" ]] || [[ ! -s "${E2E_JSON_REPORT}" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,9 @@ jobs:
       - name: Summarize E2E report
         if: always()
         env:
+          E2E_LABEL_FILTER: ${{ matrix.label_filter }}
           GOFLAGS: -mod=vendor
+          KIND_NODE_IMAGE: ${{ matrix.kind_node_image }}
         run: |
           set -euo pipefail
           if [[ -z "${E2E_JSON_REPORT:-}" ]] || [[ ! -s "${E2E_JSON_REPORT}" ]]; then

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -1306,23 +1306,17 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				g.Expect(updated.Status.Upgrade.TargetVersion).To(Equal(targetVersion))
 			}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 
-			By("Backdating upgrade start time to force the real timeout/retry path instead of waiting ten minutes")
+			By("Forcing the real timeout/retry path without waiting ten minutes")
 			Eventually(func(g Gomega) {
 				updated := &openbaov1alpha1.OpenBaoCluster{}
 				g.Expect(admin.Get(ctx, types.NamespacedName{Name: recoveryCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
 				g.Expect(updated.Status.Upgrade).NotTo(BeNil())
-
-				original := updated.DeepCopy()
-				updated.Status.Upgrade.StartedAt = ptrTo(metav1.NewTime(time.Now().Add(-(upgrade.DefaultPodReadyTimeout + time.Minute))))
-				g.Expect(admin.Status().Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
-			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
-			Expect(tenantFW.TriggerReconcile(ctx, recoveryCluster.Name)).To(Succeed())
-
-			By("Waiting for the rolling upgrade to fail with a retryable status")
-			Eventually(func(g Gomega) {
-				updated := &openbaov1alpha1.OpenBaoCluster{}
-				g.Expect(admin.Get(ctx, types.NamespacedName{Name: recoveryCluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
-				g.Expect(updated.Status.Upgrade).NotTo(BeNil())
+				if updated.Status.Upgrade.LastErrorReason != upgrade.ReasonPodNotReady {
+					original := updated.DeepCopy()
+					updated.Status.Upgrade.StartedAt = ptrTo(metav1.NewTime(time.Now().Add(-(upgrade.DefaultPodReadyTimeout + time.Minute))))
+					g.Expect(admin.Status().Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
+					g.Expect(tenantFW.TriggerReconcile(ctx, recoveryCluster.Name)).To(Succeed())
+				}
 				g.Expect(updated.Status.Upgrade.LastErrorReason).To(Equal(upgrade.ReasonPodNotReady))
 				g.Expect(updated.Status.Upgrade.CurrentPartition).To(BeNumerically(">", 0))
 				failedPartition = updated.Status.Upgrade.CurrentPartition

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -656,6 +656,7 @@
       "setting up ACME service and domain",
       "creating transit token secret for auto-unseal (include TLS CA for transit and PKI CA for ACME)",
       "verifying transit token secret can access infra-bao transit key",
+      "preparing ACME shared cache storage",
       "waiting for OpenBaoCluster to be observed by the API server",
       "verifying TLS secrets are NOT created (ACME mode)",
       "checking for prerequisite resources (ConfigMap)",
@@ -2154,8 +2155,7 @@
     "steps": [
       "Triggering a rolling upgrade with a bad non-semver image tag",
       "Waiting for the rolling upgrade to initialize",
-      "Backdating upgrade start time to force the real timeout/retry path instead of waiting ten minutes",
-      "Waiting for the rolling upgrade to fail with a retryable status",
+      "Forcing the real timeout/retry path without waiting ten minutes",
       "Injecting a stale deterministic step-down job for the retry cleanup path",
       "Restoring the target image and requesting a rolling retry",
       "Verifying retry preparation clears failed status, records the handled request, and removes the stale step-down job",

--- a/test/e2e/catalog/suites/Cluster_TLS_ACME_test.md
+++ b/test/e2e/catalog/suites/Cluster_TLS_ACME_test.md
@@ -27,6 +27,7 @@ Recorded checkpoints:
 - setting up ACME service and domain
 - creating transit token secret for auto-unseal (include TLS CA for transit and PKI CA for ACME)
 - verifying transit token secret can access infra-bao transit key
+- preparing ACME shared cache storage
 - waiting for OpenBaoCluster to be observed by the API server
 - verifying TLS secrets are NOT created (ACME mode)
 - checking for prerequisite resources (ConfigMap)

--- a/test/e2e/catalog/suites/Upgrade_Strategies_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Strategies_test.md
@@ -179,8 +179,7 @@ Labels: `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `recovery`
 Recorded checkpoints:
 - Triggering a rolling upgrade with a bad non-semver image tag
 - Waiting for the rolling upgrade to initialize
-- Backdating upgrade start time to force the real timeout/retry path instead of waiting ten minutes
-- Waiting for the rolling upgrade to fail with a retryable status
+- Forcing the real timeout/retry path without waiting ten minutes
 - Injecting a stale deterministic step-down job for the retry cleanup path
 - Restoring the target image and requesting a rolling retry
 - Verifying retry preparation clears failed status, records the handled request, and removes the stale step-down job

--- a/test/e2e/helpers/gcs.go
+++ b/test/e2e/helpers/gcs.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -8,6 +9,9 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -263,10 +267,11 @@ func CreateGCSCredentialsSecret(ctx context.Context, c client.Client, namespace,
 	return nil
 }
 
-// CreateFakeGCSBucket creates a bucket in the fake-gcs-server emulator by running a Pod inside the cluster.
+// CreateFakeGCSBucket creates a bucket in the fake-gcs-server emulator.
 // This is necessary because fake-gcs-server with -backend memory starts completely empty.
 // The bucket must exist before OpenBao's backup job attempts to write snapshots.
-// This function uses a Pod to make the HTTP request so it can access the cluster's internal DNS.
+// The request goes through the Kubernetes API server service proxy so the suite
+// does not depend on an extra curl/helper image pull.
 func CreateFakeGCSBucket(
 	ctx context.Context,
 	restCfg *rest.Config,
@@ -289,78 +294,72 @@ func CreateFakeGCSBucket(
 		return fmt.Errorf("bucket name is required")
 	}
 
-	// Normalize endpoint (remove trailing slash if present)
-	endpoint = strings.TrimSuffix(endpoint, "/")
-	url := fmt.Sprintf("%s/storage/v1/b?project=%s", endpoint, "test-project")
+	proxyURL, err := fakeGCSBucketProxyURL(restCfg, namespace, endpoint, "test-project")
+	if err != nil {
+		return err
+	}
 	payload := fmt.Sprintf(`{"name": "%s"}`, bucketName)
 
-	// Generate unique pod name
-	suffix, err := randomHexSuffix(4)
+	transport, err := rest.TransportFor(restCfg)
 	if err != nil {
-		return fmt.Errorf("failed to generate pod suffix: %w", err)
+		return fmt.Errorf("failed to create Kubernetes API transport: %w", err)
 	}
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("create-gcs-bucket-%s", suffix),
-			Namespace: namespace,
-			Labels: map[string]string{
-				"openbao.org/component": "gcs-bucket-create",
-			},
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(int64(1000)),
-				RunAsGroup:   ptr.To(int64(1000)),
-				FSGroup:      ptr.To(int64(1000)),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:    "curl",
-					Image:   "curlimages/curl:8.4.0",
-					Command: []string{"/bin/sh", "-ec"},
-					Args: []string{fmt.Sprintf(`
-set -e
-# Create bucket via HTTP POST
-response=$(curl -s -w "\n%%{http_code}" -X POST -H "Content-Type: application/json" -d '%s' "%s")
-http_code=$(echo "$response" | tail -n1)
-body=$(echo "$response" | sed '$d')
-
-# Accept 200 (created) or 409 (already exists)
-if [ "$http_code" -eq 200 ] || [ "$http_code" -eq 409 ]; then
-  echo "Bucket %s created or already exists (status: $http_code)"
-  exit 0
-else
-  echo "Failed to create bucket, status: $http_code, response: $body" >&2
-  exit 1
-fi
-`, payload, url, bucketName)},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-						RunAsNonRoot: ptr.To(true),
-					},
-				},
-			},
-		},
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   defaultHTTPTimeout,
 	}
-
-	result, err := RunPodUntilCompletion(ctx, restCfg, c, pod, 2*time.Minute)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, proxyURL, bytes.NewBufferString(payload))
 	if err != nil {
-		return fmt.Errorf("failed to run bucket creation pod: %w", err)
+		return fmt.Errorf("failed to build fake-gcs bucket creation request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 
-	if result.Phase != corev1.PodSucceeded {
-		return fmt.Errorf("bucket creation pod failed, phase=%s, logs:\n%s", result.Phase, result.Logs)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to create fake-gcs bucket via Kubernetes service proxy: %w", err)
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
-	_ = DeletePodBestEffort(ctx, c, namespace, pod.Name)
-	return nil
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusConflict {
+		return nil
+	}
+	return fmt.Errorf("failed to create fake-gcs bucket %q: status=%d body=%s", bucketName, resp.StatusCode, strings.TrimSpace(string(body)))
 }
+
+func fakeGCSBucketProxyURL(restCfg *rest.Config, namespace, endpoint, project string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSuffix(endpoint, "/"))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse fake-gcs endpoint %q: %w", endpoint, err)
+	}
+	if parsed.Scheme == "" {
+		return "", fmt.Errorf("fake-gcs endpoint %q is missing a scheme", endpoint)
+	}
+	serviceName := strings.Split(parsed.Hostname(), ".")[0]
+	if serviceName == "" {
+		return "", fmt.Errorf("fake-gcs endpoint %q is missing a service hostname", endpoint)
+	}
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	return fmt.Sprintf(
+		"%s/api/v1/namespaces/%s/services/%s:%s:%s/proxy/storage/v1/b?project=%s",
+		strings.TrimSuffix(restCfg.Host, "/"),
+		namespace,
+		parsed.Scheme,
+		serviceName,
+		port,
+		url.QueryEscape(project),
+	), nil
+}
+
+const defaultHTTPTimeout = 15 * time.Second

--- a/test/e2e/helpers/gcs_test.go
+++ b/test/e2e/helpers/gcs_test.go
@@ -1,0 +1,26 @@
+package helpers
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestFakeGCSBucketProxyURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := fakeGCSBucketProxyURL(
+		&rest.Config{Host: "https://127.0.0.1:6443/"},
+		"gcs",
+		"http://fake-gcs-server.gcs.svc.cluster.local:4443",
+		"test-project",
+	)
+	if err != nil {
+		t.Fatalf("fakeGCSBucketProxyURL() error = %v", err)
+	}
+
+	want := "https://127.0.0.1:6443/api/v1/namespaces/gcs/services/http:fake-gcs-server:4443/proxy/storage/v1/b?project=test-project"
+	if got != want {
+		t.Fatalf("fakeGCSBucketProxyURL() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Description

Fixes the post-merge E2E failures observed after the efficiency/routing work landed on `main`.

This change:

- preserves the matrix label filter and Kind node image in nightly/release E2E summary steps so report generation does not fail after successful suites.
- removes the fake-GCS bucket creation dependency on `docker.io/curlimages/curl` by creating buckets through the Kubernetes API server service proxy.
- stabilizes the rolling retry timeout shortcut so the E2E test keeps forcing the real retryable timeout path until the controller records `PodNotReady`.
- refreshes the generated E2E catalog for the updated rolling checkpoint and the existing ACME cache checkpoint drift.

Root causes:

- nightly/release used `E2E_LABEL_FILTER` in a later summary step, but only defined it on the E2E execution step.
- the fake-GCS helper pod pulled an unauthenticated Docker Hub image and hit pull-rate limiting in CI.
- the rolling retry E2E could lose the backdated timeout timestamp to concurrent status reconciliation before the controller observed it.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (code improvement/cleanup)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes.
- [ ] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions.

## Verification Process

- `go test ./test/e2e/helpers ./internal/service/upgrade/rolling ./hack/tools/e2e_plan ./hack/tools/e2e_report`
- `go test -tags=e2e ./test/e2e -run '^$'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/nightly.yml .github/workflows/release.yml`
- `make e2e-catalog e2e-manifest-validate`
- `git diff --check`
- pre-push hook: `make lint-ci`
