### PR TITLE
fix(network): Require source-scoped managed Ingress access

### DIFF
--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -226,6 +226,14 @@ spec:
         (object.spec.gateway.hostname != "" && object.spec.gateway.gatewayRef.name != "")
       message: spec.gateway.hostname and spec.gateway.gatewayRef.name are required when Gateway is enabled.
     - expression: >-
+        !has(object.spec.ingress) ||
+        !has(object.spec.ingress.enabled) ||
+        object.spec.ingress.enabled == false ||
+        (has(object.spec.network) &&
+          has(object.spec.network.trustedIngressPeers) &&
+          size(object.spec.network.trustedIngressPeers) > 0)
+      message: spec.ingress.enabled requires at least one spec.network.trustedIngressPeers entry so NetworkPolicy ingress remains source-scoped.
+    - expression: >-
         !(variables.has_pre_upgrade_snapshot || variables.has_bluegreen_pre_upgrade_snapshot) ||
         variables.has_backup
       message: spec.backup is required when pre-upgrade snapshots are enabled (spec.upgrade.preUpgradeSnapshot or spec.upgrade.blueGreen.preUpgradeSnapshot).

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -223,6 +223,14 @@ spec:
         (object.spec.gateway.hostname != "" && object.spec.gateway.gatewayRef.name != "")
       message: spec.gateway.hostname and spec.gateway.gatewayRef.name are required when Gateway is enabled.
     - expression: >-
+        !has(object.spec.ingress) ||
+        !has(object.spec.ingress.enabled) ||
+        object.spec.ingress.enabled == false ||
+        (has(object.spec.network) &&
+          has(object.spec.network.trustedIngressPeers) &&
+          size(object.spec.network.trustedIngressPeers) > 0)
+      message: spec.ingress.enabled requires at least one spec.network.trustedIngressPeers entry so NetworkPolicy ingress remains source-scoped.
+    - expression: >-
         !(variables.has_pre_upgrade_snapshot || variables.has_bluegreen_pre_upgrade_snapshot) ||
         variables.has_backup
       message: spec.backup is required when pre-upgrade snapshots are enabled (spec.upgrade.preUpgradeSnapshot or spec.upgrade.blueGreen.preUpgradeSnapshot).

--- a/docs/security/infrastructure/network-security.md
+++ b/docs/security/infrastructure/network-security.md
@@ -127,6 +127,8 @@ If you need additional ingress, use:
 - `spec.network.ingressRules` for additive peer rules
 - `spec.network.trustedIngressPeers` for user-managed ingress or passthrough proxies
 
+Managed `spec.ingress.enabled: true` configurations must declare at least one trusted ingress peer so the OpenBao API listener is not opened to every pod that can reach the namespace.
+
 <Callout type="note" title="Read replicas are client-serving Pods">
 
 When steady read replicas are enabled, the main client Service can route to both voter and read-replica Pods. That does not create a separate ingress policy surface by itself; the same cluster ingress rules still govern the client listener, and the optional dedicated read Service remains only a second Service object selecting the same client-serving port on the read pool.

--- a/docs/user-guide/openbaocluster/configuration/external-access.md
+++ b/docs/user-guide/openbaocluster/configuration/external-access.md
@@ -134,9 +134,14 @@ The dedicated read-replica Service remains available for explicit consumers, but
     enabled: true
     host: "bao.example.com"
     annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"`}
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  network:
+    trustedIngressPeers:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: ingress-nginx`}
 >
-  Use this when you already operate an ingress-controller standard and do not need the richer Gateway API route model.
+  Use this when you already operate an ingress-controller standard and do not need the richer Gateway API route model. Declare the ingress-controller peer so the operator-managed NetworkPolicy can keep OpenBao API ingress source-scoped.
 </CommandBlock>
 
   </TabItem>

--- a/docs/user-guide/openbaocluster/configuration/network.md
+++ b/docs/user-guide/openbaocluster/configuration/network.md
@@ -181,7 +181,7 @@ description: Configure the operator-managed NetworkPolicy contract, including DN
           matchLabels:
             app.kubernetes.io/name: traefik`}
 >
-  Use this when the source is a user-managed ingress controller or Gateway data plane. It is usually clearer than writing a raw `ingressRules` block for the same case.
+  Use this when the source is a user-managed ingress controller or Gateway data plane. It is usually clearer than writing a raw `ingressRules` block for the same case. Managed `spec.ingress.enabled: true` configurations require at least one trusted ingress peer.
 </CommandBlock>
 
   </TabItem>

--- a/internal/service/networking/policy_rules.go
+++ b/internal/service/networking/policy_rules.go
@@ -97,18 +97,6 @@ func buildNetworkPolicyIngressRules(
 		},
 	})
 
-	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
-		rules = append(rules, networkingv1.NetworkPolicyIngressRule{
-			Ports: []networkingv1.NetworkPolicyPort{
-				{
-					Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
-					Port:     &apiPort,
-				},
-			},
-			From: []networkingv1.NetworkPolicyPeer{},
-		})
-	}
-
 	return rules
 }
 

--- a/internal/service/networking/policy_test.go
+++ b/internal/service/networking/policy_test.go
@@ -608,3 +608,41 @@ func TestBuildNetworkPolicy_TrustedIngressPeers(t *testing.T) {
 		t.Fatal("expected trusted ingress peer rule with namespace and pod selector")
 	}
 }
