### PR TITLE
test(integration): render installer manifest in OpenShift check

### DIFF
--- a/test/manifests/openshift/openshift_compat_integration_test.go
+++ b/test/manifests/openshift/openshift_compat_integration_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+// +build integration
+
+package openshift
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func kustomizeBuild(t *testing.T, root string, rel string) []byte {
+	t.Helper()
+
+	kustomize := filepath.Join(root, "bin", "kustomize")
+	if _, err := exec.LookPath(kustomize); err != nil {
+		if p, pathErr := exec.LookPath("kustomize"); pathErr == nil {
+			kustomize = p
+		} else {
+			t.Fatalf("kustomize binary not found at %q and not in PATH", kustomize)
+		}
+	}
+
+	dir := filepath.Join(root, rel)
+	cmd := exec.Command(kustomize, "build", dir) // #nosec G204 -- test invokes repo-managed kustomize with fixed args.
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kustomize build %q failed: %v\n%s", dir, err, string(out))
+	}
+	return out
+}
+
+func TestRenderedInstallerOperatorDeployments_AreOpenShiftAdmittable(t *testing.T) {
+	root := repoRoot(t)
+	objs := parseYAMLBytes(t, "kustomize build config/default", kustomizeBuild(t, root, "config/default"))
+
+	want := map[string]bool{
+		"openbao-operator-controller":  false,
+		"openbao-operator-provisioner": false,
+	}
+
+	for _, u := range objs {
+		gvk := schema.FromAPIVersionAndKind(u.GetAPIVersion(), u.GetKind())
+		if gvk.Group != "apps" || gvk.Kind != "Deployment" {
+			continue
+		}
+
+		if _, ok := want[u.GetName()]; !ok {
+			continue
+		}
+
+		assertNoPinnedIDs(t, u)
+		want[u.GetName()] = true
+	}
+
+	for name, found := range want {
+		if !found {
+			t.Fatalf("rendered installer: expected Deployment %q not found", name)
+		}
+	}
+}

--- a/test/manifests/openshift/openshift_compat_test.go
+++ b/test/manifests/openshift/openshift_compat_test.go
@@ -33,6 +33,12 @@ func parseYAMLFile(t *testing.T, path string) []*unstructured.Unstructured {
 		t.Fatalf("read %q: %v", path, err)
 	}
 
+	return parseYAMLBytes(t, path, raw)
+}
+
+func parseYAMLBytes(t *testing.T, source string, raw []byte) []*unstructured.Unstructured {
+	t.Helper()
+
 	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(raw), 4096)
 	var out []*unstructured.Unstructured
 
@@ -42,7 +48,7 @@ func parseYAMLFile(t *testing.T, path string) []*unstructured.Unstructured {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			t.Fatalf("decode %q: %v", path, err)
+			t.Fatalf("decode %q: %v", source, err)
 		}
 
 		if len(obj) == 0 {
@@ -115,37 +121,5 @@ func TestManagerKustomizeManifests_AreOpenShiftAdmittable(t *testing.T) {
 		}
 
 		assertNoPinnedIDs(t, deployments[0])
-	}
-}
-
-func TestDistInstallOperatorDeployments_AreOpenShiftAdmittable(t *testing.T) {
-	root := repoRoot(t)
-
-	path := filepath.Join(root, "dist", "install.yaml")
-	objs := parseYAMLFile(t, path)
-
-	want := map[string]bool{
-		"openbao-operator-controller":  false,
-		"openbao-operator-provisioner": false,
-	}
-
-	for _, u := range objs {
-		gvk := schema.FromAPIVersionAndKind(u.GetAPIVersion(), u.GetKind())
-		if gvk.Group != "apps" || gvk.Kind != "Deployment" {
-			continue
-		}
-
-		if _, ok := want[u.GetName()]; !ok {
-			continue
-		}
-
-		assertNoPinnedIDs(t, u)
-		want[u.GetName()] = true
-	}
-
-	for name, found := range want {
-		if !found {
-			t.Fatalf("dist/install.yaml: expected Deployment %q not found", name)
-		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix the main CI regression after `dist/install.yaml` stopped being tracked.
- Move rendered installer OpenShift admission coverage into an integration-tagged test that runs `kustomize build config/default`.
- Keep the regular unit test focused on source manager manifests so it does not depend on generated/ignored installer output.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Test-only change. No API, CRD, Helm, RBAC, security, upgrade, or operational impact. The integration-tagged OpenShift manifest check now requires Kustomize from `bin/kustomize` or `PATH`, matching the rendered-manifest test path.

## Verification

- `go test ./test/manifests/openshift`
- `go test -tags=integration ./test/manifests/openshift -v`
- `make test`
- `make test-integration`
- `git diff --check`
- pre-push `make lint-ci`

## Reviewer Notes

`dist/install.yaml` remains generated/ignored by design. The rendered installer coverage now validates the source render path instead of a committed generated artifact.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
