### PR TITLE
ci(release): keep marker commit out of changelog

### DIFF
--- a/.github/workflows/prepare-release-as-pr.yml
+++ b/.github/workflows/prepare-release-as-pr.yml
@@ -82,7 +82,7 @@ jobs:
 
           git switch -c "${marker_branch}"
           git commit --allow-empty -s \
-            -m "chore: release ${VERSION}" \
+            -m "Release ${VERSION}" \
             -m "Release-As: ${VERSION}"
           git push --force-with-lease="refs/heads/${marker_branch}" origin "HEAD:${marker_branch}"
 


### PR DESCRIPTION
## Summary

Change the `Prepare Release-As PR` marker commit subject from a Conventional Commit (`chore: release <version>`) to a plain release marker (`Release <version>`).

This still gives release-please a `Release-As: <version>` footer to force the requested version, but prevents the marker commit from appearing in generated release notes.

## Related Issues

Related to #395 and #433.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or runtime compatibility impact. This only changes the generated empty marker commit message used by release automation.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/prepare-release-as-pr.yml`
- `git diff --check`
- `release-please release-pr --dry-run --local --target-branch release-0.2` with a simulated `fix(chart): avoid duplicate pod labels` commit plus a `Release 0.2.1` marker commit. The dry-run still opened `chore(release-0.2): release 0.2.1`, and the generated changelog contained only the real bug fix.
- Pre-push hook: `make lint-ci`.

## Reviewer Notes

Release-please logs that the plain marker subject is not parseable as a Conventional Commit. That is expected and harmless; the `Release-As: <version>` footer is still processed, while the marker is omitted from release notes.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
