### PR TITLE
fix(helm): Helm provisioner admission identity

### DIFF
--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -54,7 +54,7 @@ spec:
         '{{ include "openbao-operator.controllerServiceAccountName" . }}'
     - name: provisioner_serviceaccount_name
       expression: >-
-        'openbao-operator-provisioner'
+        '{{ include "openbao-operator.provisionerServiceAccountName" . }}'
     - name: controller_principal
       expression: >-
         'system:serviceaccount:' + variables.operator_namespace + ':' + variables.controller_serviceaccount_name

--- a/charts/openbao-operator/templates/admission/provisioner-namespace-mutations.yaml
+++ b/charts/openbao-operator/templates/admission/provisioner-namespace-mutations.yaml
@@ -19,7 +19,7 @@ spec:
         '{{ .Release.Namespace }}'
     - name: provisioner_serviceaccount_name
       expression: >-
-        'openbao-operator-provisioner'
+        '{{ include "openbao-operator.provisionerServiceAccountName" . }}'
     - name: provisioner_principal
       expression: >-
         'system:serviceaccount:' + variables.operator_namespace + ':' + variables.provisioner_serviceaccount_name

--- a/charts/openbao-operator/templates/admission/provisioner-rbac.yaml
+++ b/charts/openbao-operator/templates/admission/provisioner-rbac.yaml
@@ -22,7 +22,7 @@ spec:
         '{{ include "openbao-operator.controllerServiceAccountName" . }}'
     - name: provisioner_serviceaccount_name
       expression: >-
-        'openbao-operator-provisioner'
+        '{{ include "openbao-operator.provisionerServiceAccountName" . }}'
     - name: provisioner_principal
       expression: >-
         'system:serviceaccount:' + variables.operator_namespace + ':' + variables.provisioner_serviceaccount_name

--- a/charts/openbao-operator/templates/admission/provisioner-tenant-governance.yaml
+++ b/charts/openbao-operator/templates/admission/provisioner-tenant-governance.yaml
@@ -19,7 +19,7 @@ spec:
         '{{ .Release.Namespace }}'
     - name: provisioner_serviceaccount_name
       expression: >-
-        'openbao-operator-provisioner'
+        '{{ include "openbao-operator.provisionerServiceAccountName" . }}'
     - name: provisioner_principal
       expression: >-
         'system:serviceaccount:' + variables.operator_namespace + ':' + variables.provisioner_serviceaccount_name

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -407,6 +407,16 @@ replacements:
           group: admissionregistration.k8s.io
           version: v1
           kind: ValidatingAdmissionPolicy
+          name: openbao-operator-openbao-lock-managed-resource-mutations
+        fieldPaths:
+          - spec.variables.[name=provisioner_serviceaccount_name].expression
+        options:
+          delimiter: "'"
+          index: 1
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
           name: openbao-operator-openbao-restrict-provisioner-namespace-mutations
         fieldPaths:
           - spec.variables.[name=provisioner_serviceaccount_name].expression

--- a/config/overlays/custom-identity/kustomization.yaml
+++ b/config/overlays/custom-identity/kustomization.yaml
@@ -194,6 +194,16 @@ replacements:
           group: admissionregistration.k8s.io
           version: v1
           kind: ValidatingAdmissionPolicy
+          name: openbao-operator-openbao-lock-managed-resource-mutations
+        fieldPaths:
+          - spec.variables.[name=provisioner_serviceaccount_name].expression
+        options:
+          delimiter: "'"
+          index: 1
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
           name: openbao-operator-openbao-restrict-provisioner-namespace-mutations
         fieldPaths:
           - spec.variables.[name=provisioner_serviceaccount_name].expression

--- a/hack/helmchart/main.go
+++ b/hack/helmchart/main.go
@@ -322,6 +322,9 @@ func transformPolicyToHelm(content string) string {
 	content = strings.ReplaceAll(content,
 		`'openbao-operator-controller'`,
 		`'{{ include "openbao-operator.controllerServiceAccountName" . }}'`)
+	content = strings.ReplaceAll(content,
+		`'openbao-operator-provisioner'`,
+		`'{{ include "openbao-operator.provisionerServiceAccountName" . }}'`)
 
 	return content
 }

