### PR TITLE
fix(restore): harden restore job rendering

### DIFF
--- a/internal/service/restore/job.go
+++ b/internal/service/restore/job.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/security"
 	"github.com/dc-tec/openbao-operator/internal/adapter/storageenv"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	"github.com/dc-tec/openbao-operator/internal/service/workloadidentity"
@@ -43,7 +44,17 @@ func getRestoreExecutorImage(restore *openbaov1alpha1.OpenBaoRestore, cluster *o
 	if cluster.Spec.Backup != nil && cluster.Spec.Backup.Image != "" {
 		return cluster.Spec.Backup.Image, nil
 	}
-	return "", fmt.Errorf("no restore image specified in restore or cluster backup config")
+	image, err := constants.DefaultBackupImage()
+	if err != nil {
+		return "", operatorerrors.WrapPermanentConfig(operatorerrors.WithReason(
+			constants.ReasonHelperImageConfigurationInvalid,
+			fmt.Errorf(
+				"default restore executor image is unavailable; set spec.image on the OpenBaoRestore, set spec.backup.image on the OpenBaoCluster, or configure OPERATOR_VERSION in the operator Deployment: %w",
+				err,
+			),
+		))
+	}
+	return image, nil
 }
 
 // buildRestoreJob creates a Kubernetes Job for executing the restore.
@@ -176,6 +187,10 @@ func buildRestoreEnvVars(restore *openbaov1alpha1.OpenBaoRestore, cluster *openb
 			Value: cluster.Name,
 		},
 		{
+			Name:  constants.EnvStatefulSetName,
+			Value: restoreTargetStatefulSetName(cluster),
+		},
+		{
 			Name:  constants.EnvClusterNamespace,
 			Value: cluster.Namespace,
 		},
@@ -230,6 +245,16 @@ func buildRestoreEnvVars(restore *openbaov1alpha1.OpenBaoRestore, cluster *openb
 	// as the executor reads credentials from the mounted secret.
 
 	return envVars
+}
+
+func restoreTargetStatefulSetName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	if cluster == nil {
+		return ""
+	}
+	if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.BlueRevision != "" {
+		return fmt.Sprintf("%s-%s", cluster.Name, cluster.Status.BlueGreen.BlueRevision)
+	}
+	return cluster.Name
 }
 
 // buildRestoreVolumes builds volumes for the restore job.

