### PR TITLE
fix(rbac): allow verification pull secret reads

### DIFF
--- a/docs/security/infrastructure/rbac.md
+++ b/docs/security/infrastructure/rbac.md
@@ -157,7 +157,7 @@ The provisioner writes the RBAC that grants the controller access, but it does n
     {
       cells: [
         'Read and write allowlisted Secrets',
-        'Lifecycle workflows need specific Secret names for bootstrap, TLS, and operations.',
+        'Lifecycle workflows need specific Secret names for bootstrap, TLS, operations, and private-registry image verification.',
         'Secret access is fixed-name, non-enumerating, and guarded by dedicated admission policy.',
       ],
     },

--- a/docs/security/workload/supply-chain.md
+++ b/docs/security/workload/supply-chain.md
@@ -173,12 +173,22 @@ The Hardened profile is opinionated here. The intent is that image verification 
   imageVerification:
     enabled: true
     failurePolicy: Block
+    imagePullSecrets:
+      - name: cluster-registry-creds
   operatorImageVerification:
     enabled: true
-    failurePolicy: Block`}
+    failurePolicy: Block
+    imagePullSecrets:
+      - name: cluster-registry-creds`}
 >
   Treat the main OpenBao image and operator helper images as separate trust surfaces. They may share policy, but they should not share assumptions blindly.
 </CommandBlock>
+
+<Callout type="note" title="Private-registry verification needs controller Secret read">
+
+Verification pull Secrets are read by the controller, not by the kubelet. In multi-tenant mode, the provisioner keeps that access name-scoped by granting `get` only on the tenant Secrets referenced from enabled `spec.imageVerification.imagePullSecrets` and `spec.operatorImageVerification.imagePullSecrets`.
+
+</Callout>
 
 <CommandBlock
   language="bash"

--- a/docs/user-guide/openbaocluster/configuration/air-gapped.md
+++ b/docs/user-guide/openbaocluster/configuration/air-gapped.md
@@ -45,9 +45,9 @@ description: Mirror operator, workload, and helper images; set repository defaul
     {
       cells: [
         "Registry authentication",
-        "The operator install uses chart-level `imagePullSecrets`; each cluster uses `spec.imagePullSecrets`.",
+        "The operator install uses chart-level `imagePullSecrets`; each cluster uses `spec.imagePullSecrets`. Image verification uses its own `imagePullSecrets` fields.",
         "Create Docker registry Secrets in the namespace that will pull the images.",
-        "Do not assume the operator namespace and tenant namespaces can share pull secrets implicitly.",
+        "Do not assume the operator namespace and tenant namespaces can share pull secrets implicitly. If verification must contact a private registry, the controller also needs read access to the named tenant Secret.",
       ],
       emphasis: "caution",
     },
@@ -119,6 +119,14 @@ spec:
   image: "my-registry.corp/openbao/openbao:2.5.0"
   imagePullSecrets:
     - name: cluster-registry-creds
+  imageVerification:
+    enabled: true
+    imagePullSecrets:
+      - name: cluster-registry-creds
+  operatorImageVerification:
+    enabled: true
+    imagePullSecrets:
+      - name: cluster-registry-creds
   initContainer:
     image: "my-registry.corp/openbao-init:<operator-version>"
   backup:
@@ -141,6 +149,12 @@ spec:
 >
   The Secret must exist in the same namespace as the OpenBaoCluster that references it.
 </CommandBlock>
+
+<Callout type="note" title="Separate kubelet pulls from verification pulls">
+
+`spec.imagePullSecrets` lets Kubernetes pull the rendered Pods and Jobs. `spec.imageVerification.imagePullSecrets` and `spec.operatorImageVerification.imagePullSecrets` let the controller authenticate to the registry while resolving and verifying signatures. In multi-tenant mode, the provisioner grants the controller `get` only on those named tenant Secrets.
+
+</Callout>
 
 <DecisionTable
   kind="reference"

--- a/internal/adapter/cluster/rbac.go
+++ b/internal/adapter/cluster/rbac.go
@@ -100,6 +100,24 @@ func GetRequiredSecretPermissions(c *openbaov1alpha1.OpenBaoCluster) []SecretPer
 		})
 	}
 
+	if c.Spec.ImageVerification != nil && c.Spec.ImageVerification.Enabled {
+		for _, secretRef := range c.Spec.ImageVerification.ImagePullSecrets {
+			perms = append(perms, SecretPermission{
+				Name:       secretRef.Name,
+				Permission: PermissionRead,
+			})
+		}
+	}
+
+	if c.Spec.OperatorImageVerification != nil && c.Spec.OperatorImageVerification.Enabled {
+		for _, secretRef := range c.Spec.OperatorImageVerification.ImagePullSecrets {
+			perms = append(perms, SecretPermission{
+				Name:       secretRef.Name,
+				Permission: PermissionRead,
+			})
+		}
+	}
+
 	return perms
 }
 

