### PR TITLE
fix(config): harden generated JWT roles

### DIFF
--- a/internal/adapter/config/selfinit_gohcl.go
+++ b/internal/adapter/config/selfinit_gohcl.go
@@ -43,15 +43,26 @@ type hclPolicyData struct {
 }
 
 type hclJWTRoleData struct {
-	RoleType       string             `hcl:"role_type"`
-	UserClaim      string             `hcl:"user_claim"`
-	BoundAudiences []string           `hcl:"bound_audiences"`
-	BoundClaims    *map[string]string `hcl:"bound_claims,optional"`
-	BoundSubject   *string            `hcl:"bound_subject,optional"`
-	TokenPolicies  []string           `hcl:"token_policies"`
-	Policies       *[]string          `hcl:"policies"`
-	TTL            string             `hcl:"ttl"`
+	RoleType             string             `hcl:"role_type"`
+	UserClaim            string             `hcl:"user_claim"`
+	BoundAudiences       []string           `hcl:"bound_audiences"`
+	BoundClaims          *map[string]string `hcl:"bound_claims,optional"`
+	BoundSubject         *string            `hcl:"bound_subject,optional"`
+	TokenPolicies        []string           `hcl:"token_policies"`
+	Policies             *[]string          `hcl:"policies"`
+	TTL                  string             `hcl:"ttl"`
+	TokenTTL             string             `hcl:"token_ttl"`
+	TokenMaxTTL          string             `hcl:"token_max_ttl"`
+	TokenNoDefaultPolicy bool               `hcl:"token_no_default_policy"`
+	ClockSkewLeeway      string             `hcl:"clock_skew_leeway"`
+	ExpirationLeeway     string             `hcl:"expiration_leeway"`
+	NotBeforeLeeway      string             `hcl:"not_before_leeway"`
 }
+
+const (
+	operatorJWTTokenTTL = "1h"
+	operatorJWTLeeway   = "30s"
+)
 
 func buildInitializeBlock(label string) *hclwrite.Block {
 	return gohcl.EncodeAsBlock(hclInitialize{Name: label}, "initialize")
@@ -102,17 +113,8 @@ func buildSelfInitBootstrapInitializeBlock(cluster *openbaov1alpha1.OpenBaoClust
 	// 4. Bind Role (+ policies mirror to match existing golden)
 	{
 		subject := fmt.Sprintf("system:serviceaccount:%s:%s", config.OperatorNS, config.OperatorSA)
-		policies := []string{authPolicyNameOperator}
 		req := buildInitializeRequestBlock(reqCreateOperatorRole, opUpdate, fmt.Sprintf("%s%s", pathAuthJWTRolePrefix, authRoleNameOperator), false)
-		req.Body().AppendBlock(gohcl.EncodeAsBlock(hclJWTRoleData{
-			RoleType:       authMethodJWT,
-			UserClaim:      "sub",
-			BoundAudiences: jwtAudiences,
-			BoundSubject:   &subject,
-			TokenPolicies:  []string{authPolicyNameOperator},
-			Policies:       &policies,
-			TTL:            "1h",
-		}, "data"))
+		req.Body().AppendBlock(gohcl.EncodeAsBlock(operatorJWTRoleData(subject, authPolicyNameOperator, jwtAudiences), "data"))
 		initBody.AppendBlock(req)
 	}
 
@@ -128,17 +130,8 @@ func buildSelfInitBootstrapInitializeBlock(cluster *openbaov1alpha1.OpenBaoClust
 			}
 			{
 				subject := fmt.Sprintf("system:serviceaccount:%s:%s-backup-serviceaccount", cluster.Namespace, cluster.Name)
-				policies := []string{authPolicyNameBackup}
 				req := buildInitializeRequestBlock(reqCreateBackupRole, opUpdate, fmt.Sprintf("%s%s", pathAuthJWTRolePrefix, roleName), false)
-				req.Body().AppendBlock(gohcl.EncodeAsBlock(hclJWTRoleData{
-					RoleType:       authMethodJWT,
-					UserClaim:      "sub",
-					BoundAudiences: jwtAudiences,
-					BoundSubject:   &subject,
-					TokenPolicies:  []string{authPolicyNameBackup},
-					Policies:       &policies,
-					TTL:            "1h",
-				}, "data"))
+				req.Body().AppendBlock(gohcl.EncodeAsBlock(operatorJWTRoleData(subject, authPolicyNameBackup, jwtAudiences), "data"))
 				initBody.AppendBlock(req)
 			}
 		}
@@ -159,17 +152,8 @@ func buildSelfInitBootstrapInitializeBlock(cluster *openbaov1alpha1.OpenBaoClust
 		}
 		{
 			subject := fmt.Sprintf("system:serviceaccount:%s:%s-upgrade-serviceaccount", cluster.Namespace, cluster.Name)
-			policies := []string{authPolicyNameUpgrade}
 			req := buildInitializeRequestBlock(reqCreateUpgradeRole, opUpdate, fmt.Sprintf("%s%s", pathAuthJWTRolePrefix, roleName), false)
-			req.Body().AppendBlock(gohcl.EncodeAsBlock(hclJWTRoleData{
-				RoleType:       authMethodJWT,
-				UserClaim:      "sub",
-				BoundAudiences: jwtAudiences,
-				BoundSubject:   &subject,
-				TokenPolicies:  []string{authPolicyNameUpgrade},
-				Policies:       &policies,
-				TTL:            "1h",
-			}, "data"))
+			req.Body().AppendBlock(gohcl.EncodeAsBlock(operatorJWTRoleData(subject, authPolicyNameUpgrade, jwtAudiences), "data"))
 			initBody.AppendBlock(req)
 		}
 	}
