### PR TITLE
fix(security): allow release tag build signatures

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,15 @@ on:
       - '.release-please-manifest.json'
       - 'charts/openbao-operator/Chart.yaml'
   workflow_dispatch:
+    inputs:
+      tag_target:
+        description: "Commit to tag. Use branch-head only to retry a failed draft release after a release-branch fix."
+        required: false
+        default: release-pr-merge
+        type: choice
+        options:
+          - release-pr-merge
+          - branch-head
 
 permissions:
   contents: read
@@ -97,6 +106,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ github.ref_name }}
+          TAG_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_target || 'release-pr-merge' }}
           GH_READ_TOKEN: ${{ github.token }}
           GH_WRITE_TOKEN: ${{ steps.app-token.outputs.token }}
           OPENBAO_OPERATOR_RELEASE_TAG_GPG_PASSPHRASE: ${{ secrets.OPENBAO_OPERATOR_RELEASE_TAG_GPG_PASSPHRASE }}

--- a/hack/ci/create-release-tag-and-draft.sh
+++ b/hack/ci/create-release-tag-and-draft.sh
@@ -9,6 +9,7 @@ MANIFEST_FILE="${MANIFEST_FILE:-.release-please-manifest.json}"
 CHART_FILE="${CHART_FILE:-charts/openbao-operator/Chart.yaml}"
 RELEASE_NOTES_DIR="${RELEASE_NOTES_DIR:-release-notes}"
 DRY_RUN="${DRY_RUN:-0}"
+TAG_TARGET="${TAG_TARGET:-release-pr-merge}"
 
 GH_READ_TOKEN="${GH_READ_TOKEN:-${GH_TOKEN:-}}"
 GH_WRITE_TOKEN="${GH_WRITE_TOKEN:-${GH_TOKEN:-}}"
@@ -22,6 +23,14 @@ if [[ "${DRY_RUN}" != "1" && -z "${GH_WRITE_TOKEN}" ]]; then
   echo "GH_WRITE_TOKEN (or GH_TOKEN) is required unless DRY_RUN=1" >&2
   exit 1
 fi
