### PR TITLE
test(e2e): add KMIP unseal provider coverage

### DIFF
--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -107,6 +107,23 @@ For E2E debugging, prefer structured reports over log-only inspection. Set `E2E_
 
 E2E suites are declared in `test/e2e/suites.yaml`. When adding or changing an E2E file, update the manifest with the suite owner, risk tier, isolation class, labels, coverage tags, CI lane, and nightly policy, then run `make verify-e2e-manifest`.
 
+<CommandBlock
+  language="bash"
+  label="hsm"
+  title="Run the manual HSM/KMIP E2E lane locally"
+  code={`make docker-build-e2e-openbao-softhsm OPENBAO_SOFTHSM_IMG=openbao-softhsm:dev
+make docker-build-e2e-pykmip-server PYKMIP_SERVER_IMG=pykmip-server:dev
+
+E2E_ENABLE_SOFTHSM_SUITE=true \\
+E2E_ENABLE_KMIP_SUITE=true \\
+E2E_OPENBAO_IMAGE=openbao-softhsm:dev \\
+E2E_KMIP_SERVER_IMAGE=pykmip-server:dev \\
+E2E_LABEL_FILTER='hsm && !openshift' \\
+make test-e2e`}
+>
+  The HSM lane is manual because it needs test-only images and provider fixtures. The KMIP suite uses a PyKMIP server fixture with mTLS and a pre-seeded active AES key; the PKCS#11 suite uses a SoftHSM-enabled OpenBao image.
+</CommandBlock>
+
 <DecisionTable
   title="Special validation lanes"
   columns={["Lane", "When to use it", "Primary entry point"]}

--- a/docs/user-guide/openbaocluster/configuration/unseal.md
+++ b/docs/user-guide/openbaocluster/configuration/unseal.md
@@ -152,7 +152,7 @@ For production-oriented clusters, use an external trust source such as cloud KMS
         "KMIP",
         "Needed whenever client cert, key, or CA files are sourced from mounted credentials.",
         "Secret keys matching the filenames referenced by `clientCert`, `clientKey`, and optional `caCert` under `/etc/bao/seal-creds`.",
-        "The client certificate and key must form a valid pair; the CA bundle must be valid PEM when set.",
+        "The client certificate and key must form a valid pair; the CA bundle must be valid PEM when set. The KMIP key must already exist and be usable for encrypt/decrypt before the cluster starts.",
       ],
     },
     {
@@ -165,6 +165,45 @@ For production-oriented clusters, use an external trust source such as cloud KMS
     },
   ]}
 />
+
+## KMIP provider contract
+
+KMIP is a network-backed seal path. The operator renders the OpenBao KMIP seal stanza, projects mTLS files from `credentialsSecretRef`, and validates mounted certificate material before the workload starts. It does not create KMIP key material or configure the KMIP server.
+
+For production clusters, prepare the KMIP side first:
+
+- Create or register the wrapping key in the KMIP service.
+- Activate the key and allow encrypt/decrypt operations for the OpenBao client identity.
+- Issue a client certificate with `clientAuth` extended key usage.
+- Issue or trust a server certificate whose DNS name matches `spec.unseal.kmip.serverName`.
+- Set `tls12Ciphers` when the KMIP appliance requires a constrained TLS 1.2 cipher suite.
+
+<CommandBlock
+  language="yaml"
+  label="example"
+  title="KMIP unseal with Secret-backed mTLS files"
+  code={`apiVersion: openbao.org/v1alpha1
+kind: OpenBaoCluster
+metadata:
+  name: bao-kmip
+  namespace: openbao
+spec:
+  unseal:
+    type: kmip
+    credentialsSecretRef:
+      name: kmip-client
+    kmip:
+      endpoint: kmip.example.com:5696
+      kmsKeyID: "1"
+      clientCert: /etc/bao/seal-creds/client.crt
+      clientKey: /etc/bao/seal-creds/client.key
+      caCert: /etc/bao/seal-creds/ca.crt
+      serverName: kmip.example.com
+      encryptAlg: AES_GCM
+      tls12Ciphers: TLS_RSA_WITH_AES_128_CBC_SHA256`}
+>
+  The Secret `kmip-client` must contain `client.crt`, `client.key`, and `ca.crt`. The operator validates that the client certificate and key form a valid pair and that the CA bundle parses as PEM before OpenBao starts.
+</CommandBlock>
 
 ## PKCS#11 runtime wiring
 

--- a/hack/tools/e2e_catalog/main.go
+++ b/hack/tools/e2e_catalog/main.go
@@ -411,8 +411,7 @@ func renderSuiteMarkdown(suite suiteCatalog) string {
 			b.WriteString("\n")
 		}
 	}
-	b.WriteString("\n")
-	return b.String()
+	return strings.TrimRight(b.String(), "\n") + "\n"
 }
 
 func labelsCell(labels []string) string {

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -69,6 +69,9 @@ docker-push-upgrade: ## Push docker image with the upgrade helper.
 
 OPENBAO_SOFTHSM_BASE_IMAGE ?= openbao/openbao-hsm:2.5.3
 OPENBAO_SOFTHSM_IMG ?= openbao-softhsm:dev
+PYKMIP_BASE_IMAGE ?= python:3.11-slim
+PYKMIP_VERSION ?= 0.10.0
+PYKMIP_SERVER_IMG ?= pykmip-server:dev
 
 .PHONY: docker-build-e2e-openbao-softhsm
 docker-build-e2e-openbao-softhsm: ## Build the test-only OpenBao image with SoftHSM PKCS#11 support.
@@ -77,6 +80,15 @@ docker-build-e2e-openbao-softhsm: ## Build the test-only OpenBao image with Soft
 		--build-arg OPENBAO_HSM_BASE_IMAGE=$(OPENBAO_SOFTHSM_BASE_IMAGE) \
 		-t $(OPENBAO_SOFTHSM_IMG) \
 		test/e2e/images/openbao-softhsm
+
+.PHONY: docker-build-e2e-pykmip-server
+docker-build-e2e-pykmip-server: ## Build the test-only PyKMIP server image used by KMIP unseal E2E coverage.
+	$(CONTAINER_TOOL) build \
+		-f test/e2e/images/pykmip-server/Dockerfile \
+		--build-arg PYKMIP_BASE_IMAGE=$(PYKMIP_BASE_IMAGE) \
+		--build-arg PYKMIP_VERSION=$(PYKMIP_VERSION) \
+		-t $(PYKMIP_SERVER_IMG) \
+		test/e2e/images/pykmip-server
 
 .PHONY: docker-release
 docker-release: docker-release-build docker-release-push ## Build and push all images to registry with consistent VERSION.

--- a/test/e2e/Cluster_Unseal_KMIP_test.go
+++ b/test/e2e/Cluster_Unseal_KMIP_test.go
@@ -1,0 +1,572 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/port/openbao"
+	"github.com/dc-tec/openbao-operator/test/e2e/framework"
+)
+
+const (
+	kmipClusterName       = "kmip-pykmip"
+	kmipCredentialsName   = "kmip-pykmip-credentials"
+	kmipServerName        = "kmip-pykmip-server"
+	kmipServerTLSName     = "kmip-pykmip-server-tls"
+	kmipServerPort        = 5696
+	kmipKeyID             = "1"
+	kmipClientCommonName  = "openbao-kmip-client"
+	kmipTLS12Cipher       = "TLS_RSA_WITH_AES_128_CBC_SHA256"
+	kmipCredentialCACert  = "ca.crt"
+	kmipCredentialCert    = "client.crt"
+	kmipCredentialKey     = "client.key"
+	kmipServerCACert      = "ca.crt"
+	kmipServerCertificate = "server.crt"
+	kmipServerPrivateKey  = "server.key"
+)
+
+var _ = Describe("Cluster KMIP Unseal", Label("cluster", "lifecycle", "unseal", "kmip", "hsm"), Ordered, func() {
+	ctx := context.Background()
+
+	var (
+		f *framework.Framework
+		c client.Client
+	)
+
+	BeforeAll(func() {
+		requireKMIPSuite()
+		ensureKMIPServerImageLoaded()
+
+		var err error
+		f, err = framework.NewSetup(ctx, "kmip", operatorNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		c = f.Client
+	})
+
+	AfterAll(func() {
+		if f == nil {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+		_ = f.Cleanup(cleanupCtx)
+	})
+
+	It("initializes, restarts, and scales using a PyKMIP-backed KMIP seal", func() {
+		serverName := fmt.Sprintf("%s.%s.svc", kmipServerName, f.Namespace)
+		endpoint := fmt.Sprintf("%s:%d", serverName, kmipServerPort)
+
+		By("creating KMIP mTLS material")
+		tlsBundle, err := newKMIPTLSBundle(kmipServerName, f.Namespace, kmipClientCommonName)
+		Expect(err).NotTo(HaveOccurred())
+
+		serverTLSSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kmipServerTLSName,
+				Namespace: f.Namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				kmipServerCACert:      tlsBundle.caCert,
+				kmipServerCertificate: tlsBundle.serverCert,
+				kmipServerPrivateKey:  tlsBundle.serverKey,
+			},
+		}
+		Expect(c.Create(ctx, serverTLSSecret)).To(Succeed())
+
+		credentials := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kmipCredentialsName,
+				Namespace: f.Namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				kmipCredentialCACert: tlsBundle.caCert,
+				kmipCredentialCert:   tlsBundle.clientCert,
+				kmipCredentialKey:    tlsBundle.clientKey,
+			},
+		}
+		Expect(c.Create(ctx, credentials)).To(Succeed())
+
+		By("starting the PyKMIP fixture server")
+		Expect(c.Create(ctx, kmipFixtureService(f.Namespace, kmipServerName))).To(Succeed())
+		Expect(c.Create(ctx, kmipFixtureDeployment(f.Namespace, kmipServerName, kmipServerTLSName, kmipServerImage(), kmipClientCommonName))).To(Succeed())
+		waitForKMIPDeploymentReady(ctx, c, f.Namespace, kmipServerName)
+
+		By("creating an OpenBaoCluster configured for KMIP unseal")
+		tcp := corev1.ProtocolTCP
+		kmipPort := intstr.FromInt(kmipServerPort)
+		cluster := &openbaov1alpha1.OpenBaoCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kmipClusterName,
+				Namespace: f.Namespace,
+			},
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Profile:  openbaov1alpha1.ProfileDevelopment,
+				Version:  openBaoVersion,
+				Image:    openBaoImage,
+				Replicas: 1,
+				InitContainer: &openbaov1alpha1.InitContainerConfig{
+					Enabled: true,
+					Image:   configInitImage,
+				},
+				SelfInit: &openbaov1alpha1.SelfInitConfig{
+					Enabled: true,
+					OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+						Enabled: true,
+					},
+					Requests: framework.DefaultAdminSelfInitRequests(),
+				},
+				TLS: openbaov1alpha1.TLSConfig{
+					Enabled:        true,
+					Mode:           openbaov1alpha1.TLSModeOperatorManaged,
+					RotationPeriod: "720h",
+				},
+				Storage: openbaov1alpha1.StorageConfig{
+					Size: "1Gi",
+				},
+				Network: &openbaov1alpha1.NetworkConfig{
+					APIServerCIDR: apiServerCIDR,
+					EgressRules: []networkingv1.NetworkPolicyEgressRule{
+						{
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": kmipServerName,
+										},
+									},
+								},
+							},
+							Ports: []networkingv1.NetworkPolicyPort{
+								{
+									Protocol: &tcp,
+									Port:     &kmipPort,
+								},
+							},
+						},
+					},
+				},
+				Unseal: &openbaov1alpha1.UnsealConfig{
+					Type: openbao.SealTypeKMIP,
+					KMIP: &openbaov1alpha1.KMIPSealConfig{
+						Endpoint:     endpoint,
+						KMSKeyID:     kmipKeyID,
+						ClientCert:   "/etc/bao/seal-creds/" + kmipCredentialCert,
+						ClientKey:    "/etc/bao/seal-creds/" + kmipCredentialKey,
+						CACert:       "/etc/bao/seal-creds/" + kmipCredentialCACert,
+						ServerName:   serverName,
+						Timeout:      ptr.To(int32(20)),
+						EncryptAlg:   "AES_GCM",
+						TLS12Ciphers: kmipTLS12Cipher,
+					},
+					CredentialsSecretRef: &corev1.LocalObjectReference{
+						Name: kmipCredentialsName,
+					},
+				},
+				Maintenance: &openbaov1alpha1.MaintenanceConfig{
+					Enabled: true,
+				},
+				DeletionPolicy: openbaov1alpha1.DeletionPolicyDeleteAll,
+			},
+		}
+		if sc := strings.TrimSpace(os.Getenv("E2E_STORAGE_CLASS")); sc != "" {
+			cluster.Spec.Storage.StorageClassName = &sc
+		}
+		Expect(c.Create(ctx, cluster)).To(Succeed())
+
+		By("waiting for the initial KMIP-sealed pod to become ready")
+		_, err = f.WaitForStatefulSetReady(ctx, kmipClusterName, 1, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval)
+		Expect(err).NotTo(HaveOccurred())
+		f.WaitForCondition(kmipClusterName, openbaov1alpha1.ConditionAvailable, metav1.ConditionTrue)
+
+		By("verifying the rendered OpenBao config contains the KMIP seal stanza")
+		config := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: kmipClusterName + "-config", Namespace: f.Namespace}, config)).To(Succeed())
+		Expect(config.Data).To(HaveKey("config.hcl"))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(`seal "kmip"`))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(`endpoint`))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(endpoint))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(`kms_key_id`))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(kmipKeyID))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(`encrypt_alg`))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(`AES_GCM`))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(`tls12_ciphers`))
+		Expect(config.Data["config.hcl"]).To(ContainSubstring(kmipTLS12Cipher))
+
+		By("verifying the StatefulSet projects KMIP credential files")
+		statefulSet := &appsv1.StatefulSet{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: kmipClusterName, Namespace: f.Namespace}, statefulSet)).To(Succeed())
+		Expect(hasVolumeNamed(statefulSet.Spec.Template.Spec.Volumes, "seal-creds")).To(BeTrue())
+		Expect(hasVolumeMountNamed(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, "seal-creds")).To(BeTrue())
+
+		By("deleting the pod and validating it auto-unseals after restart")
+		pod := &corev1.Pod{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: kmipClusterName + "-0", Namespace: f.Namespace}, pod)).To(Succeed())
+		oldUID := pod.UID
+		Expect(c.Delete(ctx, pod)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			restarted := &corev1.Pod{}
+			g.Expect(c.Get(ctx, types.NamespacedName{Name: kmipClusterName + "-0", Namespace: f.Namespace}, restarted)).To(Succeed())
+			g.Expect(restarted.UID).NotTo(Equal(oldUID))
+			g.Expect(podReady(restarted)).To(BeTrue())
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+		f.WaitForCondition(kmipClusterName, openbaov1alpha1.ConditionAvailable, metav1.ConditionTrue)
+
+		By("scaling up to verify new pods can use the seeded KMIP key material")
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current := &openbaov1alpha1.OpenBaoCluster{}
+			if err := c.Get(ctx, types.NamespacedName{Name: kmipClusterName, Namespace: f.Namespace}, current); err != nil {
+				return err
+			}
+			current.Spec.Replicas = 2
+			return c.Update(ctx, current)
+		})).To(Succeed())
+		_, err = f.WaitForStatefulSetReady(ctx, kmipClusterName, 2, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval)
+		Expect(err).NotTo(HaveOccurred())
+		f.WaitForCondition(kmipClusterName, openbaov1alpha1.ConditionAvailable, metav1.ConditionTrue)
+
+		By("scaling back down cleanly")
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current := &openbaov1alpha1.OpenBaoCluster{}
+			if err := c.Get(ctx, types.NamespacedName{Name: kmipClusterName, Namespace: f.Namespace}, current); err != nil {
+				return err
+			}
+			current.Spec.Replicas = 1
+			return c.Update(ctx, current)
+		})).To(Succeed())
+		Eventually(func(g Gomega) {
+			sts := &appsv1.StatefulSet{}
+			g.Expect(c.Get(ctx, types.NamespacedName{Name: kmipClusterName, Namespace: f.Namespace}, sts)).To(Succeed())
+			g.Expect(sts.Status.ReadyReplicas).To(Equal(int32(1)))
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+		f.WaitForCondition(kmipClusterName, openbaov1alpha1.ConditionAvailable, metav1.ConditionTrue)
+	})
+})
+
+type kmipTLSBundle struct {
+	caCert     []byte
+	serverCert []byte
+	serverKey  []byte
+	clientCert []byte
+	clientKey  []byte
+}
+
+func newKMIPTLSBundle(serviceName, namespace, clientCommonName string) (kmipTLSBundle, error) {
+	caCert, caKey, err := newKMIPCA()
+	if err != nil {
+		return kmipTLSBundle{}, err
+	}
+
+	serverCert, serverKey, err := newKMIPCertificate(kmipCertificateRequest{
+		commonName: fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+		dnsNames: []string{
+			serviceName,
+			fmt.Sprintf("%s.%s", serviceName, namespace),
+			fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+			fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
+		},
+		keyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		extKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		caCert:      caCert,
+		caKey:       caKey,
+	})
+	if err != nil {
+		return kmipTLSBundle{}, err
+	}
+
+	clientCert, clientKey, err := newKMIPCertificate(kmipCertificateRequest{
+		commonName:  clientCommonName,
+		keyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		extKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		caCert:      caCert,
+		caKey:       caKey,
+	})
+	if err != nil {
+		return kmipTLSBundle{}, err
+	}
+
+	return kmipTLSBundle{
+		caCert:     pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw}),
+		serverCert: serverCert,
+		serverKey:  serverKey,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}, nil
+}
+
+func newKMIPCA() (*x509.Certificate, *rsa.PrivateKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate KMIP CA key: %w", err)
+	}
+
+	serialNumber, err := randomKMIPSerialNumber()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "OpenBao Operator KMIP E2E CA",
+			Organization: []string{"OpenBao Operator E2E"},
+		},
+		NotBefore:             now.Add(-1 * time.Hour),
+		NotAfter:              now.AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create KMIP CA certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse KMIP CA certificate: %w", err)
+	}
+	return cert, privateKey, nil
+}
+
+type kmipCertificateRequest struct {
+	commonName  string
+	dnsNames    []string
+	keyUsage    x509.KeyUsage
+	extKeyUsage []x509.ExtKeyUsage
+	caCert      *x509.Certificate
+	caKey       *rsa.PrivateKey
+}
+
+func newKMIPCertificate(req kmipCertificateRequest) ([]byte, []byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate KMIP certificate key: %w", err)
+	}
+
+	serialNumber, err := randomKMIPSerialNumber()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   req.commonName,
+			Organization: []string{"OpenBao Operator E2E"},
+		},
+		NotBefore:   now.Add(-1 * time.Hour),
+		NotAfter:    now.AddDate(0, 0, 30),
+		KeyUsage:    req.keyUsage,
+		ExtKeyUsage: req.extKeyUsage,
+		DNSNames:    req.dnsNames,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, req.caCert, &privateKey.PublicKey, req.caKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create KMIP certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	return certPEM, keyPEM, nil
+}
+
+func randomKMIPSerialNumber() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("generate KMIP certificate serial: %w", err)
+	}
+	return serialNumber, nil
+}
+
+func kmipFixtureService(namespace, name string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"app": name,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "kmip",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       kmipServerPort,
+					TargetPort: intstr.FromInt(kmipServerPort),
+				},
+			},
+		},
+	}
+}
+
+func kmipFixtureDeployment(namespace, name, tlsSecretName, image, keyOwner string) *appsv1.Deployment {
+	labels := map[string]string{
+		"app": name,
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: ptr.To(int64(1000)),
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "pykmip",
+							Image:           image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{Name: "KMIP_KEY_ID", Value: kmipKeyID},
+								{Name: "KMIP_KEY_OWNER", Value: keyOwner},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "kmip",
+									ContainerPort: kmipServerPort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(kmipServerPort)},
+								},
+								InitialDelaySeconds: 2,
+								PeriodSeconds:       2,
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(kmipServerPort)},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       10,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "tls", MountPath: "/etc/pykmip/tls", ReadOnly: true},
+								{Name: "data", MountPath: "/var/lib/pykmip"},
+								{Name: "tmp", MountPath: "/tmp"},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								ReadOnlyRootFilesystem: ptr.To(true),
+								RunAsNonRoot:           ptr.To(true),
+								RunAsUser:              ptr.To(int64(1000)),
+								RunAsGroup:             ptr.To(int64(1000)),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("96Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "tls",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  tlsSecretName,
+									DefaultMode: ptr.To[int32](0o440),
+								},
+							},
+						},
+						{
+							Name:         "data",
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						},
+						{
+							Name:         "tmp",
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func waitForKMIPDeploymentReady(ctx context.Context, c client.Client, namespace, name string) {
+	Eventually(func(g Gomega) {
+		deployment := &appsv1.Deployment{}
+		g.Expect(c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, deployment)).To(Succeed())
+		g.Expect(deployment.Status.ReadyReplicas).To(Equal(int32(1)))
+	}, 5*time.Minute, 2*time.Second).Should(Succeed())
+}
+
+func hasVolumeNamed(volumes []corev1.Volume, name string) bool {
+	for _, volume := range volumes {
+		if volume.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeMountNamed(mounts []corev1.VolumeMount, name string) bool {
+	for _, mount := range mounts {
+		if mount.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -11,8 +11,8 @@ Notes:
 
 ## Summary
 
-- Files: `18`
-- Specs: `76`
+- Files: `19`
+- Specs: `77`
 - Explicit case IDs: `31`
 - Coverage tags: `41`
 
@@ -26,6 +26,7 @@ Notes:
 | [Cluster Runtime Controls](suites/Cluster_Runtime_Controls_test.md) | 2 | 2 | 0 | `lifecycle`, `cluster`, `runtime` | `test/e2e/Cluster_Runtime_Controls_test.go` |
 | [ACME TLS (OpenBao native ACME client)](suites/Cluster_TLS_ACME_test.md) | 2 | 1 | 0 | `tls`, `security`, `slow` | `test/e2e/Cluster_TLS_ACME_test.go` |
 | [Cluster TLS Lifecycle](suites/Cluster_TLS_Lifecycle_test.md) | 1 | 1 | 0 | `tls`, `cluster`, `lifecycle` | `test/e2e/Cluster_TLS_Lifecycle_test.go` |
+| [Cluster KMIP Unseal](suites/Cluster_Unseal_KMIP_test.md) | 1 | 0 | 0 | `cluster`, `lifecycle`, `unseal`, `kmip`, `hsm` | `test/e2e/Cluster_Unseal_KMIP_test.go` |
 | [Cluster PKCS#11 Unseal](suites/Cluster_Unseal_PKCS11_test.md) | 1 | 0 | 0 | `cluster`, `lifecycle`, `unseal`, `pkcs11`, `hsm` | `test/e2e/Cluster_Unseal_PKCS11_test.go` |
 | [Manager Resilience](suites/Manager_Resilience_test.md) | 3 | 3 | 0 | `manager`, `cluster`, `e2e-anchor` | `test/e2e/Manager_Resilience_test.go` |
 | [Manager](suites/Operator_Manager_test.md) | 1 | 1 | 0 | `manager`, `critical`, `smoke` | `test/e2e/Operator_Manager_test.go` |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -756,6 +756,46 @@
     "suiteTitle": ""
   },
   {
+    "id": "cluster-unseal-kmip-initializes-restarts-and-scales-using-a-d2fcee95",
+    "generatedId": "cluster-unseal-kmip-initializes-restarts-and-scales-using-a-d2fcee95",
+    "file": "test/e2e/Cluster_Unseal_KMIP_test.go",
+    "type": "It",
+    "name": "initializes, restarts, and scales using a PyKMIP-backed KMIP seal",
+    "path": [
+      "Cluster KMIP Unseal",
+      "initializes, restarts, and scales using a PyKMIP-backed KMIP seal"
+    ],
+    "labels": [
+      "cluster",
+      "lifecycle",
+      "unseal",
+      "kmip",
+      "hsm"
+    ],
+    "domainLabels": [
+      "cluster",
+      "lifecycle",
+      "unseal",
+      "kmip",
+      "hsm"
+    ],
+    "steps": [
+      "creating KMIP mTLS material",
+      "starting the PyKMIP fixture server",
+      "creating an OpenBaoCluster configured for KMIP unseal",
+      "waiting for the initial KMIP-sealed pod to become ready",
+      "verifying the rendered OpenBao config contains the KMIP seal stanza",
+      "verifying the StatefulSet projects KMIP credential files",
+      "deleting the pod and validating it auto-unseals after restart",
+      "scaling up to verify new pods can use the seeded KMIP key material",
+      "scaling back down cleanly"
+    ],
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "cluster-unseal-pkcs11-initializes-restarts-and-scales-using-a-50e1c83b",
     "generatedId": "cluster-unseal-pkcs11-initializes-restarts-and-scales-using-a-50e1c83b",
     "file": "test/e2e/Cluster_Unseal_PKCS11_test.go",

--- a/test/e2e/catalog/suites/Cluster_DeletionPolicy_test.md
+++ b/test/e2e/catalog/suites/Cluster_DeletionPolicy_test.md
@@ -49,5 +49,3 @@ Generated fallback ID: `cluster-deletionpolicy-retains-pvcs-and-recoverability-s
 Covers: `deletion-policy`, `pvc-retention`, `recoverability-secret-retention`
 
 Labels: `lifecycle`, `cluster`, `deletion`
