### PR TITLE
fix(upgrade): treat raft promote already-voter as no-op

### DIFF
--- a/internal/adapter/openbao/client_raft.go
+++ b/internal/adapter/openbao/client_raft.go
@@ -209,27 +209,15 @@ func (c *Client) executeRaftPeerAction(ctx context.Context, serverID string, pat
 
 	resp, body, err := c.doAndReadAll(httpReq, nil, fmt.Sprintf("failed to execute raft %s request", action))
 	if err != nil {
-		if action == "demote" {
-			if translatedErr := translateRaftAPIErrorFromChain(err, portopenbao.ErrAlreadyNonVoter,
-				"already a non-voter",
-				"already non-voter",
-				"already non voter",
-			); translatedErr != nil {
-				return translatedErr
-			}
+		if translatedErr := translateRaftPeerActionAPIError(err, action); translatedErr != nil {
+			return translatedErr
 		}
 		return err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		apiErr := portopenbao.NewAPIError(fmt.Sprintf("raft %s request failed", action), resp.StatusCode, body)
-		if action == "demote" {
-			if translatedErr := translateRaftAPIErrorFromChain(apiErr, portopenbao.ErrAlreadyNonVoter,
-				"already a non-voter",
-				"already non-voter",
-				"already non voter",
-			); translatedErr != nil {
-				return translatedErr
-			}
+		if translatedErr := translateRaftPeerActionAPIError(apiErr, action); translatedErr != nil {
+			return translatedErr
 		}
 		return apiErr
 	}
@@ -310,4 +298,24 @@ func translateRaftAPIErrorFromChain(err error, sentinel error, patterns ...strin
 	}
 
 	return fmt.Errorf("%w: %w", sentinel, apiErr)
+}
+
+func translateRaftPeerActionAPIError(err error, action string) error {
+	switch action {
+	case "promote":
+		return translateRaftAPIErrorFromChain(err, portopenbao.ErrAlreadyVoter,
+			"already a voter",
+			"already voter",
+			"not a non-voter",
+			"not non-voter",
+		)
+	case "demote":
+		return translateRaftAPIErrorFromChain(err, portopenbao.ErrAlreadyNonVoter,
+			"already a non-voter",
+			"already non-voter",
+			"already non voter",
+		)
+	default:
+		return nil
+	}
 }

--- a/internal/adapter/openbao/client_test.go
+++ b/internal/adapter/openbao/client_test.go
@@ -520,15 +520,46 @@ func TestClient_DemoteRaftPeer_AlreadyNonVoterStatus(t *testing.T) {
 }
 
 func TestClient_DemoteRaftPeer_AlreadyNonVoterWrappedOverload(t *testing.T) {
+	assertTranslatedRaftPeerActionError(t, raftPeerActionTranslationTest{
+		path:         constants.APIPathRaftDemotePeer,
+		responseBody: "{\"errors\":[\"1 error occurred:\\n\\t* server is already a non-voter\\n\\n\"]}",
+		wantErr:      portopenbao.ErrAlreadyNonVoter,
+		call: func(ctx context.Context, client *Client) error {
+			return client.DemoteRaftPeer(ctx, "node-1")
+		},
+	})
+}
+
+func TestClient_PromoteRaftPeer_AlreadyVoterWrappedOverload(t *testing.T) {
+	assertTranslatedRaftPeerActionError(t, raftPeerActionTranslationTest{
+		path:         constants.APIPathRaftPromotePeer,
+		responseBody: "{\"errors\":[\"1 error occurred:\\n\\t* server is not a non-voter\\n\\n\"]}",
+		wantErr:      portopenbao.ErrAlreadyVoter,
+		call: func(ctx context.Context, client *Client) error {
+			return client.PromoteRaftPeer(ctx, "node-1")
+		},
+	})
+}
+
+type raftPeerActionTranslationTest struct {
+	path         string
+	responseBody string
+	wantErr      error
+	call         func(context.Context, *Client) error
+}
+
+func assertTranslatedRaftPeerActionError(t *testing.T, tc raftPeerActionTranslationTest) {
+	t.Helper()
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != constants.APIPathRaftDemotePeer {
+		if r.URL.Path != tc.path {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPost {
 			t.Fatalf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte("{\"errors\":[\"1 error occurred:\\n\\t* server is already a non-voter\\n\\n\"]}"))
+		_, _ = w.Write([]byte(tc.responseBody))
 	}))
 	defer server.Close()
 
@@ -540,15 +571,15 @@ func TestClient_DemoteRaftPeer_AlreadyNonVoterWrappedOverload(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 
-	err = client.DemoteRaftPeer(context.Background(), "node-1")
+	err = tc.call(context.Background(), client)
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !errors.Is(err, portopenbao.ErrAlreadyNonVoter) {
-		t.Fatalf("expected ErrAlreadyNonVoter, got %v", err)
+	if !errors.Is(err, tc.wantErr) {
+		t.Fatalf("expected %v, got %v", tc.wantErr, err)
 	}
 	if operatorerrors.IsTransientRemoteOverloaded(err) {
-		t.Fatalf("did not expect transient overload wrapper after benign demote translation, got %v", err)
+		t.Fatalf("did not expect transient overload wrapper after benign raft action translation, got %v", err)
 	}
 	assertStatusCode(t, err, http.StatusInternalServerError)
 }

--- a/internal/port/openbao/errors.go
+++ b/internal/port/openbao/errors.go
@@ -13,6 +13,8 @@ var (
 	ErrAlreadyInitialized = errors.New("OpenBao cluster already initialized")
 	// ErrAlreadyJoined indicates a raft join request was a no-op because the node is already in the cluster.
 	ErrAlreadyJoined = errors.New("OpenBao raft node already joined")
+	// ErrAlreadyVoter indicates a raft promote request was a no-op because the node is already a voter.
+	ErrAlreadyVoter = errors.New("OpenBao raft node already voter")
 	// ErrAlreadyNonVoter indicates a raft demote request was a no-op because the node is already a non-voter.
 	ErrAlreadyNonVoter = errors.New("OpenBao raft node already non-voter")
 )

--- a/internal/service/upgrade/raftops/promote.go
+++ b/internal/service/upgrade/raftops/promote.go
@@ -2,6 +2,7 @@ package raftops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,6 +37,10 @@ func promoteRaftPeerAndVerifyWithPolicy(
 	policy RetryPolicy,
 ) (bool, error) {
 	if err := client.PromoteRaftPeer(ctx, serverID); err != nil {
+		if errors.Is(err, portopenbao.ErrAlreadyVoter) {
+			return true, nil
+		}
+
 		isVoter, verifyErr := waitForRaftServerVoter(ctx, client, serverID, policy)
 		if verifyErr == nil && isVoter {
 			return true, nil

--- a/internal/service/upgrade/raftops/promote_test.go
+++ b/internal/service/upgrade/raftops/promote_test.go
@@ -72,6 +72,15 @@ func TestPromoteRaftPeerAndVerify(t *testing.T) {
 			wantReadCalls:    1,
 		},
 		{
+			name: "promote already voter error is benign without raft config verification",
+			client: &raftPeerPromoterStub{
+				promoteErr: portopenbao.ErrAlreadyVoter,
+				config:     raftConfigWithServer(false),
+			},
+			wantAlreadyVoter: true,
+			wantPromoteCalls: 1,
+		},
+		{
 			name: "promote error is benign when raft config converges to voter after stale read",
 			client: &raftPeerPromoterStub{
 				promoteErr: promoteErr,


### PR DESCRIPTION
## Description

This fixes the post-merge Blue/Green recovery failure where the break-glass rollback retry could fail during consensus repair when OpenBao returned `server is not a non-voter` for a Raft promote request.

That response means the peer is already effectively a voter, so the promote operation is a no-op. The adapter now translates that response into a typed `ErrAlreadyVoter`, and the raftops promote helper treats it as a successful already-voter state instead of surfacing it as a fatal executor failure.

## Related Issues

Follow-up to the failed `main` CI run: https://github.com/dc-tec/openbao-operator/actions/runs/25152089129/job/73725698632

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. No new comments were needed.
- [x] I have made corresponding changes to the documentation. Not applicable; behavior-only fix.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with `make test`. Not run; targeted Go tests and pre-push lint passed.
- [x] Any dependent changes have been merged and published in downstream modules. Not applicable.
- [x] For structural/boundary changes (if applicable), I included a dependency report delta and boundary-risk notes. Not applicable.
- [x] For structural/boundary changes (if applicable), I updated or confirmed policy exceptions. Not applicable.

## Verification Process

```sh
go test ./internal/adapter/openbao ./internal/service/upgrade/raftops
go test ./internal/service/upgrade/... ./internal/adapter/openbao
git diff --check
git push -u origin fix/bluegreen-promote-already-voter
```

The push hook also ran `make lint-ci`, including `golangci-lint` and the architecture policy checks.