### PR TITLE
fix(workload): mount OCI plugin directory

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -1851,8 +1851,10 @@ type PluginConfig struct {
 	// +optional
 	AutoRegister *bool `json:"autoRegister,omitempty"`
 
-	// DownloadBehavior specifies how plugins are downloaded.
-	// +kubebuilder:validation:Enum=standard;direct
+	// DownloadBehavior controls whether OpenBao startup fails or continues when
+	// declarative OCI plugin downloads fail. Valid values are "fail" and
+	// "continue"; OpenBao defaults to "fail" when unset.
+	// +kubebuilder:validation:Enum=fail;continue
 	// +optional
 	DownloadBehavior string `json:"downloadBehavior,omitempty"`
 }

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -545,10 +545,13 @@ spec:
                         description: AutoRegister controls automatic plugin registration.
                         type: boolean
                       downloadBehavior:
-                        description: DownloadBehavior specifies how plugins are downloaded.
+                        description: |-
+                          DownloadBehavior controls whether OpenBao startup fails or continues when
+                          declarative OCI plugin downloads fail. Valid values are "fail" and
+                          "continue"; OpenBao defaults to "fail" when unset.
                         enum:
-                        - standard
-                        - direct
+                        - fail
+                        - continue
                         type: string
                       filePermissions:
                         description: FilePermissions are the file permissions for

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -544,10 +544,13 @@ spec:
                         description: AutoRegister controls automatic plugin registration.
                         type: boolean
                       downloadBehavior:
-                        description: DownloadBehavior specifies how plugins are downloaded.
+                        description: |-
+                          DownloadBehavior controls whether OpenBao startup fails or continues when
+                          declarative OCI plugin downloads fail. Valid values are "fail" and
+                          "continue"; OpenBao defaults to "fail" when unset.
                         enum:
-                        - standard
-                        - direct
+                        - fail
+                        - continue
                         type: string
                       filePermissions:
                         description: FilePermissions are the file permissions for

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_full.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_full.yaml
@@ -108,7 +108,7 @@ spec:
     plugin:
       autoDownload: true
       autoRegister: false
-      downloadBehavior: "direct"
+      downloadBehavior: "continue"
       fileUID: 1000
       filePermissions: "0755"
     # Lease/TTL configuration

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_structured_config.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_structured_config.yaml
@@ -56,7 +56,7 @@ spec:
       filePermissions: "0755"
       autoDownload: true
       autoRegister: false
-      downloadBehavior: "direct" # direct or plugin
+      downloadBehavior: "continue" # fail or continue
     # Lease/TTL configuration
     defaultLeaseTTL: "720h" # 30 days
     maxLeaseTTL: "8760h" # 1 year

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1155,7 +1155,7 @@ _Appears in:_
 | `filePermissions` _string_ | FilePermissions are the file permissions for plugin files (e.g., "0755"). |  | Optional: \{\} <br /> |
 | `autoDownload` _boolean_ | AutoDownload controls automatic plugin downloads from OCI registries. |  | Optional: \{\} <br /> |
 | `autoRegister` _boolean_ | AutoRegister controls automatic plugin registration. |  | Optional: \{\} <br /> |
-| `downloadBehavior` _string_ | DownloadBehavior specifies how plugins are downloaded. |  | Enum: [standard direct] <br />Optional: \{\} <br /> |
+| `downloadBehavior` _string_ | DownloadBehavior controls whether OpenBao startup fails or continues when<br />declarative OCI plugin downloads fail. Valid values are "fail" and<br />"continue"; OpenBao defaults to "fail" when unset. |  | Enum: [fail continue] <br />Optional: \{\} <br /> |
 
 
 #### PodMetadataConfig