-
-

--- a/test/e2e/catalog/suites/Cluster_Lifecycle_test.md
+++ b/test/e2e/catalog/suites/Cluster_Lifecycle_test.md
@@ -139,5 +139,3 @@ Labels: `lifecycle`, `cluster`, `critical`, `tenant`
 
 Recorded checkpoints:
 - verifying OpenBaoTenant is provisioned
-
-

--- a/test/e2e/catalog/suites/Cluster_Profile_Hardened_test.md
+++ b/test/e2e/catalog/suites/Cluster_Profile_Hardened_test.md
@@ -118,5 +118,3 @@ Recorded checkpoints:
 - ensuring public service has ready endpoints
 - allowing verification pod egress to OpenBao cluster (NetworkPolicy)
 - reading autopilot configuration via JWT authenticated request
-
-

--- a/test/e2e/catalog/suites/Cluster_Runtime_Controls_test.md
+++ b/test/e2e/catalog/suites/Cluster_Runtime_Controls_test.md
@@ -44,5 +44,3 @@ Recorded checkpoints:
 - setting spec.runtime.restartAt to trigger a rolling restart
 - waiting for the StatefulSet pod template to carry the restart annotation
 - waiting for the original pod to be replaced
-
-

--- a/test/e2e/catalog/suites/Cluster_TLS_ACME_test.md
+++ b/test/e2e/catalog/suites/Cluster_TLS_ACME_test.md
@@ -52,5 +52,3 @@ Labels: `tls`, `security`, `slow`
 
 Recorded checkpoints:
 - verifying OpenBaoTenant is provisioned
