### PR TITLE
fix(helm): deduplicate generated RBAC labels

### DIFF
--- a/charts/openbao-operator/templates/rbac/aggregated-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/aggregated-clusterroles.yaml
@@ -4,8 +4,6 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
-    app.kubernetes.io/managed-by: kustomize
   name: {{ include "openbao-operator.fullname" . }}-openbaocluster-admin
 rules:
   - apiGroups:
@@ -27,8 +25,6 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
-    app.kubernetes.io/managed-by: kustomize
   name: {{ include "openbao-operator.fullname" . }}-openbaocluster-editor
 rules:
   - apiGroups:
@@ -56,8 +52,6 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
-    app.kubernetes.io/managed-by: kustomize
   name: {{ include "openbao-operator.fullname" . }}-openbaocluster-viewer
 rules:
   - apiGroups:

--- a/charts/openbao-operator/templates/rbac/controller-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/controller-clusterroles.yaml
@@ -36,9 +36,7 @@ metadata:
   name: {{ include "openbao-operator.fullname" . }}-controller-openbaocluster
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: kustomize
 rules:
   - apiGroups:
       - openbao.org
@@ -75,9 +73,7 @@ metadata:
   name: {{ include "openbao-operator.fullname" . }}-controller-openbaorestore
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: kustomize
 rules:
   - apiGroups:
       - openbao.org

--- a/charts/openbao-operator/templates/rbac/leader-election.yaml
+++ b/charts/openbao-operator/templates/rbac/leader-election.yaml
@@ -3,8 +3,6 @@ kind: Role
 metadata:
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
-    app.kubernetes.io/managed-by: kustomize
   name: {{ include "openbao-operator.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
 rules:

--- a/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "openbao-operator.fullname" . }}-provisioner
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
     app.kubernetes.io/component: provisioner
-    app.kubernetes.io/managed-by: kustomize
 rules:
   - apiGroups:
       - ""

--- a/charts/openbao-operator/templates/rbac/single-tenant-clusterrole.yaml
+++ b/charts/openbao-operator/templates/rbac/single-tenant-clusterrole.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "openbao-operator.fullname" . }}-single-tenant
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/name: openbao-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: kustomize
 rules:
   - apiGroups:
       - openbao.org

--- a/hack/helmchart/main.go
+++ b/hack/helmchart/main.go
@@ -20,6 +20,14 @@ const (
 	helmFullname   = `{{ include "openbao-operator.fullname" . }}`
 )
 