--- a/docs/user-guide/openbaocluster/configuration/server.md
+++ b/docs/user-guide/openbaocluster/configuration/server.md
@@ -153,7 +153,68 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
       version: "v1.0.0"
       binaryName: "openbao-plugin-secrets-aws"
       sha256sum: "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"`}
+>
+  Use an `image` plugin when OpenBao should download the plugin from an OCI registry as part of server startup. The operator renders `plugin_directory = "/openbao/plugins"` and mounts a writable, pod-local volume at that path for OCI auto-download.
+</CommandBlock>
+
+<CommandBlock
+  language="yaml"
+  label="configure"
+  title="Register preinstalled plugins"
+  code={`spec:
+  plugins:
+    - type: secret
+      name: local-example
+      command: "openbao-plugin-secrets-example"
+      version: "v1.0.0"
+      binaryName: "openbao-plugin-secrets-example"
+      sha256sum: "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"`}
+>
+  Use a `command` plugin when the binary is already available inside the OpenBao runtime image or another explicitly managed runtime path.
+</CommandBlock>
+
+<DecisionTable
+  kind="reference"
+  title="Plugin fields"
+  columns={["Surface", "Use it for", "Operational note"]}
+  rows={[
+    {
+      cells: [
+        "`spec.plugins[].image`",
+        "OCI-based plugin binaries that OpenBao downloads at startup.",
+        "Set `spec.configuration.plugin.autoDownload: true`; OpenBao pods need registry egress or access to a reachable mirror.",
+      ],
+      emphasis: "recommended",
+    },
+    {
+      cells: [
+        "`spec.plugins[].command`",
+        "Plugin binaries already present in the OpenBao runtime environment.",
+        "The operator does not create a plugin-download volume for command-only plugins.",
+      ],
+    },
+    {
+      cells: [
+        "`spec.configuration.plugin.autoRegister`",
+        "Automatic plugin catalog registration.",
+        "`args` and `env` on each plugin are only used when auto-register is enabled.",
+      ],
+    },
+    {
+      cells: [
+        "`spec.configuration.plugin.downloadBehavior`",
+        "OpenBao's OCI download mode.",
+        "Use values supported by the OpenBao version in `spec.version`; plugin auto-download settings require OpenBao 2.5.0 or newer.",
+      ],
+    },
+  ]}
 />
+
+<Callout type="note" title="Downloaded plugins are runtime cache">
+
+OCI-downloaded plugins are stored under `/openbao/plugins` on an ephemeral pod-local volume. Treat that directory as a writable startup cache, not durable storage. If the cluster runs in a private or disconnected environment, mirror the plugin image and make sure OpenBao's runtime OCI client can authenticate to that registry; Kubernetes `imagePullSecrets` only cover Kubernetes image pulls.
+
+</Callout>
 
   </TabItem>
 </Tabs>

--- a/docs/user-guide/openbaocluster/configuration/server.md
+++ b/docs/user-guide/openbaocluster/configuration/server.md
@@ -145,14 +145,14 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
   configuration:
     plugin:
       autoDownload: true
-      downloadBehavior: "direct"
+      downloadBehavior: "continue"
   plugins:
     - type: secret
       name: aws
       image: "ghcr.io/openbao/openbao-plugin-secrets-aws"
-      version: "v1.0.0"
+      version: "v0.0.1"
       binaryName: "openbao-plugin-secrets-aws"
-      sha256sum: "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"`}
+      sha256sum: "b98cb1cbfd0f567d7b614efb0621aaba10c4deda865f5e5b3d155609ada2482e"`}
 >
   Use an `image` plugin when OpenBao should download the plugin from an OCI registry as part of server startup. The operator renders `plugin_directory = "/openbao/plugins"` and mounts a writable, pod-local volume at that path for OCI auto-download.
 </CommandBlock>
@@ -203,8 +203,8 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
     {
       cells: [
         "`spec.configuration.plugin.downloadBehavior`",
-        "OpenBao's OCI download mode.",
-        "Use values supported by the OpenBao version in `spec.version`; plugin auto-download settings require OpenBao 2.5.0 or newer.",
+        "Startup behavior when an OCI plugin download fails.",
+        "Use `fail` to stop startup or `continue` to log and keep starting; plugin auto-download settings require OpenBao 2.5.0 or newer.",
       ],
     },
   ]}

--- a/internal/adapter/config/builder.go
+++ b/internal/adapter/config/builder.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	platformsemver "github.com/dc-tec/openbao-operator/internal/platform/semver"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
 const (
-	configPluginDirectoryPath = "/openbao/plugins"
-	configUnsealKeyPath       = "file:///etc/bao/unseal/key"
-	configUnsealKeyID         = "operator-generated-v1"
-	configMaxRequestDuration  = "90s"
-	configNodeIDTemplate      = "${HOSTNAME}"
+	configUnsealKeyPath      = "file:///etc/bao/unseal/key"
+	configUnsealKeyID        = "operator-generated-v1"
+	configMaxRequestDuration = "90s"
+	configNodeIDTemplate     = "${HOSTNAME}"
 
 	jwtPolicyHealthStepDownAutopilot = `path "sys/health" { capabilities = ["read"] }
 path "sys/step-down" { capabilities = ["sudo", "update"] }