-
-

--- a/test/e2e/catalog/suites/Cluster_TLS_Lifecycle_test.md
+++ b/test/e2e/catalog/suites/Cluster_TLS_Lifecycle_test.md
@@ -34,5 +34,3 @@ Recorded checkpoints:
 - verifying the pod receives a new TLS reload hash without restarting
 - reconfirming cluster readiness and stability after server Secret regeneration
 - re-reading the secret over TLS with CA validation after regeneration
-
-

--- a/test/e2e/catalog/suites/Cluster_Unseal_KMIP_test.md
+++ b/test/e2e/catalog/suites/Cluster_Unseal_KMIP_test.md
@@ -1,0 +1,32 @@
+# Cluster KMIP Unseal
+
+Source: `test/e2e/Cluster_Unseal_KMIP_test.go`
+
+Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls visible to `ginkgo outline`.
+
+## Cases
+
+| Case ID | Spec | State | Covers | Labels |
+| --- | --- | --- | --- | --- |
+| `cluster-unseal-kmip-initializes-restarts-and-scales-using-a-d2fcee95` | initializes, restarts, and scales using a PyKMIP-backed KMIP seal | active | _none_ | `cluster`, `lifecycle`, `unseal`, `kmip`, `hsm` |
+
+## `cluster-unseal-kmip-initializes-restarts-and-scales-using-a-d2fcee95`
+
+Path: `Cluster KMIP Unseal > initializes, restarts, and scales using a PyKMIP-backed KMIP seal`
+
+State: `active`
+
+Covers: _none_
+
+Labels: `cluster`, `lifecycle`, `unseal`, `kmip`, `hsm`
+
+Recorded checkpoints:
+- creating KMIP mTLS material
+- starting the PyKMIP fixture server
+- creating an OpenBaoCluster configured for KMIP unseal
+- waiting for the initial KMIP-sealed pod to become ready
+- verifying the rendered OpenBao config contains the KMIP seal stanza
+- verifying the StatefulSet projects KMIP credential files
+- deleting the pod and validating it auto-unseals after restart
+- scaling up to verify new pods can use the seeded KMIP key material
+- scaling back down cleanly

