### PR TITLE
ci(release): ignore release-please branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-*'
+      - '!release-please--branches--*'
   workflow_dispatch:
     inputs:
       release_as:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-*'
+      - '!release-please--branches--*'
     paths:
       - 'CHANGELOG.md'
       - '.release-please-manifest.json'


### PR DESCRIPTION
## Summary

- Exclude `release-please--branches--*` from release workflow push triggers.
- Prevent release-please and release-tag workflows from recursively running on release-please's own PR branches.
- Keep #437 as the canonical `release-0.2` / `0.2.1` release PR path.

## Related Issues

Refs #437

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No runtime, API, CRD, Helm, RBAC, security, upgrade, or operational impact. This only narrows release workflow push triggers so release-please PR branches do not match the `release-*` branch pattern.

## Verification

- `git diff --check HEAD~1..HEAD`
- `git push -u origin fix/release-branch-workflow-filters` pre-push hook ran `make lint-ci` successfully, including `golangci-lint` and 60 architecture tests.

## Reviewer Notes

This should land before merging #437 so release-please branch updates cannot create nested release PRs again. After this merges, duplicate nested release PRs can stay closed and #437 remains the release PR to continue with.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
