### PR TITLE
feat(openbaocluster): add ingress integration readiness

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -73,6 +73,9 @@ const (
 	// the referenced Gateway and GatewayClass integration contract for the chosen
 	// Gateway API mode.
 	ConditionGatewayIntegrationReady ConditionType = "GatewayIntegrationReady"
+	// ConditionIngressIntegrationReady indicates whether the operator can verify
+	// the managed Ingress integration contract for the chosen ingress mode.
+	ConditionIngressIntegrationReady ConditionType = "IngressIntegrationReady"
 	// ConditionAPIServerNetworkReady indicates whether the operator can validate
 	// the Kubernetes API egress contract used by the operator-managed NetworkPolicy.
 	// Unknown means the common service-VIP path is configured, but some CNIs may
@@ -352,6 +355,34 @@ type ReadReplicaConfig struct {
 	Storage *ReadReplicaStorageConfig `json:"storage,omitempty"`
 }
 
+// IngressPathType identifies how a Kubernetes Ingress path should match requests.
+// +kubebuilder:validation:Enum=Prefix;Exact;ImplementationSpecific
+type IngressPathType string
+
+const (
+	// IngressPathTypePrefix uses prefix path matching.
+	IngressPathTypePrefix IngressPathType = "Prefix"
+	// IngressPathTypeExact uses exact path matching.
+	IngressPathTypeExact IngressPathType = "Exact"
+	// IngressPathTypeImplementationSpecific defers path matching to the controller.
+	IngressPathTypeImplementationSpecific IngressPathType = "ImplementationSpecific"
+)
+
+// IngressReadinessMode identifies how the operator decides whether ingress
+// integration is ready for endpoint publication.
+// +kubebuilder:validation:Enum=Created;LoadBalancerPublished
+type IngressReadinessMode string
+
+const (
+	// IngressReadinessModeCreated considers ingress integration ready once the
+	// managed Ingress object exists.
+	IngressReadinessModeCreated IngressReadinessMode = "Created"
+	// IngressReadinessModeLoadBalancerPublished considers ingress integration
+	// ready only after the managed Ingress reports a published load balancer
+	// address in status.
+	IngressReadinessModeLoadBalancerPublished IngressReadinessMode = "LoadBalancerPublished"
+)
+
 // IngressConfig controls optional HTTP(S) ingress in front of the OpenBao Service.
 type IngressConfig struct {
 	// Enabled controls whether the Operator manages an Ingress for external access.
@@ -366,12 +397,21 @@ type IngressConfig struct {
 	// Path is the HTTP path to route to OpenBao, defaulting to "/".
 	// +optional
 	Path string `json:"path,omitempty"`
+	// PathType identifies how the ingress controller should interpret Path.
+	// +kubebuilder:default=Prefix
+	// +optional
+	PathType IngressPathType `json:"pathType,omitempty"`
 	// TLSSecretName is an optional TLS Secret name; when empty the cluster TLS Secret is used.
 	// +optional
 	TLSSecretName string `json:"tlsSecretName,omitempty"`
 	// Annotations are additional annotations to apply to the Ingress.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// ReadinessMode identifies when the operator should consider ingress
+	// integration ready for endpoint publication.
+	// +kubebuilder:default=LoadBalancerPublished
+	// +optional
+	ReadinessMode IngressReadinessMode `json:"readinessMode,omitempty"`
 }
 
 // MaintenanceConfig defines supported maintenance operations.

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -857,6 +857,24 @@ spec:
                     description: Path is the HTTP path to route to OpenBao, defaulting
                       to "/".
                     type: string
+                  pathType:
+                    default: Prefix
+                    description: PathType identifies how the ingress controller should
+                      interpret Path.
+                    enum:
+                    - Prefix
+                    - Exact
+                    - ImplementationSpecific
+                    type: string
+                  readinessMode:
+                    default: LoadBalancerPublished
+                    description: |-
+                      ReadinessMode identifies when the operator should consider ingress
+                      integration ready for endpoint publication.
+                    enum:
+                    - Created
+                    - LoadBalancerPublished
+                    type: string
                   tlsSecretName:
                     description: TLSSecretName is an optional TLS Secret name; when
                       empty the cluster TLS Secret is used.

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -856,6 +856,24 @@ spec:
                     description: Path is the HTTP path to route to OpenBao, defaulting
                       to "/".
                     type: string
+                  pathType:
+                    default: Prefix
+                    description: PathType identifies how the ingress controller should
+                      interpret Path.
+                    enum:
+                    - Prefix
+                    - Exact
+                    - ImplementationSpecific
+                    type: string
+                  readinessMode:
+                    default: LoadBalancerPublished
+                    description: |-
+                      ReadinessMode identifies when the operator should consider ingress
+                      integration ready for endpoint publication.
+                    enum:
+                    - Created
+                    - LoadBalancerPublished
+                    type: string
                   tlsSecretName:
                     description: TLSSecretName is an optional TLS Secret name; when
                       empty the cluster TLS Secret is used.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -687,8 +687,48 @@ _Appears in:_
 | `className` _string_ | ClassName is an optional IngressClassName (for example, "nginx", "traefik"). |  | Optional: \{\} <br /> |
 | `host` _string_ | Host is the primary host for external access, for example "bao.example.com". |  | MinLength: 1 <br /> |
 | `path` _string_ | Path is the HTTP path to route to OpenBao, defaulting to "/". |  | Optional: \{\} <br /> |
+| `pathType` _[IngressPathType](#ingresspathtype)_ | PathType identifies how the ingress controller should interpret Path. | Prefix | Enum: [Prefix Exact ImplementationSpecific] <br />Optional: \{\} <br /> |
 | `tlsSecretName` _string_ | TLSSecretName is an optional TLS Secret name; when empty the cluster TLS Secret is used. |  | Optional: \{\} <br /> |
 | `annotations` _object (keys:string, values:string)_ | Annotations are additional annotations to apply to the Ingress. |  | Optional: \{\} <br /> |
+| `readinessMode` _[IngressReadinessMode](#ingressreadinessmode)_ | ReadinessMode identifies when the operator should consider ingress<br />integration ready for endpoint publication. | LoadBalancerPublished | Enum: [Created LoadBalancerPublished] <br />Optional: \{\} <br /> |
+
+
+#### IngressPathType
+
+_Underlying type:_ _string_
+
+IngressPathType identifies how a Kubernetes Ingress path should match requests.
+
+_Validation:_
+- Enum: [Prefix Exact ImplementationSpecific]
+
+_Appears in:_
+- [IngressConfig](#ingressconfig)
+
+| Field | Description |
+| --- | --- |
+| `Prefix` | IngressPathTypePrefix uses prefix path matching.<br /> |
+| `Exact` | IngressPathTypeExact uses exact path matching.<br /> |
+| `ImplementationSpecific` | IngressPathTypeImplementationSpecific defers path matching to the controller.<br /> |
+
+
+#### IngressReadinessMode
+
+_Underlying type:_ _string_
+
+IngressReadinessMode identifies how the operator decides whether ingress
+integration is ready for endpoint publication.
+
+_Validation:_
+- Enum: [Created LoadBalancerPublished]
+
+_Appears in:_
+- [IngressConfig](#ingressconfig)
+
+| Field | Description |
+| --- | --- |
+| `Created` | IngressReadinessModeCreated considers ingress integration ready once the<br />managed Ingress object exists.<br /> |
+| `LoadBalancerPublished` | IngressReadinessModeLoadBalancerPublished considers ingress integration<br />ready only after the managed Ingress reports a published load balancer<br />address in status.<br /> |
 
 
 #### InitContainerConfig

--- a/internal/app/openbaocluster/ingress_integration.go
+++ b/internal/app/openbaocluster/ingress_integration.go
@@ -1,0 +1,89 @@
+package openbaocluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	networkingmanager "github.com/dc-tec/openbao-operator/internal/service/networking"
+)
+
+// IngressIntegrationDependencies groups infrastructure readers required to
+// evaluate the operator-owned ingress integration contract.
+type IngressIntegrationDependencies struct {
+	Client            client.Client
+	APIReader         client.Reader
+	Scheme            *runtime.Scheme
+	OperatorNamespace string
+	Platform          string
+}
+
+// IngressIntegrationResult is the controller-facing evaluation result for the
+// operator-managed ingress contract.
+type IngressIntegrationResult struct {
+	Status  metav1.ConditionStatus
+	Reason  string
+	Message string
+}
+
+// EvaluateIngressIntegration validates the operator-managed ingress
+// prerequisites and controller support for the selected ingress mode.
+func EvaluateIngressIntegration(
+	ctx context.Context,
+	deps IngressIntegrationDependencies,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) IngressIntegrationResult {
+	manager := networkingmanager.NewManagerWithReader(
+		deps.Client,
+		deps.APIReader,
+		deps.Scheme,
+		deps.OperatorNamespace,
+		deps.Platform,
+	)
+	err := manager.ValidateIngressIntegration(ctx, cluster)
+
+	switch {
+	case err == nil:
+		return IngressIntegrationResult{
+			Status:  metav1.ConditionTrue,
+			Reason:  constants.ReasonIngressIntegrationReady,
+			Message: "Ingress integration prerequisites are satisfied",
+		}
+	case errors.Is(err, networkingmanager.ErrIngressClassMissing):
+		return IngressIntegrationResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  constants.ReasonIngressClassMissing,
+			Message: err.Error(),
+		}
+	case errors.Is(err, networkingmanager.ErrIngressObjectMissing):
+		return IngressIntegrationResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  constants.ReasonIngressObjectPending,
+			Message: err.Error(),
+		}
+	case errors.Is(err, networkingmanager.ErrIngressLoadBalancerPending):
+		return IngressIntegrationResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  constants.ReasonIngressLoadBalancerPending,
+			Message: err.Error(),
+		}
+	case errors.Is(err, networkingmanager.ErrIngressCapabilitiesUnknown):
+		return IngressIntegrationResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  constants.ReasonIngressCapabilitiesUnknown,
+			Message: err.Error(),
+		}
+	default:
+		return IngressIntegrationResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  constants.ReasonUnknown,
+			Message: fmt.Sprintf("Failed to evaluate ingress integration prerequisites: %v", err),
+		}
+	}
+}

