### PR TITLE
fix(admission): guard hardened security context overrides

### DIFF
--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -197,6 +197,49 @@ spec:
         object.spec.operatorImageVerification.failurePolicy != "Warn"
       message: Hardened profile does not allow spec.operatorImageVerification.failurePolicy=Warn.
     - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.runAsNonRoot) ||
+        object.spec.securityContext.runAsNonRoot == true
+      message: Hardened profile does not allow spec.securityContext.runAsNonRoot=false.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.seccompProfile) ||
+        !has(object.spec.securityContext.seccompProfile.type) ||
+        object.spec.securityContext.seccompProfile.type != "Unconfined"
+      message: Hardened profile does not allow spec.securityContext.seccompProfile.type=Unconfined.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        ((!has(object.spec.securityContext.runAsUser) || object.spec.securityContext.runAsUser != 0) &&
+          (!has(object.spec.securityContext.runAsGroup) || object.spec.securityContext.runAsGroup != 0) &&
+          (!has(object.spec.securityContext.fsGroup) || object.spec.securityContext.fsGroup != 0))
+      message: Hardened profile does not allow root UID/GID overrides in spec.securityContext.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.supplementalGroups) ||
+        object.spec.securityContext.supplementalGroups.all(group, group != 0)
+      message: Hardened profile does not allow root supplemental groups in spec.securityContext.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.sysctls) ||
+        size(object.spec.securityContext.sysctls) == 0
+      message: Hardened profile does not allow pod sysctl overrides in spec.securityContext.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.windowsOptions)
+      message: Hardened profile does not allow Windows pod security options in spec.securityContext.
+    - expression: >-
         !has(object.spec.initContainer) ||
         object.spec.initContainer.enabled == true
       message: spec.initContainer is optional; when set, spec.initContainer.enabled must be true.

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -194,6 +194,49 @@ spec:
         object.spec.operatorImageVerification.failurePolicy != "Warn"
       message: Hardened profile does not allow spec.operatorImageVerification.failurePolicy=Warn.
     - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.runAsNonRoot) ||
+        object.spec.securityContext.runAsNonRoot == true
+      message: Hardened profile does not allow spec.securityContext.runAsNonRoot=false.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.seccompProfile) ||
+        !has(object.spec.securityContext.seccompProfile.type) ||
+        object.spec.securityContext.seccompProfile.type != "Unconfined"
+      message: Hardened profile does not allow spec.securityContext.seccompProfile.type=Unconfined.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        ((!has(object.spec.securityContext.runAsUser) || object.spec.securityContext.runAsUser != 0) &&
+          (!has(object.spec.securityContext.runAsGroup) || object.spec.securityContext.runAsGroup != 0) &&
+          (!has(object.spec.securityContext.fsGroup) || object.spec.securityContext.fsGroup != 0))
+      message: Hardened profile does not allow root UID/GID overrides in spec.securityContext.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.supplementalGroups) ||
+        object.spec.securityContext.supplementalGroups.all(group, group != 0)
+      message: Hardened profile does not allow root supplemental groups in spec.securityContext.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.sysctls) ||
+        size(object.spec.securityContext.sysctls) == 0
+      message: Hardened profile does not allow pod sysctl overrides in spec.securityContext.
+    - expression: >-
+        !has(object.spec.profile) ||
+        object.spec.profile != "Hardened" ||
+        !has(object.spec.securityContext) ||
+        !has(object.spec.securityContext.windowsOptions)
+      message: Hardened profile does not allow Windows pod security options in spec.securityContext.
+    - expression: >-
         !has(object.spec.initContainer) ||
         object.spec.initContainer.enabled == true
       message: spec.initContainer is optional; when set, spec.initContainer.enabled must be true.

--- a/docs/security/workload/workload-security.md
+++ b/docs/security/workload/workload-security.md
@@ -92,7 +92,7 @@ description: Pod hardening, projected-token handling, and runtime guardrails for
       cells: [
         "User and group",
         "Non-root by default on standard Kubernetes; OpenShift may assign UID/GID through SCC.",
-        "Avoid assuming a fixed platform-level UID unless you intentionally override `spec.securityContext`.",
+        "Hardened clusters may use `spec.securityContext` for safe non-root or OpenShift-compatible overrides only.",
       ],
       emphasis: "recommended",
     },
@@ -119,6 +119,14 @@ description: Pod hardening, projected-token handling, and runtime guardrails for
     },
   ]}
 />