--- a/test/e2e/catalog/suites/Manager_Resilience_test.md
+++ b/test/e2e/catalog/suites/Manager_Resilience_test.md
@@ -69,5 +69,3 @@ Recorded checkpoints:
 - scaling the cluster and restarting the controller during the reconcile
 - verifying the scale reconcile finishes without duplicating managed resources
 - reconfirming the cluster returns to an available steady state
-
-

--- a/test/e2e/catalog/suites/Operator_Manager_test.md
+++ b/test/e2e/catalog/suites/Operator_Manager_test.md
@@ -28,5 +28,3 @@ Recorded checkpoints:
 - ensuring the controller pod is ready
 - verifying that the controller manager is serving the metrics server
 - verifying that the controller metrics endpoint returns data
-
-

--- a/test/e2e/catalog/suites/Platform_OpenShift_test.md
+++ b/test/e2e/catalog/suites/Platform_OpenShift_test.md
@@ -35,5 +35,3 @@ State: `active`
 Covers: _none_
 
 Labels: `openshift`, `platform`
-
-

--- a/test/e2e/catalog/suites/Security_Guardrails_test.md
+++ b/test/e2e/catalog/suites/Security_Guardrails_test.md
@@ -271,5 +271,3 @@ State: `active`
 Covers: _none_
 
 Labels: `security`, `critical`, `tamper`