--- a/internal/service/restore/job_test.go
+++ b/internal/service/restore/job_test.go
@@ -194,6 +194,7 @@ func TestBuildRestoreEnvVars_S3(t *testing.T) {
 	// Verify common env vars
 	assert.Equal(t, "restore", envMap["EXECUTOR_MODE"])
 	assert.Equal(t, "test-cluster", envMap[constants.EnvClusterName])
+	assert.Equal(t, "test-cluster", envMap[constants.EnvStatefulSetName])
 	assert.Equal(t, "default", envMap[constants.EnvClusterNamespace])
 	assert.Equal(t, "3", envMap[constants.EnvClusterReplicas])
 	assert.Equal(t, constants.StorageProviderS3, envMap[constants.EnvBackupProvider])
@@ -217,6 +218,50 @@ func TestBuildRestoreEnvVars_S3(t *testing.T) {
 	assert.Empty(t, envMap[constants.EnvBackupGCSProject])
 	assert.Empty(t, envMap[constants.EnvBackupAzureStorageAccount])
 	assert.Empty(t, envMap[constants.EnvBackupAzureContainer])
+}
+
+func TestBuildRestoreEnvVars_BlueGreenStatefulSetName(t *testing.T) {
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "test-cluster",
+			Source: openbaov1alpha1.RestoreSource{
+				Key: "backup.snap",
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: constants.StorageProviderS3,
+					Endpoint: "https://s3.amazonaws.com",
+					Bucket:   "test-bucket",
+				},
+			},
+		},
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueRevision: "abc123",
+			},
+		},
+	}
+
+	envVars := buildRestoreEnvVars(restore, cluster)
+
+	envMap := make(map[string]string)
+	for _, env := range envVars {
+		envMap[env.Name] = env.Value
+	}
+
+	assert.Equal(t, "test-cluster-abc123", envMap[constants.EnvStatefulSetName])
 }
 
 func TestBuildRestoreEnvVars_S3Default(t *testing.T) {

--- a/internal/service/restore/manager_helpers.go
+++ b/internal/service/restore/manager_helpers.go
@@ -1,7 +1,10 @@
 package restore
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -75,5 +78,14 @@ func restoreJobFailedStatusMessage(job *batchv1.Job, failureHint string) string 
 
 // restoreJobName returns the name for the restore job.
 func restoreJobName(restore *openbaov1alpha1.OpenBaoRestore) string {
-	return fmt.Sprintf("%s%s", RestoreJobNamePrefix, restore.Name)
+	base := strings.ToLower(strings.ReplaceAll(RestoreJobNamePrefix+restore.Name, "_", "-"))
+	if len(base) <= 63 {
+		return base
+	}
+
+	sum := sha256.Sum256([]byte(restore.Name))
+	suffix := hex.EncodeToString(sum[:])[:10]
+	maxBaseLen := 63 - 1 - len(suffix)
+	base = strings.TrimRight(base[:maxBaseLen], "-")
+	return fmt.Sprintf("%s-%s", base, suffix)
 }

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -68,6 +68,11 @@ func TestRestoreJobName(t *testing.T) {
 			restoreName: "r",
 			wantPrefix:  RestoreJobNamePrefix + "r",
 		},
+		{
+			name:        "long name is truncated with hash suffix",
+			restoreName: "restore-request-e2e-claims-functional-restore-1776963121-462553",
+			wantPrefix:  RestoreJobNamePrefix + "restore-request",
+		},
 	}
 
 	for _, tt := range tests {
@@ -79,7 +84,9 @@ func TestRestoreJobName(t *testing.T) {
 			}
 
 			got := restoreJobName(restore)
-			assert.Equal(t, tt.wantPrefix, got, "restoreJobName() should be deterministic")
+			assert.True(t, strings.HasPrefix(got, tt.wantPrefix), "restoreJobName() should preserve the expected prefix")
+			assert.LessOrEqual(t, len(got), 63, "restoreJobName() must fit Kubernetes label limits")
+			assert.Equal(t, got, restoreJobName(restore), "restoreJobName() should be deterministic")
 		})
 	}
 }
@@ -1234,6 +1241,8 @@ func TestGetRestoreExecutorImage(t *testing.T) {
 		name          string
 		restoreImage  string
 		clusterImage  string
+		operatorRepo  string
+		operatorTag   string
 		expectedImage string
 		expectError   bool
 	}{
@@ -1252,7 +1261,16 @@ func TestGetRestoreExecutorImage(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name:          "no image specified returns error",
+			name:          "fallback to operator default backup image",
+			restoreImage:  "",
+			clusterImage:  "",
+			operatorRepo:  "custom/backup",
+			operatorTag:   "v3",
+			expectedImage: "custom/backup:v3",
+			expectError:   false,
+		},
+		{
+			name:          "no image specified and no operator default returns error",
 			restoreImage:  "",
 			clusterImage:  "",
 			expectedImage: "",
@@ -1262,6 +1280,9 @@ func TestGetRestoreExecutorImage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(constants.EnvOperatorBackupImageRepo, tt.operatorRepo)
+			t.Setenv(constants.EnvOperatorVersion, tt.operatorTag)
+
 			restore := &openbaov1alpha1.OpenBaoRestore{
 				Spec: openbaov1alpha1.OpenBaoRestoreSpec{
 					Image: tt.restoreImage,


### PR DESCRIPTION
## Summary

- Use the default backup executor image for restore Jobs when no explicit restore or cluster backup image is configured.
- Pass the effective target StatefulSet name to the restore executor so blue/green restores target the active blue revision.
- Normalize and truncate generated restore Job names so long restore names still produce valid Kubernetes Job names.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No CRD, Helm, RBAC, or security-policy changes. Operationally, restore Jobs can now fall back to the operator default helper image instead of requiring an explicit image, and blue/green restores pass the active blue StatefulSet name to the executor.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/service/restore`
- commit hook: affected Go files formatted and linted
- pre-push hook: `make lint-ci`

## Reviewer Notes

Split out from the claims/service catalog integration branch because the changes are core restore lifecycle hardening and are useful for direct `OpenBaoRestore` users.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.