### PR TITLE
fix(status): mark unsafe admission mode not production-ready

### DIFF
--- a/docs/reference/status-and-events.md
+++ b/docs/reference/status-and-events.md
@@ -66,13 +66,13 @@ Condition types defined in `api/v1alpha1`:
 | `GatewayIntegrationReady` | Operator-known Gateway API prerequisites and controller support for `spec.gateway` | `GatewayIntegrationReady`, `GatewayAPIMissing`, `GatewayReferenceMissing`, `GatewayClassMissing`, `GatewayClassPending`, `GatewayClassNotAccepted`, `GatewayVersionUnsupported`, `GatewayFeatureUnsupported`, `GatewayCapabilitiesUnknown`, `GatewayNotProgrammed`, `GatewayProgrammingPending`, `GatewayListenerIncompatible`, `Paused` |
 | `BackupConfigurationReady` | Operator-known backup Job prerequisites such as auth references, storage credential references, hardened-profile egress rules, and job-specific identity assumptions | `Ready`, `AuthenticationRequired`, `TokenSecretMissing`, `CredentialsSecretMissing`, `WorkloadIdentityConfigured`, `AmbientIdentityAssumed`, `NetworkEgressRulesRequired`, `Unknown`, `Paused` |
 | `CloudUnsealIdentityReady` | Operator-known authentication path for cloud KMS unseal on the main OpenBao Pods | `Ready`, `CredentialsSecretMissing`, `PrerequisitesMissing`, `WorkloadIdentityConfigured`, `AmbientIdentityAssumed`, `Unknown`, `Paused` |
-| `ProductionReady` | Indicates whether the cluster currently meets the operator's Hardened production posture checks. This condition does not represent API stability or project support level. | `ProductionReady`, `ProfileNotSet`, `DevelopmentProfile`, `AdmissionPoliciesNotReady`, `OperatorManagedTLS`, `StaticUnsealInUse`, `RootTokenStored`, Gateway or ACME readiness reasons such as `GatewayFeatureUnsupported` or `ACMEGatewayNotConfiguredForPassthrough` |
+| `ProductionReady` | Indicates whether the cluster currently meets the operator's Hardened production posture checks. This condition does not represent API stability or project support level. | `ProductionReady`, `ProfileNotSet`, `DevelopmentProfile`, `AdmissionPoliciesNotReady`, `UnsafeAdmissionDisabled`, `OperatorManagedTLS`, `StaticUnsealInUse`, `RootTokenStored`, Gateway or ACME readiness reasons such as `GatewayFeatureUnsupported` or `ACMEGatewayNotConfiguredForPassthrough` |
 | `Upgrading` | Upgrade state | `InProgress`, `Idle`, or upgrade failure reason |
 | `BackingUp` | Backup job state | `InProgress`, `Idle` |
 | `StorageConfigured` | Persistent storage class selection visibility | `StorageClassConfigured`, `StorageClassPending`, `StorageClassDefaulted`, `StorageClassUnset`, `StorageClassMismatch`, `StorageClassInconsistent` |
 | `Degraded` | Problem requiring attention | `BreakGlassRequired`, upgrade failure reason, workload or adminops error reason, `OIDCBootstrapConfigurationInvalid`, `APIServerNetworkConfigurationInvalid`, `RootTokenStored`, `Reconciling`, `Paused` |
 | `EtcdEncryptionWarning` | etcd encryption verification warning | `EtcdEncryptionUnknown` |
-| `SecurityRisk` | Relaxed security mode indicator | `DevelopmentProfile` |
+| `SecurityRisk` | Relaxed security mode indicator | `DevelopmentProfile`, `UnsafeAdmissionDisabled` |
 | `OpenBaoInitialized` | OpenBao initialization observed from registration labels | `Initialized`, `NotInitialized`, `Unknown` |
 | `OpenBaoSealed` | OpenBao seal state observed from registration labels | `Sealed`, `Unsealed`, `Unknown` |
 | `OpenBaoLeader` | Leader discovery from registration labels | `LeaderFound`, `LeaderUnknown`, `MultipleLeaders` |