--- a/internal/controller/openbaocluster/constants.go
+++ b/internal/controller/openbaocluster/constants.go
@@ -48,6 +48,7 @@ const (
 	ReasonACMEIntegrationReady                   = constants.ReasonACMEIntegrationReady
 	ReasonACMECacheReady                         = "ACMECacheReady"
 	ReasonGatewayIntegrationReady                = constants.ReasonGatewayIntegrationReady
+	ReasonIngressIntegrationReady                = constants.ReasonIngressIntegrationReady
 	ReasonAPIServerNetworkReady                  = constants.ReasonAPIServerNetworkReady
 	ReasonAPIServerEndpointIPsRecommended        = constants.ReasonAPIServerEndpointIPsRecommended
 	ReasonGatewayReferenceMissing                = constants.ReasonGatewayReferenceMissing
@@ -60,6 +61,10 @@ const (
 	ReasonGatewayNotProgrammed                   = constants.ReasonGatewayNotProgrammed
 	ReasonGatewayProgrammingPending              = constants.ReasonGatewayProgrammingPending
 	ReasonGatewayListenerIncompatible            = constants.ReasonGatewayListenerIncompatible
+	ReasonIngressClassMissing                    = constants.ReasonIngressClassMissing
+	ReasonIngressCapabilitiesUnknown             = constants.ReasonIngressCapabilitiesUnknown
+	ReasonIngressObjectPending                   = constants.ReasonIngressObjectPending
+	ReasonIngressLoadBalancerPending             = constants.ReasonIngressLoadBalancerPending
 	ReasonACMECacheNotConfigured                 = "ACMECacheNotConfigured"
 	ReasonACMECacheMissing                       = "ACMECacheMissing"
 	ReasonACMECachePending                       = "ACMECachePending"

--- a/internal/controller/openbaocluster/dependencies.go
+++ b/internal/controller/openbaocluster/dependencies.go
@@ -92,6 +92,16 @@ func (r *OpenBaoClusterReconciler) gatewayIntegrationDependencies() appopenbaocl
 	}
 }
 
