### PR TITLE
fix(security): fail closed for configured trusted roots

### DIFF
--- a/internal/adapter/security/image_verifier.go
+++ b/internal/adapter/security/image_verifier.go
@@ -33,9 +33,9 @@ type ImageVerifier struct {
 }
 
 // TrustedRootConfig specifies where to load the trusted root material from.
-// If ConfigMapName and ConfigMapNamespace are set, the trusted root will be
-// loaded from that ConfigMap (key: "trusted_root.json"). Otherwise, the
-// embedded trusted_root.json will be used.
+// If either ConfigMapName or ConfigMapNamespace is set, both values are required
+// and the trusted root must be loaded from that ConfigMap (key: "trusted_root.json").
+// When neither value is set, the embedded trusted_root.json is used.
 type TrustedRootConfig struct {
 	ConfigMapName      string
 	ConfigMapNamespace string
@@ -43,8 +43,8 @@ type TrustedRootConfig struct {
 
 // NewImageVerifier creates a new ImageVerifier with the provided logger and Kubernetes client.
 // The client is used to read ImagePullSecrets for private registry authentication.
-// trustedRootConfig is optional - if provided, the trusted root will be loaded from the
-// specified ConfigMap instead of using the embedded version.
+// trustedRootConfig is optional. When it names a ConfigMap, missing or invalid
+// ConfigMap data fails closed instead of falling back to the embedded root.
 func NewImageVerifier(logger logr.Logger, k8sClient client.Client, trustedRootConfig *TrustedRootConfig) *ImageVerifier {
 	return &ImageVerifier{
 		logger:            logger,

--- a/internal/adapter/security/image_verifier_test.go
+++ b/internal/adapter/security/image_verifier_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
@@ -48,6 +52,128 @@ func TestNewImageVerifier(t *testing.T) {
 	if verifier.client != client {
 		t.Error("NewImageVerifier() client not set correctly")
 	}
+}
+
+func TestImageVerifier_LoadTrustedRoot_UsesEmbeddedWhenConfigAbsent(t *testing.T) {
+	verifier := NewImageVerifier(logr.Discard(), fake.NewClientBuilder().Build(), nil)
+
+	trustedRoot, err := verifier.loadTrustedRoot(context.Background())
+	if err != nil {
+		t.Fatalf("loadTrustedRoot() error = %v", err)
+	}
+	if trustedRoot == nil {
+		t.Fatal("loadTrustedRoot() returned nil trusted root")
+	}
+}
+
+func TestImageVerifier_LoadTrustedRoot_ConfigMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      crclient.Client
+		config      *TrustedRootConfig
+		wantErrPart string
+	}{
+		{
+			name: "loads configured configmap",
+			client: newTrustedRootTestClient(t, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sigstore-root",
+					Namespace: "openbao-system",
+				},
+				Data: map[string]string{
+					trustedRootConfigMapKey: string(embeddedTrustedRootJSON),
+				},
+			}),
+			config: &TrustedRootConfig{
+				ConfigMapName:      "sigstore-root",
+				ConfigMapNamespace: "openbao-system",
+			},
+		},
+		{
+			name:   "missing configured configmap fails closed",
+			client: newTrustedRootTestClient(t),
+			config: &TrustedRootConfig{
+				ConfigMapName:      "sigstore-root",
+				ConfigMapNamespace: "openbao-system",
+			},
+			wantErrPart: "failed to load trusted root ConfigMap openbao-system/sigstore-root",
+		},
+		{
+			name: "missing trusted root key fails closed",
+			client: newTrustedRootTestClient(t, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sigstore-root",
+					Namespace: "openbao-system",
+				},
+				Data: map[string]string{"other": "{}"},
+			}),
+			config: &TrustedRootConfig{
+				ConfigMapName:      "sigstore-root",
+				ConfigMapNamespace: "openbao-system",
+			},
+			wantErrPart: `missing required key "trusted_root.json"`,
+		},
+		{
+			name: "invalid trusted root json fails closed",
+			client: newTrustedRootTestClient(t, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sigstore-root",
+					Namespace: "openbao-system",
+				},
+				Data: map[string]string{trustedRootConfigMapKey: "not-json"},
+			}),
+			config: &TrustedRootConfig{
+				ConfigMapName:      "sigstore-root",
+				ConfigMapNamespace: "openbao-system",
+			},
+			wantErrPart: "failed to parse trusted_root.json from ConfigMap openbao-system/sigstore-root",
+		},
+		{
+			name:        "partial config fails closed",
+			client:      newTrustedRootTestClient(t),
+			config:      &TrustedRootConfig{ConfigMapName: "sigstore-root"},
+			wantErrPart: "requires both namespace and name",
+		},
+		{
+			name:        "configured configmap without client fails closed",
+			client:      nil,
+			config:      &TrustedRootConfig{ConfigMapName: "sigstore-root", ConfigMapNamespace: "openbao-system"},
+			wantErrPart: "Kubernetes client is not available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := NewImageVerifier(logr.Discard(), tt.client, tt.config)
+
+			trustedRoot, err := verifier.loadTrustedRoot(context.Background())
+			if tt.wantErrPart != "" {
+				if err == nil {
+					t.Fatal("loadTrustedRoot() error = nil, want error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrPart) {
+					t.Fatalf("loadTrustedRoot() error = %q, want substring %q", err.Error(), tt.wantErrPart)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadTrustedRoot() error = %v", err)
+			}
+			if trustedRoot == nil {
+				t.Fatal("loadTrustedRoot() returned nil trusted root")
+			}
+		})
+	}
+}
+
+func newTrustedRootTestClient(t *testing.T, objects ...crclient.Object) crclient.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 }
 
 func TestImageVerifier_Verify_EmptyConfig(t *testing.T) {

--- a/internal/adapter/security/image_verifier_trust.go
+++ b/internal/adapter/security/image_verifier_trust.go
@@ -3,42 +3,22 @@ package security
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sigstore/sigstore-go/pkg/root"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const trustedRootConfigMapKey = "trusted_root.json"
+
 // loadTrustedRoot loads the trusted root material for keyless verification.
 func (v *ImageVerifier) loadTrustedRoot(ctx context.Context) (root.TrustedMaterial, error) {
-	if v.trustedRootConfig != nil && v.trustedRootConfig.ConfigMapName != "" && v.trustedRootConfig.ConfigMapNamespace != "" {
-		if v.client != nil {
-			configMap := &corev1.ConfigMap{}
-			err := v.client.Get(ctx, types.NamespacedName{
-				Namespace: v.trustedRootConfig.ConfigMapNamespace,
-				Name:      v.trustedRootConfig.ConfigMapName,
-			}, configMap)
-			if err == nil {
-				if trustedRootJSON, ok := configMap.Data["trusted_root.json"]; ok {
-					v.logger.Info("Loading trusted root from ConfigMap",
-						"configmap", v.trustedRootConfig.ConfigMapName,
-						"namespace", v.trustedRootConfig.ConfigMapNamespace)
-					trustedRoot, err := root.NewTrustedRootFromJSON([]byte(trustedRootJSON))
-					if err != nil {
-						return nil, fmt.Errorf("failed to parse trusted_root.json from ConfigMap %s/%s: %w",
-							v.trustedRootConfig.ConfigMapNamespace, v.trustedRootConfig.ConfigMapName, err)
-					}
-					return trustedRoot, nil
-				}
-				v.logger.Info("ConfigMap found but missing 'trusted_root.json' key, falling back to embedded",
-					"configmap", v.trustedRootConfig.ConfigMapName,
-					"namespace", v.trustedRootConfig.ConfigMapNamespace)
-			} else {
-				v.logger.V(1).Info("Failed to load ConfigMap, falling back to embedded trusted root",
-					"configmap", v.trustedRootConfig.ConfigMapName,
-					"namespace", v.trustedRootConfig.ConfigMapNamespace,
-					"error", err)
-			}
+	if v.trustedRootConfig != nil {
+		configMapName := strings.TrimSpace(v.trustedRootConfig.ConfigMapName)
+		configMapNamespace := strings.TrimSpace(v.trustedRootConfig.ConfigMapNamespace)
+		if configMapName != "" || configMapNamespace != "" {
+			return v.loadTrustedRootFromConfigMap(ctx, configMapNamespace, configMapName)
 		}
 	}
 
@@ -46,6 +26,32 @@ func (v *ImageVerifier) loadTrustedRoot(ctx context.Context) (root.TrustedMateri
 	trustedRoot, err := root.NewTrustedRootFromJSON(embeddedTrustedRootJSON)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse embedded trusted_root.json: %w", err)
+	}
+	return trustedRoot, nil
+}
+
+func (v *ImageVerifier) loadTrustedRootFromConfigMap(ctx context.Context, namespace, name string) (root.TrustedMaterial, error) {
+	if namespace == "" || name == "" {
+		return nil, fmt.Errorf("trusted root ConfigMap requires both namespace and name")
+	}
+	if v.client == nil {
+		return nil, fmt.Errorf("trusted root ConfigMap %s/%s is configured but Kubernetes client is not available", namespace, name)
+	}
+
+	configMap := &corev1.ConfigMap{}
+	if err := v.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, configMap); err != nil {
+		return nil, fmt.Errorf("failed to load trusted root ConfigMap %s/%s: %w", namespace, name, err)
+	}
+
+	trustedRootJSON, ok := configMap.Data[trustedRootConfigMapKey]
+	if !ok || strings.TrimSpace(trustedRootJSON) == "" {
+		return nil, fmt.Errorf("trusted root ConfigMap %s/%s is missing required key %q", namespace, name, trustedRootConfigMapKey)
+	}
+
+	v.logger.Info("Loading trusted root from ConfigMap", "configmap", name, "namespace", namespace)
+	trustedRoot, err := root.NewTrustedRootFromJSON([]byte(trustedRootJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s from ConfigMap %s/%s: %w", trustedRootConfigMapKey, namespace, name, err)
 	}
 	return trustedRoot, nil
 }


### PR DESCRIPTION
## Summary

Custom trusted-root ConfigMap loading now fails closed when explicitly configured. The embedded `trusted_root.json` is still used when no ConfigMap is configured, but a configured ConfigMap must have both namespace and name, be readable, contain the `trusted_root.json` key, and parse successfully.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low for default installs: behavior is unchanged when no trusted-root ConfigMap is configured. Explicit custom trusted-root configuration now fails instead of silently falling back to the embedded root if the ConfigMap is missing, malformed, or incomplete.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/adapter/security -run '^(TestImageVerifier_LoadTrustedRoot|TestNewImageVerifier)$'`
- `GOFLAGS=-mod=vendor go test ./internal/adapter/security`
- `make lint-ci`
- `git diff --check`

## Reviewer Notes

Generated artifacts and docs are not affected. The branch contains one DCO-signed conventional commit.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.