### PR TITLE
fix(upgrade): harden rolling upgrade resume

### DIFF
--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -454,6 +454,16 @@ func TestValidateUpgrade_ResumeHealthBlocksQuorumLoss(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
+	if !operatorerrors.IsTransientClusterState(err) {
+		t.Fatalf("expected transient cluster state error, got %v", err)
+	}
+	reason, ok := operatorerrors.Reason(err)
+	if !ok {
+		t.Fatalf("expected reasoned error, got %v", err)
+	}
+	if reason != upgrade.ReasonClusterNotReady {
+		t.Fatalf("reason=%q, want %q", reason, upgrade.ReasonClusterNotReady)
+	}
 	if !strings.Contains(err.Error(), "quorum-ready replicas") {
 		t.Fatalf("validateUpgrade() error = %v, want quorum-ready replicas failure", err)
 	}
@@ -641,6 +651,16 @@ func TestValidateUpgrade_ResumeHealthBlocksNonTargetUnavailableReplica(t *testin
 	err := mgr.validateUpgrade(context.Background(), testLogger(), cluster)
 	if err == nil {
 		t.Fatal("expected validation error")
+	}
+	if !operatorerrors.IsTransientClusterState(err) {
+		t.Fatalf("expected transient cluster state error, got %v", err)
+	}
+	reason, ok := operatorerrors.Reason(err)
+	if !ok {
+		t.Fatalf("expected reasoned error, got %v", err)
+	}
+	if reason != upgrade.ReasonPodNotReady {
+		t.Fatalf("reason=%q, want %q", reason, upgrade.ReasonPodNotReady)
 	}
 	if !strings.Contains(err.Error(), "non-target pod test-cluster-0 is not ready") {
 		t.Fatalf("validateUpgrade() error = %v, want non-target readiness failure", err)

--- a/internal/service/upgrade/rolling/rollout.go
+++ b/internal/service/upgrade/rolling/rollout.go
@@ -124,6 +124,11 @@ func (m *Manager) ensureTargetPodLeadershipTransferred(
 	target rolloutTargetPod,
 	metrics *upgrade.Metrics,
 ) (bool, error) {
+	if cluster.Spec.Replicas <= 1 {
+		logger.Info("Skipping leader step-down for single-replica rolling upgrade", "pod", target.Name)
+		return true, nil
+	}
+
 	leaderPodName, err := m.currentLeaderPodByLabel(ctx, cluster)
 	if err != nil {
 		logger.Info("Unable to determine current leader from pod labels; attempting safe step-down", "error", err)

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -371,6 +371,56 @@ func TestStepDownLeader_SkipsJobWhenTargetPodIsNotLeader(t *testing.T) {
 	}
 }
 
+func TestEnsureTargetPodLeadershipTransferred_SkipsSingleReplicaStepDown(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+	_ = openbaov1alpha1.AddToScheme(scheme)
+
+	ns := testNamespace
+	name := "c1"
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 1,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				TargetVersion: "2.5.0",
+				FromVersion:   "2.4.4",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	mgr := newManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
+		t.Fatalf("client factory should not be called for single-replica step-down skip")
+		return nil, nil
+	}, nil)
+
+	ok, err := mgr.ensureTargetPodLeadershipTransferred(
+		context.Background(),
+		testr.New(t),
+		cluster,
+		rolloutTargetPod{CurrentPartition: 1, NextPartition: 0, Ordinal: 0, Name: name + "-0"},
+		upgrade.NewMetrics(ns, name),
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected leadership transfer to be skipped")
+	}
+
+	jobs := &batchv1.JobList{}
+	if err := c.List(context.Background(), jobs, client.InNamespace(ns)); err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) != 0 {
+		t.Fatalf("jobs = %d, want 0", len(jobs.Items))
+	}
+}
+
 func TestPerformPodByPodUpgrade_ResumesWhenTargetAlreadyRolledOut(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme)

--- a/internal/service/upgrade/rolling/validate_health.go
+++ b/internal/service/upgrade/rolling/validate_health.go
@@ -137,22 +137,24 @@ func ensureResumeReadyReplicaQuorum(cluster *openbaov1alpha1.OpenBaoCluster, tar
 	if int(readyReplicas) >= quorumRequired {
 		return nil
 	}
-	if err := markResumeUpgradeTimeout(cluster, targetPodName); err != nil {
-		return err
-	}
-	return fmt.Errorf("rolling upgrade cannot continue without quorum-ready replicas (%d/%d ready, need %d)",
+	msg := fmt.Sprintf("rolling upgrade cannot continue without quorum-ready replicas (%d/%d ready, need %d)",
 		readyReplicas, cluster.Spec.Replicas, quorumRequired)
+	if err := markResumeUpgradeTimeout(cluster, targetPodName); err != nil {
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+	return transientClusterStatef(upgrade.ReasonClusterNotReady, "%s", msg)
 }
 
 func ensureResumePodQuorum(cluster *openbaov1alpha1.OpenBaoCluster, targetPodName string, podCount int, quorumRequired int) error {
 	if podCount >= quorumRequired {
 		return nil
 	}
-	if err := markResumeUpgradeTimeout(cluster, targetPodName); err != nil {
-		return err
-	}
-	return fmt.Errorf("rolling upgrade cannot continue with too few cluster pods (%d/%d, need at least %d)",
+	msg := fmt.Sprintf("rolling upgrade cannot continue with too few cluster pods (%d/%d, need at least %d)",
 		podCount, cluster.Spec.Replicas, quorumRequired)
+	if err := markResumeUpgradeTimeout(cluster, targetPodName); err != nil {
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+	return transientClusterStatef(upgrade.ReasonClusterNotReady, "%s", msg)
 }
 
 func (m *Manager) requireHealthyLeaderQuorum(
@@ -251,7 +253,7 @@ func resumePodReadyBlocker(cluster *openbaov1alpha1.OpenBaoCluster, podName stri
 	if timeoutErr := markResumeUpgradeTimeout(cluster, podName); timeoutErr != nil {
 		return fmt.Errorf("%v: %w", err, timeoutErr)
 	}
-	return err
+	return transientClusterState(upgrade.ReasonPodNotReady, err)
 }
 
 func resumePodHealthBlocker(cluster *openbaov1alpha1.OpenBaoCluster, podName string, format string, args ...any) error {
@@ -259,14 +261,18 @@ func resumePodHealthBlocker(cluster *openbaov1alpha1.OpenBaoCluster, podName str
 	if timeoutErr := failUpgradeIfStartedTimeout(cluster, podHealthTimeout(podName)); timeoutErr != nil {
 		return fmt.Errorf("%v: %w", err, timeoutErr)
 	}
-	return err
+	return transientClusterState(upgrade.ReasonHealthCheckFailed, err)
+}
+
+func transientClusterState(reason string, err error) error {
+	return operatorerrors.WithReason(
+		reason,
+		operatorerrors.WrapTransientClusterState(err),
+	)
 }
 
 func transientClusterStatef(reason string, format string, args ...any) error {
-	return operatorerrors.WithReason(
-		reason,
-		operatorerrors.WrapTransientClusterState(fmt.Errorf(format, args...)),
-	)
+	return transientClusterState(reason, fmt.Errorf(format, args...))
 }
 
 // checkPodHealth queries each pod's health status and returns counts.


### PR DESCRIPTION
## Summary

- Skip leader step-down during rolling upgrades for single-replica clusters, where there is no alternate leader to transfer to.
- Preserve typed transient cluster-state reasons for rolling-upgrade resume blockers such as insufficient quorum and non-target pod readiness failures.
- Add focused unit coverage for the single-replica path and reasoned transient resume errors.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, or generated artifact changes. Operational impact is limited to rolling upgrade orchestration: single-replica clusters avoid an impossible leader step-down, and transient resume blockers keep structured reason metadata for controller handling/status.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/service/upgrade/rolling`
- commit hook: affected Go files formatted and linted
- pre-push hook: `make lint-ci`

## Reviewer Notes

Split out from the claims/service catalog integration branch because this is core `OpenBaoCluster` rolling-upgrade lifecycle hardening and is useful independently of claims.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.