### PR TITLE
fix(config): use SemVer precedence for OpenBao version checks

### DIFF
--- a/.ast-grep/policy/architecture-boundaries.yml
+++ b/.ast-grep/policy/architecture-boundaries.yml
@@ -47,6 +47,7 @@ layerCoverage:
       - platform/reconcile
       - platform/resourceapply
       - platform/resourceidentity
+      - platform/semver
       - platform/statusapply
       - platform/statuspatch
       - platform/testutil

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
@@ -55,7 +56,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect

--- a/internal/adapter/config/builder.go
+++ b/internal/adapter/config/builder.go
@@ -3,10 +3,10 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	platformsemver "github.com/dc-tec/openbao-operator/internal/platform/semver"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -239,57 +239,7 @@ func validateConfigVersionCompatibility(cluster *openbaov1alpha1.OpenBaoCluster)
 }
 
 func openBaoVersionAtLeast(version string, wantMajor, wantMinor, wantPatch int) (bool, error) {
-	parsed, err := parseSemVer(version)
-	if err != nil {
-		return false, err
-	}
-
-	if parsed.major != wantMajor {
-		return parsed.major > wantMajor, nil
-	}
-	if parsed.minor != wantMinor {
-		return parsed.minor > wantMinor, nil
-	}
-	return parsed.patch >= wantPatch, nil
-}
-
-type semVer struct {
-	major int
-	minor int
-	patch int
-}
-
-func parseSemVer(version string) (semVer, error) {
-	if strings.TrimSpace(version) == "" {
-		return semVer{}, fmt.Errorf("version string is empty")
-	}
-
-	trimmed := strings.TrimPrefix(strings.TrimSpace(version), "v")
-
-	// Strip build metadata and prerelease suffixes.
-	if idx := strings.IndexAny(trimmed, "+-"); idx != -1 {
-		trimmed = trimmed[:idx]
-	}
-
-	parts := strings.Split(trimmed, ".")
-	if len(parts) != 3 {
-		return semVer{}, fmt.Errorf("invalid version format %q: expected MAJOR.MINOR.PATCH", version)
-	}
-
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return semVer{}, fmt.Errorf("invalid major version %q: %w", parts[0], err)
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return semVer{}, fmt.Errorf("invalid minor version %q: %w", parts[1], err)
-	}
-	patch, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return semVer{}, fmt.Errorf("invalid patch version %q: %w", parts[2], err)
-	}
-
-	return semVer{major: major, minor: minor, patch: patch}, nil
+	return platformsemver.AtLeast(version, wantMajor, wantMinor, wantPatch)
 }
 
 func upgradePolicyForCluster(cluster *openbaov1alpha1.OpenBaoCluster) string {

--- a/internal/adapter/config/builder_fuzz_test.go
+++ b/internal/adapter/config/builder_fuzz_test.go
@@ -8,9 +8,10 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	platformsemver "github.com/dc-tec/openbao-operator/internal/platform/semver"
 )
 