+func (r *OpenBaoClusterReconciler) ingressIntegrationDependencies() appopenbaocluster.IngressIntegrationDependencies {
+	return appopenbaocluster.IngressIntegrationDependencies{
+		Client:            r.Client,
+		APIReader:         r.APIReader,
+		Scheme:            r.ControllerRuntime.Scheme,
+		OperatorNamespace: r.OperatorNamespace,
+		Platform:          r.Platform,
+	}
+}
+
 func (r *OpenBaoClusterReconciler) apiServerNetworkDependencies() appopenbaocluster.APIServerNetworkDependencies {
 	return appopenbaocluster.APIServerNetworkDependencies{
 		Client:            r.Client,

--- a/internal/controller/openbaocluster/status.go
+++ b/internal/controller/openbaocluster/status.go
@@ -34,6 +34,7 @@ func (r *OpenBaoClusterReconciler) updateStatus(ctx context.Context, logger logr
 	r.setACMEIntegrationReadyCondition(ctx, cluster)
 	r.setACMECacheReadyCondition(ctx, cluster)
 	r.setGatewayIntegrationReadyCondition(ctx, cluster)
+	r.setIngressIntegrationReadyCondition(ctx, cluster)
 	r.setBackupConfigurationReadyCondition(ctx, cluster)
 	r.setCloudUnsealIdentityReadyCondition(ctx, cluster)
 

--- a/internal/controller/openbaocluster/status_condition_contract.go
+++ b/internal/controller/openbaocluster/status_condition_contract.go
@@ -67,6 +67,17 @@ var gatewayIntegrationReadyConditionContract = newConditionContract(
 	conditionContractEntry{reason: reasonUnknown, status: metav1.ConditionUnknown},
 )
 
+var ingressIntegrationReadyConditionContract = newConditionContract(
+	conditionContractEntry{reason: ReasonIngressIntegrationReady, status: metav1.ConditionTrue},
+	conditionContractEntry{reason: ReasonIngressClassMissing, status: metav1.ConditionFalse},
+	conditionContractEntry{reason: ReasonIngressCapabilitiesUnknown, status: metav1.ConditionUnknown},
+	conditionContractEntry{reason: ReasonIngressObjectPending, status: metav1.ConditionUnknown},
+	conditionContractEntry{reason: ReasonIngressLoadBalancerPending, status: metav1.ConditionUnknown},
+	conditionContractEntry{reason: reasonPaused, status: metav1.ConditionUnknown},
+	conditionContractEntry{reason: ReasonProfileNotSet, status: metav1.ConditionUnknown},
+	conditionContractEntry{reason: reasonUnknown, status: metav1.ConditionUnknown},
+)
+
 var apiServerNetworkReadyConditionContract = newConditionContract(
 	conditionContractEntry{reason: ReasonAPIServerNetworkReady, status: metav1.ConditionTrue},
 	conditionContractEntry{reason: ReasonAPIServerEndpointIPsRecommended, status: metav1.ConditionUnknown},
@@ -232,6 +243,19 @@ func setGatewayIntegrationReadyEvaluatedCondition(
 		cluster.Generation,
 		statusConditionResult{Status: result.Status, Reason: result.Reason, Message: result.Message},
 		gatewayIntegrationReadyConditionContract,
+	)
+}
+
+func setIngressIntegrationReadyEvaluatedCondition(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	result appopenbaocluster.IngressIntegrationResult,
+) {
+	applyConditionContract(
+		&cluster.Status.Conditions,
+		openbaov1alpha1.ConditionIngressIntegrationReady,
+		cluster.Generation,
+		statusConditionResult{Status: result.Status, Reason: result.Reason, Message: result.Message},
+		ingressIntegrationReadyConditionContract,
 	)
 }
 

--- a/internal/controller/openbaocluster/status_condition_contract_test.go
+++ b/internal/controller/openbaocluster/status_condition_contract_test.go
@@ -11,39 +11,31 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
 
-func TestSetACMEIntegrationReadyEvaluatedCondition_AllowsKnownReasonStatusPairs(t *testing.T) {
-	t.Parallel()
+type evaluatedConditionCase struct {
+	name   string
+	status metav1.ConditionStatus
+	reason string
+}
 
-	tests := []struct {
-		name   string
-		status metav1.ConditionStatus
-		reason string
-	}{
-		{name: "ready", status: metav1.ConditionTrue, reason: ReasonACMEIntegrationReady},
-		{name: "gateway api missing", status: metav1.ConditionFalse, reason: ReasonGatewayAPIMissing},
-		{name: "gateway passthrough missing", status: metav1.ConditionFalse, reason: ReasonACMEGatewayNotConfiguredForPassthrough},
-		{name: "domain not resolvable", status: metav1.ConditionFalse, reason: ReasonACMEDomainNotResolvable},
-		{name: "prerequisites missing", status: metav1.ConditionFalse, reason: ReasonPrerequisitesMissing},
-		{name: "paused", status: metav1.ConditionUnknown, reason: reasonPaused},
-		{name: "profile not set", status: metav1.ConditionUnknown, reason: ReasonProfileNotSet},
-		{name: "unknown", status: metav1.ConditionUnknown, reason: reasonUnknown},
-	}
+func runEvaluatedConditionContractTest(
+	t *testing.T,
+	conditionType openbaov1alpha1.ConditionType,
+	cases []evaluatedConditionCase,
+	apply func(*openbaov1alpha1.OpenBaoCluster, metav1.ConditionStatus, string),
+) {
+	t.Helper()
 
-	for _, tt := range tests {
+	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster := newOpenBaoClusterStatusTestObject()
 			cluster.Generation = 17
 
-			setACMEIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.ACMEIntegrationResult{
-				Status:  tt.status,
-				Reason:  tt.reason,
-				Message: "contract message",
-			})
+			apply(cluster, tt.status, tt.reason)
 
 			assertClusterCondition(
 				t,
 				cluster,
-				openbaov1alpha1.ConditionACMEIntegrationReady,
+				conditionType,
 				true,
 				tt.status,
 				tt.reason,
@@ -98,6 +90,66 @@ func TestSetGatewayIntegrationReadyEvaluatedCondition_AllowsKnownReasonStatusPai
 				tt.reason,
 				"contract message",
 			)
+		})
+	}
+}
+
+func TestSetExternalIntegrationReadyEvaluatedCondition_AllowsKnownReasonStatusPairs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		conditionType openbaov1alpha1.ConditionType
+		cases         []evaluatedConditionCase
+		apply         func(*openbaov1alpha1.OpenBaoCluster, metav1.ConditionStatus, string)
+	}{
+		{
+			name:          "acme",
+			conditionType: openbaov1alpha1.ConditionACMEIntegrationReady,
+			cases: []evaluatedConditionCase{
+				{name: "ready", status: metav1.ConditionTrue, reason: ReasonACMEIntegrationReady},
+				{name: "gateway api missing", status: metav1.ConditionFalse, reason: ReasonGatewayAPIMissing},
+				{name: "gateway passthrough missing", status: metav1.ConditionFalse, reason: ReasonACMEGatewayNotConfiguredForPassthrough},
+				{name: "domain not resolvable", status: metav1.ConditionFalse, reason: ReasonACMEDomainNotResolvable},
+				{name: "prerequisites missing", status: metav1.ConditionFalse, reason: ReasonPrerequisitesMissing},
+				{name: "paused", status: metav1.ConditionUnknown, reason: reasonPaused},
+				{name: "profile not set", status: metav1.ConditionUnknown, reason: ReasonProfileNotSet},
+				{name: "unknown", status: metav1.ConditionUnknown, reason: reasonUnknown},
+			},
+			apply: func(cluster *openbaov1alpha1.OpenBaoCluster, status metav1.ConditionStatus, reason string) {
+				setACMEIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.ACMEIntegrationResult{
+					Status:  status,
+					Reason:  reason,
+					Message: "contract message",
+				})
+			},
+		},
+		{
+			name:          "ingress",
+			conditionType: openbaov1alpha1.ConditionIngressIntegrationReady,
+			cases: []evaluatedConditionCase{
+				{name: "ready", status: metav1.ConditionTrue, reason: ReasonIngressIntegrationReady},
+				{name: "class missing", status: metav1.ConditionFalse, reason: ReasonIngressClassMissing},
+				{name: "capabilities unknown", status: metav1.ConditionUnknown, reason: ReasonIngressCapabilitiesUnknown},
+				{name: "object pending", status: metav1.ConditionUnknown, reason: ReasonIngressObjectPending},
+				{name: "load balancer pending", status: metav1.ConditionUnknown, reason: ReasonIngressLoadBalancerPending},
+				{name: "paused", status: metav1.ConditionUnknown, reason: reasonPaused},
+				{name: "profile not set", status: metav1.ConditionUnknown, reason: ReasonProfileNotSet},
+				{name: "unknown", status: metav1.ConditionUnknown, reason: reasonUnknown},
+			},
+			apply: func(cluster *openbaov1alpha1.OpenBaoCluster, status metav1.ConditionStatus, reason string) {
+				setIngressIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.IngressIntegrationResult{
+					Status:  status,
+					Reason:  reason,
+					Message: "contract message",
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runEvaluatedConditionContractTest(t, tt.conditionType, tt.cases, tt.apply)
 		})
 	}
 }

