### PR TITLE
fix(storage): retry transient S3 bucket ensure failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
+	github.com/aws/smithy-go v1.25.1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-containerregistry v0.21.5
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -75,7 +76,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/internal/adapter/storage/s3.go
+++ b/internal/adapter/storage/s3.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sort"
 	"time"
@@ -21,6 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/s3blob"
@@ -33,6 +37,11 @@ import (
 const (
 	// DefaultUploadTimeout is the default timeout for upload operations.
 	DefaultUploadTimeout = 30 * time.Minute
+)
+
+var (
+	s3EnsureExistsMaxAttempts = 12
+	s3EnsureExistsRetryDelay  = 2 * time.Second
 )
 
 // Bucket wraps a Go CDK blob.Bucket with a simplified interface.
@@ -208,17 +217,6 @@ func OpenS3Bucket(ctx context.Context, cfg S3ClientConfig) (blobstore.BlobStore,
 }
 
 func ensureS3Bucket(ctx context.Context, client *s3.Client, bucketName, region string) error {
-	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(bucketName),
-	})
-	if err == nil {
-		return nil // Bucket exists/accessible
-	}
-
-	// Try to create if not found
-	// Note: We don't check specifically for NotFound error because HeadBucket behavior implies
-	// any error means we can't access it, so we try create. If create fails (e.g. permission),
-	// we'll return that error.
 	createInput := &s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
 	}
@@ -229,15 +227,103 @@ func ensureS3Bucket(ctx context.Context, client *s3.Client, bucketName, region s
 		}
 	}
 
-	_, err = client.CreateBucket(ctx, createInput)
-	if err != nil {
-		// Ignore if it effectively exists now (race condition or owned by us)
-		// Usually BucketAlreadyOwnedByYou or similar
-		// But checking exact error types across AWS SDK v2 can be verbose.
-		// For now we assume if Create fails, it might be a real error.
-		return err
+	var lastErr error
+	for attempt := 1; attempt <= s3EnsureExistsMaxAttempts; attempt++ {
+		_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{
+			Bucket: aws.String(bucketName),
+		})
+		if err == nil {
+			return nil
+		}
+
+		_, err = client.CreateBucket(ctx, createInput)
+		if err == nil {
+			return nil
+		}
+		if s3BucketAlreadyExists(err) {
+			return nil
+		}
+		lastErr = err
+		if !shouldRetryS3EnsureExists(err) {
+			return err
+		}
+
+		if attempt == s3EnsureExistsMaxAttempts {
+			break
+		}
+
+		timer := time.NewTimer(s3EnsureExistsRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
 	}
-	return nil
+
+	return lastErr
+}
+
+func shouldRetryS3EnsureExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return false
+	}
+
+	var hostnameErr x509.HostnameError
+	if errors.As(err, &hostnameErr) {
+		return false
+	}
+
+	var certInvalidErr x509.CertificateInvalidError
+	if errors.As(err, &certInvalidErr) {
+		return false
+	}
+
+	var sendErr *smithyhttp.RequestSendError
+	if errors.As(err, &sendErr) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var responseErr *smithyhttp.ResponseError
+	if errors.As(err, &responseErr) {
+		statusCode := responseErr.HTTPStatusCode()
+		return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorFault() == smithy.FaultServer
+	}
+
+	return false
+}
+
+func s3BucketAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	switch apiErr.ErrorCode() {
+	case "BucketAlreadyExists", "BucketAlreadyOwnedByYou":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildAWSConfig constructs AWS SDK config with credentials and custom TLS settings.

--- a/internal/adapter/storage/s3_test.go
+++ b/internal/adapter/storage/s3_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"gocloud.dev/blob/memblob"
 )
@@ -264,5 +266,51 @@ func TestOpenS3Bucket_Features(t *testing.T) {
 				t.Fatalf("OpenS3Bucket() unexpected error = %v", err)
 			}
 		})
+	}
+}
+
+func TestOpenS3Bucket_EnsureExistsRetriesTransientFailure(t *testing.T) {
+	originalAttempts := s3EnsureExistsMaxAttempts
+	originalDelay := s3EnsureExistsRetryDelay
+	s3EnsureExistsMaxAttempts = 3
+	s3EnsureExistsRetryDelay = 10 * time.Millisecond
+	t.Cleanup(func() {
+		s3EnsureExistsMaxAttempts = originalAttempts
+		s3EnsureExistsRetryDelay = originalDelay
+	})
+
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := requestCount.Add(1)
+		if current < 3 {
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodHead, http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	bucket, err := OpenS3Bucket(context.Background(), S3ClientConfig{
+		Endpoint:        server.URL,
+		Bucket:          "test-bucket",
+		Region:          "us-east-1",
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+		EnsureExists:    true,
+		UsePathStyle:    true,
+	})
+	if err != nil {
+		t.Fatalf("OpenS3Bucket() unexpected error = %v", err)
+	}
+	_ = bucket.Close()
+
+	if requestCount.Load() < 3 {
+		t.Fatalf("expected transient retries before success, got %d requests", requestCount.Load())
 	}
 }


### PR DESCRIPTION
## Summary

- Retry transient S3 bucket ensure failures when `ensureExists` is enabled for backup storage.
- Treat bucket-already-exists responses as success to handle races with S3-compatible backends.
- Keep certificate validation failures non-retryable and add focused coverage for transient retry behavior.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, or generated artifact changes. Operational impact is limited to S3/S3-compatible backup storage bucket creation checks when `ensureExists` is enabled. The retry loop is bounded and respects context cancellation.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/adapter/storage`
- `make verify-tidy verify-vendor`
- commit hook: affected Go files formatted and linted
- pre-push hook: `make lint-ci`

## Reviewer Notes

Split out from the claims/service catalog integration branch because this is core backup storage reliability work and is useful independently of claims.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.