### PR TITLE
ci(release): support release branch automation

### DIFF
--- a/.github/workflows/prepare-release-as-pr.yml
+++ b/.github/workflows/prepare-release-as-pr.yml
@@ -1,0 +1,129 @@
+name: Prepare Release-As PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Base branch for the release marker PR, for example release-0.2"
+        required: true
+        type: string
+      version:
+        description: "Exact SemVer version for Release-As, for example 0.2.1"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: prepare-release-as-pr-${{ inputs.target_branch }}-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release-as-pr:
+    name: Create Release-As Marker PR
+    runs-on: ubuntu-24.04
+    if: ${{ !github.event.repository.fork }}
+    steps:
+      - name: Validate inputs
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${TARGET_BRANCH}" =~ ^(main|release-[0-9]+(\.[0-9]+)*)$ ]]; then
+            echo "target_branch must be main or release-X[.Y...], got '${TARGET_BRANCH}'" >&2
+            exit 1
+          fi
+
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must be SemVer, got '${VERSION}'" >&2
+            exit 1
+          fi
+
+      - name: Mint GitHub App token (openbao-operator-release-pr)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.OPENBAO_OPERATOR_RELEASE_PR_APP_ID }}
+          private-key: ${{ secrets.OPENBAO_OPERATOR_RELEASE_PR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
+      - name: Checkout target branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create Release-As marker branch
+        id: marker
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          marker_branch="release-as-${TARGET_BRANCH}-${VERSION}"
+          echo "branch=${marker_branch}" >> "${GITHUB_OUTPUT}"
+
+          if git ls-remote --exit-code --heads origin "${marker_branch}" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${marker_branch}:refs/remotes/origin/${marker_branch}"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git switch -c "${marker_branch}"
+          git commit --allow-empty -s \
+            -m "chore: release ${VERSION}" \
+            -m "Release-As: ${VERSION}"
+          git push --force-with-lease="refs/heads/${marker_branch}" origin "HEAD:${marker_branch}"
+
+      - name: Open or update marker PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          VERSION: ${{ inputs.version }}
+          MARKER_BRANCH: ${{ steps.marker.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          existing_pr="$(
+            gh pr list \
+              --repo "${REPO}" \
+              --state open \
+              --base "${TARGET_BRANCH}" \
+              --head "${MARKER_BRANCH}" \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          body="$(mktemp)"
+          cat > "${body}" <<EOF
+          This PR adds an empty release marker commit for release-please.
+
+          After this PR merges into \`${TARGET_BRANCH}\`, the Release Please PR workflow should open or update the release PR for \`${VERSION}\`.
+          EOF
+
+          if [[ -n "${existing_pr}" ]]; then
+            gh pr edit "${existing_pr}" \
+              --repo "${REPO}" \
+              --title "chore(${TARGET_BRANCH}): request release ${VERSION}" \
+              --body-file "${body}"
+            echo "Updated existing PR #${existing_pr}."
+          else
+            gh pr create \
+              --repo "${REPO}" \
+              --base "${TARGET_BRANCH}" \
+              --head "${MARKER_BRANCH}" \
+              --title "chore(${TARGET_BRANCH}): request release ${VERSION}" \
+              --body-file "${body}"
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
   workflow_dispatch:
     inputs:
       release_as:
-        description: "Optional semver override for the release PR (for example 0.1.0-rc.6)"
+        description: "Optional semver override for the release PR. Prefer the Prepare Release-As PR workflow for audited overrides."
         required: false
         type: string
 
@@ -15,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-please-pr
+  group: release-please-pr-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -41,6 +42,7 @@ jobs:
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
+          target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           release-as: ${{ github.event_name == 'workflow_dispatch' && inputs.release_as || '' }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
     paths:
       - 'CHANGELOG.md'
       - '.release-please-manifest.json'
@@ -15,7 +16,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: release-please-tag
+  group: release-please-tag-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -94,6 +95,7 @@ jobs:
       - name: Create tag and draft release
         env:
           REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.ref_name }}
           GH_READ_TOKEN: ${{ github.token }}
           GH_WRITE_TOKEN: ${{ steps.app-token.outputs.token }}
           OPENBAO_OPERATOR_RELEASE_TAG_GPG_PASSPHRASE: ${{ secrets.OPENBAO_OPERATOR_RELEASE_TAG_GPG_PASSPHRASE }}

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -36,7 +36,7 @@ journey: contribute
     {
       cells: [
         "Stable release",
-        "Merge the release-please PR so the `Release Tag` workflow can resolve the merged release PR, create the signed stable version tag, and create the draft GitHub Release from `main`.",
+        "Merge the release-please PR so the `Release Tag` workflow can resolve the merged release PR, create the signed stable version tag, and create the draft GitHub Release from `main` or a `release-*` branch.",
         "GitHub Release assets, OCI Helm chart, signed images, stable docs snapshot, docs deployment, and provenance evidence.",
         "Stable releases become permanent release-line docs and own the default `/docs` route.",
       ],
@@ -44,8 +44,16 @@ journey: contribute
     },
     {
       cells: [
+        "Patch release",
+        "Backport the targeted fixes to the relevant `release-*` branch, then use the `Prepare Release-As PR` workflow to create the auditable `Release-As: X.Y.Z` marker PR.",
+        "Same release artifacts as stable releases, built from the patch branch tag.",
+        "Keep the patch branch narrow; patch releases in an existing stable line reuse that line's docs snapshot.",
+      ],
+    },
+    {
+      cells: [
         "Prerelease",
-        "Prefer a tiny PR that carries an empty commit with `Release-As: 0.1.0-rc.6`, then merge the resulting release-please PR so the `Release Tag` workflow creates the signed prerelease tag and draft GitHub Release.",
+        "Prefer the `Prepare Release-As PR` workflow to create a tiny PR that carries an empty commit with `Release-As: 0.1.0-rc.6`, then merge the resulting release-please PR so the `Release Tag` workflow creates the signed prerelease tag and draft GitHub Release.",
         "GitHub Release assets, OCI Helm chart, signed images, docs site deployment, and provenance evidence.",
         "Prereleases use `/docs/next` plus release notes; do not create a permanent versioned docs snapshot.",
       ],
@@ -75,6 +83,12 @@ Before merging the first stable `X.Y.0` release PR for a release line, snapshot 
 
 </Callout>
 
+<Callout type="note" title="Patch branch workflow state">
+
+GitHub Actions runs workflow definitions from the branch that receives the push. Before using release-please on an older `release-*` branch for the first time, make sure the branch contains the current release workflow support, including `Release Please PR`, `Release Tag`, and `Prepare Release-As PR` behavior.
+
+</Callout>
+
 <CommandBlock
   language="bash"
   label="configure"
@@ -87,16 +101,19 @@ Before merging the first stable `X.Y.0` release PR for a release line, snapshot 
 <CommandBlock
   language="bash"
   label="configure"
-  title="Cut an explicit prerelease with a Release-As PR"
-  code={`git switch -c chore/release-as-0.1.0-rc.6
-git commit --allow-empty -m $'chore: release 0.1.0-rc.6\n\nRelease-As: 0.1.0-rc.6\nSigned-off-by: Your Name <you@example.com>'`}
+  title="Cut an explicit release with a Release-As PR"
+  code={`# In GitHub Actions, run:
+# Prepare Release-As PR
+#
+# target_branch: main        # or release-0.2
+# version: 0.1.0-rc.6       # or 0.2.1`}
 >
-  This flow creates an explicit prerelease target on `main` when the inferred Conventional Commit bump is not the intended version.
+  This workflow creates a tiny PR containing an empty `Release-As: <version>` commit. Merge that marker PR first; the branch-aware Release Please workflow then opens or updates the real release PR.
 </CommandBlock>
 
 <Callout type="note" title="`workflow_dispatch` `release_as` path">
 
-`Release Please PR` still exposes a `workflow_dispatch` `release_as` input, and it can produce the expected release PR. The `Release-As:` PR path remains the fallback for release lines where the dispatch path is not yet reliable.
+`Release Please PR` still exposes a `workflow_dispatch` `release_as` input, but maintainers should prefer the `Prepare Release-As PR` workflow. The marker PR leaves the version override in git history and works consistently for `main` and `release-*` branches.
 
 </Callout>
 


### PR DESCRIPTION
## Summary

- Enable the release-please PR and release-tag workflows on `release-*` branches.
- Add a `Prepare Release-As PR` workflow that creates or updates an auditable empty `Release-As: <version>` marker PR.
- Document the patch release flow, including the need to carry current release workflow support on older release branches before using them.

## Related Issues

Related to #395.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or runtime compatibility impact. The operational impact is limited to release automation: release workflows can now run from `release-*` branches, and explicit version overrides can be recorded through a small marker PR instead of relying on the manual `release_as` dispatch input.

## Verification

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml .github/workflows/release-tag.yml .github/workflows/prepare-release-as-pr.yml`
- `git diff --check`
- `make docs-build`
- Local marker workflow simulation against a temporary bare `origin`, including a rerun that force-updated the same `release-as-release-0.2-0.2.1` branch with `--force-with-lease`.
- `release-please release-pr --dry-run --local --target-branch release-0.2`, which reported it would open `chore(release-0.2): release 0.2.1` and update `CHANGELOG.md`, `version.txt`, `charts/openbao-operator/Chart.yaml`, and `.release-please-manifest.json`.
- `DRY_RUN=1 BASE_BRANCH=release-0.2 hack/ci/create-release-tag-and-draft.sh` with a fake `gh` client, which reported it would create the signed annotated `0.2.1` tag and draft release from the merged branch-scoped release PR.
- Pre-push hook: `make lint-ci`.

## Reviewer Notes

After this lands on `main`, carry the same release workflow support onto `release-0.2` before running the `0.2.1` patch flow. GitHub Actions reads workflow definitions from the branch that receives the event, so the release branch needs the branch-aware workflow definitions before `Prepare Release-As PR`, `Release Please PR`, and `Release Tag` can run there.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