@@ -149,7 +149,7 @@ func RenderHCL(cluster *openbaov1alpha1.OpenBaoCluster, infra InfrastructureDeta
 		ClusterName:     cluster.Name,
 		APIAddr:         apiAddr,
 		ClusterAddr:     clusterAddr,
-		PluginDirectory: configPluginDirectoryPath,
+		PluginDirectory: constants.PathPlugins,
 	}, body)
 
 	listenerBlock, err := buildListenerBlock(cluster)

--- a/internal/adapter/config/builder_fuzz_test.go
+++ b/internal/adapter/config/builder_fuzz_test.go
@@ -228,7 +228,7 @@ func FuzzRenderHCL(f *testing.F) {
 		telemetryAddr string
 		enableObs     bool
 	}{
-		{"demo", "default", "2.5.0", "demo", "default", 8200, 8201, "info", "3600h", "7200h", "direct", "file", "stdout", `{"file_path":"stdout"}`, "127.0.0.1:8125", true},
+		{"demo", "default", "2.5.0", "demo", "default", 8200, 8201, "info", "3600h", "7200h", "continue", "file", "stdout", `{"file_path":"stdout"}`, "127.0.0.1:8125", true},
 		{"acme", "operators", "2.4.4", "acme", "operators", 8200, 8201, "debug", "", "", "", "socket", "custom-socket", `{"address":"127.0.0.1:9000"}`, "", false},
 		{"broken", "default", "not-a-version", "", "", 0, -1, "", "", "", "", "", "", `{}`, "", false},
 	}

--- a/internal/adapter/config/builder_test.go
+++ b/internal/adapter/config/builder_test.go
@@ -85,7 +85,7 @@ func TestRenderHCLWithStructuredConfiguration(t *testing.T) {
 			FilePermissions:  "0755",
 			AutoDownload:     &autoDownload,
 			AutoRegister:     &autoRegister,
-			DownloadBehavior: "direct",
+			DownloadBehavior: "continue",
 		},
 		DefaultLeaseTTL: "720h",
 		MaxLeaseTTL:     "8760h",

--- a/internal/adapter/config/testdata/render_hcl_structured_config.hcl
+++ b/internal/adapter/config/testdata/render_hcl_structured_config.hcl
@@ -40,6 +40,6 @@ plugin_file_uid          = 1000
 plugin_file_permissions  = "0755"
 plugin_auto_download     = true
 plugin_auto_register     = false
-plugin_download_behavior = "direct"
+plugin_download_behavior = "continue"
 default_lease_ttl        = "720h"
 max_lease_ttl            = "8760h"

--- a/internal/platform/constants/filesystem.go
+++ b/internal/platform/constants/filesystem.go
@@ -2,16 +2,18 @@ package constants
 
 // Common mount paths used by OpenBao pods and helper executables.
 const (
-	PathTLS    = "/etc/bao/tls"
-	PathConfig = "/etc/bao/config"
-	PathData   = "/bao/data"
+	PathTLS     = "/etc/bao/tls"
+	PathConfig  = "/etc/bao/config"
+	PathData    = "/bao/data"
+	PathPlugins = "/openbao/plugins"
 )
 
 // Common volume names used by OpenBao pods.
 const (
-	VolumeTLS    = "tls"
-	VolumeConfig = "config"
-	VolumeData   = "data"
+	VolumeTLS     = "tls"
+	VolumeConfig  = "config"
+	VolumeData    = "data"
+	VolumePlugins = "plugins"
 )
 
 // TLS file paths mounted into OpenBao pods and helper executables.

