### PR TITLE
ci(release): stop release-please branch recursion

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-*'
+      - '!release-please--branches--*'
   workflow_dispatch:
     inputs:
       release_as:
@@ -25,8 +26,52 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ !github.event.repository.fork }}
     steps:
+      - name: Checkout for release-only guard
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect release artifact-only push
+        id: release-artifact-guard
+        if: ${{ github.event_name == 'push' }}
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${BEFORE_SHA}" =~ ^0+$ ]]; then
+            echo "skip_release_please=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            echo "skip_release_please=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          mapfile -t changed_files < <(git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}")
+          if (( ${#changed_files[@]} == 0 )); then
+            echo "skip_release_please=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          for file in "${changed_files[@]}"; do
+            case "${file}" in
+              CHANGELOG.md|.release-please-manifest.json|charts/openbao-operator/Chart.yaml) ;;
+              *)
+                echo "skip_release_please=false" >> "${GITHUB_OUTPUT}"
+                exit 0
+                ;;
+            esac
+          done
+
+          echo "Push only changed release artifacts; skipping release-please."
+          echo "skip_release_please=true" >> "${GITHUB_OUTPUT}"
+
       - name: Mint GitHub App token (openbao-operator-release-pr)
         id: app-token
+        if: ${{ steps.release-artifact-guard.outputs.skip_release_please != 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.OPENBAO_OPERATOR_RELEASE_PR_APP_ID }}
@@ -39,6 +84,7 @@ jobs:
 
       - name: Run release-please (PR only)
         id: release
+        if: ${{ steps.release-artifact-guard.outputs.skip_release_please != 'true' }}
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -49,14 +95,14 @@ jobs:
           skip-github-release: true
 
       - name: Check out release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release-artifact-guard.outputs.skip_release_please != 'true' && steps.release.outputs.prs_created == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Sync Chart metadata and changelog on release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release-artifact-guard.outputs.skip_release_please != 'true' && steps.release.outputs.prs_created == 'true' }}
         env:
           OWNER: ${{ github.repository_owner }}
           RELEASE_PR_BRANCH: release-please--branches--${{ github.ref_name }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-*'
+      - '!release-please--branches--*'
     paths:
       - 'CHANGELOG.md'
       - '.release-please-manifest.json'


### PR DESCRIPTION
## Summary

- Excludes `release-please--branches--*` from the `Release Please PR` and `Release Tag` push triggers.
- Adds a push-time guard that skips release-please when a push only changes release artifact files: `CHANGELOG.md`, `.release-please-manifest.json`, and `charts/openbao-operator/Chart.yaml`.
- Keeps `workflow_dispatch` and empty `Release-As:` marker commits working because the guard only skips non-empty release-artifact-only pushes.

## Related Issues

Follow-up to the recursive release-please PR loop that created #450-#455 from #395.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Release workflow only. This prevents recursive release-please runs on release-please head branches and avoids opening a new release PR from release-artifact-only merge commits. Manual Release-As dispatches and normal code/documentation changes still run release-please.

## Verification

- `./bin/actionlint .github/workflows/*.yml`
- `git diff --check`
- `make lint-ci` via the pre-push hook.
- Confirmed the recursive PRs #450-#455 were closed, their nested branches were deleted, and no active `Release Please PR` runs remained before opening this PR.

## Reviewer Notes

The active main release PR #395 and its branch `release-please--branches--main` were intentionally left intact.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
