### PR TITLE
fix(provisioner): support external tenant PSS label ownership

### DIFF
--- a/charts/openbao-operator/README.md
+++ b/charts/openbao-operator/README.md
@@ -28,6 +28,17 @@ tenancy:
   mode: multi
 ```
 
+### Multi-tenant mode with platform-managed Pod Security labels
+
+Use this when Rancher or another platform policy layer owns namespace labels. The chart keeps tenant RBAC and quota onboarding in the operator, removes namespace update/patch RBAC from the Provisioner, and configures admission policy to deny Provisioner namespace mutations.
+
+```yaml
+tenancy:
+  mode: multi
+  namespacePodSecurityLabels:
+    mode: external
+```
+
 ### Single-tenant mode
 
 ```yaml

--- a/charts/openbao-operator/templates/admission/provisioner-namespace-mutations.yaml
+++ b/charts/openbao-operator/templates/admission/provisioner-namespace-mutations.yaml
@@ -48,6 +48,13 @@ spec:
         !variables.is_system_namespace
       message: "The Provisioner may not mutate system namespaces."
 
+{{ if eq .Values.tenancy.namespacePodSecurityLabels.mode "external" }}
+    # Rule 1: Namespace Pod Security labels are externally managed, so the Provisioner must not mutate Namespaces.
+    - expression: >-
+        !variables.is_provisioner
+      message: >-
+        The Provisioner may not mutate Namespaces when tenant namespace Pod Security labels are externally managed.
+{{ else }}
     # Rule 1: Only enforce Pod Security Standards labels (restricted), and do not change anything else.
     - expression: >-
         !variables.is_provisioner ||
@@ -86,6 +93,7 @@ spec:
           )
         )
       message: "The Provisioner may only enforce Pod Security Standards labels (restricted) on Namespaces."
+{{ end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/charts/openbao-operator/templates/provisioner/deployment.yaml
+++ b/charts/openbao-operator/templates/provisioner/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ include "openbao-operator.controllerServiceAccountName" . }}
             - name: OPERATOR_VERSION
               value: {{ include "openbao-operator.operatorVersion" . | quote }}
+            - name: OPENBAO_TENANT_NAMESPACE_POD_SECURITY_LABELS_MODE
+              value: {{ .Values.tenancy.namespacePodSecurityLabels.mode | quote }}
             {{- if not .Values.admissionPolicies.enabled }}
             - name: OPENBAO_UNSAFE_ADMISSION_DISABLED
               value: "true"

--- a/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
@@ -13,8 +13,10 @@ rules:
       - namespaces
     verbs:
       - get
+{{ if eq .Values.tenancy.namespacePodSecurityLabels.mode "enforce" }}
       - update
       - patch
+{{ end }}
 
   - apiGroups:
       - openbao.org