-
-

--- a/test/e2e/catalog/suites/Tenant_Data_Isolation_test.md
+++ b/test/e2e/catalog/suites/Tenant_Data_Isolation_test.md
@@ -27,5 +27,3 @@ Recorded checkpoints:
 - verifying each tenant can still reach and read its own cluster
 - verifying a labeled pod in tenant A still cannot reach tenant B's data plane
 - verifying the same labeled access path works inside tenant B
-
-

--- a/test/e2e/catalog/suites/Tenant_Isolation_test.md
+++ b/test/e2e/catalog/suites/Tenant_Isolation_test.md
@@ -99,5 +99,3 @@ Recorded checkpoints:
 - creating RoleBinding in target namespace
 - patching controller deployment with WATCH_NAMESPACE
 - waiting for controller to restart with new configuration
-
-

--- a/test/e2e/catalog/suites/Upgrade_Operation_Lock_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Operation_Lock_test.md
@@ -30,5 +30,3 @@ Recorded checkpoints:
 - waiting for the upgrade to complete
 - re-triggering reconcile so the queued backup request is picked up immediately
 - verifying the queued backup starts once the upgrade lock is released
-
-

--- a/test/e2e/catalog/suites/Upgrade_Strategies_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Strategies_test.md
@@ -268,5 +268,3 @@ Recorded checkpoints:
 - Waiting for the rollback consensus repair job to fail
 - Verifying secret persists in safe mode
 - Asserting safe mode is set on the cluster