--- a/internal/controller/openbaocluster/status_ingress_integration.go
+++ b/internal/controller/openbaocluster/status_ingress_integration.go
@@ -1,0 +1,24 @@
+package openbaocluster
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
+)
+
+func (r *OpenBaoClusterReconciler) setIngressIntegrationReadyCondition(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) {
+	if cluster.Spec.Ingress == nil || !cluster.Spec.Ingress.Enabled {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
+		return
+	}
+
+	result := appopenbaocluster.EvaluateIngressIntegration(
+		ctx,
+		r.ingressIntegrationDependencies(),
+		cluster,
+	)
+	setIngressIntegrationReadyEvaluatedCondition(cluster, result)
+}

--- a/internal/controller/openbaocluster/status_ingress_test.go
+++ b/internal/controller/openbaocluster/status_ingress_test.go
@@ -1,0 +1,144 @@
+package openbaocluster
+
+import (
+	"context"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+const testIngressStatusClassName = "nginx"
+
+func TestSetIngressIntegrationReadyCondition_FastContract(t *testing.T) {
+	t.Parallel()
+
+	scheme := newOpenBaoClusterTestScheme(t)
+
+	newIngressClass := func() *networkingv1.IngressClass {
+		return &networkingv1.IngressClass{ObjectMeta: metav1.ObjectMeta{Name: testIngressStatusClassName}}
+	}
+	newIngress := func(addresses ...string) *networkingv1.Ingress {
+		published := make([]networkingv1.IngressLoadBalancerIngress, 0, len(addresses))
+		for _, address := range addresses {
+			published = append(published, networkingv1.IngressLoadBalancerIngress{Hostname: address})
+		}
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+			Status: networkingv1.IngressStatus{
+				LoadBalancer: networkingv1.IngressLoadBalancerStatus{Ingress: published},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		cluster       *openbaov1alpha1.OpenBaoCluster
+		objects       []client.Object
+		wantPresent   bool
+		wantStatus    metav1.ConditionStatus
+		wantReason    string
+		wantMessageIn string
+	}{
+		{
+			name: "ingress disabled removes condition",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newOpenBaoClusterStatusTestObject()
+				cluster.Status.Conditions = []metav1.Condition{{
+					Type:   string(openbaov1alpha1.ConditionIngressIntegrationReady),
+					Status: metav1.ConditionTrue,
+					Reason: ReasonIngressIntegrationReady,
+				}}
+				return cluster
+			}(),
+			wantPresent: false,
+		},
+		{
+			name: "ingress integration ready",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newOpenBaoClusterStatusTestObject()
+				className := testIngressStatusClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:       true,
+					ClassName:     &className,
+					Host:          "bao.example.test",
+					ReadinessMode: openbaov1alpha1.IngressReadinessModeLoadBalancerPublished,
+				}
+				return cluster
+			}(),
+			objects:       []client.Object{newIngressClass(), newIngress("lb.example.test")},
+			wantPresent:   true,
+			wantStatus:    metav1.ConditionTrue,
+			wantReason:    ReasonIngressIntegrationReady,
+			wantMessageIn: "prerequisites are satisfied",
+		},
+		{
+			name: "ingress class missing is explicit",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newOpenBaoClusterStatusTestObject()
+				className := testIngressStatusClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:   true,
+					ClassName: &className,
+					Host:      "bao.example.test",
+				}
+				return cluster
+			}(),
+			objects:       []client.Object{newIngress()},
+			wantPresent:   true,
+			wantStatus:    metav1.ConditionFalse,
+			wantReason:    ReasonIngressClassMissing,
+			wantMessageIn: "IngressClass",
+		},
+		{
+			name: "load balancer pending is unknown",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newOpenBaoClusterStatusTestObject()
+				className := testIngressStatusClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:       true,
+					ClassName:     &className,
+					Host:          "bao.example.test",
+					ReadinessMode: openbaov1alpha1.IngressReadinessModeLoadBalancerPublished,
+				}
+				return cluster
+			}(),
+			objects:       []client.Object{newIngressClass(), newIngress()},
+			wantPresent:   true,
+			wantStatus:    metav1.ConditionUnknown,
+			wantReason:    ReasonIngressLoadBalancerPending,
+			wantMessageIn: "load balancer address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if len(tt.objects) > 0 {
+				builder = builder.WithObjects(tt.objects...)
+			}
+
+			reconciler := &OpenBaoClusterReconciler{
+				Client: builder.Build(),
+				ControllerRuntime: ControllerRuntime{
+					Scheme: scheme,
+				},
+			}
+
+			reconciler.setIngressIntegrationReadyCondition(context.Background(), tt.cluster)
+			assertClusterCondition(
+				t,
+				tt.cluster,
+				openbaov1alpha1.ConditionIngressIntegrationReady,
+				tt.wantPresent,
+				tt.wantStatus,
+				tt.wantReason,
+				tt.wantMessageIn,
+			)
+		})
+	}
+}