--- a/internal/adapter/cluster/rbac_test.go
+++ b/internal/adapter/cluster/rbac_test.go
@@ -236,6 +236,70 @@ func TestGetRequiredSecretPermissions(t *testing.T) {
 			},
 		},
 		{
+			name: "Image verification pull secrets are readable",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("verified"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					ImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+						Enabled: true,
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "main-registry-creds"},
+						},
+					},
+					OperatorImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+						Enabled: true,
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "helper-registry-creds"},
+						},
+					},
+				},
+			},
+			wantWriters: []string{
+				"verified-root-token",
+				"verified-tls-ca",
+				"verified-tls-server",
+				"verified-unseal-key",
+			},
+			wantReaders: []string{
+				"helper-registry-creds",
+				"main-registry-creds",
+			},
+		},
+		{
+			name: "Disabled image verification pull secrets are not readable",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("verification-disabled"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled: true,
+						Mode:    openbaov1alpha1.TLSModeOperatorManaged,
+					},
+					ImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+						Enabled: false,
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "unused-main-registry-creds"},
+						},
+					},
+					OperatorImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+						Enabled: false,
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "unused-helper-registry-creds"},
+						},
+					},
+				},
+			},
+			wantWriters: []string{
+				"verification-disabled-root-token",
+				"verification-disabled-tls-ca",
+				"verification-disabled-tls-server",
+				"verification-disabled-unseal-key",
+			},
+		},
+		{
 			name: "Full configuration with all secret types",
 			cluster: &openbaov1alpha1.OpenBaoCluster{
 				ObjectMeta: objectMeta("full"),

--- a/internal/controller/provisioner/tenant_secrets_rbac_controller_test.go
+++ b/internal/controller/provisioner/tenant_secrets_rbac_controller_test.go
@@ -152,6 +152,18 @@ func TestTenantSecretsRBACReconcile_ProvisionedNamespaceSyncsAllowlists(t *testi
 			Upgrade: &openbaov1alpha1.UpgradeConfig{
 				JWTAuthRole: "upgrade-role",
 			},
+			ImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled: true,
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "main-registry-creds"},
+				},
+			},
+			OperatorImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled: true,
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "helper-registry-creds"},
+				},
+			},
 			Unseal: &openbaov1alpha1.UnsealConfig{
 				CredentialsSecretRef: &corev1.LocalObjectReference{Name: "unseal-creds"},
 			},
@@ -200,7 +212,7 @@ func TestTenantSecretsRBACReconcile_ProvisionedNamespaceSyncsAllowlists(t *testi
 	}, readerRole); err != nil {
 		t.Fatalf("expected reader role: %v", err)
 	}
-	wantReaderSecrets := []string{"backup-creds", "backup-token", "unseal-creds"}
+	wantReaderSecrets := []string{"backup-creds", "backup-token", "helper-registry-creds", "main-registry-creds", "unseal-creds"}
 	sort.Strings(wantReaderSecrets)
 	if gotReaderSecrets := extractSecretResourceNames(readerRole.Rules); !slices.Equal(gotReaderSecrets, wantReaderSecrets) {
 		t.Fatalf("reader secrets = %v, want %v", gotReaderSecrets, wantReaderSecrets)

--- a/internal/service/provisioner/manager_test.go
+++ b/internal/service/provisioner/manager_test.go
@@ -553,6 +553,18 @@ func TestEnsureTenantSecretRBAC_CreatesRolesAndRoleBindings(t *testing.T) {
 					Name: "upgrade-token",
 				},
 			},
+			ImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled: true,
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "main-registry-creds"},
+				},
+			},
+			OperatorImageVerification: &openbaov1alpha1.ImageVerificationConfig{
+				Enabled: true,
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "helper-registry-creds"},
+				},
+			},
 		},
 	}
 
@@ -579,6 +591,8 @@ func TestEnsureTenantSecretRBAC_CreatesRolesAndRoleBindings(t *testing.T) {
 	expectedReaderNames := []string{
 		"backup-creds",
 		"backup-token",
+		"helper-registry-creds",
+		"main-registry-creds",
 		"unseal-creds",
 		"upgrade-token",
 	}


### PR DESCRIPTION
## Summary

- Add enabled image verification pull Secrets to the tenant Secret reader allowlist so the controller can authenticate to private registries before signature verification.
- Keep the access least-privilege: tenant namespace only, `get` only, and scoped to the exact Secret names referenced by `spec.imageVerification.imagePullSecrets` or `spec.operatorImageVerification.imagePullSecrets`.
- Document the security/RBAC implications for private-registry verification.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

RBAC/security impact is intentionally narrow. In multi-tenant mode, enabled image verification pull Secret references now add controller read access to the tenant Secret reader Role. The grant is `get` only, uses `resourceNames`, and is only for Secrets explicitly referenced by enabled verification blocks. Disabled verification blocks do not grant Secret access. No CRD or API shape changes.

## Verification

- `go test ./internal/adapter/cluster`
- `go test ./internal/service/provisioner`
- `go test ./internal/controller/provisioner`
- `helm lint charts/openbao-operator --namespace openbao-operator-system`
- `helm template openbao-operator charts/openbao-operator --namespace openbao-operator-system --include-crds > /tmp/openbao-operator-helm-template.yaml`
- `git diff --check`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

The important distinction is between kubelet pull Secrets and verification pull Secrets. `spec.imagePullSecrets` alone remains kubelet-facing. The controller only receives Secret read access when the same or another Secret is explicitly referenced from enabled verification config.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.