### PR TITLE
ci(release): sign build images before e2e gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
       ref: ${{ github.ref }}
       source_date_epoch: ${{ needs.prepare.outputs.source_date_epoch }}
       cache-scope: ${{ needs.prepare.outputs.build_tag }}
+      sign_images: true
     secrets: inherit
 
   rebuild:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: trusted
         type: string
+      sign_images:
+        description: "Sign pushed image digests with keyless cosign before returning build outputs"
+        required: false
+        default: false
+        type: boolean
     outputs:
       manager_digest:
         description: "Digest of the manager image"
@@ -133,6 +138,20 @@ jobs:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      - name: Install cosign
+        if: ${{ inputs.sign_images }}
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: v3.0.4
+
+      - name: Sign image (keyless)
+        if: ${{ inputs.sign_images }}
+        env:
+          IMAGE_REF: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes --new-bundle-format=true "${IMAGE_REF}"
 
   collect-digests:
     name: Collect Image Digests


### PR DESCRIPTION
## Summary

- Adds an optional `sign_images` input to the reusable image build workflow.
- Enables pre-E2E keyless cosign signing for the primary release build images so hardened signed E2E verifies `build-${sha}` images after signatures exist.
- Leaves the independent rebuild images unsigned so byte reproducibility remains focused on build equivalence.

## Related Issues

Follow-up to release run https://github.com/dc-tec/openbao-operator/actions/runs/26057503821.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Release workflow only. No API, CRD, Helm, RBAC, runtime, or operational behavior changes. The release build now adds cosign signatures to the temporary `build-${sha}` image digests before release E2E starts; the existing promotion signing remains unchanged.

## Verification

- `./bin/actionlint .github/workflows/*.yml`
- `git diff --check`
- Focused shell assertions that primary `build` enables `sign_images`, `rebuild` does not, the reusable input defaults to `false`, and the cosign sign step runs before reusable build outputs return.
- `make lint-ci` via the pre-push hook.
- Confirmed the stale `0.2.1` draft release and remote tag return 404 before opening this PR.

GitHub OIDC keyless signing itself cannot be fully exercised locally; the workflow uses the same pinned cosign installer and signing flags as the existing promotion step.

## Reviewer Notes

This depends on the already-merged release-branch subject allowance for `reusable-build.yml@refs/tags/*`; otherwise the signature would exist but hardened E2E would reject its identity.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