+
+<Callout type="warning" title="Hardened security context overrides">
+
+The Hardened profile rejects pod-level `spec.securityContext` overrides that weaken runtime guarantees. Do not set
+`runAsNonRoot: false`, root UID/GID values, root supplemental groups, `seccompProfile.type: Unconfined`, pod sysctls,
+or Windows pod security options for Hardened OpenBao clusters.
+
+</Callout>
 
 <Callout type="note" title="Init container behavior">
 

--- a/internal/controller/openbaocluster/constants.go
+++ b/internal/controller/openbaocluster/constants.go
@@ -35,6 +35,7 @@ const (
 	ReasonTransitAddressNotHTTPS                 = "TransitAddressNotHTTPS"
 	ReasonTransitInlineToken                     = "TransitInlineToken"
 	ReasonUnsealTLSSkipVerify                    = "UnsealTLSSkipVerify"
+	ReasonSecurityContextWeakening               = "SecurityContextWeakening"
 	ReasonUserAccessConfigured                   = "UserAccessConfigured"
 	ReasonUserAccessUnverified                   = "UserAccessUnverified"
 	ReasonRootTokenStored                        = "RootTokenStored"

--- a/internal/controller/openbaocluster/status_production_ready.go
+++ b/internal/controller/openbaocluster/status_production_ready.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -53,6 +54,10 @@ func evaluateProductionReady(cluster *openbaov1alpha1.OpenBaoCluster, admissionR
 
 	if transitAddressRequiresHTTPS(cluster) {
 		return metav1.ConditionFalse, ReasonTransitAddressNotHTTPS, "Hardened profile requires spec.unseal.transit.address to use a valid HTTPS URL"
+	}
+
+	if cluster.Spec.Profile == openbaov1alpha1.ProfileHardened && hardenedSecurityContextWeakensPodSecurity(cluster) {
+		return metav1.ConditionFalse, ReasonSecurityContextWeakening, "Hardened profile does not allow spec.securityContext overrides that weaken non-root, seccomp, sysctl, or OS constraints"
 	}
 
 	if usesCloudKMSUnseal(cluster) {
@@ -196,6 +201,43 @@ func transitAddressRequiresHTTPS(cluster *openbaov1alpha1.OpenBaoCluster) bool {
 	}
 
 	return !strings.EqualFold(u.Scheme, "https") || strings.TrimSpace(u.Host) == ""
+}
+
+func hardenedSecurityContextWeakensPodSecurity(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if cluster == nil || cluster.Spec.SecurityContext == nil {
+		return false
+	}
+
+	securityContext := cluster.Spec.SecurityContext
+	if securityContext.RunAsNonRoot != nil && !*securityContext.RunAsNonRoot {
+		return true
+	}
+	if securityContext.RunAsUser != nil && *securityContext.RunAsUser == 0 {
+		return true
+	}
+	if securityContext.RunAsGroup != nil && *securityContext.RunAsGroup == 0 {
+		return true
+	}
+	if securityContext.FSGroup != nil && *securityContext.FSGroup == 0 {
+		return true
+	}
+	for _, supplementalGroup := range securityContext.SupplementalGroups {
+		if supplementalGroup == 0 {
+			return true
+		}
+	}
+	if securityContext.SeccompProfile != nil &&
+		securityContext.SeccompProfile.Type == corev1.SeccompProfileTypeUnconfined {
+		return true
+	}
+	if len(securityContext.Sysctls) > 0 {
+		return true
+	}
+	if securityContext.WindowsOptions != nil {
+		return true
+	}
+
+	return false
 }
 
 func usesCloudKMSUnseal(cluster *openbaov1alpha1.OpenBaoCluster) bool {

--- a/internal/controller/openbaocluster/status_production_ready_test.go
+++ b/internal/controller/openbaocluster/status_production_ready_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
@@ -172,6 +174,32 @@ func TestEvaluateProductionReady(t *testing.T) {
 			},
 			wantStatus: metav1.ConditionFalse,
 			wantReason: ReasonTransitAddressNotHTTPS,
+		},
+		{
+			name: "hardened with security context weakening",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Profile:  openbaov1alpha1.ProfileHardened,
+					SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: true},
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeExternal,
+					},
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "transit",
+						Transit: &openbaov1alpha1.TransitSealConfig{
+							Address:   "https://infra-bao.example",
+							KeyName:   "autounseal",
+							MountPath: "transit/",
+						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(false),
+					},
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: ReasonSecurityContextWeakening,
 		},
 		{
 			name: "hardened cloud kms without ready unseal identity condition",
@@ -361,6 +389,107 @@ func TestEvaluateProductionReady(t *testing.T) {
 			status, reason, _ := evaluateProductionReady(tt.cluster, true, "")
 			assert.Equal(t, tt.wantStatus, status)
 			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}
+
+func TestHardenedSecurityContextWeakensPodSecurity(t *testing.T) {
+	tests := []struct {
+		name            string
+		securityContext *corev1.PodSecurityContext
+		want            bool
+	}{
+		{
+			name:            "nil security context",
+			securityContext: nil,
+			want:            false,
+		},
+		{
+			name: "safe non-root overrides",
+			securityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:       ptr.To(true),
+				RunAsUser:          ptr.To(int64(1001)),
+				RunAsGroup:         ptr.To(int64(1001)),
+				FSGroup:            ptr.To(int64(1001)),
+				SupplementalGroups: []int64{1002},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "run as root allowed",
+			securityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(false),
+			},
+			want: true,
+		},
+		{
+			name: "root run as user",
+			securityContext: &corev1.PodSecurityContext{
+				RunAsUser: ptr.To(int64(0)),
+			},
+			want: true,
+		},
+		{
+			name: "root run as group",
+			securityContext: &corev1.PodSecurityContext{
+				RunAsGroup: ptr.To(int64(0)),
+			},
+			want: true,
+		},
+		{
+			name: "root fs group",
+			securityContext: &corev1.PodSecurityContext{
+				FSGroup: ptr.To(int64(0)),
+			},
+			want: true,
+		},
+		{
+			name: "root supplemental group",
+			securityContext: &corev1.PodSecurityContext{
+				SupplementalGroups: []int64{0},
+			},
+			want: true,
+		},
+		{
+			name: "unconfined seccomp",
+			securityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeUnconfined,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod sysctls",
+			securityContext: &corev1.PodSecurityContext{
+				Sysctls: []corev1.Sysctl{{
+					Name:  "kernel.shm_rmid_forced",
+					Value: "1",
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "windows options",
+			securityContext: &corev1.PodSecurityContext{
+				WindowsOptions: &corev1.WindowsSecurityContextOptions{},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					SecurityContext: tt.securityContext,
+				},
+			}
+
+			assert.Equal(t, tt.want, hardenedSecurityContextWeakensPodSecurity(cluster))
 		})
 	}
 }

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -426,7 +427,135 @@ func TestVAP_OpenBaoCluster_AllowsHardenedOfficialImageVerificationDefaults(t *t
 	namespace := newTestNamespace(t)
 	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
 
-	cluster := newMinimalClusterObj(namespace, "cluster-hardened-image-verification-defaults")
+	cluster := newValidHardenedAdmissionCluster(namespace, "cluster-hardened-image-verification-defaults")
+	cluster.Spec.ImageVerification = &openbaov1alpha1.ImageVerificationConfig{
+		Enabled:       true,
+		FailurePolicy: "Block",
+	}
+	cluster.Spec.OperatorImageVerification = &openbaov1alpha1.ImageVerificationConfig{
+		Enabled:       true,
+		FailurePolicy: "Block",
+	}
+
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf(
+			"expected Hardened OpenBaoCluster with enabled official image verification defaults to succeed, got: %v",
+			err,
+		)
+	}
+}
+
+func TestVAP_OpenBaoCluster_RejectsHardenedWeakeningSecurityContext(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	tests := []struct {
+		name      string
+		configure func(*corev1.PodSecurityContext)
+		wantError string
+	}{
+		{
+			name: "run as root",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.RunAsNonRoot = ptr.To(false)
+			},
+			wantError: "Hardened profile does not allow spec.securityContext.runAsNonRoot=false",
+		},
+		{
+			name: "unconfined seccomp",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.SeccompProfile = &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeUnconfined,
+				}
+			},
+			wantError: "Hardened profile does not allow spec.securityContext.seccompProfile.type=Unconfined",
+		},
+		{
+			name: "root uid",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.RunAsUser = ptr.To(int64(0))
+			},
+			wantError: "Hardened profile does not allow root UID/GID overrides in spec.securityContext",
+		},
+		{
+			name: "root gid",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.RunAsGroup = ptr.To(int64(0))
+			},
+			wantError: "Hardened profile does not allow root UID/GID overrides in spec.securityContext",
+		},
+		{
+			name: "root fs group",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.FSGroup = ptr.To(int64(0))
+			},
+			wantError: "Hardened profile does not allow root UID/GID overrides in spec.securityContext",
+		},
+		{
+			name: "root supplemental group",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.SupplementalGroups = []int64{0}
+			},
+			wantError: "Hardened profile does not allow root supplemental groups in spec.securityContext",
+		},
+		{
+			name: "pod sysctl",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.Sysctls = []corev1.Sysctl{{
+					Name:  "kernel.shm_rmid_forced",
+					Value: "1",
+				}}
+			},
+			wantError: "Hardened profile does not allow pod sysctl overrides in spec.securityContext",
+		},
+		{
+			name: "windows options",
+			configure: func(securityContext *corev1.PodSecurityContext) {
+				securityContext.WindowsOptions = &corev1.WindowsSecurityContextOptions{}
+			},
+			wantError: "Hardened profile does not allow Windows pod security options in spec.securityContext",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newValidHardenedAdmissionCluster(namespace, fmt.Sprintf("cluster-hardened-security-%d", i))
+			cluster.Spec.SecurityContext = &corev1.PodSecurityContext{}
+			tt.configure(cluster.Spec.SecurityContext)
+
+			err := k8sClient.Create(ctx, cluster)
+			requireAdmissionDenied(t, err)
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("unexpected error message: %v", err)
+			}
+		})
+	}
+}
+
+func TestVAP_OpenBaoCluster_AllowsHardenedSafeSecurityContextOverrides(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	cluster := newValidHardenedAdmissionCluster(namespace, "cluster-hardened-safe-security")
+	cluster.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot:        ptr.To(true),
+		RunAsUser:           ptr.To(int64(1001)),
+		RunAsGroup:          ptr.To(int64(1001)),
+		FSGroup:             ptr.To(int64(1001)),
+		FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
+		SupplementalGroups:  []int64{1002},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("expected Hardened OpenBaoCluster with safe securityContext overrides to succeed, got: %v", err)
+	}
+}
+
+func newValidHardenedAdmissionCluster(namespace, name string) *openbaov1alpha1.OpenBaoCluster {
+	cluster := newMinimalClusterObj(namespace, name)
 	cluster.Spec.Profile = openbaov1alpha1.ProfileHardened
 	cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeExternal
 	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
@@ -446,21 +575,8 @@ func TestVAP_OpenBaoCluster_AllowsHardenedOfficialImageVerificationDefaults(t *t
 			KMSKeyID: "alias/openbao-unseal",
 		},
 	}