--- a/hack/helmchart/main_test.go
+++ b/hack/helmchart/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTransformPolicyToHelm_RewritesProvisionerServiceAccountVariable(t *testing.T) {
+	input := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: openbao-restrict-provisioner-rbac
+spec:
+  variables:
+    - name: provisioner_serviceaccount_name
+      expression: >-
+        'openbao-operator-provisioner'
+`
+
+	got := transformPolicyToHelm(input)
+	want := `'{{ include "openbao-operator.provisionerServiceAccountName" . }}'`
+	if !strings.Contains(got, want) {
+		t.Fatalf("transformed policy missing provisioner helper expression %q:\n%s", want, got)
+	}
+	if strings.Contains(got, `'openbao-operator-provisioner'`) {
+		t.Fatalf("transformed policy still contains stale provisioner ServiceAccount name:\n%s", got)
+	}
+}

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -240,6 +240,22 @@ helm-test: helm-sync helm-lint ## Test the Helm chart without requiring a live c
 		--namespace openbao-operator-system \
 		--include-crds \
 		--set tenancy.mode=multi > /dev/null
+	@echo "Testing Helm chart: provisioner admission identity follows fullnameOverride..."
+	@render="$$(helm template baoctl charts/openbao-operator \
+		--namespace openbao-system \
+		--include-crds \
+		--set tenancy.mode=multi \
+		--set fullnameOverride=baoctl)"; \
+		echo "$$render" | grep -q "name: baoctl-provisioner"; \
+		echo "$$render" | grep -q "'baoctl-provisioner'"; \
+		if echo "$$render" | grep -q "'openbao-operator-provisioner'"; then \
+			echo "Helm admission policies rendered a stale provisioner ServiceAccount name"; \
+			exit 1; \
+		fi
+	@if grep -R "'openbao-operator-provisioner'" charts/openbao-operator/templates/admission; then \
+		echo "Helm admission templates must derive the provisioner ServiceAccount name from helpers"; \
+		exit 1; \
+	fi
 	@echo "Testing Helm chart: templating with single-tenant mode..."
 	@helm template openbao-operator charts/openbao-operator \
 		--namespace openbao-operator-system \

--- a/test/integration/kustomize_custom_identity_test.go
+++ b/test/integration/kustomize_custom_identity_test.go
@@ -54,6 +54,11 @@ func TestKustomizeCustomIdentityOverlay_RewritesOperatorIdentityFields(t *testin
 		objs,
 		"demo-openbao-operator-openbao-restrict-controller-secret-writes",
 	)
+	lockManagedPolicy := mustFindPolicy(
+		t,
+		objs,
+		"demo-openbao-operator-openbao-lock-managed-resource-mutations",
+	)
 	provisionerPolicy := mustFindPolicy(t, objs, "demo-openbao-operator-openbao-restrict-provisioner-rbac")
 	tenantGovernancePolicy := mustFindPolicy(
 		t,
@@ -110,6 +115,13 @@ func TestKustomizeCustomIdentityOverlay_RewritesOperatorIdentityFields(t *testin
 		"controller_serviceaccount_name",
 	); got != testQuotedPrefixedCtrlSA {
 		t.Fatalf("controller secret policy controller_serviceaccount_name=%q, want %q", got, testQuotedPrefixedCtrlSA)
+	}
+	if got := policyVariableExpression(
+		t,
+		lockManagedPolicy,
+		"provisioner_serviceaccount_name",
+	); got != testQuotedPrefixedProvSA {
+		t.Fatalf("lock managed policy provisioner_serviceaccount_name=%q, want %q", got, testQuotedPrefixedProvSA)
 	}
 	if got := policyVariableExpression(
 		t,


### PR DESCRIPTION
## Summary

- Render provisioner admission policy variables from the Helm provisioner ServiceAccount helper instead of a fixed name.
- Include the lock-managed policy in custom-identity kustomize replacement so prefixed installs keep the same provisioner principal.
- Add Helm and kustomize regressions for overridden full names and custom identities.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Helm/admission rendering only. Custom release names and `fullnameOverride` now render policy variables that match the provisioner ServiceAccount. Default installs keep the same provisioner identity. No API or CRD schema change.

## Verification

- `GOFLAGS=-mod=vendor go test ./hack/helmchart`
- `GOFLAGS=-mod=vendor go test ./test/integration -tags=integration -run '^TestKustomizeCustomIdentityOverlay_RewritesOperatorIdentityFields$' -count=1 -v`
- `make helm-test`
- `make verify-helm`
- `git diff --check`
- pre-push hook: `make lint-ci`

## Reviewer Notes

`config/policy` keeps the base kustomize identity. The Helm sync tool rewrites that base identity to the chart helper, while kustomize custom-identity overlays replace rendered policy variables from ServiceAccount names.

No documentation update is needed because this preserves the existing documented naming behavior for customized Helm installs.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