+
+func TestBuildNetworkPolicy_IngressEnabledDoesNotAllowUnrestrictedAPIIngress(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-ingress",
+			Namespace: "openbao",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Ingress: &openbaov1alpha1.IngressConfig{
+				Enabled: true,
+				Host:    "bao.example.com",
+			},
+		},
+	}
+
+	policy, err := buildNetworkPolicy(cluster, &apiServerInfo{ServiceNetworkCIDR: "10.96.0.0/12"}, "openbao-operator-system")
+	if err != nil {
+		t.Fatalf("buildNetworkPolicy() error: %v", err)
+	}
+
+	for i, rule := range policy.Spec.Ingress {
+		if !networkPolicyRuleAllowsPort(rule.Ports, constants.PortAPI) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			t.Fatalf("ingress rule %d allows API port without source peers: %#v", i, rule)
+		}
+	}
+}
+
+func networkPolicyRuleAllowsPort(ports []networkingv1.NetworkPolicyPort, want int32) bool {
+	for _, port := range ports {
+		if port.Port != nil && port.Port.IntValue() == int(want) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/Cluster_Runtime_Controls_test.go
+++ b/test/e2e/Cluster_Runtime_Controls_test.go
@@ -189,6 +189,17 @@ var _ = Describe("Cluster Runtime Controls", Label("lifecycle", "cluster", "runt
 			Host:    host,
 			Path:    "/",
 		}
+		cluster.Spec.Network = &openbaov1alpha1.NetworkConfig{
+			TrustedIngressPeers: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "ingress-system",
+						},
+					},
+				},
+			},
+		}
 		Expect(c.Create(ctx, cluster)).To(Succeed())
 		DeferCleanup(func() { _ = c.Delete(ctx, cluster) })
 

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -207,6 +208,45 @@ func TestVAP_OpenBaoCluster_RejectsOIDCBootstrapWithoutSelfInitEnabled(t *testin
 	requireAdmissionDenied(t, err)
 	if !strings.Contains(err.Error(), "spec.selfInit.oidc.enabled requires spec.selfInit.enabled to be true") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoCluster_RequiresTrustedIngressPeersForManagedIngress(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	cluster := newMinimalClusterObj(namespace, "cluster-ingress-without-peer")
+	cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+		Enabled: true,
+		Host:    "bao.example.com",
+	}
+
+	err := k8sClient.Create(ctx, cluster)
+	requireAdmissionDenied(t, err)
+	wantMessage := "spec.ingress.enabled requires at least one spec.network.trustedIngressPeers"
+	if !strings.Contains(err.Error(), wantMessage) {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+
+	allowed := newMinimalClusterObj(namespace, "cluster-ingress-with-peer")
+	allowed.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+		Enabled: true,
+		Host:    "bao.example.com",
+	}
+	allowed.Spec.Network = &openbaov1alpha1.NetworkConfig{
+		TrustedIngressPeers: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": "ingress-system",
+					},
+				},
+			},
+		},
+	}
+
+	if err := k8sClient.Create(ctx, allowed); err != nil {
+		t.Fatalf("expected ingress with trusted ingress peers to succeed, got: %v", err)
 	}
 }
 

--- a/test/integration/infra_network_test.go
+++ b/test/integration/infra_network_test.go
@@ -122,6 +122,17 @@ func TestInfraNetwork_Ingress_CreatesAndDeletes(t *testing.T) {
 		Enabled: true,
 		Host:    "bao.example.local",
 	}
+	cluster.Spec.Network = &openbaov1alpha1.NetworkConfig{
+		TrustedIngressPeers: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": "ingress-system",
+					},
+				},
+			},
+		},
+	}
 	if err := k8sClient.Create(ctx, cluster); err != nil {
 		t.Fatalf("create OpenBaoCluster: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Stop adding an unrestricted OpenBao API NetworkPolicy ingress rule when managed Ingress is enabled.
- Require at least one `spec.network.trustedIngressPeers` entry for `spec.ingress.enabled=true` through the OpenBaoCluster admission policy.
- Document the managed Ingress peer requirement in external access and NetworkPolicy guidance.
- Add unit and envtest coverage for the source-scoped NetworkPolicy and admission behavior.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This tightens managed Ingress behavior. Existing clusters that set `spec.ingress.enabled=true` must also configure at least one `spec.network.trustedIngressPeers` entry before creating or updating the OpenBaoCluster under admission enforcement. Existing generated NetworkPolicies will no longer include a source-less API ingress allow rule after reconciliation.

Gateway API and raw `spec.network.ingressRules` behavior are unchanged.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/service/networking -tags=integration -run 'TestBuildNetworkPolicy_(TrustedIngressPeers|IngressEnabledDoesNotAllowUnrestrictedAPIIngress)' -count=1`
- `GOFLAGS=-mod=vendor go test ./test/integration -tags=integration -run '^TestVAP_OpenBaoCluster_RequiresTrustedIngressPeersForManagedIngress$' -count=1 -v`
- `make helm-test`
- `make verify-helm`
- `make docs-build`
- `git diff --check`
- pre-push hook: `make lint-ci`

## Reviewer Notes

The admission guard is intentionally paired with the NetworkPolicy builder change. Without an explicit peer, the operator cannot infer the ingress-controller source from Kubernetes Ingress metadata alone.

Release notes should call out the migration for users of managed Ingress: add `spec.network.trustedIngressPeers` for the ingress controller namespace or pod selector before upgrading with admission enforcement enabled.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