--- a/internal/service/workload/constants.go
+++ b/internal/service/workload/constants.go
@@ -6,6 +6,7 @@ const (
 	dataVolumeName           = constants.VolumeData
 	tlsVolumeName            = constants.VolumeTLS
 	configVolumeName         = constants.VolumeConfig
+	pluginVolumeName         = constants.VolumePlugins
 	configInitVolumeName     = "config-init"
 	configRenderedVolumeName = "config-rendered"
 	unsealVolumeName         = "unseal"
@@ -21,6 +22,7 @@ const (
 	openBaoTLSMountPath      = constants.PathTLS
 	openBaoUnsealMountPath   = "/etc/bao/unseal"
 	openBaoDataPath          = constants.PathData
+	openBaoPluginPath        = constants.PathPlugins
 	serviceAccountMountPath  = "/var/run/secrets/kubernetes.io/serviceaccount"
 	kubeRootCAConfigMapName  = "kube-root-ca.crt"
 	openBaoBinaryName        = constants.BinaryBao

--- a/internal/service/workload/plugin_directory.go
+++ b/internal/service/workload/plugin_directory.go
@@ -1,0 +1,23 @@
+package workload
+
+import (
+	"strings"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func usesDeclarativeOCIPluginDownload(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if cluster == nil || cluster.Spec.Configuration == nil || cluster.Spec.Configuration.Plugin == nil {
+		return false
+	}
+	autoDownload := cluster.Spec.Configuration.Plugin.AutoDownload
+	if autoDownload == nil || !*autoDownload {
+		return false
+	}
+	for _, plugin := range cluster.Spec.Plugins {
+		if strings.TrimSpace(plugin.Image) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/workload/plugin_directory_test.go
+++ b/internal/service/workload/plugin_directory_test.go
@@ -1,0 +1,124 @@
+package workload
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestStatefulSet_OCIPluginAutoDownloadMountsWritablePluginDirectory(t *testing.T) {
+	cluster := newMinimalCluster("oci-plugins", "default")
+	cluster.Spec.Version = "2.5.3"
+	cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
+		Plugin: &openbaov1alpha1.PluginConfig{
+			AutoDownload: ptr.To(true),
+		},
+	}
+	cluster.Spec.Plugins = []openbaov1alpha1.Plugin{
+		{
+			Type:       "secret",
+			Name:       "nats",
+			Image:      "ghcr.io/example/openbao-plugin",
+			Version:    "1.2.3",
+			BinaryName: "openbao-plugin",
+			SHA256Sum:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+
+	statefulSet, err := buildStatefulSet(cluster, "test-config", true, "", "", "")
+	if err != nil {
+		t.Fatalf("buildStatefulSet() error = %v", err)
+	}
+
+	pluginVolume, ok := getVolume(statefulSet.Spec.Template.Spec.Volumes, pluginVolumeName)
+	if !ok {
+		t.Fatalf("expected %q volume to be present", pluginVolumeName)
+	}
+	if pluginVolume.EmptyDir == nil {
+		t.Fatalf("expected %q volume to use emptyDir", pluginVolumeName)
+	}
+
+	pluginMount, ok := getVolumeMount(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, pluginVolumeName)
+	if !ok {
+		t.Fatalf("expected OpenBao container to mount %q volume", pluginVolumeName)
+	}
+	if pluginMount.MountPath != openBaoPluginPath {
+		t.Fatalf("plugin mount path = %q, want %q", pluginMount.MountPath, openBaoPluginPath)
+	}
+	if pluginMount.ReadOnly {
+		t.Fatalf("expected %q mount to be writable", pluginVolumeName)
+	}
+}
+
+func TestStatefulSet_OCIPluginDirectoryVolumeOmittedWhenAutoDownloadUnused(t *testing.T) {
+	tests := []struct {
+		name         string
+		autoDownload *bool
+		plugins      []openbaov1alpha1.Plugin
+	}{
+		{
+			name:         "no plugin config",
+			autoDownload: nil,
+			plugins: []openbaov1alpha1.Plugin{
+				{Type: "secret", Name: "nats", Image: "ghcr.io/example/openbao-plugin"},
+			},
+		},
+		{
+			name:         "auto download disabled",
+			autoDownload: ptr.To(false),
+			plugins: []openbaov1alpha1.Plugin{
+				{Type: "secret", Name: "nats", Image: "ghcr.io/example/openbao-plugin"},
+			},
+		},
+		{
+			name:         "auto download enabled without plugins",
+			autoDownload: ptr.To(true),
+		},
+		{
+			name:         "auto download enabled for command plugin",
+			autoDownload: ptr.To(true),
+			plugins: []openbaov1alpha1.Plugin{
+				{Type: "secret", Name: "local", Command: "/usr/local/bin/openbao-plugin"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newMinimalCluster("oci-plugins-unused", "default")
+			cluster.Spec.Version = "2.5.3"
+			if tt.autoDownload != nil {
+				cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
+					Plugin: &openbaov1alpha1.PluginConfig{
+						AutoDownload: tt.autoDownload,
+					},
+				}
+			}
+			cluster.Spec.Plugins = tt.plugins
+
+			statefulSet, err := buildStatefulSet(cluster, "test-config", true, "", "", "")
+			if err != nil {
+				t.Fatalf("buildStatefulSet() error = %v", err)
+			}
+
+			if hasVolume(statefulSet.Spec.Template.Spec.Volumes, pluginVolumeName) {
+				t.Fatalf("did not expect %q volume", pluginVolumeName)
+			}
+			if hasVolumeMount(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, pluginVolumeName) {
+				t.Fatalf("did not expect OpenBao container to mount %q volume", pluginVolumeName)
+			}
+		})
+	}
+}
+
+func getVolumeMount(mounts []corev1.VolumeMount, name string) (*corev1.VolumeMount, bool) {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i], true
+		}
+	}
+	return nil, false
+}

--- a/internal/service/workload/statefulset_builder_containers.go
+++ b/internal/service/workload/statefulset_builder_containers.go
@@ -219,6 +219,13 @@ func buildContainerVolumeMounts(cluster *openbaov1alpha1.OpenBaoCluster, rendere
 		})
 	}
 
+	if usesDeclarativeOCIPluginDownload(cluster) {
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      pluginVolumeName,
+			MountPath: openBaoPluginPath,
+		})
+	}
+
 	mounts = append(mounts, newSealWiringProvider(cluster).VolumeMounts()...)
 
 	// Add utils volume mount (Read-Only for security)