+
+case "${TAG_TARGET}" in
+  release-pr-merge | branch-head) ;;
+  *)
+    echo "TAG_TARGET must be either 'release-pr-merge' or 'branch-head', got '${TAG_TARGET}'" >&2
+    exit 1
+    ;;
+esac
 
 require_file() {
   local path="$1"
@@ -203,6 +212,29 @@ if [[ "${manifest_at_merge}" != "${version}" || "${chart_version_at_merge}" != "
   exit 1
 fi
 
+tag_oid="${merge_oid}"
+
+if [[ "${TAG_TARGET}" == "branch-head" ]]; then
+  tag_oid="$(git rev-parse HEAD)"
+
+  if ! git merge-base --is-ancestor "${merge_oid}" "${tag_oid}"; then
+    echo "branch-head tag target ${tag_oid} does not descend from release PR merge commit ${merge_oid}" >&2
+    exit 1
+  fi
+
+  manifest_at_target="$(git show "${tag_oid}:${MANIFEST_FILE}" | jq -er '."."')"
+  chart_version_at_target="$(git show "${tag_oid}:${CHART_FILE}" | chart_value /dev/stdin "version")"
+  chart_app_version_at_target="$(git show "${tag_oid}:${CHART_FILE}" | chart_value /dev/stdin "appVersion")"
+
+  if [[ "${manifest_at_target}" != "${version}" || "${chart_version_at_target}" != "${version}" || "${chart_app_version_at_target}" != "${version}" ]]; then
+    echo "release files at branch-head tag target ${tag_oid} do not match ${version}" >&2
+    echo "  manifest@target:   ${manifest_at_target}" >&2
+    echo "  chart@target:      ${chart_version_at_target}" >&2
+    echo "  appVersion@target: ${chart_app_version_at_target}" >&2
+    exit 1
+  fi
+fi
+
 notes_file="$(mktemp)"
 generated_notes_file="$(mktemp)"
 trap 'rm -f "${notes_file}" "${generated_notes_file}"' EXIT
@@ -231,23 +263,23 @@ fi
 
 if git rev-parse -q --verify "refs/tags/${version}" >/dev/null 2>&1; then
   local_tag_commit="$(git rev-list -n1 "${version}")"
-  if [[ "${local_tag_commit}" != "${merge_oid}" ]]; then
-    echo "local tag ${version} points at ${local_tag_commit}, expected ${merge_oid}" >&2
+  if [[ "${local_tag_commit}" != "${tag_oid}" ]]; then
+    echo "local tag ${version} points at ${local_tag_commit}, expected ${tag_oid}" >&2
     exit 1
   fi
 elif git ls-remote --exit-code --tags origin "refs/tags/${version}" >/dev/null 2>&1; then
   git fetch --no-tags origin "refs/tags/${version}:refs/tags/${version}" >/dev/null 2>&1
   remote_tag_commit="$(git rev-list -n1 "${version}")"
-  if [[ "${remote_tag_commit}" != "${merge_oid}" ]]; then
-    echo "remote tag ${version} points at ${remote_tag_commit}, expected ${merge_oid}" >&2
+  if [[ "${remote_tag_commit}" != "${tag_oid}" ]]; then
+    echo "remote tag ${version} points at ${remote_tag_commit}, expected ${tag_oid}" >&2
     exit 1
   fi
 else
   if [[ "${DRY_RUN}" == "1" ]]; then
-    echo "[dry-run] would create signed annotated tag ${version} at ${merge_oid}"
+    echo "[dry-run] would create signed annotated tag ${version} at ${tag_oid} (${TAG_TARGET})"
   else
     require_git_tag_signing
-    git tag -s "${version}" "${merge_oid}" -m "Release ${version}"
+    git tag -s "${version}" "${tag_oid}" -m "Release ${version}"
     git push origin "refs/tags/${version}"
   fi
 fi

--- a/internal/adapter/security/cluster_image_verification_test.go
+++ b/internal/adapter/security/cluster_image_verification_test.go
@@ -71,6 +71,7 @@ func assertOperatorSubjectRegExp(t *testing.T, expr string) {
 		"https://github.com/dc-tec/openbao-operator/.github/workflows/publish-edge.yml@refs/heads/main",
 		"https://github.com/dc-tec/openbao-operator/.github/workflows/publish-nightly.yml@refs/heads/main",
 		"https://github.com/dc-tec/openbao-operator/.github/workflows/reusable-build.yml@refs/heads/main",
+		"https://github.com/dc-tec/openbao-operator/.github/workflows/reusable-build.yml@refs/tags/0.2.1",
 	}
 	for _, subject := range trusted {
 		if !re.MatchString(subject) {

--- a/internal/port/security/image_verification.go
+++ b/internal/port/security/image_verification.go
@@ -16,7 +16,7 @@ const (
 	defaultGitHubOIDCIssuerRegExp = "^https://token\\.actions\\.githubusercontent\\.com$"
 
 	openBaoReleaseSubjectRegExp = "^https://github\\.com/openbao/openbao/\\.github/workflows/release\\.yml@refs/tags/v?[0-9A-Za-z][0-9A-Za-z._+-]*$"
-	operatorSubjectRegExp       = "^https://github\\.com/dc-tec/openbao-operator/\\.github/workflows/(release\\.yml@refs/tags/.+|publish-edge\\.yml@refs/heads/main|publish-nightly\\.yml@refs/heads/main|reusable-build\\.yml@refs/heads/main)$"
+	operatorSubjectRegExp       = "^https://github\\.com/dc-tec/openbao-operator/\\.github/workflows/(release\\.yml@refs/tags/.+|publish-edge\\.yml@refs/heads/main|publish-nightly\\.yml@refs/heads/main|reusable-build\\.yml@(refs/heads/main|refs/tags/.+))$"
 
 	operatorInitOfficialRepository    = "ghcr.io/dc-tec/openbao-init"
 	operatorBackupOfficialRepository  = "ghcr.io/dc-tec/openbao-backup"


### PR DESCRIPTION
## Summary

- Allow operator helper image verification defaults to trust `reusable-build.yml` when it runs from release tags. The failed `0.2.1` release gate signed helper images with `reusable-build.yml@refs/tags/0.2.1`, but the default operator image subject regex only allowed that reusable workflow from `refs/heads/main`.
- Add a manual-only `Release Tag` retry mode that can tag the checked-out branch head after a release-branch fix, while keeping the default behavior of tagging the canonical release PR merge commit.

## Related Issues

Related to the failed `0.2.1` release gate run: https://github.com/dc-tec/openbao-operator/actions/runs/26052321055/job/76593355597

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. The image verification change is limited to the default keyless subject allowlist for official operator helper images. It permits `reusable-build.yml` from release tags in this repository, while still rejecting feature-branch reusable-build subjects.

The release-tag workflow default remains unchanged. The new `branch-head` tag target is only available through `workflow_dispatch` and validates that the branch head descends from the merged release PR commit and still carries matching release manifest/chart versions.

## Verification

- `go test ./internal/port/security ./internal/adapter/security`
- `make ci-core`
- `bash -n hack/ci/create-release-tag-and-draft.sh`
- `DRY_RUN=1 TAG_TARGET=branch-head BASE_BRANCH=release-0.2 REPO=dc-tec/openbao-operator GH_READ_TOKEN=... GH_WRITE_TOKEN=... bash hack/ci/create-release-tag-and-draft.sh`
- `DRY_RUN=1 TAG_TARGET=release-pr-merge BASE_BRANCH=release-0.2 REPO=dc-tec/openbao-operator GH_READ_TOKEN=... GH_WRITE_TOKEN=... bash hack/ci/create-release-tag-and-draft.sh`
- `actionlint .github/workflows/release-tag.yml`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

After this lands on `release-0.2`, retry the `Release Tag` workflow manually from `release-0.2` with `tag_target=branch-head`. The stale `0.2.1` draft release and tag were removed, so the retry can recreate both from the corrected branch head.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.