--- a/charts/openbao-operator/values.schema.json
+++ b/charts/openbao-operator/values.schema.json
@@ -96,6 +96,25 @@
         "targetNamespace": {
           "type": "string",
           "description": "Target namespace for single-tenant mode"
+        },
+        "namespacePodSecurityLabels": {
+          "type": "object",
+          "description": "Tenant namespace Pod Security label management",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "description": "Tenant namespace Pod Security label ownership. enforce lets the provisioner apply restricted labels; external delegates labels to the platform policy layer.",
+              "enum": [
+                "enforce",
+                "external"
+              ],
+              "default": "enforce"
+            }
+          },
+          "required": [
+            "mode"
+          ]
         }
       },
       "required": [

--- a/charts/openbao-operator/values.yaml
+++ b/charts/openbao-operator/values.yaml
@@ -54,6 +54,14 @@ tenancy:
   # -- If empty, defaults to the release namespace.
   targetNamespace: ""
 
+  # -- Tenant namespace Pod Security label management.
+  # -- mode=enforce lets the provisioner apply restricted Pod Security labels
+  # -- to tenant namespaces during OpenBaoTenant onboarding.
+  # -- mode=external delegates those namespace labels to the platform policy layer
+  # -- and prevents the provisioner from mutating Namespace objects.
+  namespacePodSecurityLabels:
+    mode: enforce
+
 # -- Controller deployment configuration
 controller:
   # -- Number of controller replicas

--- a/docs/architecture/lifecycle/day0-provisioning.md
+++ b/docs/architecture/lifecycle/day0-provisioning.md
@@ -63,7 +63,7 @@ description: Tenant provisioning flow from OpenBaoTenant creation through namesp
       items: [
         'tenant Role and RoleBinding resources',
         'Secret reader and writer allowlist roles',
-        'Pod Security labels plus optional ResourceQuota and LimitRange defaults',
+        'Pod Security labels when configured plus optional ResourceQuota and LimitRange defaults',
       ],
     },
     {
@@ -106,7 +106,7 @@ Day 0 also defines the handoff into Day 1. In multi-tenant mode, `OpenBaoCluster
     Ctrl->>App: Reconcile tenant request
     App->>Manager: Apply tenant provisioning contract
     Manager->>Namespace: Create tenant Role / RoleBinding
-    Manager->>Namespace: Apply Pod Security labels
+    Manager->>Namespace: Apply Pod Security labels when configured to own them
     Manager->>Namespace: Apply optional quota defaults
     Manager->>Namespace: Sync Secret allowlist roles
     Namespace-->>Admin: Namespace ready for OpenBaoCluster
@@ -134,7 +134,7 @@ Day 0 also defines the handoff into Day 1. In multi-tenant mode, `OpenBaoCluster
       cells: ['Secret allowlists', 'Provisioner manager plus tenant Secret RBAC sync.', 'Multi-tenant safety depends on explicit Secret access derived from actual managed cluster references.'],
     },
     {
-      cells: ['Policy defaults', 'Provisioner manager.', 'Pod Security labels and optional quotas give the namespace a safe baseline before a cluster is created.'],
+      cells: ['Policy defaults', 'Provisioner manager plus platform policy when namespace labels are externally managed.', 'Pod Security labels and optional quotas give the namespace a safe baseline before a cluster is created.'],
     },
   ]}
 />

--- a/docs/architecture/provisioner-manager.md
+++ b/docs/architecture/provisioner-manager.md
@@ -3,12 +3,12 @@ title: Provisioner Manager
 hide_title: true
 pageType: concept
 journey: architecture
-description: Provision tenant namespaces with scoped RBAC, Secret allowlists, Pod Security labels, and quota defaults for OpenBaoTenant.
+description: Provision tenant namespaces with scoped RBAC, Secret allowlists, Pod Security label ownership, and quota defaults for OpenBaoTenant.
 ---
 
 <PageHeader
   title="Provision tenant namespaces with scoped RBAC, Secret allowlists, and policy defaults."
-  lede="The provisioner manager owns the tenant-onboarding contract for `OpenBaoTenant`. It creates namespace-scoped permissions for the operator, applies Pod Security and quota defaults, and keeps Secret access narrowed to explicit allowlists derived from managed clusters."
+  lede="The provisioner manager owns the tenant-onboarding contract for `OpenBaoTenant`. It creates namespace-scoped permissions for the operator, applies quota defaults, applies Pod Security labels when configured to own them, and keeps Secret access narrowed to explicit allowlists derived from managed clusters."
 />
 
 
@@ -28,14 +28,14 @@ description: Provision tenant namespaces with scoped RBAC, Secret allowlists, Po
       items: [
         'tenant-scoped operator Role and RoleBinding resources',
         'reader and writer Secret allowlists derived from tenant clusters',
-        'Pod Security labels plus optional ResourceQuota and LimitRange defaults',
+        'Pod Security labels when configured plus optional ResourceQuota and LimitRange defaults',
       ],
     },
     {
       label: 'Writes',
       items: [
         'tenant Role / RoleBinding and Secret RBAC resources',
-        'namespace labels that enforce Pod Security defaults',
+        'namespace labels that enforce Pod Security defaults unless platform policy owns them',
         'ResourceQuota and LimitRange resources from OpenBaoTenant.spec',
       ],
     },