--- a/internal/service/workload/statefulset_builder_probe_volumes.go
+++ b/internal/service/workload/statefulset_builder_probe_volumes.go
@@ -190,6 +190,15 @@ func buildStatefulSetVolumes(cluster *openbaov1alpha1.OpenBaoCluster, spec State
 		})
 	}
 
+	if usesDeclarativeOCIPluginDownload(cluster) {
+		volumes = append(volumes, corev1.Volume{
+			Name: pluginVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+	}
+
 	volumes = append(volumes, newSealWiringProvider(cluster).Volumes()...)
 
 	// If self-init is enabled, add the self-init ConfigMap volume, unless disabled (Green pods)

--- a/test/e2e/Cluster_Runtime_Controls_test.go
+++ b/test/e2e/Cluster_Runtime_Controls_test.go
@@ -18,19 +18,26 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	platformsemver "github.com/dc-tec/openbao-operator/internal/platform/semver"
 	"github.com/dc-tec/openbao-operator/test/e2e/framework"
+	e2ehelpers "github.com/dc-tec/openbao-operator/test/e2e/helpers"
 )
 
 var _ = Describe("Cluster Runtime Controls", Label("lifecycle", "cluster", "runtime"), Ordered, func() {
 	ctx := context.Background()
 
 	var (
-		f *framework.Framework
-		c client.Client
+		f   *framework.Framework
+		c   client.Client
+		cfg *rest.Config
 	)
 
 	newDevelopmentCluster := func(name string) *openbaov1alpha1.OpenBaoCluster {
@@ -115,8 +122,46 @@ var _ = Describe("Cluster Runtime Controls", Label("lifecycle", "cluster", "runt
 		return cert
 	}
 
+	pluginChecksumForClusterArchitecture := func() string {
+		nodes := &corev1.NodeList{}
+		Expect(c.List(ctx, nodes)).To(Succeed())
+		Expect(nodes.Items).NotTo(BeEmpty())
+
+		arch := ""
+		for i := range nodes.Items {
+			node := &nodes.Items[i]
+			nodeArch := node.Labels["kubernetes.io/arch"]
+			if nodeArch == "" {
+				nodeArch = node.Status.NodeInfo.Architecture
+			}
+			if nodeArch == "" {
+				continue
+			}
+			if arch == "" {
+				arch = nodeArch
+				continue
+			}
+			if arch != nodeArch {
+				Skip(fmt.Sprintf("OCI plugin checksum fixture is single-architecture; cluster has both %q and %q nodes", arch, nodeArch))
+			}
+		}
+
+		switch arch {
+		case "amd64":
+			return "c8d23e6d31be2a59d0c269bb7243158c4c61c5073f7ba50ce6f1a0050e023e2d"
+		case "arm64":
+			return "b98cb1cbfd0f567d7b614efb0621aaba10c4deda865f5e5b3d155609ada2482e"
+		default:
+			Skip(fmt.Sprintf("OCI plugin checksum fixture is not defined for node architecture %q", arch))
+			return ""
+		}
+	}
+
 	BeforeAll(func() {
 		var err error
+		cfg, err = ctrlconfig.GetConfig()
+		Expect(err).NotTo(HaveOccurred())
+
 		f, err = framework.NewSetup(ctx, "cluster-runtime", operatorNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		c = f.Client
@@ -237,6 +282,140 @@ var _ = Describe("Cluster Runtime Controls", Label("lifecycle", "cluster", "runt
 			cert := parseServerCertificate(secret)
 			g.Expect(cert.DNSNames).To(ContainElement(host))
 		}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+	})
+
+	It("registers an OCI plugin with a writable plugin directory", Label(
+		"case:cluster-oci-plugin-install",
+		"covers:plugin-auto-download",
+		"covers:plugin-directory",
+	), func() {
+		const (
+			clusterName      = "plugin-cluster"
+			pluginPolicyName = "plugin-admin"
+			pluginRoleName   = "plugin-admin"
+		)
+
+		ok, err := platformsemver.AtLeast(openBaoVersion, 2, 5, 0)
+		Expect(err).NotTo(HaveOccurred())
+		if !ok {
+			Skip(fmt.Sprintf("declarative OCI plugin auto-download requires OpenBao >= 2.5.0; got %s", openBaoVersion))
+		}
+
+		pluginChecksum := pluginChecksumForClusterArchitecture()
+		port443 := intstr.FromInt(443)
+		tcp := corev1.ProtocolTCP
+
+		cluster := newDevelopmentCluster(clusterName)
+		cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
+			Plugin: &openbaov1alpha1.PluginConfig{
+				AutoDownload: ptr.To(true),
+				AutoRegister: ptr.To(true),
+			},
+		}
+		cluster.Spec.Network.EgressRules = append(cluster.Spec.Network.EgressRules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: "0.0.0.0/0",
+					},
+				},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: &tcp,
+					Port:     &port443,
+				},
+			},
+		})
+		cluster.Spec.Plugins = []openbaov1alpha1.Plugin{
+			{
+				Type:       "secret",
+				Name:       "aws",
+				Image:      "ghcr.io/openbao/openbao-plugin-secrets-aws",
+				Version:    "v0.0.1",
+				BinaryName: "openbao-plugin-secrets-aws",
+				SHA256Sum:  pluginChecksum,
+			},
+		}
+		cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
+			Enabled: true,
+			OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+				Enabled: true,
+			},
+			Requests: append(
+				framework.DefaultAdminSelfInitRequests(),
+				e2ehelpers.CreateJWTPolicyRoleRequests(
+					f.Namespace,
+					"default",
+					pluginPolicyName,
+					pluginRoleName,
+					`path "*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}`,
+				)...,
+			),
+		}
+
+		Expect(c.Create(ctx, cluster)).To(Succeed())
+		DeferCleanup(func() { _ = c.Delete(ctx, cluster) })
+
+		By("waiting for the OpenBao pod to become ready")
+		sts, err := f.WaitForStatefulSetReady(ctx, clusterName, 1, 10*time.Minute, framework.DefaultPollInterval)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the StatefulSet mounts a writable plugin directory")
+		pluginVolumeFound := false
+		for _, volume := range sts.Spec.Template.Spec.Volumes {
+			if volume.Name == constants.VolumePlugins {
+				pluginVolumeFound = true
+				Expect(volume.EmptyDir).NotTo(BeNil())
+				break
+			}
+		}
+		Expect(pluginVolumeFound).To(BeTrue())
+
+		pluginMountFound := false
+		for _, container := range sts.Spec.Template.Spec.Containers {
+			if container.Name != constants.ContainerBao {
+				continue
+			}
+			for _, mount := range container.VolumeMounts {
+				if mount.Name == constants.VolumePlugins {
+					pluginMountFound = true
+					Expect(mount.MountPath).To(Equal(constants.PathPlugins))
+					Expect(mount.ReadOnly).To(BeFalse())
+					break
+				}
+			}
+		}
+		Expect(pluginMountFound).To(BeTrue())
+
+		waitForClusterAvailable(clusterName)
+
+		By("verifying OpenBao registered the declarative OCI plugin")
+		Eventually(func(g Gomega) {
+			baoAddr, err := e2ehelpers.ResolveActiveOpenBaoAddress(ctx, c, f.Namespace, clusterName)
+			g.Expect(err).NotTo(HaveOccurred())
+			_, err = e2ehelpers.RunCommandViaJWT(
+				ctx,
+				cfg,
+				c,
+				f.Namespace,
+				openBaoImage,
+				baoAddr,
+				"default",
+				pluginRoleName,
+				map[string]string{
+					constants.LabelOpenBaoCluster:   clusterName,
+					constants.LabelOpenBaoComponent: constants.ComponentBackup,
+				},
+				fmt.Sprintf(`
+bao plugin list secret | grep -E '^aws[[:space:]]+v0\.0\.1'
+bao plugin info -version=v0.0.1 secret aws | grep %q
+`, pluginChecksum),
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 	})
 
 })

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,9 +12,9 @@ Notes:
 ## Summary
 
 - Files: `19`