@@ -189,22 +173,32 @@ func buildSelfInitBootstrapInitializeBlock(cluster *openbaov1alpha1.OpenBaoClust
 		}
 		{
 			subject := fmt.Sprintf("system:serviceaccount:%s:%s-restore-serviceaccount", cluster.Namespace, cluster.Name)
-			policies := []string{authPolicyNameRestore}
 			req := buildInitializeRequestBlock(reqCreateRestoreRole, opUpdate, fmt.Sprintf("%s%s", pathAuthJWTRolePrefix, restoreRoleName), false)
-			req.Body().AppendBlock(gohcl.EncodeAsBlock(hclJWTRoleData{
-				RoleType:       authMethodJWT,
-				UserClaim:      "sub",
-				BoundAudiences: jwtAudiences,
-				BoundSubject:   &subject,
-				TokenPolicies:  []string{authPolicyNameRestore},
-				Policies:       &policies,
-				TTL:            "1h",
-			}, "data"))
+			req.Body().AppendBlock(gohcl.EncodeAsBlock(operatorJWTRoleData(subject, authPolicyNameRestore, jwtAudiences), "data"))
 			initBody.AppendBlock(req)
 		}
 	}
 
 	return initBlock
+}
+
+func operatorJWTRoleData(subject, policy string, audiences []string) hclJWTRoleData {
+	policies := []string{policy}
+	return hclJWTRoleData{
+		RoleType:             authMethodJWT,
+		UserClaim:            "sub",
+		BoundAudiences:       audiences,
+		BoundSubject:         &subject,
+		TokenPolicies:        []string{policy},
+		Policies:             &policies,
+		TTL:                  operatorJWTTokenTTL,
+		TokenTTL:             operatorJWTTokenTTL,
+		TokenMaxTTL:          operatorJWTTokenTTL,
+		TokenNoDefaultPolicy: true,
+		ClockSkewLeeway:      operatorJWTLeeway,
+		ExpirationLeeway:     operatorJWTLeeway,
+		NotBeforeLeeway:      operatorJWTLeeway,
+	}
 }
 
 func jwtAuthAudiences(config OperatorBootstrapConfig) []string {

--- a/internal/adapter/config/testdata/render_self_init_backup_upgrade_policies.hcl
+++ b/internal/adapter/config/testdata/render_self_init_backup_upgrade_policies.hcl
@@ -26,13 +26,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/openbao-operator"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
-      token_policies  = ["openbao-operator"]
-      policies        = ["openbao-operator"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
+      token_policies          = ["openbao-operator"]
+      policies                = ["openbao-operator"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
   request "create-backup-policy" {
@@ -46,13 +52,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/backup"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:default:hardened-cluster-backup-serviceaccount"
-      token_policies  = ["openbao-operator-backup"]
-      policies        = ["openbao-operator-backup"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:default:hardened-cluster-backup-serviceaccount"
+      token_policies          = ["openbao-operator-backup"]
+      policies                = ["openbao-operator-backup"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
   request "create-upgrade-policy" {
@@ -66,13 +78,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/upgrade"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:default:hardened-cluster-upgrade-serviceaccount"
-      token_policies  = ["openbao-operator-upgrade"]
-      policies        = ["openbao-operator-upgrade"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:default:hardened-cluster-upgrade-serviceaccount"
+      token_policies          = ["openbao-operator-upgrade"]
+      policies                = ["openbao-operator-upgrade"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
 }

--- a/internal/adapter/config/testdata/render_self_init_no_backup_upgrade.hcl
+++ b/internal/adapter/config/testdata/render_self_init_no_backup_upgrade.hcl
@@ -26,13 +26,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/openbao-operator"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
-      token_policies  = ["openbao-operator"]
-      policies        = ["openbao-operator"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
+      token_policies          = ["openbao-operator"]
+      policies                = ["openbao-operator"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
 }

--- a/internal/adapter/config/testdata/render_self_init_restore_policy.hcl
+++ b/internal/adapter/config/testdata/render_self_init_restore_policy.hcl
@@ -26,13 +26,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/openbao-operator"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
-      token_policies  = ["openbao-operator"]
-      policies        = ["openbao-operator"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
+      token_policies          = ["openbao-operator"]
+      policies                = ["openbao-operator"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
   request "create-restore-policy" {
@@ -46,13 +52,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/restore"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:default:hardened-cluster-restore-serviceaccount"
-      token_policies  = ["openbao-operator-restore"]
-      policies        = ["openbao-operator-restore"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:default:hardened-cluster-restore-serviceaccount"
+      token_policies          = ["openbao-operator-restore"]
+      policies                = ["openbao-operator-restore"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
 }

--- a/internal/adapter/config/testdata/render_self_init_token_secret_ref.hcl
+++ b/internal/adapter/config/testdata/render_self_init_token_secret_ref.hcl
@@ -26,13 +26,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/openbao-operator"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
-      token_policies  = ["openbao-operator"]
-      policies        = ["openbao-operator"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
+      token_policies          = ["openbao-operator"]
+      policies                = ["openbao-operator"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
 }

--- a/internal/adapter/config/testdata/render_self_init_with_bootstrap.hcl
+++ b/internal/adapter/config/testdata/render_self_init_with_bootstrap.hcl
@@ -26,13 +26,19 @@ initialize "operator-bootstrap" {
     operation = "update"
     path      = "auth/jwt-operator/role/openbao-operator"
     data {
-      role_type       = "jwt"
-      user_claim      = "sub"
-      bound_audiences = ["openbao-internal"]
-      bound_subject   = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
-      token_policies  = ["openbao-operator"]
-      policies        = ["openbao-operator"]
-      ttl             = "1h"
+      role_type               = "jwt"
+      user_claim              = "sub"
+      bound_audiences         = ["openbao-internal"]
+      bound_subject           = "system:serviceaccount:openbao-operator-system:openbao-operator-controller"
+      token_policies          = ["openbao-operator"]
+      policies                = ["openbao-operator"]
+      ttl                     = "1h"
+      token_ttl               = "1h"
+      token_max_ttl           = "1h"
+      token_no_default_policy = true
+      clock_skew_leeway       = "30s"
+      expiration_leeway       = "30s"
+      not_before_leeway       = "30s"
     }
   }
 }


### PR DESCRIPTION
## Summary

Hardens self-init generated JWT roles for the operator, backup, upgrade, and restore identities. The generated role data now centralizes common JWT role settings and explicitly sets token TTLs, disables the implicit `default` policy, and tightens JWT clock-related leeways.

The generated HCL golden fixtures are updated to reflect the new role configuration.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

No CRD, Helm, or RBAC changes. Security/operational impact is limited to generated OpenBao self-init JWT role configuration for operator-managed auth roles. Tokens keep the existing 1h effective lifetime, now expressed with `token_ttl` and `token_max_ttl`, and no longer receive the implicit `default` policy. Generated roles already attach explicit token policies.

## Verification

- `make bootstrap`
- `UPDATE_GOLDEN=true go test ./internal/adapter/config`
- `go test ./internal/adapter/config ./internal/service/bootstrap ./internal/adapter/raft ./internal/app/openbaocluster`
- `go test ./internal/adapter/openbao ./internal/adapter/config ./internal/service/bootstrap ./internal/adapter/raft ./internal/app/openbaocluster`
- `make lint-ci` via pre-push hook

## Reviewer Notes

This PR now targets `main` directly. PR #419 has already landed on `main`, so this branch was rebased onto the updated trunk and no longer depends on a stack base.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.