+var helmManagedLabelKeys = map[string]struct{}{
+	"helm.sh/chart":                {},
+	"app.kubernetes.io/name":       {},
+	"app.kubernetes.io/instance":   {},
+	"app.kubernetes.io/managed-by": {},
+	"app.kubernetes.io/version":    {},
+}
+
 type options struct {
 	crdInputDir     string
 	crdOutputDir    string
@@ -674,6 +682,8 @@ func addHelmLabelsToRBAC(content string) string {
 	lines := strings.Split(content, "\n")
 	result := make([]string, 0, len(lines)+4) // Extra space for Helm labels
 	inMetadata := false
+	inMetadataLabels := false
+	metadataLabelsIndent := 0
 	labelsSeen := false
 	labelsInjected := false
 
@@ -707,10 +717,18 @@ func addHelmLabelsToRBAC(content string) string {
 		}
 
 		trimmed := strings.TrimSpace(line)
+		if inMetadataLabels && trimmed != "" && len(leadingWhitespace(line)) <= metadataLabelsIndent {
+			inMetadataLabels = false
+		}
+		if inMetadataLabels && isHelmManagedLabelLine(line) {
+			continue
+		}
 
 		// If there's an existing labels block, inject Helm labels into it as the first entry.
 		if trimmed == "labels:" {
 			labelsSeen = true
+			inMetadataLabels = true
+			metadataLabelsIndent = len(leadingWhitespace(line))
 			result = append(result, line)
 
 			childIndent := leadingWhitespace(line) + "  "
@@ -742,6 +760,17 @@ func addHelmLabelsToRBAC(content string) string {
 	}
 
 	return strings.Join(result, "\n")
+}
+
+func isHelmManagedLabelLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	key, _, ok := strings.Cut(trimmed, ":")
+	if !ok {
+		return false
+	}
+	key = strings.Trim(key, `"'`)
+	_, ok = helmManagedLabelKeys[key]
+	return ok
 }
 
 // wrapGatewayAPIRules wraps Gateway API rules in a conditional.

--- a/hack/helmchart/main_test.go
+++ b/hack/helmchart/main_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	syaml "sigs.k8s.io/yaml"
 )
 
 func TestTransformPolicyToHelm_RewritesProvisionerServiceAccountVariable(t *testing.T) {
@@ -24,5 +30,98 @@ spec:
 	}
 	if strings.Contains(got, `'openbao-operator-provisioner'`) {
 		t.Fatalf("transformed policy still contains stale provisioner ServiceAccount name:\n%s", got)
+	}
+}
+
+func TestTransformRBACToHelm_DeduplicatesCommonLabels(t *testing.T) {
+	input := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openbao-operator-controller
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters
+    verbs:
+      - get
+`
+
+	got := transformRBACToHelm(input, "controller", false)
+	if !strings.Contains(got, `{{- include "openbao-operator.labels" . | nindent 4 }}`) {
+		t.Fatalf("transformed RBAC missing Helm labels helper:\n%s", got)
+	}
+	if strings.Contains(got, "app.kubernetes.io/name: openbao-operator") {
+		t.Fatalf("transformed RBAC still contains duplicate app name label:\n%s", got)
+	}
+	if strings.Contains(got, "app.kubernetes.io/managed-by: kustomize") {
+		t.Fatalf("transformed RBAC still contains duplicate managed-by label:\n%s", got)
+	}
+	if !strings.Contains(got, "app.kubernetes.io/component: controller") {
+		t.Fatalf("transformed RBAC dropped component label:\n%s", got)
+	}
+}
+
+func TestHelmTemplateRendersStrictYAML(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+	}{
+		{name: "default"},
+		{name: "multi", args: []string{"--set", "tenancy.mode=multi"}},
+		{name: "single", args: []string{"--set", "tenancy.mode=single", "--set", "tenancy.targetNamespace=openbao-system"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := renderChart(t, tt.args...)
+			assertStrictYAML(t, rendered)
+		})
+	}
+}
+
+func renderChart(t *testing.T, extraArgs ...string) []byte {
+	t.Helper()
+
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm binary not available")
+	}
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current file path")
+	}
+	chartDir := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "charts", "openbao-operator"))
+	args := []string{
+		"template",
+		"test",
+		chartDir,
+		"--namespace",
+		"openbao",
+		"--include-crds",
+	}
+	args = append(args, extraArgs...)
+	cmd := exec.Command("helm", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, string(output))
+	}
+	return output
+}
+
+func assertStrictYAML(t *testing.T, rendered []byte) {
+	t.Helper()
+
+	for i, doc := range bytes.Split(rendered, []byte("\n---")) {
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+		var out map[string]interface{}
+		if err := syaml.UnmarshalStrict(doc, &out); err != nil {
+			t.Fatalf("rendered document %d failed strict YAML decoding: %v\n%s", i+1, err, string(doc))
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the Helm chart RBAC templates so they no longer render duplicate YAML label keys under `metadata.labels`.

The RBAC Helm sync transform now removes label keys that are already owned by the chart's common `openbao-operator.labels` helper, while preserving labels that are not part of the helper, such as `app.kubernetes.io/component` and RBAC aggregation labels. The generated RBAC chart templates were refreshed from that transform.

A regression test now renders the chart in default, multi-tenant, and single-tenant modes and decodes every rendered document with `sigs.k8s.io/yaml.UnmarshalStrict`, matching the strict parsing behavior that exposed this through Flux.

## Related Issues

Closes #413

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Helm chart only. This does not change RBAC rules or workload behavior. The removed labels are still rendered through the common Helm label helper, so the resulting resources retain the chart-standard `app.kubernetes.io/name`, `app.kubernetes.io/managed-by`, and related labels without duplicate YAML keys.

This should make Flux HelmRelease installs parse the rendered chart successfully once included in the next chart release. The already-published `0.2.0` chart artifact remains unchanged.

## Verification

- `make bootstrap`
- `make verify-helm`
- `GOFLAGS=-mod=vendor go test ./hack/helmchart`
- `make helm-test`
- Pre-push hook: `make lint-ci`

Full `make ci-core` was not run locally because this is a narrow Helm chart generation fix and the targeted chart, generator, and lint checks cover the touched surface.

## Reviewer Notes

The root cause was `hack/helmchart` injecting the full common Helm labels helper into RBAC manifests that already carried Kustomize-owned `app.kubernetes.io/name` and `app.kubernetes.io/managed-by` labels. Plain `helm template` accepts that YAML, but Flux's strict post-render parsing rejects the duplicate mapping keys.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [ ] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