@@ -78,7 +78,7 @@ The tenant `RoleBinding` is also the explicit handoff marker into the cluster co
       cells: ['Controller handoff', 'When the tenant namespace is actually ready for `OpenBaoCluster` reconciliation.', 'GitOps paths can submit tenant and cluster objects together only if the controller has a deterministic, namespace-scoped readiness marker.'],
     },
     {
-      cells: ['Pod Security labels', 'The baseline namespace policy applied to tenant workloads and operator-managed pods.', 'Tenants need a secure default even before any cluster objects are created.'],
+      cells: ['Pod Security labels', 'The baseline namespace policy applied to tenant workloads and operator-managed pods when the chart is in enforce mode.', 'Tenants need a secure default even before any cluster objects are created, whether owned by the Provisioner or by platform policy.'],
     },
     {
       cells: ['Quota defaults', 'Optional ResourceQuota and LimitRange resources derived from OpenBaoTenant.spec.', 'Tenants need resource guardrails that travel with the namespace onboarding contract.'],
@@ -90,14 +90,14 @@ The tenant `RoleBinding` is also the explicit handoff marker into the cluster co
 
 <DiagramFrame
   title="Tenant onboarding flow"
-  caption="Provisioning applies namespace-scoped guardrails first, then keeps Secret allowlists synchronized as managed clusters appear or disappear in the tenant namespace."
+  caption="Provisioning applies namespace-scoped guardrails first, then keeps Secret allowlists synchronized as managed clusters appear or disappear in the tenant namespace. Pod Security labels can be owned by the Provisioner or by platform policy."
   code={`graph TD
     Tenant["OpenBaoTenant"] --> Ctrl["Provisioner controller"]
     Ctrl --> App["internal/app/provisioner"]
     App --> Manager["Provisioner manager"]
     Manager --> RBAC["Tenant Role / RoleBinding"]
     Manager --> Secrets["Reader / writer Secret allowlists"]
-    Manager --> Labels["Pod Security labels"]
+    Manager -. enforce mode .-> Labels["Pod Security labels"]
     Manager --> Quotas["ResourceQuota / LimitRange"]
     Quotas --> Ready["Tenant namespace ready for OpenBaoCluster"]
 

--- a/docs/security/infrastructure/admission-policies.md
+++ b/docs/security/infrastructure/admission-policies.md
@@ -145,8 +145,8 @@ Disabling admission policies is treated as unsafe mode. Even if the cluster othe
     {
       cells: [
         'Namespace mutation',
-        'Provisioner namespace updates are limited to fixed Pod Security label enforcement and blocked in system namespaces.',
-        'Tenant onboarding should not become a generic namespace-mutation channel.',
+        'Provisioner namespace updates are limited to fixed Pod Security label enforcement and blocked in system namespaces. In external Pod Security label mode, provisioner namespace mutations are denied entirely.',
+        'Tenant onboarding should not become a generic namespace-mutation channel, and platform-owned namespace labels should stay owned by platform policy.',
       ],
     },
     {

--- a/docs/security/infrastructure/rbac.md
+++ b/docs/security/infrastructure/rbac.md
@@ -104,9 +104,9 @@ The operator disables default token auto-mounting and uses explicit projected Se
     },
     {
       cells: [
-        'Patch Namespaces for fixed PSS labels',
-        'Tenant namespaces must be hardened as part of onboarding.',
-        'Namespace mutation is limited to the fixed Pod Security label set and blocked in system namespaces.',
+        'Patch Namespaces for fixed PSS labels in default enforce mode',
+        'Tenant namespaces need a Pod Security baseline unless a platform policy layer already owns it.',
+        'Namespace mutation is limited to the fixed Pod Security label set and blocked in system namespaces. In external mode, Helm removes namespace update/patch RBAC from the provisioner.',
       ],
     },
     {

--- a/docs/security/multi-tenancy/tenant-isolation.md
+++ b/docs/security/multi-tenancy/tenant-isolation.md
@@ -43,7 +43,7 @@ description: How namespace introduction, split controller identities, admission 
       cells: [
         "Network and namespace hardening",
         "Cross-tenant traffic and insecure sidecar drift are reduced by default.",
-        "Default-deny `NetworkPolicy` and Restricted Pod Security labels apply at onboarding time.",
+        "Default-deny `NetworkPolicy` applies at onboarding time. Restricted Pod Security labels are applied by the Provisioner unless the chart delegates namespace labels to platform policy.",
       ],
     },
   ]}
@@ -135,7 +135,7 @@ Use <SiteLink docId="user-guide/openbaotenant/onboarding">Onboard the target nam
       cells: [
         "Namespace-level runtime baseline",
         "Tenant namespaces start from Restricted pod-security enforcement and default network isolation.",
-        "Provisioner-owned namespace labels and network-policy defaults.",
+        "Provisioner-owned namespace labels and network-policy defaults, or platform-owned namespace labels when `tenancy.namespacePodSecurityLabels.mode=external` is set.",
       ],
     },
   ]}

--- a/docs/security/workload/workload-security.md
+++ b/docs/security/workload/workload-security.md
@@ -176,8 +176,8 @@ The config-rendering init container inherits the same pod-level hardening contra
     {
       cells: [
         "Tenant namespace PSS labels",
-        "Provisioned namespaces are labeled for Restricted Pod Security enforcement, audit, and warning.",
-        "Insecure sidecars or helper workloads should fail at the namespace boundary rather than weakening the cluster quietly.",
+        "Provisioned namespaces are labeled for Restricted Pod Security enforcement, audit, and warning by the Provisioner unless namespace label ownership is delegated to platform policy.",
+        "Insecure sidecars or helper workloads should fail at the namespace boundary rather than weakening the cluster quietly; external mode keeps that baseline as a platform responsibility.",
       ],
       emphasis: "recommended",
     },

--- a/docs/user-guide/openbaotenant/onboarding.md
+++ b/docs/user-guide/openbaotenant/onboarding.md
@@ -25,6 +25,12 @@ Create the Kubernetes namespace through your normal platform workflow first, the
 
 </Callout>
 
+<Callout type="note" title="Platform-managed Pod Security labels">
+
+By default, tenant onboarding applies Restricted Pod Security labels to the target namespace. On Rancher or other clusters where namespace labels are owned by platform admission, install the chart with `tenancy.namespacePodSecurityLabels.mode=external`. In that mode the Provisioner still writes tenant RBAC, quotas, limits, and Secret allowlists, but it does not mutate `Namespace` objects. The platform policy layer must enforce the namespace Pod Security baseline.
+
+</Callout>
+
 <Callout type="note" title="GitOps can submit tenant and cluster together">
 
 If your GitOps pipeline applies `OpenBaoTenant` and `OpenBaoCluster` in the same sync, the cluster controllers pause cleanly until tenant onboarding is finished. The handoff is complete once the Provisioner has written the tenant `RoleBinding` and `OpenBaoTenant` reports `status.provisioned: true`.
@@ -204,6 +210,13 @@ If a namespace owner creates `OpenBaoTenant` in one namespace and targets a diff
         'Provisioning never completes or clusters keep requeueing without creating workload resources',
         'The Provisioner is missing, unhealthy, or cannot write the tenant guardrails and tenant RoleBinding',
         'Operator install health, the Provisioner deployment, and the tenant `RoleBinding` in the target namespace',
+      ],
+    },
+    {
+      cells: [
+        'Provisioning reports an admission or Unauthorized error while updating the target namespace',
+        'A platform policy layer owns namespace labels while the chart is still in default Pod Security label enforcement mode',
+        'Use `tenancy.namespacePodSecurityLabels.mode=external` when platform policy owns those labels',
       ],
     },
     {

--- a/hack/helmchart/main.go
+++ b/hack/helmchart/main.go
@@ -257,6 +257,12 @@ func syncPolicies(opts options) error {
 				return fmt.Errorf("read %q: %w", inPath, err)
 			}
 			transformed := transformPolicyToHelm(content)
+			if inputFile == "openbao-restrict-provisioner-namespace-mutations.yaml" {
+				transformed, err = addNamespacePodSecurityLabelPolicyMode(transformed)
+				if err != nil {
+					return fmt.Errorf("add namespace Pod Security label mode to %q: %w", inputFile, err)
+				}
+			}
 			parts = append(parts, transformed)
 		}
 
@@ -335,6 +341,34 @@ func transformPolicyToHelm(content string) string {
 		`'{{ include "openbao-operator.provisionerServiceAccountName" . }}'`)
 
 	return content
+}
+
+func addNamespacePodSecurityLabelPolicyMode(content string) (string, error) {
+	const startMarker = "    # Rule 1: Only enforce Pod Security Standards labels (restricted), " +
+		"and do not change anything else."
+	const endMarker = "      message: " +
+		`"The Provisioner may only enforce Pod Security Standards labels (restricted) on Namespaces."`
+
+	start := strings.Index(content, startMarker)
+	if start == -1 {
+		return "", fmt.Errorf("namespace Pod Security label rule start marker not found")
+	}
+	relativeEnd := strings.Index(content[start:], endMarker)
+	if relativeEnd == -1 {
+		return "", fmt.Errorf("namespace Pod Security label rule end marker not found")
+	}
+	end := start + relativeEnd + len(endMarker)
+
+	externalRule := `{{ if eq .Values.tenancy.namespacePodSecurityLabels.mode "external" }}
+    # Rule 1: Namespace Pod Security labels are externally managed, so the Provisioner must not mutate Namespaces.
+    - expression: >-
+        !variables.is_provisioner
+      message: >-
+        The Provisioner may not mutate Namespaces when tenant namespace Pod Security labels are externally managed.
+{{ else }}
+`
+	replacement := externalRule + content[start:end] + "\n{{ end }}"
+	return content[:start] + replacement + content[end:], nil
 }
 
 // addHelmLabels adds standard Helm labels after the metadata block.
@@ -421,6 +455,10 @@ func syncProvisionerRBAC(opts options) error {
 		return fmt.Errorf("read provisioner_minimal_role.yaml: %w", err)
 	}
 	provisionerRole = transformRBACToHelm(provisionerRole, "provisioner", false)
+	provisionerRole, err = addNamespacePodSecurityLabelRBACMode(provisionerRole)
+	if err != nil {
+		return fmt.Errorf("add namespace Pod Security label mode to provisioner RBAC: %w", err)
+	}
 	parts = append(parts, provisionerRole)
 
 	// 2. Provisioner ClusterRoleBindings
@@ -444,6 +482,25 @@ func syncProvisionerRBAC(opts options) error {
 	output := fmt.Sprintf("{{- if eq .Values.tenancy.mode \"multi\" }}\n%s{{- end }}\n", strings.Join(parts, "---\n"))
 	outPath := filepath.Join(opts.rbacOutputDir, "provisioner-clusterroles.yaml")
 	return writeFile(outPath, output)
+}
+
+func addNamespacePodSecurityLabelRBACMode(content string) (string, error) {
+	const namespaceVerbs = `    verbs:
+      - get
+      - update
+      - patch
+`
+	const namespaceVerbsWithMode = `    verbs:
+      - get
+{{ if eq .Values.tenancy.namespacePodSecurityLabels.mode "enforce" }}
+      - update
+      - patch
+{{ end }}
+`
+	if !strings.Contains(content, namespaceVerbs) {
+		return "", fmt.Errorf("namespace get/update/patch verbs block not found")
+	}
+	return strings.Replace(content, namespaceVerbs, namespaceVerbsWithMode, 1), nil
 }
 
 // syncControllerRBAC syncs controller-related RBAC.

--- a/hack/helmchart/main_test.go
+++ b/hack/helmchart/main_test.go
@@ -66,6 +66,64 @@ rules:
 	}
 }
 
+func TestAddNamespacePodSecurityLabelRBACMode_ConditionsNamespaceMutationVerbs(t *testing.T) {
+	input := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openbao-operator-provisioner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - update
+      - patch
+`
+
+	got, err := addNamespacePodSecurityLabelRBACMode(input)
+	if err != nil {
+		t.Fatalf("addNamespacePodSecurityLabelRBACMode() failed: %v", err)
+	}
+	if !strings.Contains(got, `{{ if eq .Values.tenancy.namespacePodSecurityLabels.mode "enforce" }}`) {
+		t.Fatalf("transformed RBAC missing namespace Pod Security label mode conditional:\n%s", got)
+	}
+	if !strings.Contains(got, "      - get\n{{ if") {
+		t.Fatalf("transformed RBAC should leave get outside the conditional:\n%s", got)
+	}
+}
+
+func TestAddNamespacePodSecurityLabelPolicyMode_AddsExternalDenyRule(t *testing.T) {
+	input := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: openbao-restrict-provisioner-namespace-mutations
+spec:
+  validations:
+    # Rule 1: Only enforce Pod Security Standards labels (restricted), and do not change anything else.
+    - expression: >-
+        !variables.is_provisioner
+      message: "The Provisioner may only enforce Pod Security Standards labels (restricted) on Namespaces."
+`
+
+	got, err := addNamespacePodSecurityLabelPolicyMode(input)
+	if err != nil {
+		t.Fatalf("addNamespacePodSecurityLabelPolicyMode() failed: %v", err)
+	}
+	for _, want := range []string{
+		`{{ if eq .Values.tenancy.namespacePodSecurityLabels.mode "external" }}`,
+		"The Provisioner may not mutate Namespaces when tenant namespace Pod Security labels are externally managed.",
+		`{{ else }}`,
+		"The Provisioner may only enforce Pod Security Standards labels (restricted) on Namespaces.",
+		`{{ end }}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("transformed policy missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestHelmTemplateRendersStrictYAML(t *testing.T) {
 	for _, tt := range []struct {
 		name string
@@ -73,6 +131,10 @@ func TestHelmTemplateRendersStrictYAML(t *testing.T) {
 	}{
 		{name: "default"},
 		{name: "multi", args: []string{"--set", "tenancy.mode=multi"}},
+		{
+			name: "external-namespace-pod-security-labels",
+			args: []string{"--set", "tenancy.namespacePodSecurityLabels.mode=external"},
+		},
 		{name: "single", args: []string{"--set", "tenancy.mode=single", "--set", "tenancy.targetNamespace=openbao-system"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/platform/constants/env.go
+++ b/internal/platform/constants/env.go
@@ -89,8 +89,9 @@ const (
 	EnvRestoreUsePathStyle = "RESTORE_USE_PATH_STYLE"
 
 	// Operator
-	EnvOperatorVersion    = "OPERATOR_VERSION"
-	EnvOpenBaoJWTAudience = "OPENBAO_JWT_AUDIENCE"
+	EnvOperatorVersion                      = "OPERATOR_VERSION"
+	EnvOpenBaoJWTAudience                   = "OPENBAO_JWT_AUDIENCE"
+	EnvTenantNamespacePodSecurityLabelsMode = "OPENBAO_TENANT_NAMESPACE_POD_SECURITY_LABELS_MODE"
 
 	// Operator-managed image repositories
 	EnvOperatorBackupImageRepo  = "OPERATOR_BACKUP_IMAGE_REPOSITORY"

--- a/internal/service/provisioner/manager.go
+++ b/internal/service/provisioner/manager.go
@@ -4,20 +4,28 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+)
+
+const (
+	NamespacePodSecurityLabelsModeEnforce  = "enforce"
+	NamespacePodSecurityLabelsModeExternal = "external"
 )
 
 // Manager handles the provisioning of RBAC resources for tenant namespaces.
 type Manager struct {
-	client     client.Client
-	operatorSA OperatorServiceAccount
-	logger     logr.Logger
+	client                         client.Client
+	operatorSA                     OperatorServiceAccount
+	logger                         logr.Logger
+	namespacePodSecurityLabelsMode string
 }
 
 // NewManager creates a new provisioner Manager.
@@ -39,14 +47,39 @@ func NewManager(c client.Client, logger logr.Logger) (*Manager, error) {
 	}
 	controllerSANamespace := saNamespace
 
+	namespacePodSecurityLabelsMode, err := resolveNamespacePodSecurityLabelsMode()
+	if err != nil {
+		return nil, err
+	}
+
 	return &Manager{
 		client: c,
 		operatorSA: OperatorServiceAccount{
 			Name:      controllerSAName,
 			Namespace: controllerSANamespace,
 		},
-		logger: logger,
+		logger:                         logger,
+		namespacePodSecurityLabelsMode: namespacePodSecurityLabelsMode,
 	}, nil
+}
+
+func resolveNamespacePodSecurityLabelsMode() (string, error) {
+	mode := strings.TrimSpace(os.Getenv(constants.EnvTenantNamespacePodSecurityLabelsMode))
+	if mode == "" {
+		return NamespacePodSecurityLabelsModeEnforce, nil
+	}
+	mode = strings.ToLower(mode)
+	switch mode {
+	case NamespacePodSecurityLabelsModeEnforce, NamespacePodSecurityLabelsModeExternal:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("%s must be %q or %q, got %q",
+			constants.EnvTenantNamespacePodSecurityLabelsMode,
+			NamespacePodSecurityLabelsModeEnforce,
+			NamespacePodSecurityLabelsModeExternal,
+			mode,
+		)
+	}
 }
 
 // applyResource uses Server-Side Apply.

--- a/internal/service/provisioner/manager_tenant.go
+++ b/internal/service/provisioner/manager_tenant.go
@@ -27,8 +27,12 @@ func (m *Manager) EnsureTenantRBAC(ctx context.Context, tenant *openbaov1alpha1.
 		return fmt.Errorf("failed to apply tenant RoleBinding %s/%s: %w", namespace, TenantRoleBindingName, err)
 	}
 
-	if err := m.ensureNamespacePodSecurityLabels(ctx, namespace); err != nil {
-		return err
+	if m.namespacePodSecurityLabelsMode == NamespacePodSecurityLabelsModeEnforce {
+		if err := m.ensureNamespacePodSecurityLabels(ctx, namespace); err != nil {
+			return err
+		}
+	} else {
+		m.logger.Info("Skipping tenant namespace Pod Security label enforcement; platform owns namespace Pod Security labels", "namespace", namespace)
 	}
 	if err := m.EnsureTenantSecretRBAC(ctx, namespace); err != nil {
 		return err

--- a/internal/service/provisioner/manager_test.go
+++ b/internal/service/provisioner/manager_test.go
@@ -2,9 +2,11 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -40,6 +42,52 @@ func newTestClient(t *testing.T, objs ...client.Object) client.Client {
 		builder = builder.WithObjects(objs...)
 	}
 	return builder.Build()
+}
+
+type namespaceUpdateDenyingClient struct {
+	client.Client
+}
+
+func (c namespaceUpdateDenyingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*corev1.Namespace); ok {
+		return apierrors.NewForbidden(
+			corev1.Resource("namespaces"),
+			obj.GetName(),
+			errors.New("namespace updates are managed by platform policy"),
+		)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func newTestTenant(namespace string) *openbaov1alpha1.OpenBaoTenant {
+	return &openbaov1alpha1.OpenBaoTenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tenant",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoTenantSpec{
+			TargetNamespace: namespace,
+		},
+	}
+}
+
+func TestNewManager_InvalidNamespacePodSecurityLabelsMode(t *testing.T) {
+	t.Setenv(constants.EnvTenantNamespacePodSecurityLabelsMode, "unsupported")
+
+	_, err := NewManager(newTestClient(t), logr.Discard())
+	if err == nil {
+		t.Fatal("NewManager() error = nil, want invalid namespace Pod Security labels mode error")
+	}
+	for _, want := range []string{
+		constants.EnvTenantNamespacePodSecurityLabelsMode,
+		NamespacePodSecurityLabelsModeEnforce,
+		NamespacePodSecurityLabelsModeExternal,
+		"unsupported",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("NewManager() error = %q, want it to contain %q", err.Error(), want)
+		}
+	}
 }
 
 func TestEnsureTenantRBAC_CreatesRoleAndRoleBinding(t *testing.T) {
@@ -140,6 +188,86 @@ func TestEnsureTenantRBAC_CreatesRoleAndRoleBinding(t *testing.T) {
 			t.Errorf("Namespace missing Pod Security label %q", key)
 		} else if actualValue != expectedValue {
 			t.Errorf("Namespace label %q = %q, want %q", key, actualValue, expectedValue)
+		}
+	}
+}
+
+func TestEnsureTenantRBAC_ExternalNamespacePodSecurityLabelsModeSkipsNamespaceUpdate(t *testing.T) {
+	t.Setenv(constants.EnvTenantNamespacePodSecurityLabelsMode, NamespacePodSecurityLabelsModeExternal)
+
+	namespace := testNamespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			Labels: map[string]string{
+				"existing-label": "value",
+			},
+		},
+	}
+	baseClient := newTestClient(t, ns)
+	k8sClient := namespaceUpdateDenyingClient{Client: baseClient}
+	manager, err := NewManager(k8sClient, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewManager() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := manager.EnsureTenantRBAC(ctx, newTestTenant(namespace)); err != nil {
+		t.Fatalf("EnsureTenantRBAC() error = %v", err)
+	}
+
+	role := &rbacv1.Role{}
+	if err := baseClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: TenantRoleName}, role); err != nil {
+		t.Fatalf("expected Role to exist: %v", err)
+	}
+	roleBinding := &rbacv1.RoleBinding{}
+	if err := baseClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: TenantRoleBindingName}, roleBinding); err != nil {
+		t.Fatalf("expected RoleBinding to exist: %v", err)
+	}
+
+	updatedNS := &corev1.Namespace{}
+	if err := baseClient.Get(ctx, types.NamespacedName{Name: namespace}, updatedNS); err != nil {
+		t.Fatalf("expected Namespace to exist: %v", err)
+	}
+	if updatedNS.Labels["existing-label"] != "value" {
+		t.Errorf("Namespace pre-existing label was not preserved")
+	}
+	for _, key := range []string{
+		"pod-security.kubernetes.io/enforce",
+		"pod-security.kubernetes.io/audit",
+		"pod-security.kubernetes.io/warn",
+	} {
+		if _, exists := updatedNS.Labels[key]; exists {
+			t.Errorf("Namespace has Pod Security label %q in external mode", key)
+		}
+	}
+}
+
+func TestEnsureTenantRBAC_EnforceNamespacePodSecurityLabelsModeTreatsNamespaceUpdateDenialAsFatal(t *testing.T) {
+	t.Setenv(constants.EnvTenantNamespacePodSecurityLabelsMode, NamespacePodSecurityLabelsModeEnforce)
+
+	namespace := testNamespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	k8sClient := namespaceUpdateDenyingClient{Client: newTestClient(t, ns)}
+	manager, err := NewManager(k8sClient, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewManager() failed: %v", err)
+	}
+
+	err = manager.EnsureTenantRBAC(context.Background(), newTestTenant(namespace))
+	if err == nil {
+		t.Fatal("EnsureTenantRBAC() error = nil, want namespace update denial")
+	}
+	for _, want := range []string{
+		"failed to update namespace",
+		"namespace updates are managed by platform policy",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("EnsureTenantRBAC() error = %q, want it to contain %q", err.Error(), want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `tenancy.namespacePodSecurityLabels.mode` with default `enforce` and optional `external` ownership.
- Skips Provisioner namespace Pod Security label updates in external mode, removes namespace `update`/`patch` RBAC from the chart, and makes the namespace-mutation VAP deny Provisioner namespace mutations entirely.
- Updates Helm sync generation, focused tests, and docs so platform-managed namespace labels are an explicit supported install path.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Default behavior is unchanged: `enforce` still lets the Provisioner apply Restricted Pod Security labels during tenant onboarding. The new `external` mode is opt-in and reduces the Provisioner's namespace permissions for clusters where Rancher or another platform policy layer owns namespace labels. In external mode, the platform must enforce the tenant namespace Pod Security baseline.

No CRD/API changes are introduced. The Helm value affects chart-rendered RBAC, the Provisioner deployment environment, and the namespace-mutation admission policy.

## Verification

- `go test ./internal/service/provisioner ./internal/app/provisioner ./internal/controller/provisioner ./hack/helmchart`
- `helm lint charts/openbao-operator --namespace openbao-operator-system`
- `helm template openbao-operator charts/openbao-operator --namespace openbao-operator-system --include-crds`
- `helm template openbao-operator charts/openbao-operator --namespace openbao-operator-system --set tenancy.namespacePodSecurityLabels.mode=external`
- `make verify-helm`
- Pre-push hook ran `make lint-ci`

## Reviewer Notes

The Helm sync generator now owns the chart conditionals for external mode, so `make verify-helm` remains stable after regeneration.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