--- a/internal/controller/openbaocluster/status_pause_profile.go
+++ b/internal/controller/openbaocluster/status_pause_profile.go
@@ -53,6 +53,16 @@ func (r *OpenBaoClusterReconciler) updateStatusForPaused(ctx context.Context, lo
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
 	}
 
+	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
+		setIngressIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.IngressIntegrationResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "Ingress integration prerequisites are not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
+	}
+
 	if cluster.Spec.Backup != nil {
 		setBackupConfigurationReadyEvaluatedCondition(cluster, appopenbaocluster.BackupConfigurationResult{
 			Status:  metav1.ConditionUnknown,
@@ -123,6 +133,16 @@ func (r *OpenBaoClusterReconciler) updateStatusForProfileNotSet(ctx context.Cont
 		})
 	} else {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
+	}
+
+	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
+		setIngressIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.IngressIntegrationResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "Ingress integration prerequisites are not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
 	}
 
 	if cluster.Spec.Backup != nil {

--- a/internal/controller/openbaocluster/status_production_ready.go
+++ b/internal/controller/openbaocluster/status_production_ready.go
@@ -104,6 +104,16 @@ func evaluateProductionReady(cluster *openbaov1alpha1.OpenBaoCluster, admissionR
 			return status, reason, message
 		}
 	}
