### PR TITLE
fix(upgrade): set executor job resource requirements

### DIFF
--- a/internal/service/upgrade/job_builder.go
+++ b/internal/service/upgrade/job_builder.go
@@ -6,6 +6,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -71,6 +72,7 @@ func buildUpgradeExecutorJob(
 							Name:            "upgrade-executor",
 							Image:           image,
 							SecurityContext: buildUpgradeExecutorContainerSecurityContext(),
+							Resources:       buildUpgradeExecutorResources(),
 							Env: buildUpgradeExecutorEnv(
 								cluster,
 								action,
@@ -207,6 +209,19 @@ func buildUpgradeExecutorContainerSecurityContext() *corev1.SecurityContext {
 		},
 		ReadOnlyRootFilesystem: ptr.To(true),
 		RunAsNonRoot:           ptr.To(true),
+	}
+}
+
+func buildUpgradeExecutorResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
 	}
 }
 

--- a/internal/service/upgrade/job_test.go
+++ b/internal/service/upgrade/job_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -166,6 +168,50 @@ func TestBuildUpgradeExecutorJob_AllowsOIDCWithoutUpgradeConfig(t *testing.T) {
 	}
 	if !foundRole {
 		t.Fatalf("missing %s env var", constants.EnvUpgradeJWTAuthRole)
+	}
+}
+
+func TestBuildUpgradeExecutorJob_SetsResourceRequirements(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Upgrade: &openbaov1alpha1.UpgradeConfig{
+				Image:       "test-image",
+				JWTAuthRole: "test-role",
+			},
+		},
+	}
+
+	job, err := buildUpgradeExecutorJob(
+		cluster,
+		"test-job",
+		ExecutorAction("test"),
+		"run-id",
+		"",
+		"",
+		"",
+		portopenbao.ClientConfig{},
+		constants.PlatformKubernetes,
+	)
+	if err != nil {
+		t.Fatalf("buildUpgradeExecutorJob() error = %v", err)
+	}
+
+	resources := job.Spec.Template.Spec.Containers[0].Resources
+	if got := resources.Requests[corev1.ResourceCPU]; got.Cmp(resource.MustParse("100m")) != 0 {
+		t.Fatalf("CPU request = %s, want 100m", got.String())
+	}
+	if got := resources.Requests[corev1.ResourceMemory]; got.Cmp(resource.MustParse("128Mi")) != 0 {
+		t.Fatalf("memory request = %s, want 128Mi", got.String())
+	}
+	if got := resources.Limits[corev1.ResourceCPU]; got.Cmp(resource.MustParse("500m")) != 0 {
+		t.Fatalf("CPU limit = %s, want 500m", got.String())
+	}
+	if got := resources.Limits[corev1.ResourceMemory]; got.Cmp(resource.MustParse("512Mi")) != 0 {
+		t.Fatalf("memory limit = %s, want 512Mi", got.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Upgrade executor Jobs now set explicit CPU and memory requests and limits on the executor container. The defaults match the existing backup and restore executor Jobs: `100m`/`128Mi` requests and `500m`/`512Mi` limits.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. This only changes generated upgrade executor Job pod specs by adding resource requirements. No CRD or API changes are included.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/service/upgrade -run '^(TestBuildUpgradeExecutorJob_|TestEnsureExecutorJob_)'`
- `GOFLAGS=-mod=vendor go test ./internal/service/upgrade`
- `make lint-ci`
- `git diff --check`

## Reviewer Notes

Generated artifacts and docs are not affected. The branch contains one DCO-signed conventional commit.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.