-- Specs: `77`
-- Explicit case IDs: `31`
-- Coverage tags: `41`
+- Specs: `78`
+- Explicit case IDs: `32`
+- Coverage tags: `43`
 
 ## Suites
 
@@ -23,7 +23,7 @@ Notes:
 | [Cluster Lifecycle: Deletion Policy](suites/Cluster_DeletionPolicy_test.md) | 3 | 3 | 0 | `lifecycle`, `cluster`, `deletion` | `test/e2e/Cluster_DeletionPolicy_test.go` |
 | [Cluster Lifecycle](suites/Cluster_Lifecycle_test.md) | 7 | 0 | 0 | `lifecycle`, `cluster`, `profile-development`, `scaling`, `autopilot`, `smoke`, `critical`, `tenant` | `test/e2e/Cluster_Lifecycle_test.go` |
 | [Hardened profile (External TLS + Transit auto-unseal + SelfInit)](suites/Cluster_Profile_Hardened_test.md) | 5 | 3 | 0 | `profile-hardened`, `security`, `cluster`, `upgrade`, `bluegreen`, `hardened`, `rolling` | `test/e2e/Cluster_Profile_Hardened_test.go` |
-| [Cluster Runtime Controls](suites/Cluster_Runtime_Controls_test.md) | 2 | 2 | 0 | `lifecycle`, `cluster`, `runtime` | `test/e2e/Cluster_Runtime_Controls_test.go` |
+| [Cluster Runtime Controls](suites/Cluster_Runtime_Controls_test.md) | 3 | 3 | 0 | `lifecycle`, `cluster`, `runtime` | `test/e2e/Cluster_Runtime_Controls_test.go` |
 | [ACME TLS (OpenBao native ACME client)](suites/Cluster_TLS_ACME_test.md) | 2 | 1 | 0 | `tls`, `security`, `slow` | `test/e2e/Cluster_TLS_ACME_test.go` |
 | [Cluster TLS Lifecycle](suites/Cluster_TLS_Lifecycle_test.md) | 1 | 1 | 0 | `tls`, `cluster`, `lifecycle` | `test/e2e/Cluster_TLS_Lifecycle_test.go` |
 | [Cluster KMIP Unseal](suites/Cluster_Unseal_KMIP_test.md) | 1 | 0 | 0 | `cluster`, `lifecycle`, `unseal`, `kmip`, `hsm` | `test/e2e/Cluster_Unseal_KMIP_test.go` |