-	cluster.Spec.ImageVerification = &openbaov1alpha1.ImageVerificationConfig{
-		Enabled:       true,
-		FailurePolicy: "Block",
-	}
-	cluster.Spec.OperatorImageVerification = &openbaov1alpha1.ImageVerificationConfig{
-		Enabled:       true,
-		FailurePolicy: "Block",
-	}
 
-	if err := k8sClient.Create(ctx, cluster); err != nil {
-		t.Fatalf(
-			"expected Hardened OpenBaoCluster with enabled official image verification defaults to succeed, got: %v",
-			err,
-		)
-	}
+	return cluster
 }
 
 func TestVAP_OpenBaoCluster_RejectsDisabledInitContainerOverride(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reject Hardened `spec.securityContext` overrides that weaken the pod runtime baseline, including `runAsNonRoot=false`, root UID/GID values, root supplemental groups, `Unconfined` seccomp, pod sysctls, and Windows pod security options.
- Mark `ProductionReady=False` for already-existing Hardened clusters that carry those weakening overrides.
- Document the Hardened override boundary and regenerate the Helm admission policy template.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This tightens Hardened profile admission. Existing Hardened clusters that set weakening pod-level `spec.securityContext` values must remove them before creating or updating under admission enforcement. Safe non-root and OpenShift-compatible overrides remain allowed, and Development profile behavior is unchanged.

Existing clusters that already have weakening Hardened overrides are reported as not production-ready through the `ProductionReady` condition.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/controller/openbaocluster -run '^(TestEvaluateProductionReady|TestHardenedSecurityContextWeakensPodSecurity)$'`
- `GOFLAGS=-mod=vendor go test ./test/integration -tags=integration -run '^TestVAP_OpenBaoCluster_(RejectsHardenedWeakeningSecurityContext|AllowsHardenedSafeSecurityContextOverrides|RequiresTrustedIngressPeersForManagedIngress)$' -count=1 -v`
- `make verify-helm`
- `make helm-test`
- `make docs-build`
- `git diff --check`
- pre-push hook: `make lint-ci`

## Reviewer Notes

The admission checks are paired with a status fallback so clusters created before the policy is enforced still surface the weakened runtime posture.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