+	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
+		if status, reason, message, blocked := requireConditionNotFalse(
+			cluster,
+			openbaov1alpha1.ConditionIngressIntegrationReady,
+			"Ingress integration readiness has not been evaluated",
+			"Ingress integration prerequisites are not ready",
+		); blocked {
+			return status, reason, message
+		}
+	}
 
 	selfInitEnabled := cluster.Spec.SelfInit != nil && cluster.Spec.SelfInit.Enabled
 	if !selfInitEnabled {

--- a/internal/platform/constants/openbaocluster_reasons.go
+++ b/internal/platform/constants/openbaocluster_reasons.go
@@ -12,6 +12,7 @@ const (
 	ReasonACMEIntegrationReady                   = "ACMEIntegrationReady"
 
 	ReasonGatewayIntegrationReady         = "GatewayIntegrationReady"
+	ReasonIngressIntegrationReady         = "IngressIntegrationReady"
 	ReasonGatewayReferenceMissing         = "GatewayReferenceMissing"
 	ReasonGatewayClassMissing             = "GatewayClassMissing"
 	ReasonGatewayClassPending             = "GatewayClassPending"
@@ -22,6 +23,10 @@ const (
 	ReasonGatewayNotProgrammed            = "GatewayNotProgrammed"
 	ReasonGatewayProgrammingPending       = "GatewayProgrammingPending"
 	ReasonGatewayListenerIncompatible     = "GatewayListenerIncompatible"
+	ReasonIngressClassMissing             = "IngressClassMissing"
+	ReasonIngressCapabilitiesUnknown      = "IngressCapabilitiesUnknown"
+	ReasonIngressObjectPending            = "IngressObjectPending"
+	ReasonIngressLoadBalancerPending      = "IngressLoadBalancerPending"
 	ReasonAPIServerNetworkReady           = "APIServerNetworkReady"
 	ReasonAPIServerEndpointIPsRecommended = "APIServerEndpointIPsRecommended"
 

--- a/internal/service/networking/common.go
+++ b/internal/service/networking/common.go
@@ -47,6 +47,20 @@ var ErrGatewayProgrammingPending = errors.New("gateway programming pending")
 // incompatible with the selected HTTPRoute/TLSRoute mode.
 var ErrGatewayListenerIncompatible = errors.New("gateway listener incompatible")
 
+// ErrIngressClassMissing indicates the selected IngressClass does not exist.
+var ErrIngressClassMissing = errors.New("referenced IngressClass not found")
+
+// ErrIngressCapabilitiesUnknown indicates the operator cannot verify the selected
+// ingress integration because required reads are not available.
+var ErrIngressCapabilitiesUnknown = errors.New("ingress capabilities unknown")
+
+// ErrIngressObjectMissing indicates the managed Ingress object does not exist yet.
+var ErrIngressObjectMissing = errors.New("managed ingress missing")
+
+// ErrIngressLoadBalancerPending indicates the managed Ingress has not yet
+// published a load balancer address in status.
+var ErrIngressLoadBalancerPending = errors.New("ingress load balancer pending")
+
 // ErrAPIServerNetworkConfigurationInvalid indicates that the operator could not
 // derive a safe least-privilege Kubernetes API egress allow-list from the
 // cluster spec and runtime environment.

--- a/internal/service/networking/ingress.go
+++ b/internal/service/networking/ingress.go
@@ -62,6 +62,12 @@ func buildIngress(cluster *openbaov1alpha1.OpenBaoCluster) *networkingv1.Ingress
 	}
 
 	pathType := networkingv1.PathTypePrefix
+	switch ing.PathType {
+	case openbaov1alpha1.IngressPathTypeExact:
+		pathType = networkingv1.PathTypeExact
+	case openbaov1alpha1.IngressPathTypeImplementationSpecific:
+		pathType = networkingv1.PathTypeImplementationSpecific
+	}
 	backendServiceName := externalServiceName(cluster)
 
 	rule := networkingv1.IngressRule{

--- a/internal/service/networking/ingress_integration.go
+++ b/internal/service/networking/ingress_integration.go
@@ -1,0 +1,78 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+// ValidateIngressIntegration evaluates the operator-known ingress contract for
+// the selected ingress mode. It validates the referenced IngressClass when one
+// is configured and evaluates the managed Ingress readiness posture.
+func (m *Manager) ValidateIngressIntegration(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if cluster == nil || cluster.Spec.Ingress == nil || !cluster.Spec.Ingress.Enabled {
+		return nil
+	}
+
+	className := ""
+	if cluster.Spec.Ingress.ClassName != nil {
+		className = strings.TrimSpace(*cluster.Spec.Ingress.ClassName)
+	}
+	if className != "" {
+		ingressClass := &networkingv1.IngressClass{}
+		if err := m.reader.Get(ctx, types.NamespacedName{Name: className}, ingressClass); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("%w: referenced IngressClass %q was not found", ErrIngressClassMissing, className)
+			}
+			if apierrors.IsForbidden(err) {
+				return fmt.Errorf(
+					"%w: cannot verify referenced IngressClass %q because the operator cannot read it: %v",
+					ErrIngressCapabilitiesUnknown,
+					className,
+					err,
+				)
+			}
+			return fmt.Errorf("failed to get referenced IngressClass %q: %w", className, err)
+		}
+	}
+
+	ingress := &networkingv1.Ingress{}
+	key := types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}
+	if err := m.reader.Get(ctx, key, ingress); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("%w: managed Ingress %s/%s was not found", ErrIngressObjectMissing, key.Namespace, key.Name)
+		}
+		if apierrors.IsForbidden(err) {
+			return fmt.Errorf(
+				"%w: cannot verify managed Ingress %s/%s because the operator cannot read it: %v",
+				ErrIngressCapabilitiesUnknown,
+				key.Namespace,
+				key.Name,
+				err,
+			)
+		}
+		return fmt.Errorf("failed to get managed Ingress %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	if ingressReadinessMode(cluster.Spec.Ingress) == openbaov1alpha1.IngressReadinessModeCreated {
+		return nil
+	}
+	if len(ingress.Status.LoadBalancer.Ingress) == 0 {
+		return fmt.Errorf("%w: managed Ingress %s/%s has not published a load balancer address yet", ErrIngressLoadBalancerPending, ingress.Namespace, ingress.Name)
+	}
+
+	return nil
+}
+
+func ingressReadinessMode(ingress *openbaov1alpha1.IngressConfig) openbaov1alpha1.IngressReadinessMode {
+	if ingress == nil || ingress.ReadinessMode == "" {
+		return openbaov1alpha1.IngressReadinessModeLoadBalancerPublished
+	}
+	return ingress.ReadinessMode
+}