@@ -118,6 +118,7 @@ Expect `Normal` events for routine progression and accepted operator input. Expe
 | :--- | :--- | :--- |
 | `Warning` | `ProfileNotSet` | `spec.profile` missing; reconciliation blocked. |
 | `Warning` | `DevelopmentProfile` | Development profile warning for production. |
+| `Warning` | `UnsafeAdmissionDisabled` | Unsafe admission mode is active, required admission guardrails are not enforced, and Hardened clusters are not production-ready. |
 | `Normal` | `AmbientUnsealIdentity` | Cloud KMS unseal is relying on ambient identity or the provider default chain for the main OpenBao Pods. This note is emitted only when the operator is not using a credentials Secret or explicit inline cloud credentials. |
 | `Warning` | `StaticUnsealInUse` | Static unseal warning. |
 | `Warning` | `RootTokenStored` | Self-init is disabled and the operator stored the root token Secret. |

--- a/internal/controller/openbaocluster/constants.go
+++ b/internal/controller/openbaocluster/constants.go
@@ -15,6 +15,7 @@ const (
 	ReasonPrerequisitesReady                   = "PrerequisitesReady"
 	ReasonAdmissionPoliciesNotReady            = "AdmissionPoliciesNotReady"
 	ReasonAdmissionPoliciesReady               = "AdmissionPoliciesReady"
+	ReasonUnsafeAdmissionDisabled              = "UnsafeAdmissionDisabled"
 
 	ReasonInProgress = "InProgress"
 
@@ -106,11 +107,12 @@ const (
 	controllerNameAdminOps = "openbaocluster-adminops"
 	controllerNameStatus   = "openbaocluster-status"
 
-	annotationLastDevelopmentWarning   = "openbao.org/last-development-warning"
-	annotationLastAmbientUnsealNote    = "openbao.org/last-ambient-unseal-identity-note"
-	annotationLastProfileNotSetWarning = "openbao.org/last-profile-not-set-warning"
-	annotationLastRootTokenWarning     = "openbao.org/last-root-token-warning"
-	annotationLastStaticUnsealWarning  = "openbao.org/last-static-unseal-warning"
+	annotationLastDevelopmentWarning     = "openbao.org/last-development-warning"
+	annotationLastAmbientUnsealNote      = "openbao.org/last-ambient-unseal-identity-note"
+	annotationLastProfileNotSetWarning   = "openbao.org/last-profile-not-set-warning"
+	annotationLastRootTokenWarning       = "openbao.org/last-root-token-warning"
+	annotationLastStaticUnsealWarning    = "openbao.org/last-static-unseal-warning"
+	annotationLastUnsafeAdmissionWarning = "openbao.org/last-unsafe-admission-warning"
 )
 
 const securityWarningInterval = time.Hour

--- a/internal/controller/openbaocluster/security_events.go
+++ b/internal/controller/openbaocluster/security_events.go
@@ -14,6 +14,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
+	"github.com/dc-tec/openbao-operator/internal/platform/admission"
 )
 
 func (r *OpenBaoClusterReconciler) emitSecurityWarningEvents(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
@@ -42,6 +43,10 @@ func (r *OpenBaoClusterReconciler) emitSecurityWarningEvents(ctx context.Context
 
 	if cluster.Spec.Profile == openbaov1alpha1.ProfileDevelopment {
 		maybeWarn(annotationLastDevelopmentWarning, ReasonDevelopmentProfile, "Cluster is using Development profile; this is not suitable for production")
+	}
+
+	if admission.UnsafeAdmissionDisabled() {
+		maybeWarn(annotationLastUnsafeAdmissionWarning, ReasonUnsafeAdmissionDisabled, "Unsafe admission mode is active; required admission guardrails are not enforced and Hardened clusters are not production-ready")
 	}
 
 	if isStaticUnseal(cluster) {

--- a/internal/controller/openbaocluster/security_events_test.go
+++ b/internal/controller/openbaocluster/security_events_test.go
@@ -89,6 +89,60 @@ func TestEmitSecurityWarningEvents_RecordsAndPersistsTimestamps(t *testing.T) {
 	}
 }
 
+func TestEmitSecurityWarningEvents_EmitsUnsafeAdmissionModeWarning(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+
+	scheme := newOpenBaoClusterTestScheme(t)
+	cluster := newOpenBaoClusterStatusTestObject()
+	cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+		Type: "transit",
+		Transit: &openbaov1alpha1.TransitSealConfig{
+			Address:   "https://infra-bao.example",
+			KeyName:   "autounseal",
+			MountPath: "transit/",
+		},
+	}
+	cluster.Annotations = map[string]string{}
+
+	recorder := events.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster).
+		Build()
+	reconciler := &OpenBaoClusterReconciler{
+		Client: k8sClient,
+		ControllerRuntime: ControllerRuntime{
+			Recorder: recorder,
+		},
+	}
+
+	if err := reconciler.emitSecurityWarningEvents(context.Background(), logr.Discard(), cluster); err != nil {
+		t.Fatalf("emitSecurityWarningEvents() error = %v", err)
+	}
+
+	found := false
+	for i := 0; i < 3; i++ {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, ReasonUnsafeAdmissionDisabled) {
+				found = true
+			}
+		default:
+		}
+	}
+	if !found {
+		t.Fatal("expected unsafe admission mode warning event to be recorded")
+	}
+
+	updated := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), updated); err != nil {
+		t.Fatalf("get updated cluster: %v", err)
+	}
+	if updated.Annotations[annotationLastUnsafeAdmissionWarning] == "" {
+		t.Fatalf("expected annotation %q to be persisted", annotationLastUnsafeAdmissionWarning)
+	}
+}
+
 func TestEmitSecurityWarningEvents_EmitsAmbientUnsealIdentityNote(t *testing.T) {
 	scheme := newOpenBaoClusterTestScheme(t)
 	cluster := newOpenBaoClusterStatusTestObject()

--- a/internal/controller/openbaocluster/status_condition_apply_test.go
+++ b/internal/controller/openbaocluster/status_condition_apply_test.go
@@ -114,6 +114,34 @@ func TestBuildSealedConditionAndApplyHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("applyAllConditions surfaces unsafe admission mode", func(t *testing.T) {
+		cluster := newOpenBaoClusterStatusTestObject()
+		cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeExternal
+		cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+			Type: "transit",
+			Transit: &openbaov1alpha1.TransitSealConfig{
+				Address:   "https://infra-bao.example",
+				KeyName:   "autounseal",
+				MountPath: "transit/",
+			},
+		}
+		admissionStatus := &admission.Status{
+			OverallReady: true,
+			UnsafeMode:   true,
+		}
+
+		applyAllConditions(cluster, &clusterState{}, admissionStatus, metav1.Now())
+
+		securityRisk := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionSecurityRisk))
+		if securityRisk == nil || securityRisk.Status != metav1.ConditionTrue || securityRisk.Reason != ReasonUnsafeAdmissionDisabled {
+			t.Fatalf("SecurityRisk condition = %#v, want true %s", securityRisk, ReasonUnsafeAdmissionDisabled)
+		}
+		productionReady := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionProductionReady))
+		if productionReady == nil || productionReady.Status != metav1.ConditionFalse || productionReady.Reason != ReasonUnsafeAdmissionDisabled {
+			t.Fatalf("ProductionReady condition = %#v, want false %s", productionReady, ReasonUnsafeAdmissionDisabled)
+		}
+	})
+
 	t.Run("applyNodeSecurityCapabilityMismatchCondition removes condition when apparmor disabled", func(t *testing.T) {
 		cluster := newOpenBaoClusterStatusTestObject()
 		cluster.Status.Conditions = []metav1.Condition{{

--- a/internal/controller/openbaocluster/status_helpers.go
+++ b/internal/controller/openbaocluster/status_helpers.go
@@ -97,7 +97,17 @@ func applyAllConditions(
 		Message:            "The operator cannot verify etcd encryption status. Ensure etcd encryption at rest is enabled in your Kubernetes cluster to protect Secrets (including unseal keys and root tokens) stored in etcd.",
 	})
 
-	if cluster.Spec.Profile == openbaov1alpha1.ProfileDevelopment {
+	unsafeAdmission := admissionStatus != nil && admissionStatus.UnsafeMode
+	if unsafeAdmission {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               string(openbaov1alpha1.ConditionSecurityRisk),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: gen,
+			LastTransitionTime: now,
+			Reason:             ReasonUnsafeAdmissionDisabled,
+			Message:            "Unsafe admission mode is active; required admission guardrails are not enforced.",
+		})
+	} else if cluster.Spec.Profile == openbaov1alpha1.ProfileDevelopment {
 		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 			Type:               string(openbaov1alpha1.ConditionSecurityRisk),
 			Status:             metav1.ConditionTrue,
@@ -115,7 +125,7 @@ func applyAllConditions(
 	if admissionStatus != nil {
 		admissionSummary = admissionStatus.SummaryMessage()
 	}
-	productionStatus, productionReason, productionMessage := evaluateProductionReady(cluster, admissionReady, admissionSummary)
+	productionStatus, productionReason, productionMessage := evaluateProductionReady(cluster, admissionReady, admissionSummary, unsafeAdmission)
 	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 		Type:               string(openbaov1alpha1.ConditionProductionReady),
 		Status:             productionStatus,

--- a/internal/controller/openbaocluster/status_helpers_fuzz_test.go
+++ b/internal/controller/openbaocluster/status_helpers_fuzz_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func FuzzEvaluateProductionReady(f *testing.F) {
-	f.Add(uint8(0), uint8(0), uint8(0), true, true, "all good")
-	f.Add(uint8(1), uint8(1), uint8(1), false, false, "missing admission")
-	f.Add(uint8(2), uint8(2), uint8(0), true, false, "development")
+	f.Add(uint8(0), uint8(0), uint8(0), true, true, false, "all good")
+	f.Add(uint8(1), uint8(1), uint8(1), false, false, false, "missing admission")
+	f.Add(uint8(2), uint8(2), uint8(0), true, false, true, "development")
 
-	f.Fuzz(func(t *testing.T, profileSeed, tlsSeed, unsealSeed uint8, selfInitEnabled, admissionReady bool, admissionSummary string) {
+	f.Fuzz(func(t *testing.T, profileSeed, tlsSeed, unsealSeed uint8, selfInitEnabled, admissionReady, unsafeAdmission bool, admissionSummary string) {
 		cluster := newOpenBaoClusterStatusTestObject()
 		cluster.Spec.Profile = fuzzProfile(profileSeed)
 		cluster.Spec.TLS = openbaov1alpha1.TLSConfig{
@@ -30,7 +30,7 @@ func FuzzEvaluateProductionReady(f *testing.F) {
 		}
 		cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{Enabled: selfInitEnabled}
 
-		status, reason, message := evaluateProductionReady(cluster, admissionReady, strings.TrimSpace(admissionSummary))
+		status, reason, message := evaluateProductionReady(cluster, admissionReady, strings.TrimSpace(admissionSummary), unsafeAdmission)
 		if reason == "" {
 			t.Fatalf("expected non-empty reason for production-ready evaluation")
 		}

--- a/internal/controller/openbaocluster/status_production_ready.go
+++ b/internal/controller/openbaocluster/status_production_ready.go
@@ -12,13 +12,17 @@ import (
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
-func evaluateProductionReady(cluster *openbaov1alpha1.OpenBaoCluster, admissionReady bool, admissionSummary string) (metav1.ConditionStatus, string, string) {
+func evaluateProductionReady(cluster *openbaov1alpha1.OpenBaoCluster, admissionReady bool, admissionSummary string, unsafeAdmission bool) (metav1.ConditionStatus, string, string) {
 	if cluster.Spec.Profile == "" {
 		return metav1.ConditionFalse, ReasonProfileNotSet, "spec.profile must be explicitly set to Hardened or Development"
 	}
 
 	if cluster.Spec.Profile == openbaov1alpha1.ProfileDevelopment {
 		return metav1.ConditionFalse, ReasonDevelopmentProfile, "Development profile is not suitable for production"
+	}
+
+	if unsafeAdmission {
+		return metav1.ConditionFalse, ReasonUnsafeAdmissionDisabled, "Hardened profile requires enforced admission policies; unsafe admission mode is not considered production-ready"
 	}
 
 	if !admissionReady {

--- a/internal/controller/openbaocluster/status_production_ready_test.go
+++ b/internal/controller/openbaocluster/status_production_ready_test.go
@@ -14,10 +14,11 @@ import (
 
 func TestEvaluateProductionReady(t *testing.T) {
 	tests := []struct {
-		name       string
-		cluster    *openbaov1alpha1.OpenBaoCluster
-		wantStatus metav1.ConditionStatus
-		wantReason string
+		name            string
+		cluster         *openbaov1alpha1.OpenBaoCluster
+		unsafeAdmission bool
+		wantStatus      metav1.ConditionStatus
+		wantReason      string
 	}{
 		{
 			name: "profile not set",
@@ -36,6 +37,30 @@ func TestEvaluateProductionReady(t *testing.T) {
 			},
 			wantStatus: metav1.ConditionFalse,
 			wantReason: ReasonDevelopmentProfile,
+		},
+		{
+			name: "hardened with unsafe admission mode",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Profile:  openbaov1alpha1.ProfileHardened,
+					SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: true},
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeExternal,
+					},
+					Unseal: &openbaov1alpha1.UnsealConfig{
+						Type: "transit",
+						Transit: &openbaov1alpha1.TransitSealConfig{
+							Address:   "https://infra-bao.example",
+							KeyName:   "autounseal",
+							MountPath: "transit/",
+						},
+					},
+				},
+			},
+			unsafeAdmission: true,
+			wantStatus:      metav1.ConditionFalse,
+			wantReason:      ReasonUnsafeAdmissionDisabled,
 		},
 		{
 			name: "hardened with invalid api server network config",
@@ -386,7 +411,7 @@ func TestEvaluateProductionReady(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status, reason, _ := evaluateProductionReady(tt.cluster, true, "")
+			status, reason, _ := evaluateProductionReady(tt.cluster, true, "", tt.unsafeAdmission)
 			assert.Equal(t, tt.wantStatus, status)
 			assert.Equal(t, tt.wantReason, reason)
 		})

--- a/internal/platform/admission/check.go
+++ b/internal/platform/admission/check.go
@@ -34,6 +34,7 @@ type Status struct {
 	CheckedAt    time.Time
 	Dependencies []DependencyStatus
 	OverallReady bool
+	UnsafeMode   bool
 }
 
 const (
@@ -207,6 +208,10 @@ func CheckDependencies(ctx context.Context, c client.Reader, deps []Dependency, 
 // SummaryMessage returns a single-line summary for logs, Events, or Conditions.
 // It is safe to log (contains no sensitive data).
 func (s Status) SummaryMessage() string {
+	if s.UnsafeMode {
+		return "Admission policies are disabled by unsafe mode"
+	}
+
 	if s.OverallReady {
 		return "Required admission policies are installed and correctly bound"
 	}

--- a/internal/platform/admission/fuzz_test.go
+++ b/internal/platform/admission/fuzz_test.go
@@ -43,16 +43,17 @@ func FuzzDefaultNamePrefixes(f *testing.F) {
 }
 
 func FuzzStatusSummaryMessage(f *testing.F) {
-	f.Add("dep-a", "missing binding", false, false)
-	f.Add("dep-b", "", false, true)
-	f.Add("", "", true, false)
+	f.Add("dep-a", "missing binding", false, false, false)
+	f.Add("dep-b", "", false, true, false)
+	f.Add("", "", true, false, true)
 
-	f.Fuzz(func(t *testing.T, depName, issue string, ready, overallReady bool) {
+	f.Fuzz(func(t *testing.T, depName, issue string, ready, overallReady, unsafeMode bool) {
 		depName = sanitizeAdmissionSummaryName(depName, "")
 		issue = sanitizeAdmissionSummaryText(issue)
 
 		status := Status{
 			OverallReady: overallReady,
+			UnsafeMode:   unsafeMode,
 			Dependencies: []DependencyStatus{
 				{
 					Dependency: Dependency{Name: depName},

--- a/internal/platform/admission/runtime.go
+++ b/internal/platform/admission/runtime.go
@@ -14,6 +14,11 @@ func RefreshStatus(ctx context.Context, tracker *Tracker, reader client.Reader) 
 	if tracker != nil {
 		return tracker.EnsureFresh(ctx)
 	}
+	if UnsafeAdmissionDisabled() {
+		status := unsafeModeStatus()
+		SetAdmissionDependenciesReady(status.OverallReady)
+		return cloneStatus(&status), nil
+	}
 
 	// Preserve existing unit-test behavior when callers seed the legacy global
 	// readiness signal without constructing a tracker.

--- a/internal/platform/admission/runtime_test.go
+++ b/internal/platform/admission/runtime_test.go
@@ -279,6 +279,11 @@ func TestCheckDependencies_SummaryMessage(t *testing.T) {
 		t.Fatalf("unexpected ready summary: %q", got)
 	}
 
+	unsafe := Status{OverallReady: true, UnsafeMode: true}
+	if got := unsafe.SummaryMessage(); got != "Admission policies are disabled by unsafe mode" {
+		t.Fatalf("unexpected unsafe summary: %q", got)
+	}
+
 	notReady := Status{
 		OverallReady: false,
 		Dependencies: []DependencyStatus{
@@ -413,6 +418,25 @@ func TestUnsafeAdmissionDisabled(t *testing.T) {
 				t.Fatalf("UnsafeAdmissionDisabled()=%v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRefreshStatus_UnsafeAdmissionDisabled(t *testing.T) {
+	SetAdmissionDependenciesReady(false)
+	t.Cleanup(func() {
+		SetAdmissionDependenciesReady(false)
+	})
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+
+	status, err := RefreshStatus(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("RefreshStatus() error = %v", err)
+	}
+	if status == nil || !status.OverallReady || !status.UnsafeMode {
+		t.Fatalf("RefreshStatus() = %#v, want overall ready unsafe status", status)
+	}
+	if !AdmissionDependenciesReady() {
+		t.Fatal("expected legacy admission readiness signal to be true")
 	}
 }
 

--- a/internal/platform/admission/tracker.go
+++ b/internal/platform/admission/tracker.go
@@ -62,16 +62,18 @@ func (t *Tracker) MarkReadyForUnsafeMode() {
 	if t == nil {
 		return
 	}
-	t.Set(Status{
-		CheckedAt:    time.Now(),
-		OverallReady: true,
-	})
+	t.Set(unsafeModeStatus())
 }
 
 // EnsureFresh refreshes the cached status when it is stale or absent.
 func (t *Tracker) EnsureFresh(ctx context.Context) (*Status, error) {
 	if t == nil {
 		return nil, nil
+	}
+	if UnsafeAdmissionDisabled() {
+		status := unsafeModeStatus()
+		t.Set(status)
+		return cloneStatus(&status), nil
 	}
 
 	t.mu.RLock()
@@ -90,6 +92,11 @@ func (t *Tracker) EnsureFresh(ctx context.Context) (*Status, error) {
 func (t *Tracker) Refresh(ctx context.Context) (*Status, error) {
 	if t == nil {
 		return nil, nil
+	}
+	if UnsafeAdmissionDisabled() {
+		status := unsafeModeStatus()
+		t.Set(status)
+		return cloneStatus(&status), nil
 	}
 
 	status, err := CheckDependencies(ctx, t.reader, t.dependencies, t.namePrefixes)
@@ -121,4 +128,12 @@ func cloneStatus(status *Status) *Status {
 	}
 
 	return &cloned
+}
+
+func unsafeModeStatus() Status {
+	return Status{
+		CheckedAt:    time.Now(),
+		OverallReady: true,
+		UnsafeMode:   true,
+	}
 }

--- a/internal/platform/admission/tracker_test.go
+++ b/internal/platform/admission/tracker_test.go
@@ -61,6 +61,47 @@ func TestTracker_EnsureFreshCachesRecentStatus(t *testing.T) {
 	}
 }
 
+func TestTracker_MarkReadyForUnsafeMode(t *testing.T) {
+	tracker := NewTracker(nil, nil, nil, time.Minute)
+
+	tracker.MarkReadyForUnsafeMode()
+
+	current := tracker.Current()
+	if current == nil {
+		t.Fatal("Current() returned nil")
+	}
+	if !current.OverallReady || !current.UnsafeMode {
+		t.Fatalf("Current() = %#v, want overall ready unsafe status", current)
+	}
+}
+
+func TestTracker_EnsureFreshKeepsUnsafeMode(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+
+	tracker := NewTracker(
+		fake.NewClientBuilder().Build(),
+		[]Dependency{{
+			Name:        "missing-policy",
+			PolicyName:  "missing-policy",
+			BindingName: "missing-binding",
+		}},
+		[]string{""},
+		time.Nanosecond,
+	)
+	tracker.Set(Status{
+		CheckedAt:    time.Now().Add(-time.Hour),
+		OverallReady: false,
+	})
+
+	current, err := tracker.EnsureFresh(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureFresh() returned unexpected error: %v", err)
+	}
+	if current == nil || !current.OverallReady || !current.UnsafeMode {
+		t.Fatalf("EnsureFresh() = %#v, want overall ready unsafe status", current)
+	}
+}
+
 func TestTracker_RefreshBypassesRecentCache(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Unsafe admission mode now carries an explicit admission status flag instead of looking identical to fully enforced admission policies. Hardened clusters report `ProductionReady=False` with `UnsafeAdmissionDisabled`, `SecurityRisk=True` while unsafe mode is active, and a warning event is emitted with a persisted timestamp. The status and events reference documents the new reason.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Hardened clusters running with `OPENBAO_UNSAFE_ADMISSION_DISABLED=true` will no longer report `ProductionReady=True`. This does not change the existing unsafe-mode reconciliation bypasses; it only makes the degraded posture visible in status and events.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/platform/admission -run '^(TestCheckDependencies_SummaryMessage|TestRefreshStatus_UnsafeAdmissionDisabled|TestTracker_MarkReadyForUnsafeMode|TestTracker_EnsureFreshKeepsUnsafeMode|TestUnsafeAdmissionDisabled)$'`
- `GOFLAGS=-mod=vendor go test ./internal/controller/openbaocluster -run '^(TestEvaluateProductionReady|TestBuildSealedConditionAndApplyHelpers|TestEmitSecurityWarningEvents_)'`
- `GOFLAGS=-mod=vendor go test ./internal/platform/admission`
- `GOFLAGS=-mod=vendor go test ./internal/controller/openbaocluster`
- `GOFLAGS=-mod=vendor go test ./internal/controller/openbaorestore ./internal/controller/provisioner ./internal/app/provisioner`
- `make docs-build`
- `make lint-ci`
- `git diff --check`

## Reviewer Notes

Generated artifacts are not affected.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.