@@ -66,6 +66,8 @@ Notes:
 | `manager-metrics-endpoint` | 1 |
 | `network-isolation` | 1 |
 | `operation-lock` | 1 |
+| `plugin-auto-download` | 1 |
+| `plugin-directory` | 1 |
 | `pod-rollout` | 1 |
 | `pod-stability` | 1 |
 | `post-failover-reconcile` | 1 |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -593,6 +593,44 @@
     "suiteTitle": ""
   },
   {
+    "id": "cluster-oci-plugin-install",
+    "generatedId": "cluster-runtime-controls-registers-an-oci-plugin-with-a-b5786be4",
+    "caseLabel": "cluster-oci-plugin-install",
+    "coverage": [
+      "plugin-auto-download",
+      "plugin-directory"
+    ],
+    "file": "test/e2e/Cluster_Runtime_Controls_test.go",
+    "type": "It",
+    "name": "registers an OCI plugin with a writable plugin directory",
+    "path": [
+      "Cluster Runtime Controls",
+      "registers an OCI plugin with a writable plugin directory"
+    ],
+    "labels": [
+      "lifecycle",
+      "cluster",
+      "runtime",
+      "case:cluster-oci-plugin-install",
+      "covers:plugin-auto-download",
+      "covers:plugin-directory"
+    ],
+    "domainLabels": [
+      "lifecycle",
+      "cluster",
+      "runtime"
+    ],
+    "steps": [
+      "waiting for the OpenBao pod to become ready",
+      "verifying the StatefulSet mounts a writable plugin directory",
+      "verifying OpenBao registered the declarative OCI plugin"
+    ],
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "cluster-restart-at-rolls-pod",
     "generatedId": "cluster-runtime-controls-rolls-the-openbao-pod-when-runtime-c0619ab5",
     "caseLabel": "cluster-restart-at-rolls-pod",

--- a/test/e2e/catalog/suites/Cluster_Runtime_Controls_test.md
+++ b/test/e2e/catalog/suites/Cluster_Runtime_Controls_test.md
@@ -9,6 +9,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | Case ID | Spec | State | Covers | Labels |
 | --- | --- | --- | --- | --- |
 | `cluster-ingress-host-san` | creates ingress resources and includes the ingress host in the server certificate | active | `ingress`, `external-service`, `tls-san` | `lifecycle`, `cluster`, `runtime` |
+| `cluster-oci-plugin-install` | registers an OCI plugin with a writable plugin directory | active | `plugin-auto-download`, `plugin-directory` | `lifecycle`, `cluster`, `runtime` |
 | `cluster-restart-at-rolls-pod` | rolls the OpenBao pod when runtime.restartAt changes | active | `restart-at`, `pod-rollout` | `lifecycle`, `cluster`, `runtime` |
 
 ## `cluster-ingress-host-san`
@@ -26,6 +27,24 @@ Labels: `lifecycle`, `cluster`, `runtime`
 Recorded checkpoints:
 - verifying the ingress and public service are created for external access
 - verifying the operator-managed server certificate includes the ingress host
+
+
+## `cluster-oci-plugin-install`
+
+Path: `Cluster Runtime Controls > registers an OCI plugin with a writable plugin directory`
+
+State: `active`
+
+Generated fallback ID: `cluster-runtime-controls-registers-an-oci-plugin-with-a-b5786be4`
+
+Covers: `plugin-auto-download`, `plugin-directory`
+
+Labels: `lifecycle`, `cluster`, `runtime`
+
+Recorded checkpoints:
+- waiting for the OpenBao pod to become ready
+- verifying the StatefulSet mounts a writable plugin directory
+- verifying OpenBao registered the declarative OCI plugin
 
 
 ## `cluster-restart-at-rolls-pod`

--- a/test/e2e/suites.yaml
+++ b/test/e2e/suites.yaml
@@ -418,6 +418,8 @@ suites:
     coverage:
       - external-service
       - ingress
+      - plugin-auto-download
+      - plugin-directory
       - pod-rollout
       - restart-at
       - tls-san


### PR DESCRIPTION
## Summary

- Mount a writable `emptyDir` at `/openbao/plugins` when declarative OCI plugin auto-download is enabled for an OpenBaoCluster.
- Render OpenBao's `plugin_directory` to the mounted path and keep the mount conditional so clusters without OCI plugin downloads are unchanged.
- Align plugin `downloadBehavior` values with OpenBao's accepted `fail` / `continue` enum.
- Clarify plugin docs around OCI `image` plugins, preinstalled `command` plugins, auto-registration, and the image-root binary expectation.
- Add a Cluster Runtime Controls E2E case that provisions an OCI plugin, checks the writable plugin mount, and verifies declarative catalog registration.

## Related Issues

Closes #417

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

The workload change only adds the `plugins` `emptyDir` volume and OpenBao container mount when `spec.configuration.plugin.autoDownload=true` and at least one declarative plugin uses `image`. Existing clusters without OCI plugin auto-download should render the same pod volume shape as before.

The `downloadBehavior` schema now rejects unsupported values and keeps the documented values aligned with OpenBao. Users that configured the previously documented `direct` value must move to `continue` or `fail`; OpenBao itself rejects `direct`.

## Verification

- `go test ./internal/service/workload ./internal/adapter/config ./api/v1alpha1`
- `go test -tags=e2e ./test/e2e -run '^$'`
- `make test-e2e E2E_LABEL_FILTER='case:cluster-oci-plugin-install' E2E_FAIL_ON_EMPTY=true E2E_TIMEOUT=30m` (1 selected, 1 passed, 77 skipped)
- `make e2e-catalog e2e-manifest-validate e2e-ci-matrix-validate e2e-nightly-matrix-validate e2e-release-matrix-validate`
- `make verify-e2e-manifest`
- `make verify-generated verify-helm`
- `make helm-test`
- `npm --prefix website run build` (passes with the existing `vscode-languageserver-types` webpack warning)
- Pre-push hook: `make lint-ci`
- Manual k3d verification: official `ghcr.io/openbao/openbao-plugin-secrets-aws:v0.0.1` downloaded, registered, and enabled successfully with `/openbao/plugins` mounted writable.

## Reviewer Notes

OpenBao's OCI plugin downloader expects the plugin binary at the image root. The NATS plugin image discussed in #417 stores its binary under `/etc/vault/vault_plugins`, so after this fix it moves from the read-only filesystem failure to an image-layout failure. That appears to be an OpenBao OCI plugin contract rather than an operator path issue, and the docs now call this out.

The E2E case covers the operator-owned regression surface: OpenBao starts with OCI plugin auto-download enabled, the generated StatefulSet mounts a writable plugin directory, and OpenBao registers the declarative plugin metadata. Full plugin execution remains covered by the manual k3d smoke test because it also depends on OpenBao materializing and executing the downloaded binary.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