-func FuzzParseSemVer(f *testing.F) {
+func FuzzOpenBaoVersionAtLeast(f *testing.F) {
 	seeds := []string{
 		"",
 		"2.4.4",
@@ -27,7 +28,7 @@ func FuzzParseSemVer(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, version string) {
-		_, _ = parseSemVer(version)
+		_, _ = openBaoVersionAtLeast(version, 2, 5, 0)
 	})
 }
 
@@ -202,7 +203,7 @@ func sanitizeCRToken(v, fallback string) string {
 }
 
 func sanitizeVersion(v string) string {
-	if _, err := parseSemVer(v); err == nil {
+	if _, err := platformsemver.Parse(v); err == nil {
 		return v
 	}
 	return "2.5.0"

--- a/internal/adapter/config/builder_test.go
+++ b/internal/adapter/config/builder_test.go
@@ -107,27 +107,40 @@ func TestRenderHCLWithStructuredConfiguration(t *testing.T) {
 }
 
 func TestRenderHCLRejectsPluginAutoConfigForUnsupportedVersions(t *testing.T) {
-	cluster := newMinimalCluster("structured-config", "default")
-	autoDownload := true
-	cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
-		Plugin: &openbaov1alpha1.PluginConfig{
-			AutoDownload: &autoDownload,
-		},
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "older release", version: "2.4.4"},
+		{name: "target prerelease", version: "2.5.0-rc.1"},
 	}
 
-	infraDetails := InfrastructureDetails{
-		HeadlessServiceName: cluster.Name,
-		Namespace:           cluster.Namespace,
-		APIPort:             8200,
-		ClusterPort:         8201,
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newMinimalCluster("structured-config", "default")
+			cluster.Spec.Version = tt.version
+			autoDownload := true
+			cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
+				Plugin: &openbaov1alpha1.PluginConfig{
+					AutoDownload: &autoDownload,
+				},
+			}
 
-	_, err := RenderHCL(cluster, infraDetails)
-	if err == nil {
-		t.Fatalf("RenderHCL() expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "requires OpenBao >= 2.5.0") {
-		t.Fatalf("RenderHCL() error = %v, want version gate error", err)
+			infraDetails := InfrastructureDetails{
+				HeadlessServiceName: cluster.Name,
+				Namespace:           cluster.Namespace,
+				APIPort:             8200,
+				ClusterPort:         8201,
+			}
+
+			_, err := RenderHCL(cluster, infraDetails)
+			if err == nil {
+				t.Fatalf("RenderHCL() expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "requires OpenBao >= 2.5.0") {
+				t.Fatalf("RenderHCL() error = %v, want version gate error", err)
+			}
+		})
 	}
 }
 

--- a/internal/platform/semver/version.go
+++ b/internal/platform/semver/version.go
@@ -1,0 +1,124 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	masterminds "github.com/Masterminds/semver/v3"
+)
+
+const maxInt = uint64(1<<(strconv.IntSize-1) - 1)
+
+// Version wraps a strict semantic version parsed by a dedicated SemVer library.
+type Version struct {
+	value *masterminds.Version
+
+	major int
+	minor int
+	patch int
+}
+
+// New returns a semantic version from numeric MAJOR.MINOR.PATCH parts.
+func New(major, minor, patch int) (*Version, error) {
+	if major < 0 {
+		return nil, fmt.Errorf("major version cannot be negative: %d", major)
+	}
+	if minor < 0 {
+		return nil, fmt.Errorf("minor version cannot be negative: %d", minor)
+	}
+	if patch < 0 {
+		return nil, fmt.Errorf("patch version cannot be negative: %d", patch)
+	}
+	return Parse(fmt.Sprintf("%d.%d.%d", major, minor, patch))
+}
+
+// Parse parses a strict semantic version string. A leading lowercase "v" is
+// accepted for compatibility with image tags and user-facing OpenBao versions.
+func Parse(version string) (*Version, error) {
+	trimmed := strings.TrimSpace(version)
+	if trimmed == "" {
+		return nil, fmt.Errorf("version string is empty")
+	}
+
+	parsed, err := masterminds.StrictNewVersion(strings.TrimPrefix(trimmed, "v"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid semantic version %q: %w", version, err)
+	}
+
+	major, err := versionPartToInt(parsed.Major(), "major")
+	if err != nil {
+		return nil, err
+	}
+	minor, err := versionPartToInt(parsed.Minor(), "minor")
+	if err != nil {
+		return nil, err
+	}
+	patch, err := versionPartToInt(parsed.Patch(), "patch")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Version{
+		value: parsed,
+		major: major,
+		minor: minor,
+		patch: patch,
+	}, nil
+}
+
+// AtLeast reports whether version is greater than or equal to want.
+func AtLeast(version string, wantMajor, wantMinor, wantPatch int) (bool, error) {
+	parsed, err := Parse(version)
+	if err != nil {
+		return false, err
+	}
+	want, err := New(wantMajor, wantMinor, wantPatch)
+	if err != nil {
+		return false, err
+	}
+	return parsed.Compare(want) >= 0, nil
+}
+
+// Compare returns -1, 0, or 1 when v is less than, equal to, or greater than
+// other according to SemVer precedence. Build metadata does not affect ordering.
+func (v *Version) Compare(other *Version) int {
+	return v.value.Compare(other.value)
+}
+
+// Major returns the major version number.
+func (v *Version) Major() int {
+	return v.major
+}
+
+// Minor returns the minor version number.
+func (v *Version) Minor() int {
+	return v.minor
+}
+
+// Patch returns the patch version number.
+func (v *Version) Patch() int {
+	return v.patch
+}
+
+// Prerelease returns the prerelease portion of the version.
+func (v *Version) Prerelease() string {
+	return v.value.Prerelease()
+}
+
+// Build returns the build metadata portion of the version.
+func (v *Version) Build() string {
+	return v.value.Metadata()
+}
+
+// String returns the canonical semantic version string without a leading "v".
+func (v *Version) String() string {
+	return v.value.String()
+}
+
+func versionPartToInt(part uint64, name string) (int, error) {
+	if part > maxInt {
+		return 0, fmt.Errorf("%s version %d exceeds supported integer range", name, part)
+	}
+	return int(part), nil
+}

--- a/internal/platform/semver/version_test.go
+++ b/internal/platform/semver/version_test.go
@@ -1,0 +1,94 @@
+package semver
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		wantErr bool
+	}{
+		{name: "release", version: "2.5.0", want: "2.5.0"},
+		{name: "v prefix", version: "v2.5.0", want: "2.5.0"},
+		{name: "prerelease and build", version: "2.5.0-rc.1+build.7", want: "2.5.0-rc.1+build.7"},
+		{name: "missing patch", version: "2.5", wantErr: true},
+		{name: "leading zero segment", version: "2.05.0", wantErr: true},
+		{name: "empty", version: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse(%q) error = %v, wantErr %v", tt.version, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.String() != tt.want {
+				t.Fatalf("Parse(%q).String() = %q, want %q", tt.version, got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareUsesSemVerPrecedence(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{name: "numeric prerelease identifiers", a: "2.5.0-rc.10", b: "2.5.0-rc.2", want: 1},
+		{name: "release after prerelease", a: "2.5.0", b: "2.5.0-rc.1", want: 1},
+		{name: "build metadata ignored", a: "2.5.0+build.1", b: "2.5.0+build.2", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := Parse(tt.a)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.a, err)
+			}
+			b, err := Parse(tt.b)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.b, err)
+			}
+			if got := a.Compare(b); got != tt.want {
+				t.Fatalf("%q Compare %q = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+		wantErr bool
+	}{
+		{name: "older", version: "2.4.4", want: false},
+		{name: "target", version: "2.5.0", want: true},
+		{name: "newer", version: "2.6.0", want: true},
+		{name: "target prerelease", version: "2.5.0-rc.1", want: false},
+		{name: "target with metadata", version: "2.5.0+build.1", want: true},
+		{name: "invalid", version: "not-a-version", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AtLeast(tt.version, 2, 5, 0)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("AtLeast(%q) error = %v, wantErr %v", tt.version, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("AtLeast(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/upgrade/version.go
+++ b/internal/service/upgrade/version.go
@@ -2,12 +2,11 @@ package upgrade
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/go-logr/logr"
 
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	platformsemver "github.com/dc-tec/openbao-operator/internal/platform/semver"
 )
 
 // VersionChange represents the type of version change detected.
@@ -55,63 +54,17 @@ func (v SemVer) String() string {
 // - 2.4.0-rc1+build123
 // - v2.4.0 (optional 'v' prefix)
 func ParseVersion(version string) (*SemVer, error) {
-	if version == "" {
-		return nil, fmt.Errorf("version string is empty")
-	}
-
-	// Strip optional 'v' prefix
-	version = strings.TrimPrefix(version, "v")
-
-	// Extract build metadata (after '+')
-	var build string
-	if idx := strings.Index(version, "+"); idx != -1 {
-		build = version[idx+1:]
-		version = version[:idx]
-	}
-
-	// Extract prerelease (after '-')
-	var prerelease string
-	if idx := strings.Index(version, "-"); idx != -1 {
-		prerelease = version[idx+1:]
-		version = version[:idx]
-	}
-
-	// Parse major.minor.patch
-	parts := strings.Split(version, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid version format %q: expected MAJOR.MINOR.PATCH", version)
-	}
-
-	major, err := strconv.Atoi(parts[0])
+	parsed, err := platformsemver.Parse(version)
 	if err != nil {
-		return nil, fmt.Errorf("invalid major version %q: %w", parts[0], err)
-	}
-	if major < 0 {
-		return nil, fmt.Errorf("major version cannot be negative: %d", major)
-	}
-
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return nil, fmt.Errorf("invalid minor version %q: %w", parts[1], err)
-	}
-	if minor < 0 {
-		return nil, fmt.Errorf("minor version cannot be negative: %d", minor)
-	}
-
-	patch, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return nil, fmt.Errorf("invalid patch version %q: %w", parts[2], err)
-	}
-	if patch < 0 {
-		return nil, fmt.Errorf("patch version cannot be negative: %d", patch)
+		return nil, err
 	}
 
 	return &SemVer{
-		Major:      major,
-		Minor:      minor,
-		Patch:      patch,
-		Prerelease: prerelease,
-		Build:      build,
+		Major:      parsed.Major(),
+		Minor:      parsed.Minor(),
+		Patch:      parsed.Patch(),
+		Prerelease: parsed.Prerelease(),
+		Build:      parsed.Build(),
 	}, nil
 }
 
@@ -171,62 +124,31 @@ func ValidateUpgradeTargetVersion(logger logr.Logger, currentVersion, targetVers
 // CompareVersions compares two version strings and returns the type of change.
 // Returns an error if either version is invalid.
 func CompareVersions(from, to string) (VersionChange, error) {
-	fromVer, err := ParseVersion(from)
+	fromVer, err := platformsemver.Parse(from)
 	if err != nil {
 		return VersionChangeNone, fmt.Errorf("invalid 'from' version: %w", err)
 	}
 
-	toVer, err := ParseVersion(to)
+	toVer, err := platformsemver.Parse(to)
 	if err != nil {
 		return VersionChangeNone, fmt.Errorf("invalid 'to' version: %w", err)
 	}
 
-	// Compare major versions
-	if toVer.Major < fromVer.Major {
+	cmp := toVer.Compare(fromVer)
+	switch {
+	case cmp < 0:
 		return VersionChangeDowngrade, nil
+	case cmp == 0:
+		return VersionChangeNone, nil
 	}
-	if toVer.Major > fromVer.Major {
+
+	if toVer.Major() != fromVer.Major() {
 		return VersionChangeMajor, nil
 	}
-
-	// Major versions are equal, compare minor versions
-	if toVer.Minor < fromVer.Minor {
-		return VersionChangeDowngrade, nil
-	}
-	if toVer.Minor > fromVer.Minor {
+	if toVer.Minor() != fromVer.Minor() {
 		return VersionChangeMinor, nil
 	}
-
-	// Major and minor versions are equal, compare patch versions
-	if toVer.Patch < fromVer.Patch {
-		return VersionChangeDowngrade, nil
-	}
-	if toVer.Patch > fromVer.Patch {
-		return VersionChangePatch, nil
-	}
-
-	// Core versions are equal, check prerelease
-	// A prerelease version has lower precedence than a release version
-	// e.g., 2.4.0-rc1 < 2.4.0
-	if fromVer.Prerelease != "" && toVer.Prerelease == "" {
-		// Going from prerelease to release is an upgrade
-		return VersionChangePatch, nil
-	}
-	if fromVer.Prerelease == "" && toVer.Prerelease != "" {
-		// Going from release to prerelease is a downgrade
-		return VersionChangeDowngrade, nil
-	}
-	if fromVer.Prerelease != toVer.Prerelease {
-		// Different prerelease strings, compare lexicographically
-		// This is simplified; full semver uses more complex rules
-		if toVer.Prerelease < fromVer.Prerelease {
-			return VersionChangeDowngrade, nil
-		}
-		return VersionChangePatch, nil
-	}
-
-	// Versions are identical
-	return VersionChangeNone, nil
+	return VersionChangePatch, nil
 }
 
 // IsDowngrade returns true if changing from 'from' to 'to' would be a downgrade.

--- a/internal/service/upgrade/version_test.go
+++ b/internal/service/upgrade/version_test.go
@@ -333,6 +333,24 @@ func TestCompareVersions(t *testing.T) {
 			to:         "2.4.0-beta",
 			wantChange: VersionChangePatch,
 		},
+		{
+			name:       "numeric prerelease identifiers use semver precedence",
+			from:       "2.4.0-rc.2",
+			to:         "2.4.0-rc.10",
+			wantChange: VersionChangePatch,
+		},
+		{
+			name:       "numeric prerelease downgrade uses semver precedence",
+			from:       "2.4.0-rc.10",
+			to:         "2.4.0-rc.2",
+			wantChange: VersionChangeDowngrade,
+		},
+		{
+			name:       "build metadata does not affect precedence",
+			from:       "2.4.0+build.1",
+			to:         "2.4.0+build.2",
+			wantChange: VersionChangeNone,
+		},
 
 		// Error cases
 		{


### PR DESCRIPTION
## Summary

Replaces handwritten OpenBao version parsing and comparison with a shared helper backed by `github.com/Masterminds/semver/v3`.

This fixes prerelease ordering for upgrade decisions, including cases such as `2.5.0-rc.10` versus `2.5.0-rc.2`, and makes build metadata neutral for precedence. It also removes the duplicate config compatibility parser so plugin version gates use the same SemVer rules as upgrade validation.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. This changes version comparison behavior to match SemVer precedence. The main operational impact is stricter and more correct classification of prerelease upgrade/downgrade paths and version-gated config behavior. No API, CRD, Helm, RBAC, or security surface changes are intended.

## Verification

- `go test ./internal/platform/semver ./internal/service/upgrade ./internal/adapter/config`
- `go test ./...`
- `make verify-arch-policy test-ast`
- `make lint-ast`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

The first commit adds the shared platform helper and registers it in the architecture policy. The following commits move the upgrade and config compatibility call paths onto that helper.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
