### PR TITLE
fix(openbao): share JWT token cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/zclconf/go-cty v1.18.1
 	gocloud.dev v0.45.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.277.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -209,7 +210,6 @@ require (
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/internal/adapter/openbao/factory.go
+++ b/internal/adapter/openbao/factory.go
@@ -5,15 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
-
-type cachedToken struct {
-	token      string
-	expiration time.Time
-}
 
 // ClientFactory centralizes OpenBao client construction for a shared configuration template
 // (e.g., per-cluster CA bundle, client settings, timeouts).
@@ -22,9 +16,9 @@ type cachedToken struct {
 type ClientFactory struct {
 	template portopenbao.ClientConfig
 
-	mu         sync.RWMutex
-	clients    map[string]*http.Client
-	tokenCache map[string]cachedToken
+	mu        sync.RWMutex
+	clients   map[string]*http.Client
+	jwtTokens *jwtTokenCache
 
 	// clientState is the shared client state for this factory.
 	clientState *clientState
@@ -36,10 +30,14 @@ func newClientFactoryWithState(template portopenbao.ClientConfig, state *clientS
 	t := template
 	t.BaseURL = ""
 	t.Token = ""
+	jwtTokens := newJWTTokenCache()
+	if state != nil && state.jwtTokens != nil {
+		jwtTokens = state.jwtTokens
+	}
 	return &ClientFactory{
 		template:    t,
 		clients:     make(map[string]*http.Client),
-		tokenCache:  make(map[string]cachedToken),
+		jwtTokens:   jwtTokens,
 		clientState: state,
 	}
 }
@@ -105,40 +103,24 @@ func (f *ClientFactory) NewWithToken(baseURL, token string) (*Client, error) {
 
 // LoginJWT authenticates via JWT against the provided baseURL and returns the OpenBao client token.
 func (f *ClientFactory) LoginJWT(ctx context.Context, baseURL, role, jwtToken string) (string, error) {
-	// Check token cache
-	f.mu.RLock()
-	cached, ok := f.tokenCache[role]
-	f.mu.RUnlock()
-
-	if ok && time.Now().Before(cached.expiration) {
-		return cached.token, nil
+	if f == nil {
+		return "", fmt.Errorf("client factory is required")
 	}
 
-	client, err := f.New(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to create OpenBao client for JWT login: %w", err)
-	}
-
-	token, ttl, err := client.LoginJWT(ctx, role, jwtToken)
-	if err != nil {
-		return "", fmt.Errorf("failed to authenticate using JWT Auth: %w", err)
-	}
-
-	// Cache the token with some buffer (e.g., 5 seconds or 10% of TTL)
-	// OpenBao TTL is in seconds.
-	if ttl > 0 {
-		f.mu.Lock()
-		// Expire 10 seconds early to be safe
-		expiration := time.Now().Add(time.Duration(ttl)*time.Second - 10*time.Second)
-		if time.Now().Before(expiration) {
-			f.tokenCache[role] = cachedToken{
-				token:      token,
-				expiration: expiration,
-			}
+	token, err := f.jwtTokens.getOrLogin(ctx, baseURL, role, jwtToken, func(ctx context.Context) (string, int, error) {
+		client, err := f.New(baseURL)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to create OpenBao client for JWT login: %w", err)
 		}
-		f.mu.Unlock()
+		token, ttl, err := client.LoginJWT(ctx, role, jwtToken)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to authenticate using JWT Auth: %w", err)
+		}
+		return token, ttl, nil
+	})
+	if err != nil {
+		return "", err
 	}
-
 	return token, nil
 }
 

--- a/internal/adapter/openbao/factory_test.go
+++ b/internal/adapter/openbao/factory_test.go
@@ -3,12 +3,16 @@ package openbao
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+const testJWTCachedToken = "cached-token"
 
 func newTestClientFactory(template ClientConfig) *ClientFactory {
 	return newClientFactoryWithState(template, newClientState(template))
@@ -162,7 +166,7 @@ func TestClientFactory_LoginJWT_Caching(t *testing.T) {
 			atomic.AddInt32(&loginRequests, 1)
 			w.Header().Set("Content-Type", "application/json")
 			// Return a token with 12s TTL (2s valid cache, given 10s buffer)
-			_, _ = w.Write([]byte(`{"auth":{"client_token":"cached-token","ttl":12}}`))
+			_, _ = w.Write([]byte(`{"auth":{"client_token":"` + testJWTCachedToken + `","ttl":12}}`))
 			return
 		}
 		http.NotFound(w, r)
@@ -176,7 +180,7 @@ func TestClientFactory_LoginJWT_Caching(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoginJWT error: %v", err)
 	}
-	if token != "cached-token" {
+	if token != testJWTCachedToken {
 		t.Errorf("unexpected token: %s", token)
 	}
 	if count := atomic.LoadInt32(&loginRequests); count != 1 {
@@ -188,7 +192,7 @@ func TestClientFactory_LoginJWT_Caching(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoginJWT 2 error: %v", err)
 	}
-	if token != "cached-token" {
+	if token != testJWTCachedToken {
 		t.Errorf("unexpected token 2: %s", token)
 	}
 	if count := atomic.LoadInt32(&loginRequests); count != 1 {
@@ -205,5 +209,107 @@ func TestClientFactory_LoginJWT_Caching(t *testing.T) {
 	}
 	if count := atomic.LoadInt32(&loginRequests); count != 2 {
 		t.Errorf("expected 2 login requests, got %d (cache not expired?)", count)
+	}
+}
+
+func TestClientManager_LoginJWT_CacheSharedAcrossFactories(t *testing.T) {
+	t.Parallel()
+
+	var loginRequests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != apiPathAuthJWTLogin {
+			http.NotFound(w, r)
+			return
+		}
+		count := atomic.AddInt32(&loginRequests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"auth":{"client_token":"token-%d","ttl":3600}}`, count)
+	}))
+	defer server.Close()
+
+	mgr := NewClientManager(ClientConfig{})
+	defer mgr.Close()
+
+	f1 := mgr.FactoryFor("ns/cluster", nil)
+	f2 := mgr.FactoryFor("ns/cluster", nil)
+
+	token, err := f1.LoginJWT(context.Background(), server.URL, "role", "jwt-a")
+	if err != nil {
+		t.Fatalf("LoginJWT() error: %v", err)
+	}
+	if token != "token-1" {
+		t.Fatalf("LoginJWT() token=%q, want token-1", token)
+	}
+
+	token, err = f2.LoginJWT(context.Background(), server.URL, "role", "jwt-a")
+	if err != nil {
+		t.Fatalf("LoginJWT() with second factory error: %v", err)
+	}
+	if token != "token-1" {
+		t.Fatalf("LoginJWT() with second factory token=%q, want token-1", token)
+	}
+	if count := atomic.LoadInt32(&loginRequests); count != 1 {
+		t.Fatalf("expected shared cache to reuse token across factories, got %d login requests", count)
+	}
+
+	token, err = f2.LoginJWT(context.Background(), server.URL, "role", "jwt-b")
+	if err != nil {
+		t.Fatalf("LoginJWT() with rotated JWT error: %v", err)
+	}
+	if token != "token-2" {
+		t.Fatalf("LoginJWT() with rotated JWT token=%q, want token-2", token)
+	}
+	if count := atomic.LoadInt32(&loginRequests); count != 2 {
+		t.Fatalf("expected rotated JWT to get a fresh OpenBao token, got %d login requests", count)
+	}
+}
+
+func TestClientFactory_LoginJWT_CollapsesConcurrentCacheMisses(t *testing.T) {
+	t.Parallel()
+
+	var loginRequests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != apiPathAuthJWTLogin {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&loginRequests, 1)
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"auth":{"client_token":"` + testJWTCachedToken + `","ttl":3600}}`))
+	}))
+	defer server.Close()
+
+	factory := newTestClientFactory(ClientConfig{})
+	start := make(chan struct{})
+	errs := make(chan error, 16)
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			token, err := factory.LoginJWT(context.Background(), server.URL, "role", "jwt")
+			if err != nil {
+				errs <- err
+				return
+			}
+			if token != testJWTCachedToken {
+				errs <- fmt.Errorf("token=%q, want %s", token, testJWTCachedToken)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if count := atomic.LoadInt32(&loginRequests); count != 1 {
+		t.Fatalf("expected one JWT login for concurrent cache miss, got %d", count)
 	}
 }

--- a/internal/adapter/openbao/jwt_token_cache.go
+++ b/internal/adapter/openbao/jwt_token_cache.go
@@ -1,0 +1,98 @@
+package openbao
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	"k8s.io/apimachinery/pkg/util/cache"
+)
+
+const jwtTokenCacheSkew = 10 * time.Second
+
+type jwtTokenLoginFunc func(context.Context) (token string, ttlSeconds int, err error)
+
+type jwtTokenCache struct {
+	cache *cache.Expiring
+	group singleflight.Group
+}
+
+func newJWTTokenCache() *jwtTokenCache {
+	return &jwtTokenCache{cache: cache.NewExpiring()}
+}
+
+func (c *jwtTokenCache) getOrLogin(ctx context.Context, baseURL, role, jwtToken string, login jwtTokenLoginFunc) (string, error) {
+	if c == nil || c.cache == nil {
+		return loginWithoutCache(ctx, login)
+	}
+
+	key := jwtTokenCacheKey(baseURL, role, jwtToken)
+	if token, ok := c.get(key); ok {
+		return token, nil
+	}
+
+	value, err, _ := c.group.Do(key, func() (any, error) {
+		if token, ok := c.get(key); ok {
+			return token, nil
+		}
+
+		token, ttlSeconds, err := login(ctx)
+		if err != nil {
+			return "", err
+		}
+		ttl := jwtTokenCacheTTL(ttlSeconds)
+		if ttl > 0 {
+			c.cache.Set(key, token, ttl)
+		}
+		return token, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	token, ok := value.(string)
+	if !ok || token == "" {
+		return "", fmt.Errorf("JWT auth returned empty token")
+	}
+	return token, nil
+}
+
+func (c *jwtTokenCache) get(key string) (string, bool) {
+	value, ok := c.cache.Get(key)
+	if !ok {
+		return "", false
+	}
+	token, ok := value.(string)
+	return token, ok && token != ""
+}
+
+func loginWithoutCache(ctx context.Context, login jwtTokenLoginFunc) (string, error) {
+	token, _, err := login(ctx)
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", fmt.Errorf("JWT auth returned empty token")
+	}
+	return token, nil
+}
+
+func jwtTokenCacheTTL(ttlSeconds int) time.Duration {
+	if ttlSeconds <= 0 {
+		return 0
+	}
+
+	ttl := time.Duration(ttlSeconds) * time.Second
+	if ttl <= jwtTokenCacheSkew {
+		return 0
+	}
+	return ttl - jwtTokenCacheSkew
+}
+
+func jwtTokenCacheKey(baseURL, role, jwtToken string) string {
+	sum := sha256.Sum256([]byte(jwtToken))
+	return baseURL + "\x00" + role + "\x00" + hex.EncodeToString(sum[:])
+}

--- a/internal/adapter/openbao/transport.go
+++ b/internal/adapter/openbao/transport.go
@@ -49,6 +49,8 @@ type clientState struct {
 
 	failureThreshold int
 	openDuration     time.Duration
+
+	jwtTokens *jwtTokenCache
 }
 
 // newClientState creates a new clientState with the given configuration.
@@ -77,6 +79,7 @@ func newClientState(cfg portopenbao.ClientConfig) *clientState {
 		breakers:         make(map[string]*circuitBreaker),
 		failureThreshold: failureThreshold,
 		openDuration:     openDuration,
+		jwtTokens:        newJWTTokenCache(),
 	}
 }
 


### PR DESCRIPTION
## Summary

Moves JWT auth token caching from each short-lived `ClientFactory` into shared per-cluster OpenBao client state. The cache uses Kubernetes' expiring cache plus `singleflight` to avoid repeated `/auth/jwt-operator/login` calls across reconciles and to collapse concurrent cache misses.

Cache keys include the OpenBao base URL, role, and a SHA-256 fingerprint of the projected JWT so token reuse stays scoped to the same authenticated workload token.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, or RBAC changes. Operational impact should be lower JWT auth load and less audit-device noise for repeated authenticated OpenBao client creation. Security-sensitive behavior is intentionally scoped by base URL, role, and JWT fingerprint; rotated or different projected JWTs do not share cached OpenBao tokens.

## Verification

- `make bootstrap`
- `go test ./internal/adapter/openbao`
- `go test ./internal/adapter/openbao -run 'TestClientFactory_LoginJWT_CollapsesConcurrentCacheMisses|TestClientManager_LoginJWT_CacheSharedAcrossFactories' -count=20`
- `go test ./internal/adapter/openbao ./internal/adapter/config ./internal/service/bootstrap ./internal/adapter/raft ./internal/app/openbaocluster`

## Reviewer Notes

This is the bottom PR in the JWT hardening stack. PR #420 builds on this branch for generated role configuration hardening.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.