### PR TITLE
test(admission): stabilize readiness gauge assertion

### DIFF
--- a/internal/platform/admission/runtime_test.go
+++ b/internal/platform/admission/runtime_test.go
@@ -441,7 +441,10 @@ func TestRefreshStatus_UnsafeAdmissionDisabled(t *testing.T) {
 }
 
 func TestSetAdmissionDependenciesReady(t *testing.T) {
-	t.Parallel()
+	SetAdmissionDependenciesReady(false)
+	t.Cleanup(func() {
+		SetAdmissionDependenciesReady(false)
+	})
 
 	SetAdmissionDependenciesReady(true)
 	if !AdmissionDependenciesReady() {


### PR DESCRIPTION
## Summary

Stabilizes `TestSetAdmissionDependenciesReady` by making the package-global readiness/gauge assertion run sequentially and resetting the shared readiness state before and after the test.

This removes the intermittent race where other admission tests can call `SetAdmissionDependenciesReady` while this test is asserting the global Prometheus gauge value.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

None. Test-only change; no API, CRD, Helm, RBAC, security, upgrade, or operational impact.

## Verification

- `go test ./internal/platform/admission -count=200`
- `git push` pre-push hook passed `make lint-ci` (`golangci-lint` plus 60 ast-grep policy tests)

## Reviewer Notes

The test mutates package-global readiness state and the global `openbao_admission_dependencies_ready` gauge. It should not use `t.Parallel()` while asserting those global values.

No docs or generated artifacts are affected.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
