### PR TITLE
ci(helm): run Go checks for helper changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,13 @@ jobs:
             echo "docs=false" >> "${GITHUB_OUTPUT}"
           fi
 
-          if changed_matches '^(internal/|cmd/|api/|config/|test/|docs/reference/api\.md|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/(ci/|boilerplate\.go\.txt)|\.golangci\.yml|\.github/tools/)'; then
+          if changed_matches '^(internal/|cmd/|api/|config/|test/|docs/reference/api\.md|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/(ci/|helm(chart|values)/|boilerplate\.go\.txt)|\.golangci\.yml|\.github/tools/)'; then
             echo "go_quality=true" >> "${GITHUB_OUTPUT}"
           else
             echo "go_quality=false" >> "${GITHUB_OUTPUT}"
           fi
 
-          if changed_matches '^(internal/|cmd/|api/|config/|go\.(mod|sum)$|vendor/|Makefile|mk/|test/(integration/|unit/))'; then
+          if changed_matches '^(internal/|cmd/|api/|config/|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/helm(chart|values)/|test/(integration/|unit/))'; then
             echo "go_tests=true" >> "${GITHUB_OUTPUT}"
           else
             echo "go_tests=false" >> "${GITHUB_OUTPUT}"

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/gateway-api v1.5.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -232,5 +233,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )


### PR DESCRIPTION
## Summary

- Promotes `sigs.k8s.io/yaml` to a direct module dependency after the Helm chart test added a direct import.
- Routes `hack/helmchart/` and `hack/helmvalues/` changes through PR Go quality and test jobs so `verify-tidy`, vendor, lint, formatting, and Go tests are not skipped for these helper packages.

## Related Issues

Follow-up to #414 and the post-merge `Verify go.mod/go.sum` failure on `main`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

None. This only updates module dependency classification and PR CI routing for Helm helper Go packages.

## Verification

- `make verify-tidy`
- `make verify-vendor`
- `GOFLAGS="-mod=vendor" go test ./hack/helmchart ./hack/helmvalues`
- `GOFLAGS="-mod=mod" go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/ci.yml`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

PR #414 changed `hack/helmchart/main_test.go`, which PR routing classified as `chart=true` but not `go_quality=true`. That skipped `Verify go.mod/go.sum` on the PR, while `main` push CI runs tidy unconditionally and caught the direct import drift.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