--- a/internal/service/networking/ingress_integration_test.go
+++ b/internal/service/networking/ingress_integration_test.go
@@ -1,0 +1,185 @@
+package networking
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+const testIngressClassName = "nginx"
+
+func TestValidateIngressIntegration(t *testing.T) {
+	t.Parallel()
+
+	newIngressClass := func() *networkingv1.IngressClass {
+		return &networkingv1.IngressClass{ObjectMeta: metav1.ObjectMeta{Name: testIngressClassName}}
+	}
+	newIngress := func(addresses ...string) *networkingv1.Ingress {
+		statusAddresses := make([]networkingv1.IngressLoadBalancerIngress, 0, len(addresses))
+		for _, address := range addresses {
+			statusAddresses = append(statusAddresses, networkingv1.IngressLoadBalancerIngress{Hostname: address})
+		}
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+			Status: networkingv1.IngressStatus{
+				LoadBalancer: networkingv1.IngressLoadBalancerStatus{Ingress: statusAddresses},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		cluster   *openbaov1alpha1.OpenBaoCluster
+		objects   []client.Object
+		wantError error
+	}{
+		{
+			name:    "disabled ingress returns nil",
+			cluster: newMinimalCluster("example", "default"),
+		},
+		{
+			name: "load balancer published succeeds",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newMinimalCluster("example", "default")
+				className := testIngressClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:       true,
+					ClassName:     &className,
+					Host:          "bao.example.test",
+					ReadinessMode: openbaov1alpha1.IngressReadinessModeLoadBalancerPublished,
+				}
+				return cluster
+			}(),
+			objects: []client.Object{newIngressClass(), newIngress("lb.example.test")},
+		},
+		{
+			name: "missing ingress class is explicit",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newMinimalCluster("example", "default")
+				className := testIngressClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:   true,
+					ClassName: &className,
+					Host:      "bao.example.test",
+				}
+				return cluster
+			}(),
+			objects:   []client.Object{newIngress()},
+			wantError: ErrIngressClassMissing,
+		},
+		{
+			name: "load balancer pending is explicit",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newMinimalCluster("example", "default")
+				className := testIngressClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:       true,
+					ClassName:     &className,
+					Host:          "bao.example.test",
+					ReadinessMode: openbaov1alpha1.IngressReadinessModeLoadBalancerPublished,
+				}
+				return cluster
+			}(),
+			objects:   []client.Object{newIngressClass(), newIngress()},
+			wantError: ErrIngressLoadBalancerPending,
+		},
+		{
+			name: "created readiness mode succeeds without load balancer address",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newMinimalCluster("example", "default")
+				className := testIngressClassName
+				cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+					Enabled:       true,
+					ClassName:     &className,
+					Host:          "bao.example.test",
+					ReadinessMode: openbaov1alpha1.IngressReadinessModeCreated,
+				}
+				return cluster
+			}(),
+			objects: []client.Object{newIngressClass(), newIngress()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(testScheme)
+			if len(tt.objects) > 0 {
+				builder = builder.WithObjects(tt.objects...)
+			}
+
+			k8sClient := builder.Build()
+			manager := NewManagerWithReader(k8sClient, k8sClient, testScheme, "openbao-operator-system", "")
+			err := manager.ValidateIngressIntegration(context.Background(), tt.cluster)
+			if tt.wantError == nil {
+				if err != nil {
+					t.Fatalf("ValidateIngressIntegration() error = %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantError) {
+				t.Fatalf("ValidateIngressIntegration() error = %v, want %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestBuildIngressUsesConfiguredPathType(t *testing.T) {
+	t.Parallel()
+
+	cluster := newMinimalCluster("example", "default")
+	className := testIngressClassName
+	cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+		Enabled:   true,
+		ClassName: &className,
+		Host:      "bao.example.test",
+		Path:      "/vault",
+		PathType:  openbaov1alpha1.IngressPathTypeExact,
+	}
+
+	ingress := buildIngress(cluster)
+	if ingress == nil {
+		t.Fatal("buildIngress() = nil, want ingress")
+	}
+	if ingress.Spec.IngressClassName == nil || *ingress.Spec.IngressClassName != testIngressClassName {
+		t.Fatalf("ingressClassName = %#v, want nginx", ingress.Spec.IngressClassName)
+	}
+	if len(ingress.Spec.Rules) != 1 || ingress.Spec.Rules[0].HTTP == nil || len(ingress.Spec.Rules[0].HTTP.Paths) != 1 {
+		t.Fatalf("ingress rules = %#v, want one HTTP path", ingress.Spec.Rules)
+	}
+	path := ingress.Spec.Rules[0].HTTP.Paths[0]
+	if path.PathType == nil || *path.PathType != networkingv1.PathTypeExact {
+		t.Fatalf("pathType = %#v, want Exact", path.PathType)
+	}
+	if path.Backend.Service == nil || path.Backend.Service.Port.Number != 8200 {
+		t.Fatalf("backend = %#v, want API service backend", path.Backend.Service)
+	}
+	if len(ingress.Spec.TLS) != 1 || ingress.Spec.TLS[0].SecretName == "" {
+		t.Fatalf("tls = %#v, want default TLS secret", ingress.Spec.TLS)
+	}
+}
+
+func TestBuildIngressUsesExplicitTLSSecret(t *testing.T) {
+	t.Parallel()
+
+	cluster := newMinimalCluster("example", "default")
+	cluster.Spec.Ingress = &openbaov1alpha1.IngressConfig{
+		Enabled:       true,
+		Host:          "bao.example.test",
+		TLSSecretName: "edge-server-tls",
+	}
+
+	ingress := buildIngress(cluster)
+	if ingress == nil {
+		t.Fatal("buildIngress() = nil, want ingress")
+	}
+	if len(ingress.Spec.TLS) != 1 || ingress.Spec.TLS[0].SecretName != "edge-server-tls" {
+		t.Fatalf("tls secret = %#v, want edge-server-tls", ingress.Spec.TLS)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `IngressIntegrationReady` status evaluation for `OpenBaoCluster` resources with managed Ingress enabled.
- Add `spec.ingress.pathType` and `spec.ingress.readinessMode` so users can control Ingress path matching and readiness semantics.
- Validate referenced IngressClass, managed Ingress existence, and optional load balancer publication; wire the result into production-readiness and paused/profile-not-set status handling.
- Update generated OpenBaoCluster CRD, Helm CRD, and API reference artifacts.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Adds optional OpenBaoCluster spec/status API fields and a new condition. Existing clusters remain compatible. For clusters that already enable `spec.ingress.enabled`, the status controller will now report `IngressIntegrationReady`; production-readiness can surface ingress integration failures when ingress is configured. No RBAC, Helm value, or admission policy changes are included.

## Verification

- `GOFLAGS=-mod=vendor go test ./api/v1alpha1 ./internal/service/networking ./internal/app/openbaocluster ./internal/controller/openbaocluster`
- `make manifests generate api-reference helm-sync`
- staged generated-artifact stability check: `make verify-generated verify-helm`
- commit hook: affected Go files formatted and linted
- pre-push hook: `make lint-ci`

## Reviewer Notes

Split out from the claims/service catalog integration branch because this is a core OpenBaoCluster ingress readiness feature and is useful independently of claims.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.