### PR TITLE
fix(config): align audit device options with OpenBao

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -1050,6 +1050,12 @@ type SelfInitRequest struct {
 // SelfInitAuditDevice provides structured configuration for enabling audit devices
 // via self-init requests. This replaces the need for raw JSON in the Data field.
 // See: https://openbao.org/api-docs/system/audit/
+// +kubebuilder:validation:XValidation:rule="self.type == 'file' || !has(self.fileOptions)",message="fileOptions is only supported when type is file"
+// +kubebuilder:validation:XValidation:rule="self.type != 'file' || has(self.fileOptions)",message="fileOptions is required when type is file"
+// +kubebuilder:validation:XValidation:rule="self.type == 'http' || !has(self.httpOptions)",message="httpOptions is only supported when type is http"
+// +kubebuilder:validation:XValidation:rule="self.type != 'http' || has(self.httpOptions)",message="httpOptions is required when type is http"
+// +kubebuilder:validation:XValidation:rule="self.type == 'syslog' || !has(self.syslogOptions)",message="syslogOptions is only supported when type is syslog"
+// +kubebuilder:validation:XValidation:rule="self.type == 'socket' || !has(self.socketOptions)",message="socketOptions is only supported when type is socket"
 type SelfInitAuditDevice struct {
 	// Type is the type of audit device (e.g., "file", "syslog", "socket", "http").
 	// +kubebuilder:validation:Enum=file;syslog;socket;http
@@ -2006,6 +2012,8 @@ type OpenBaoClusterSpec struct {
 	// Audit configures declarative audit devices for the OpenBao cluster.
 	// See: https://openbao.org/docs/configuration/audit/
 	// +optional
+	// +listType=map
+	// +listMapKey=path
 	Audit []AuditDevice `json:"audit,omitempty"`
 	// Plugins configures declarative plugins for the OpenBao cluster.
 	// See: https://openbao.org/docs/configuration/plugins/
@@ -2481,6 +2489,12 @@ type OpenBaoClusterList struct {
 
 // AuditDevice defines a declarative audit device configuration.
 // See: https://openbao.org/docs/configuration/audit/
+// +kubebuilder:validation:XValidation:rule="self.type == 'file' || !has(self.fileOptions)",message="fileOptions is only supported when type is file"
+// +kubebuilder:validation:XValidation:rule="self.type != 'file' || has(self.fileOptions) || has(self.options)",message="file audit devices require fileOptions or raw options containing file_path"
+// +kubebuilder:validation:XValidation:rule="self.type == 'http' || !has(self.httpOptions)",message="httpOptions is only supported when type is http"
+// +kubebuilder:validation:XValidation:rule="self.type != 'http' || has(self.httpOptions) || has(self.options)",message="http audit devices require httpOptions or raw options containing uri"
+// +kubebuilder:validation:XValidation:rule="self.type == 'syslog' || !has(self.syslogOptions)",message="syslogOptions is only supported when type is syslog"
+// +kubebuilder:validation:XValidation:rule="self.type == 'socket' || !has(self.socketOptions)",message="socketOptions is only supported when type is socket"
 type AuditDevice struct {
 	// Type is the type of audit device (e.g., "file", "syslog", "socket", "http").
 	// +kubebuilder:validation:Enum=file;syslog;socket;http
@@ -2508,10 +2522,11 @@ type AuditDevice struct {
 	// Only used when Type is "socket".
 	// +optional
 	SocketOptions *SocketAuditOptions `json:"socketOptions,omitempty"`
-	// Options contains device-specific configuration options as a map.
+	// Options contains device-specific configuration options as a string map.
 	// This is a fallback for backward compatibility and advanced use cases.
 	// If structured options (FileOptions, HTTPOptions, etc.) are provided, they take precedence.
-	// The structure depends on the audit device type.
+	// OpenBao audit options are string-to-string; scalar JSON values are rendered as strings,
+	// while nested objects and arrays are rejected. For HTTP headers, prefer httpOptions.headers.
 	// +optional
 	Options *apiextensionsv1.JSON `json:"options,omitempty"`
 }
@@ -2537,7 +2552,8 @@ type HTTPAuditOptions struct {
 	URI string `json:"uri"`
 	// Headers is a JSON object describing headers. Must take the shape map[string][]string,
 	// i.e., an object of headers, with each having one or more values.
-	// Headers without values will be ignored.
+	// Headers without values will be ignored. The operator renders this object as OpenBao's
+	// expected JSON-encoded options.headers string.
 	// +optional
 	Headers *apiextensionsv1.JSON `json:"headers,omitempty"`
 }

--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -2490,9 +2490,7 @@ type OpenBaoClusterList struct {
 // AuditDevice defines a declarative audit device configuration.
 // See: https://openbao.org/docs/configuration/audit/
 // +kubebuilder:validation:XValidation:rule="self.type == 'file' || !has(self.fileOptions)",message="fileOptions is only supported when type is file"
-// +kubebuilder:validation:XValidation:rule="self.type != 'file' || has(self.fileOptions) || has(self.options)",message="file audit devices require fileOptions or raw options containing file_path"
 // +kubebuilder:validation:XValidation:rule="self.type == 'http' || !has(self.httpOptions)",message="httpOptions is only supported when type is http"
-// +kubebuilder:validation:XValidation:rule="self.type != 'http' || has(self.httpOptions) || has(self.options)",message="http audit devices require httpOptions or raw options containing uri"
 // +kubebuilder:validation:XValidation:rule="self.type == 'syslog' || !has(self.syslogOptions)",message="syslogOptions is only supported when type is syslog"
 // +kubebuilder:validation:XValidation:rule="self.type == 'socket' || !has(self.socketOptions)",message="socketOptions is only supported when type is socket"
 type AuditDevice struct {

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -176,14 +176,8 @@ spec:
                   x-kubernetes-validations:
                   - message: fileOptions is only supported when type is file
                     rule: self.type == 'file' || !has(self.fileOptions)
-                  - message: file audit devices require fileOptions or raw options
-                      containing file_path
-                    rule: self.type != 'file' || has(self.fileOptions) || has(self.options)
                   - message: httpOptions is only supported when type is http
                     rule: self.type == 'http' || !has(self.httpOptions)
-                  - message: http audit devices require httpOptions or raw options
-                      containing uri
-                    rule: self.type != 'http' || has(self.httpOptions) || has(self.options)
                   - message: syslogOptions is only supported when type is syslog
                     rule: self.type == 'syslog' || !has(self.syslogOptions)
                   - message: socketOptions is only supported when type is socket

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -97,7 +97,8 @@ spec:
                           description: |-
                             Headers is a JSON object describing headers. Must take the shape map[string][]string,
                             i.e., an object of headers, with each having one or more values.
-                            Headers without values will be ignored.
+                            Headers without values will be ignored. The operator renders this object as OpenBao's
+                            expected JSON-encoded options.headers string.
                           x-kubernetes-preserve-unknown-fields: true
                         uri:
                           description: URI is the URI of the remote server where the
@@ -109,10 +110,11 @@ spec:
                       type: object
                     options:
                       description: |-
-                        Options contains device-specific configuration options as a map.
+                        Options contains device-specific configuration options as a string map.
                         This is a fallback for backward compatibility and advanced use cases.
                         If structured options (FileOptions, HTTPOptions, etc.) are provided, they take precedence.
-                        The structure depends on the audit device type.
+                        OpenBao audit options are string-to-string; scalar JSON values are rendered as strings,
+                        while nested objects and arrays are rejected. For HTTP headers, prefer httpOptions.headers.
                       x-kubernetes-preserve-unknown-fields: true
                     path:
                       description: Path is the path of the audit device in the root
@@ -171,7 +173,25 @@ spec:
                   - path
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: fileOptions is only supported when type is file
+                    rule: self.type == 'file' || !has(self.fileOptions)
+                  - message: file audit devices require fileOptions or raw options
+                      containing file_path
+                    rule: self.type != 'file' || has(self.fileOptions) || has(self.options)
+                  - message: httpOptions is only supported when type is http
+                    rule: self.type == 'http' || !has(self.httpOptions)
+                  - message: http audit devices require httpOptions or raw options
+                      containing uri
+                    rule: self.type != 'http' || has(self.httpOptions) || has(self.options)
+                  - message: syslogOptions is only supported when type is syslog
+                    rule: self.type == 'syslog' || !has(self.syslogOptions)
+                  - message: socketOptions is only supported when type is socket
+                    rule: self.type == 'socket' || !has(self.socketOptions)
                 type: array
+                x-kubernetes-list-map-keys:
+                - path
+                x-kubernetes-list-type: map
               backup:
                 description: Backup configures scheduled backups for the cluster.
                 properties:
@@ -3428,7 +3448,8 @@ spec:
                                   description: |-
                                     Headers is a JSON object describing headers. Must take the shape map[string][]string,
                                     i.e., an object of headers, with each having one or more values.
-                                    Headers without values will be ignored.
+                                    Headers without values will be ignored. The operator renders this object as OpenBao's
+                                    expected JSON-encoded options.headers string.
                                   x-kubernetes-preserve-unknown-fields: true
                                 uri:
                                   description: URI is the URI of the remote server
@@ -3489,6 +3510,21 @@ spec:
                           required:
                           - type
                           type: object
+                          x-kubernetes-validations:
+                          - message: fileOptions is only supported when type is file
+                            rule: self.type == 'file' || !has(self.fileOptions)
+                          - message: fileOptions is required when type is file
+                            rule: self.type != 'file' || has(self.fileOptions)
+                          - message: httpOptions is only supported when type is http
+                            rule: self.type == 'http' || !has(self.httpOptions)
+                          - message: httpOptions is required when type is http
+                            rule: self.type != 'http' || has(self.httpOptions)
+                          - message: syslogOptions is only supported when type is
+                              syslog
+                            rule: self.type == 'syslog' || !has(self.syslogOptions)
+                          - message: socketOptions is only supported when type is
+                              socket
+                            rule: self.type == 'socket' || !has(self.socketOptions)
                         authMethod:
                           description: |-
                             AuthMethod configures an auth method when Path starts with "sys/auth/".

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -175,14 +175,8 @@ spec:
                   x-kubernetes-validations:
                   - message: fileOptions is only supported when type is file
                     rule: self.type == 'file' || !has(self.fileOptions)
-                  - message: file audit devices require fileOptions or raw options
-                      containing file_path
-                    rule: self.type != 'file' || has(self.fileOptions) || has(self.options)
                   - message: httpOptions is only supported when type is http
                     rule: self.type == 'http' || !has(self.httpOptions)
-                  - message: http audit devices require httpOptions or raw options
-                      containing uri
-                    rule: self.type != 'http' || has(self.httpOptions) || has(self.options)
                   - message: syslogOptions is only supported when type is syslog
                     rule: self.type == 'syslog' || !has(self.syslogOptions)
                   - message: socketOptions is only supported when type is socket

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -96,7 +96,8 @@ spec:
                           description: |-
                             Headers is a JSON object describing headers. Must take the shape map[string][]string,
                             i.e., an object of headers, with each having one or more values.
-                            Headers without values will be ignored.
+                            Headers without values will be ignored. The operator renders this object as OpenBao's
+                            expected JSON-encoded options.headers string.
                           x-kubernetes-preserve-unknown-fields: true
                         uri:
                           description: URI is the URI of the remote server where the
@@ -108,10 +109,11 @@ spec:
                       type: object
                     options:
                       description: |-
-                        Options contains device-specific configuration options as a map.
+                        Options contains device-specific configuration options as a string map.
                         This is a fallback for backward compatibility and advanced use cases.
                         If structured options (FileOptions, HTTPOptions, etc.) are provided, they take precedence.
-                        The structure depends on the audit device type.
+                        OpenBao audit options are string-to-string; scalar JSON values are rendered as strings,
+                        while nested objects and arrays are rejected. For HTTP headers, prefer httpOptions.headers.
                       x-kubernetes-preserve-unknown-fields: true
                     path:
                       description: Path is the path of the audit device in the root
@@ -170,7 +172,25 @@ spec:
                   - path
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: fileOptions is only supported when type is file
+                    rule: self.type == 'file' || !has(self.fileOptions)
+                  - message: file audit devices require fileOptions or raw options
+                      containing file_path
+                    rule: self.type != 'file' || has(self.fileOptions) || has(self.options)
+                  - message: httpOptions is only supported when type is http
+                    rule: self.type == 'http' || !has(self.httpOptions)
+                  - message: http audit devices require httpOptions or raw options
+                      containing uri
+                    rule: self.type != 'http' || has(self.httpOptions) || has(self.options)
+                  - message: syslogOptions is only supported when type is syslog
+                    rule: self.type == 'syslog' || !has(self.syslogOptions)
+                  - message: socketOptions is only supported when type is socket
+                    rule: self.type == 'socket' || !has(self.socketOptions)
                 type: array
+                x-kubernetes-list-map-keys:
+                - path
+                x-kubernetes-list-type: map
               backup:
                 description: Backup configures scheduled backups for the cluster.
                 properties:
@@ -3427,7 +3447,8 @@ spec:
                                   description: |-
                                     Headers is a JSON object describing headers. Must take the shape map[string][]string,
                                     i.e., an object of headers, with each having one or more values.
-                                    Headers without values will be ignored.
+                                    Headers without values will be ignored. The operator renders this object as OpenBao's
+                                    expected JSON-encoded options.headers string.
                                   x-kubernetes-preserve-unknown-fields: true
                                 uri:
                                   description: URI is the URI of the remote server
@@ -3488,6 +3509,21 @@ spec:
                           required:
                           - type
                           type: object
+                          x-kubernetes-validations:
+                          - message: fileOptions is only supported when type is file
+                            rule: self.type == 'file' || !has(self.fileOptions)
+                          - message: fileOptions is required when type is file
+                            rule: self.type != 'file' || has(self.fileOptions)
+                          - message: httpOptions is only supported when type is http
+                            rule: self.type == 'http' || !has(self.httpOptions)
+                          - message: httpOptions is required when type is http
+                            rule: self.type != 'http' || has(self.httpOptions)
+                          - message: syslogOptions is only supported when type is
+                              syslog
+                            rule: self.type == 'syslog' || !has(self.syslogOptions)
+                          - message: socketOptions is only supported when type is
+                              socket
+                            rule: self.type == 'socket' || !has(self.socketOptions)
                         authMethod:
                           description: |-
                             AuthMethod configures an auth method when Path starts with "sys/auth/".

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -160,7 +160,7 @@ _Appears in:_
 | `httpOptions` _[HTTPAuditOptions](#httpauditoptions)_ | HTTPOptions configures options for HTTP audit devices.<br />Only used when Type is "http". |  | Optional: \{\} <br /> |
 | `syslogOptions` _[SyslogAuditOptions](#syslogauditoptions)_ | SyslogOptions configures options for syslog audit devices.<br />Only used when Type is "syslog". |  | Optional: \{\} <br /> |
 | `socketOptions` _[SocketAuditOptions](#socketauditoptions)_ | SocketOptions configures options for socket audit devices.<br />Only used when Type is "socket". |  | Optional: \{\} <br /> |
-| `options` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#json-v1-apiextensions-k8s-io)_ | Options contains device-specific configuration options as a map.<br />This is a fallback for backward compatibility and advanced use cases.<br />If structured options (FileOptions, HTTPOptions, etc.) are provided, they take precedence.<br />The structure depends on the audit device type. |  | Optional: \{\} <br /> |
+| `options` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#json-v1-apiextensions-k8s-io)_ | Options contains device-specific configuration options as a string map.<br />This is a fallback for backward compatibility and advanced use cases.<br />If structured options (FileOptions, HTTPOptions, etc.) are provided, they take precedence.<br />OpenBao audit options are string-to-string; scalar JSON values are rendered as strings,<br />while nested objects and arrays are rejected. For HTTP headers, prefer httpOptions.headers. |  | Optional: \{\} <br /> |
 
 
 #### AutoRollbackConfig
@@ -642,7 +642,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `uri` _string_ | URI is the URI of the remote server where the audit logs will be written. |  | MinLength: 1 <br /> |
-| `headers` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#json-v1-apiextensions-k8s-io)_ | Headers is a JSON object describing headers. Must take the shape map[string][]string,<br />i.e., an object of headers, with each having one or more values.<br />Headers without values will be ignored. |  | Optional: \{\} <br /> |
+| `headers` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#json-v1-apiextensions-k8s-io)_ | Headers is a JSON object describing headers. Must take the shape map[string][]string,<br />i.e., an object of headers, with each having one or more values.<br />Headers without values will be ignored. The operator renders this object as OpenBao's<br />expected JSON-encoded options.headers string. |  | Optional: \{\} <br /> |
 
 
 #### ImageVerificationConfig

--- a/internal/adapter/config/audit_options.go
+++ b/internal/adapter/config/audit_options.go
@@ -1,0 +1,289 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+const (
+	auditTypeFile   = "file"
+	auditTypeHTTP   = "http"
+	auditTypeSyslog = "syslog"
+	auditTypeSocket = "socket"
+
+	auditOptionFilePath     = "file_path"
+	auditOptionMode         = "mode"
+	auditOptionURI          = "uri"
+	auditOptionHeaders      = "headers"
+	auditOptionFacility     = "facility"
+	auditOptionTag          = "tag"
+	auditOptionAddress      = "address"
+	auditOptionSocketType   = "socket_type"
+	auditOptionWriteTimeout = "write_timeout"
+
+	auditDeviceContext          = "audit device"
+	auditDeviceOptionsContext   = "audit device options"
+	auditHTTPHeadersContext     = "HTTP audit device headers"
+	selfInitAuditHeadersContext = "audit device headers"
+)
+
+type auditOptionFamilies struct {
+	file   bool
+	http   bool
+	syslog bool
+	socket bool
+}
+
+func auditOptionFamiliesForDevice(device openbaov1alpha1.AuditDevice) auditOptionFamilies {
+	return auditOptionFamilies{
+		file:   device.FileOptions != nil,
+		http:   device.HTTPOptions != nil,
+		syslog: device.SyslogOptions != nil,
+		socket: device.SocketOptions != nil,
+	}
+}
+
+func auditOptionFamiliesForSelfInit(device *openbaov1alpha1.SelfInitAuditDevice) auditOptionFamilies {
+	return auditOptionFamilies{
+		file:   device.FileOptions != nil,
+		http:   device.HTTPOptions != nil,
+		syslog: device.SyslogOptions != nil,
+		socket: device.SocketOptions != nil,
+	}
+}
+
+func validateDeclarativeAuditDevice(index int, device openbaov1alpha1.AuditDevice) (string, string, error) {
+	context := fmt.Sprintf("audit device %d", index)
+	auditType := strings.TrimSpace(device.Type)
+	auditPath := normalizeAuditPath(device.Path)
+	if auditType == "" {
+		return "", "", fmt.Errorf("%s: type is required", context)
+	}
+	if auditPath == "" {
+		return "", "", fmt.Errorf("%s: path is required", context)
+	}
+	if err := validateAuditOptionFamilies(context, auditType, auditOptionFamiliesForDevice(device)); err != nil {
+		return "", "", err
+	}
+
+	switch auditType {
+	case auditTypeFile:
+		if device.FileOptions != nil {
+			if strings.TrimSpace(device.FileOptions.FilePath) == "" {
+				return "", "", fmt.Errorf("%s: fileOptions.filePath is required for file audit devices", context)
+			}
+		} else {
+			hasFilePath, err := rawAuditOptionHasNonEmptyKey(device.Options, auditOptionFilePath)
+			if err != nil {
+				return "", "", fmt.Errorf("%s: %w", context, err)
+			}
+			if !hasFilePath {
+				return "", "", fmt.Errorf("%s: fileOptions.filePath or options.file_path is required for file audit devices", context)
+			}
+		}
+	case auditTypeHTTP:
+		if device.HTTPOptions != nil {
+			if strings.TrimSpace(device.HTTPOptions.URI) == "" {
+				return "", "", fmt.Errorf("%s: httpOptions.uri is required for http audit devices", context)
+			}
+		} else {
+			hasURI, err := rawAuditOptionHasNonEmptyKey(device.Options, auditOptionURI)
+			if err != nil {
+				return "", "", fmt.Errorf("%s: %w", context, err)
+			}
+			if !hasURI {
+				return "", "", fmt.Errorf("%s: httpOptions.uri or options.uri is required for http audit devices", context)
+			}
+		}
+	case auditTypeSyslog, auditTypeSocket:
+	default:
+		return "", "", fmt.Errorf("%s: unsupported audit device type %q", context, auditType)
+	}
+
+	return auditType, auditPath, nil
+}
+
+func validateSelfInitAuditDevice(device *openbaov1alpha1.SelfInitAuditDevice) error {
+	if device == nil {
+		return fmt.Errorf("audit device config is nil")
+	}
+	auditType := strings.TrimSpace(device.Type)
+	if auditType == "" {
+		return fmt.Errorf("audit device type is required")
+	}
+	if err := validateAuditOptionFamilies(auditDeviceContext, auditType, auditOptionFamiliesForSelfInit(device)); err != nil {
+		return err
+	}
+	switch auditType {
+	case auditTypeFile:
+		if device.FileOptions != nil && strings.TrimSpace(device.FileOptions.FilePath) == "" {
+			return fmt.Errorf("fileOptions.filePath is required for file audit device")
+		}
+	case auditTypeHTTP:
+		if device.HTTPOptions != nil && strings.TrimSpace(device.HTTPOptions.URI) == "" {
+			return fmt.Errorf("httpOptions.uri is required for http audit device")
+		}
+	}
+	return nil
+}
+
+func validateAuditOptionFamilies(context, auditType string, families auditOptionFamilies) error {
+	switch {
+	case auditType != auditTypeFile && families.file:
+		return fmt.Errorf("%s: fileOptions is only supported for file audit devices", context)
+	case auditType != auditTypeHTTP && families.http:
+		return fmt.Errorf("%s: httpOptions is only supported for http audit devices", context)
+	case auditType != auditTypeSyslog && families.syslog:
+		return fmt.Errorf("%s: syslogOptions is only supported for syslog audit devices", context)
+	case auditType != auditTypeSocket && families.socket:
+		return fmt.Errorf("%s: socketOptions is only supported for socket audit devices", context)
+	default:
+		return nil
+	}
+}
+
+func normalizeAuditPath(path string) string {
+	return strings.Trim(strings.TrimSpace(path), "/")
+}
+
+func rawAuditOptionHasNonEmptyKey(options *apiextensionsv1.JSON, key string) (bool, error) {
+	if options == nil || len(bytes.TrimSpace(options.Raw)) == 0 {
+		return false, nil
+	}
+	decoded, err := decodeAuditStringOptions(options.Raw, auditDeviceOptionsContext)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(decoded[key]) != "", nil
+}
+
+func decodeAuditStringOptions(raw []byte, context string) (map[string]string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.UseNumber()
+	var decoded map[string]any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("%s must be a JSON object with string-compatible scalar values: %w", context, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("%s must contain exactly one JSON object", context)
+	}
+	if decoded == nil {
+		return nil, fmt.Errorf("%s must be a JSON object with string-compatible scalar values", context)
+	}
+
+	options := make(map[string]string, len(decoded))
+	for key, value := range decoded {
+		if strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("%s contains an empty option key", context)
+		}
+		switch typed := value.(type) {
+		case string:
+			options[key] = typed
+		case bool:
+			options[key] = strconv.FormatBool(typed)
+		case json.Number:
+			options[key] = typed.String()
+		default:
+			return nil, fmt.Errorf("%s option %q must be a string-compatible scalar, got %T", context, key, value)
+		}
+	}
+
+	return options, nil
+}
+
+func auditOptionsToCty(options map[string]string) map[string]cty.Value {
+	ctyOptions := make(map[string]cty.Value, len(options))
+	for key, value := range options {
+		ctyOptions[key] = cty.StringVal(value)
+	}
+	return ctyOptions
+}
+
+func buildFileAuditOptions(options *openbaov1alpha1.FileAuditOptions) map[string]cty.Value {
+	rendered := map[string]cty.Value{
+		auditOptionFilePath: cty.StringVal(options.FilePath),
+	}
+	if options.Mode != "" {
+		rendered[auditOptionMode] = cty.StringVal(options.Mode)
+	}
+	return rendered
+}
+
+func buildHTTPAuditOptions(options *openbaov1alpha1.HTTPAuditOptions, headersContext string) (map[string]cty.Value, error) {
+	rendered := map[string]cty.Value{
+		auditOptionURI: cty.StringVal(options.URI),
+	}
+	if options.Headers != nil && len(options.Headers.Raw) > 0 {
+		headers, err := normalizeHTTPAuditHeaders(options.Headers.Raw, headersContext)
+		if err != nil {
+			return nil, err
+		}
+		rendered[auditOptionHeaders] = cty.StringVal(headers)
+	}
+	return rendered, nil
+}
+
+func buildSyslogAuditOptions(options *openbaov1alpha1.SyslogAuditOptions) map[string]cty.Value {
+	rendered := make(map[string]cty.Value)
+	if options.Facility != "" {
+		rendered[auditOptionFacility] = cty.StringVal(options.Facility)
+	}
+	if options.Tag != "" {
+		rendered[auditOptionTag] = cty.StringVal(options.Tag)
+	}
+	return rendered
+}
+
+func buildSocketAuditOptions(options *openbaov1alpha1.SocketAuditOptions) map[string]cty.Value {
+	rendered := make(map[string]cty.Value)
+	if options.Address != "" {
+		rendered[auditOptionAddress] = cty.StringVal(options.Address)
+	}
+	if options.SocketType != "" {
+		rendered[auditOptionSocketType] = cty.StringVal(options.SocketType)
+	}
+	if options.WriteTimeout != "" {
+		rendered[auditOptionWriteTimeout] = cty.StringVal(options.WriteTimeout)
+	}
+	return rendered
+}
+
+func normalizeHTTPAuditHeaders(raw []byte, context string) (string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return "", nil
+	}
+
+	var headers map[string][]string
+	if err := json.Unmarshal(trimmed, &headers); err != nil {
+		return "", fmt.Errorf("%s must be a JSON object with string array values: %w", context, err)
+	}
+	if headers == nil {
+		return "", fmt.Errorf("%s must be a JSON object with string array values", context)
+	}
+	for header := range headers {
+		if strings.TrimSpace(header) == "" {
+			return "", fmt.Errorf("%s contains an empty header name", context)
+		}
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, trimmed); err != nil {
+		return "", fmt.Errorf("compact %s: %w", context, err)
+	}
+	return compact.String(), nil
+}

--- a/internal/adapter/config/builder_test.go
+++ b/internal/adapter/config/builder_test.go
@@ -266,6 +266,163 @@ func TestRenderHCLWithAuditPluginsTelemetry(t *testing.T) {
 	compareGolden(t, "render_hcl_audit_plugins_telemetry", got)
 }
 
+func TestRenderHCLWithHTTPAuditHeaders(t *testing.T) {
+	cluster := newMinimalCluster("http-audit", "default")
+	cluster.Spec.Audit = []openbaov1alpha1.AuditDevice{
+		{
+			Type: "http",
+			Path: "remote",
+			HTTPOptions: &openbaov1alpha1.HTTPAuditOptions{
+				URI:     "https://audit.example.test/ingest",
+				Headers: &apiextensionsv1.JSON{Raw: []byte(`{"X-Audit":["one","two"],"Authorization":["Bearer token"]}`)},
+			},
+		},
+	}
+
+	got, err := RenderHCL(cluster, InfrastructureDetails{
+		HeadlessServiceName: cluster.Name,
+		Namespace:           cluster.Namespace,
+		APIPort:             8200,
+		ClusterPort:         8201,
+	})
+	if err != nil {
+		t.Fatalf("RenderHCL() error = %v", err)
+	}
+
+	rendered := string(got)
+	want := `headers = "{\"X-Audit\":[\"one\",\"two\"],\"Authorization\":[\"Bearer token\"]}"`
+	if !strings.Contains(rendered, want) {
+		t.Fatalf("RenderHCL() headers not rendered as JSON string %q:\n%s", want, rendered)
+	}
+	if strings.Contains(rendered, `X-Audit =`) {
+		t.Fatalf("RenderHCL() rendered HTTP headers as nested HCL instead of a JSON string:\n%s", rendered)
+	}
+}
+
+func TestRenderHCLWithRawAuditOptionsCoercesScalarsToStrings(t *testing.T) {
+	cluster := newMinimalCluster("raw-audit", "default")
+	cluster.Spec.Audit = []openbaov1alpha1.AuditDevice{
+		{
+			Type: "socket",
+			Path: "custom-socket",
+			Options: &apiextensionsv1.JSON{
+				Raw: []byte(`{"address":"127.0.0.1:9000","log_raw":true,"timeout":42}`),
+			},
+		},
+	}
+
+	got, err := RenderHCL(cluster, InfrastructureDetails{
+		HeadlessServiceName: cluster.Name,
+		Namespace:           cluster.Namespace,
+		APIPort:             8200,
+		ClusterPort:         8201,
+	})
+	if err != nil {
+		t.Fatalf("RenderHCL() error = %v", err)
+	}
+
+	rendered := string(got)
+	for _, want := range []string{`log_raw = "true"`, `timeout = "42"`} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("RenderHCL() missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderHCLRejectsInvalidAuditDevices(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices []openbaov1alpha1.AuditDevice
+		wantErr string
+	}{
+		{
+			name: "duplicate path",
+			devices: []openbaov1alpha1.AuditDevice{
+				{
+					Type:        "file",
+					Path:        "stdout",
+					FileOptions: &openbaov1alpha1.FileAuditOptions{FilePath: "stdout"},
+				},
+				{
+					Type: "syslog",
+					Path: "/stdout/",
+					SyslogOptions: &openbaov1alpha1.SyslogAuditOptions{
+						Tag: "openbao",
+					},
+				},
+			},
+			wantErr: `duplicate path "stdout"`,
+		},
+		{
+			name: "file missing required options",
+			devices: []openbaov1alpha1.AuditDevice{
+				{
+					Type: "file",
+					Path: "stdout",
+				},
+			},
+			wantErr: "fileOptions.filePath or options.file_path is required",
+		},
+		{
+			name: "http headers nested in raw options",
+			devices: []openbaov1alpha1.AuditDevice{
+				{
+					Type: "http",
+					Path: "remote",
+					Options: &apiextensionsv1.JSON{
+						Raw: []byte(`{"uri":"https://audit.example.test/ingest","headers":{"X-Audit":["one"]}}`),
+					},
+				},
+			},
+			wantErr: `option "headers" must be a string-compatible scalar`,
+		},
+		{
+			name: "wrong structured option family",
+			devices: []openbaov1alpha1.AuditDevice{
+				{
+					Type:        "http",
+					Path:        "remote",
+					FileOptions: &openbaov1alpha1.FileAuditOptions{FilePath: "stdout"},
+				},
+			},
+			wantErr: "fileOptions is only supported for file audit devices",
+		},
+		{
+			name: "raw options with trailing JSON",
+			devices: []openbaov1alpha1.AuditDevice{
+				{
+					Type: auditTypeSocket,
+					Path: "custom-socket",
+					Options: &apiextensionsv1.JSON{
+						Raw: []byte(`{"address":"127.0.0.1:9000"}{"address":"127.0.0.1:9001"}`),
+					},
+				},
+			},
+			wantErr: "must contain exactly one JSON object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newMinimalCluster("invalid-audit", "default")
+			cluster.Spec.Audit = tt.devices
+
+			_, err := RenderHCL(cluster, InfrastructureDetails{
+				HeadlessServiceName: cluster.Name,
+				Namespace:           cluster.Namespace,
+				APIPort:             8200,
+				ClusterPort:         8201,
+			})
+			if err == nil {
+				t.Fatal("RenderHCL() expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("RenderHCL() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestRenderHCLWithObservabilityMetricsTelemetry(t *testing.T) {
 	cluster := newMinimalCluster("telemetry-cluster", "default")
 	cluster.Spec.Observability = &openbaov1alpha1.ObservabilityConfig{
@@ -330,6 +487,41 @@ func TestRenderHCLWithSelfInitRequests(t *testing.T) {
 	}
 
 	compareGolden(t, "render_self_init_requests", got)
+}
+
+func TestRenderSelfInitHCLWithHTTPAuditHeaders(t *testing.T) {
+	cluster := newMinimalCluster("selfinit-http-audit", "default")
+	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
+		Enabled: true,
+		Requests: []openbaov1alpha1.SelfInitRequest{
+			{
+				Name:      "enable-http-audit",
+				Operation: openbaov1alpha1.SelfInitOperationUpdate,
+				Path:      "sys/audit/remote",
+				AuditDevice: &openbaov1alpha1.SelfInitAuditDevice{
+					Type: "http",
+					HTTPOptions: &openbaov1alpha1.HTTPAuditOptions{
+						URI:     "https://audit.example.test/ingest",
+						Headers: &apiextensionsv1.JSON{Raw: []byte(`{"X-Audit":["one"]}`)},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := RenderSelfInitHCL(cluster, nil)
+	if err != nil {
+		t.Fatalf("RenderSelfInitHCL() error = %v", err)
+	}
+
+	rendered := string(got)
+	want := `headers = "{\"X-Audit\":[\"one\"]}"`
+	if !strings.Contains(rendered, want) {
+		t.Fatalf("RenderSelfInitHCL() headers not rendered as JSON string %q:\n%s", want, rendered)
+	}
+	if strings.Contains(rendered, `X-Audit =`) {
+		t.Fatalf("RenderSelfInitHCL() rendered HTTP headers as nested HCL instead of a JSON string:\n%s", rendered)
+	}
 }
 
 // goldenFile reads the golden file for the given test name.

--- a/internal/adapter/config/render_audit.go
+++ b/internal/adapter/config/render_audit.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -10,14 +12,22 @@ import (
 
 func buildAuditDeviceBlocks(devices []openbaov1alpha1.AuditDevice) ([]*hclwrite.Block, error) {
 	blocks := make([]*hclwrite.Block, 0, len(devices))
-	for _, device := range devices {
-		if device.Type == "" || device.Path == "" {
-			continue
+	seenPaths := make(map[string]struct{}, len(devices))
+	for index, device := range devices {
+		auditType, auditPath, err := validateDeclarativeAuditDevice(index, device)
+		if err != nil {
+			return nil, err
 		}
+		if _, ok := seenPaths[auditPath]; ok {
+			return nil, fmt.Errorf("audit device %d: duplicate path %q", index, auditPath)
+		}
+		seenPaths[auditPath] = struct{}{}
+		device.Type = auditType
+		device.Path = auditPath
 
 		block := gohcl.EncodeAsBlock(hclAuditDevice{
-			Type:        device.Type,
-			Path:        device.Path,
+			Type:        auditType,
+			Path:        auditPath,
 			Description: stringPtr(device.Description),
 		}, "audit")
 
@@ -37,50 +47,25 @@ func buildAuditOptionsValue(device openbaov1alpha1.AuditDevice) (cty.Value, bool
 	var options map[string]cty.Value
 
 	switch device.Type {
-	case "file":
+	case auditTypeFile:
 		if device.FileOptions != nil {
-			options = map[string]cty.Value{
-				"file_path": cty.StringVal(device.FileOptions.FilePath),
-			}
-			if device.FileOptions.Mode != "" {
-				options["mode"] = cty.StringVal(device.FileOptions.Mode)
-			}
+			options = buildFileAuditOptions(device.FileOptions)
 		}
-	case "http":
+	case auditTypeHTTP:
 		if device.HTTPOptions != nil {
-			options = map[string]cty.Value{
-				"uri": cty.StringVal(device.HTTPOptions.URI),
+			httpOptions, err := buildHTTPAuditOptions(device.HTTPOptions, auditHTTPHeadersContext)
+			if err != nil {
+				return cty.NilVal, false, err
 			}
-			if device.HTTPOptions.Headers != nil && len(device.HTTPOptions.Headers.Raw) > 0 {
-				headersVal, err := decodeJSONToCty(device.HTTPOptions.Headers.Raw, "HTTP audit device headers")
-				if err != nil {
-					return cty.NilVal, false, err
-				}
-				options["headers"] = headersVal
-			}
+			options = httpOptions
 		}
-	case "syslog":
+	case auditTypeSyslog:
 		if device.SyslogOptions != nil {
-			options = make(map[string]cty.Value)
-			if device.SyslogOptions.Facility != "" {
-				options["facility"] = cty.StringVal(device.SyslogOptions.Facility)
-			}
-			if device.SyslogOptions.Tag != "" {
-				options["tag"] = cty.StringVal(device.SyslogOptions.Tag)
-			}
+			options = buildSyslogAuditOptions(device.SyslogOptions)
 		}
-	case "socket":
+	case auditTypeSocket:
 		if device.SocketOptions != nil {
-			options = make(map[string]cty.Value)
-			if device.SocketOptions.Address != "" {
-				options["address"] = cty.StringVal(device.SocketOptions.Address)
-			}
-			if device.SocketOptions.SocketType != "" {
-				options["socket_type"] = cty.StringVal(device.SocketOptions.SocketType)
-			}
-			if device.SocketOptions.WriteTimeout != "" {
-				options["write_timeout"] = cty.StringVal(device.SocketOptions.WriteTimeout)
-			}
+			options = buildSocketAuditOptions(device.SocketOptions)
 		}
 	}
 
@@ -89,11 +74,14 @@ func buildAuditOptionsValue(device openbaov1alpha1.AuditDevice) (cty.Value, bool
 	}
 
 	if device.Options != nil && len(device.Options.Raw) > 0 {
-		ctyVal, err := decodeJSONToCty(device.Options.Raw, "audit device options")
+		rawOptions, err := decodeAuditStringOptions(device.Options.Raw, auditDeviceOptionsContext)
 		if err != nil {
 			return cty.NilVal, false, err
 		}
-		return ctyVal, true, nil
+		if len(rawOptions) == 0 {
+			return cty.NilVal, false, nil
+		}
+		return cty.ObjectVal(auditOptionsToCty(rawOptions)), true, nil
 	}
 
 	return cty.NilVal, false, nil

--- a/internal/adapter/config/selfinit_data.go
+++ b/internal/adapter/config/selfinit_data.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/zclconf/go-cty/cty"
@@ -9,66 +10,42 @@ import (
 
 // buildAuditDeviceData builds the API request data for an audit device from structured config.
 func buildAuditDeviceData(device *openbaov1alpha1.SelfInitAuditDevice) (cty.Value, error) {
-	if device == nil {
-		return cty.NilVal, fmt.Errorf("audit device config is nil")
+	if err := validateSelfInitAuditDevice(device); err != nil {
+		return cty.NilVal, err
 	}
 
 	var optionsMap map[string]cty.Value
 
-	switch device.Type {
-	case "file":
+	auditType := strings.TrimSpace(device.Type)
+	switch auditType {
+	case auditTypeFile:
 		if device.FileOptions == nil {
 			return cty.NilVal, fmt.Errorf("fileOptions is required for file audit device")
 		}
-		optionsMap = map[string]cty.Value{
-			"file_path": cty.StringVal(device.FileOptions.FilePath),
-		}
-		if device.FileOptions.Mode != "" {
-			optionsMap["mode"] = cty.StringVal(device.FileOptions.Mode)
-		}
-	case "http":
+		optionsMap = buildFileAuditOptions(device.FileOptions)
+	case auditTypeHTTP:
 		if device.HTTPOptions == nil {
 			return cty.NilVal, fmt.Errorf("httpOptions is required for http audit device")
 		}
-		optionsMap = map[string]cty.Value{
-			"uri": cty.StringVal(device.HTTPOptions.URI),
+		httpOptions, err := buildHTTPAuditOptions(device.HTTPOptions, selfInitAuditHeadersContext)
+		if err != nil {
+			return cty.NilVal, err
 		}
-		if device.HTTPOptions.Headers != nil && len(device.HTTPOptions.Headers.Raw) > 0 {
-			headersVal, err := decodeJSONToCty(device.HTTPOptions.Headers.Raw, "audit device headers")
-			if err != nil {
-				return cty.NilVal, err
-			}
-			optionsMap["headers"] = headersVal
-		}
-	case "syslog":
+		optionsMap = httpOptions
+	case auditTypeSyslog:
 		if device.SyslogOptions != nil {
-			optionsMap = make(map[string]cty.Value)
-			if device.SyslogOptions.Facility != "" {
-				optionsMap["facility"] = cty.StringVal(device.SyslogOptions.Facility)
-			}
-			if device.SyslogOptions.Tag != "" {
-				optionsMap["tag"] = cty.StringVal(device.SyslogOptions.Tag)
-			}
+			optionsMap = buildSyslogAuditOptions(device.SyslogOptions)
 		}
-	case "socket":
+	case auditTypeSocket:
 		if device.SocketOptions != nil {
-			optionsMap = make(map[string]cty.Value)
-			if device.SocketOptions.Address != "" {
-				optionsMap["address"] = cty.StringVal(device.SocketOptions.Address)
-			}
-			if device.SocketOptions.SocketType != "" {
-				optionsMap["socket_type"] = cty.StringVal(device.SocketOptions.SocketType)
-			}
-			if device.SocketOptions.WriteTimeout != "" {
-				optionsMap["write_timeout"] = cty.StringVal(device.SocketOptions.WriteTimeout)
-			}
+			optionsMap = buildSocketAuditOptions(device.SocketOptions)
 		}
 	default:
-		return cty.NilVal, fmt.Errorf("unsupported audit device type: %s", device.Type)
+		return cty.NilVal, fmt.Errorf("unsupported audit device type: %s", auditType)
 	}
 
 	dataMap := map[string]cty.Value{
-		"type": cty.StringVal(device.Type),
+		"type": cty.StringVal(auditType),
 	}
 	if device.Description != "" {
 		dataMap["description"] = cty.StringVal(device.Description)


### PR DESCRIPTION
## Summary

Align OpenBao audit device rendering with upstream OpenBao's `string->string` audit option contract.

This fixes HTTP audit headers by rendering `httpOptions.headers` as the JSON-encoded `options.headers` string OpenBao expects, instead of nested HCL. It also rejects nested raw audit option values, coerces scalar raw options to strings, validates duplicate declarative audit paths, and adds CRD validation for type-specific audit option families.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

API/CRD impact: `spec.audit` is now a map-list keyed by `path`, so duplicate audit paths are rejected at admission. Type-specific structured option fields are now constrained to their matching audit type. File and HTTP audit devices must provide their required options either via structured fields or raw options.

Compatibility impact: invalid audit specs that previously rendered into OpenBao startup/runtime failures are rejected earlier. Valid existing audit specs continue to render, with raw scalar options normalized to strings.

Security impact: HTTP headers remain user-supplied configuration, but they are now passed to OpenBao in the documented JSON-string format instead of as nested HCL data.

## Verification

- `make manifests generate api-reference helm-sync`
- `go test ./...`
- `make verify-generated verify-helm`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

The first commit changes runtime rendering and tests. The second commit adds API/CRD validation and generated artifacts. Reviewers should focus on the raw `options` compatibility behavior: scalar JSON values are rendered as strings, while objects and arrays are rejected because OpenBao audit options are `string->string`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