-
-

--- a/test/e2e/catalog/suites/Upgrade_Target_Drift_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Target_Drift_test.md
@@ -29,5 +29,3 @@ Recorded checkpoints:
 - verifying the stale green workload is cleaned up
 - verifying the stale target is abandoned before any rollback
 - verifying no stale workload remains in the namespace
-
-

--- a/test/e2e/catalog/suites/anti_tamper_policy_test.md
+++ b/test/e2e/catalog/suites/anti_tamper_policy_test.md
@@ -35,5 +35,3 @@ Generated fallback ID: `anti-tamper-policy-prevents-deletion-of-the-managed-stat
 Covers: `anti-tamper`, `statefulset-protection`
 
 Labels: `security`, `tamper`, `cluster`, `slow`
-
-

--- a/test/e2e/catalog/suites/backup_restore_test.md
+++ b/test/e2e/catalog/suites/backup_restore_test.md
@@ -145,5 +145,3 @@ Recorded checkpoints:
 - waiting for restore to drain steady read replicas before execution continues
 - Verifying secret persists after restore
 - Verifying restore metrics are emitted
-
-

--- a/test/e2e/images/pykmip-server/Dockerfile
+++ b/test/e2e/images/pykmip-server/Dockerfile
@@ -1,0 +1,19 @@
+ARG PYKMIP_BASE_IMAGE=python:3.11-slim
+FROM ${PYKMIP_BASE_IMAGE}
+
+ARG PYKMIP_VERSION=0.10.0
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+RUN python -m pip install --no-cache-dir "PyKMIP==${PYKMIP_VERSION}" && \
+    mkdir -p /var/lib/pykmip && \
+    chown -R 1000:1000 /var/lib/pykmip
+
+COPY pykmip-test-server /usr/local/bin/pykmip-test-server
+
+RUN chmod 0555 /usr/local/bin/pykmip-test-server
+
+USER 1000:1000
+
+EXPOSE 5696
+ENTRYPOINT ["/usr/local/bin/pykmip-test-server"]

--- a/test/e2e/images/pykmip-server/pykmip-test-server
+++ b/test/e2e/images/pykmip-server/pykmip-test-server
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Small PyKMIP fixture server for OpenBao Operator E2E tests."""
+
+import logging
+import os
+import sys
+import time
+import warnings
+
+from cryptography.utils import CryptographyDeprecationWarning
+from kmip.core import enums
+from kmip.pie import objects
+from kmip.services.server import KmipServer
+from kmip.services.server.engine import KmipEngine
+
+warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+
+DEFAULT_KEY_ID = 1
+DEFAULT_KEY_OWNER = "openbao-kmip-client"
+DEFAULT_KEY_VALUE = bytes.fromhex(
+    "00112233445566778899aabbccddeeff"
+    "102132435465768798a9bacbdcedfe0f"
+)
+
+
+def env(name, default):
+    return os.environ.get(name, default).strip()
+
+
+def seed_key(database_path):
+    key_id = int(env("KMIP_KEY_ID", str(DEFAULT_KEY_ID)))
+    key_owner = env("KMIP_KEY_OWNER", DEFAULT_KEY_OWNER)
+
+    engine = KmipEngine(database_path=database_path)
+    session = engine._data_store_session_factory()  # noqa: SLF001 - fixture setup.
+    try:
+        existing = (
+            session.query(objects.SymmetricKey)
+            .filter(objects.SymmetricKey.unique_identifier == key_id)
+            .one_or_none()
+        )
+        if existing is not None:
+            existing.state = enums.State.ACTIVE
+            existing.operation_policy_name = "default"
+            existing._owner = key_owner  # noqa: SLF001 - PyKMIP access policy owner.
+            session.commit()
+            logging.info("Using existing KMIP key id=%s owner=%s", key_id, key_owner)
+            return
+
+        key = objects.SymmetricKey(
+            enums.CryptographicAlgorithm.AES,
+            256,
+            DEFAULT_KEY_VALUE,
+            masks=[
+                enums.CryptographicUsageMask.ENCRYPT,
+                enums.CryptographicUsageMask.DECRYPT,
+            ],
+            name="openbao-kmip-key",
+        )
+        key.unique_identifier = key_id
+        key.state = enums.State.ACTIVE
+        key.operation_policy_name = "default"
+        key.initial_date = int(time.time())
+        key._owner = key_owner  # noqa: SLF001 - PyKMIP access policy owner.
+
+        session.add(key)
+        session.commit()
+        logging.info("Seeded KMIP key id=%s owner=%s", key_id, key_owner)
+    finally:
+        session.close()
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stdout,
+    )
+
+    host = env("PYKMIP_HOST", "0.0.0.0")
+    port = int(env("PYKMIP_PORT", "5696"))
+    database_path = env("PYKMIP_DATABASE_PATH", "/var/lib/pykmip/pykmip.db")
+    cert_path = env("PYKMIP_SERVER_CERT", "/etc/pykmip/tls/server.crt")
+    key_path = env("PYKMIP_SERVER_KEY", "/etc/pykmip/tls/server.key")
+    ca_path = env("PYKMIP_CA_CERT", "/etc/pykmip/tls/ca.crt")
+    cipher_suites = env(
+        "PYKMIP_TLS12_CIPHERS",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+    )
+
+    seed_key(database_path)
+
+    server = KmipServer(
+        hostname=host,
+        port=port,
+        certificate_path=cert_path,
+        key_path=key_path,
+        ca_path=ca_path,
+        auth_suite="TLS1.2",
+        config_path=None,
+        log_path="/tmp/pykmip.log",
+        enable_tls_client_auth=True,
+        tls_cipher_suites=cipher_suites,
+        logging_level="INFO",
+        database_path=database_path,
+    )
+
+    logging.info("Starting PyKMIP fixture on %s:%s", host, port)
+    server.start()
+    try:
+        server.serve()
+    finally:
+        server.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/e2e/kmip_suite.go
+++ b/test/e2e/kmip_suite.go
@@ -1,0 +1,67 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/dc-tec/openbao-operator/test/utils"
+)
+
+const (
+	envEnableKMIPSuite = "E2E_ENABLE_KMIP_SUITE"
+	envKMIPServerImage = "E2E_KMIP_SERVER_IMAGE"
+
+	defaultKMIPServerImage = "pykmip-server:dev"
+)
+
+func requireKMIPSuite() {
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv(envEnableKMIPSuite)), "true") {
+		ginkgo.Skip(fmt.Sprintf(
+			"requires KMIP suite; build the fixture with "+
+				"`make docker-build-e2e-pykmip-server PYKMIP_SERVER_IMG=%s` "+
+				"and run with %s=true %s=%s",
+			defaultKMIPServerImage,
+			envEnableKMIPSuite,
+			envKMIPServerImage,
+			defaultKMIPServerImage,
+		))
+	}
+}
+
+func kmipServerImage() string {
+	if image := strings.TrimSpace(os.Getenv(envKMIPServerImage)); image != "" {
+		return image
+	}
+	return defaultKMIPServerImage
+}
+
+func ensureKMIPServerImageLoaded() {
+	if useExistingCluster {
+		return
+	}
+
+	image := kmipServerImage()
+	if _, err := utils.Run(exec.Command("docker", "image", "inspect", image)); err != nil { // #nosec G204 -- test harness
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Pulling KMIP server fixture image %q...\n", image)
+		_, err = utils.Run(exec.Command("docker", "pull", image)) // #nosec G204 -- test harness
+		if err != nil {
+			ginkgo.Fail(fmt.Sprintf(
+				"KMIP server fixture image %q is not available locally or remotely; build it with `make docker-build-e2e-pykmip-server PYKMIP_SERVER_IMG=%s`",
+				image,
+				image,
+			))
+		}
+	}
+
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Loading KMIP server fixture image %q into kind\n", image)
+	if err := utils.LoadImageToKindClusterWithName(image); err != nil {
+		ginkgo.Fail(fmt.Sprintf("failed to load KMIP server fixture image %q into kind: %v", image, err))
+	}
+}

--- a/test/e2e/suites.yaml
+++ b/test/e2e/suites.yaml
@@ -180,8 +180,8 @@ ciLanes:
     preloadStorageEmulators: []
 
   - id: hsm
-    name: "HSM / PKCS#11"
-    labelFilter: "((hsm || pkcs11) && !openshift)"
+    name: "HSM / KMIP / PKCS#11"
+    labelFilter: "((hsm || kmip || pkcs11) && !openshift)"
     prScope: manual
     timeoutMinutes: 45
     e2eTimeout: 40m
@@ -374,6 +374,27 @@ suites:
       - lifecycle
       - unseal
       - pkcs11
+      - hsm
+    coverage: []
+    ci:
+      lanes:
+        - hsm
+      pullRequest: manual
+    nightly:
+      policy: primary-version-full
+
+  - id: cluster-unseal-kmip
+    title: "Cluster KMIP Unseal"
+    owner: core
+    riskTier: high
+    isolation: global-mutator
+    files:
+      - test/e2e/Cluster_Unseal_KMIP_test.go
+    labels:
+      - cluster
+      - lifecycle
+      - unseal
+      - kmip
       - hsm
     coverage: []
     ci:


### PR DESCRIPTION
## Summary

Adds provider-backed KMIP unseal coverage without changing runtime operator code. The existing KMIP rendering and Secret projection path already works; this PR adds a guarded PyKMIP fixture, a focused E2E that initializes/restarts/scales an OpenBao cluster with a KMIP seal, and docs for local HSM/KMIP validation.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

No runtime code, CRD, Helm, RBAC, or API behavior changes. The new Dockerfile and PyKMIP server are test-only E2E fixtures. The HSM lane remains manual and opt-in via `E2E_ENABLE_KMIP_SUITE=true`.

## Verification

- `make docker-build-e2e-pykmip-server PYKMIP_SERVER_IMG=pykmip-server:dev`
- `E2E_ENABLE_KMIP_SUITE=true E2E_KMIP_SERVER_IMAGE=pykmip-server:dev E2E_LABEL_FILTER='kmip && hsm' E2E_FAIL_ON_EMPTY=true make test-e2e`
- `GOFLAGS=-mod=vendor go test -tags=e2e ./test/e2e -run '^$'`
- `make e2e-catalog e2e-manifest-validate`
- `make e2e-ci-matrix-validate e2e-nightly-matrix-validate e2e-release-matrix-validate`
- `git diff --check`
- `make security-scan-fs`
- pre-push hook: `make lint-ci`

## Reviewer Notes

The E2E uncovered two fixture-specific hardening gaps during local validation: the PyKMIP pod needed an explicit `seccompProfile`, and its TLS Secret needed group-readable projection for the non-root user. Both are handled in the test fixture manifest.

The KMIP test currently covers the baseline operator contract: mTLS KMIP, pre-created active AES key, encrypt/decrypt usage, restart auto-unseal, and scale-up/scale-down. It does not attempt to certify all enterprise KMIP appliance policies or cipher combinations.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.