### PR TITLE
docs(release): support release-line docs refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,56 @@ jobs:
       - name: Build docs
         uses: ./.github/actions/docs-build
 
+  release-line-docs:
+    name: Release-line Docs Snapshot
+    needs: changes
+    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-') && needs.changes.outputs.docs == 'true'
+    runs-on: *runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify release-line docs snapshot changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Release-line docs check only supports release-X.Y branches; got ${BASE_REF}" >&2
+            exit 1
+          fi
+
+          docs_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.0"
+          git fetch --no-tags --prune --depth=1 origin "${BASE_SHA}" || true
+
+          changed="$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
+          docs_changed="$(grep -E '^(docs/|website/sidebars\.ts$)' <<< "${changed}" || true)"
+          if [[ -z "${docs_changed}" ]]; then
+            echo "No source docs changed."
+            exit 0
+          fi
+
+          snapshot_changed="$(
+            grep -E "^website/versioned_docs/version-${docs_version//./\\.}/|^website/versioned_sidebars/version-${docs_version//./\\.}-sidebars\\.json$|^website/versions\\.json$" <<< "${changed}" || true
+          )"
+          if [[ -n "${snapshot_changed}" ]]; then
+            echo "Release-line docs snapshot changed for ${docs_version}."
+            exit 0
+          fi
+
+          {
+            echo "PRs against ${BASE_REF} that change source docs must refresh the ${docs_version} release-line docs snapshot."
+            echo
+            echo "Run from the release branch and commit the generated files:"
+            echo "  make docs-refresh-version DOCS_VERSION=${docs_version}"
+          } >&2
+          exit 1
+
   helm:
     name: Helm Chart
     needs: changes
@@ -1008,6 +1058,7 @@ jobs:
       - fuzz
       - openbao-config-compat
       - docs
+      - release-line-docs
       - helm
       - helm-e2e-smoke
       - build-artifacts
@@ -1032,6 +1083,7 @@ jobs:
           FUZZ: ${{ needs.fuzz.result }}
           OPENBAO_CONFIG_COMPAT: ${{ needs.openbao-config-compat.result }}
           DOCS: ${{ needs.docs.result }}
+          RELEASE_LINE_DOCS: ${{ needs.release-line-docs.result }}
           HELM: ${{ needs.helm.result }}
           HELM_E2E_SMOKE: ${{ needs.helm-e2e-smoke.result }}
           BUILD_ARTIFACTS: ${{ needs.build-artifacts.result }}
@@ -1066,6 +1118,7 @@ jobs:
           fuzz=${FUZZ}
           openbao-config-compat=${OPENBAO_CONFIG_COMPAT}
           docs=${DOCS}
+          release-line-docs=${RELEASE_LINE_DOCS}
           helm=${HELM}
           helm-e2e-smoke=${HELM_E2E_SMOKE}
           build-artifacts=${BUILD_ARTIFACTS}

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -79,7 +79,7 @@ journey: contribute
 
 <Callout type="important" title="Stable release-line docs snapshots">
 
-Before merging the first stable `X.Y.0` release PR for a release line, snapshot the docs for that release line and commit the generated artifacts. Patch releases in the same line publish release notes and reuse the `X.Y.0` docs snapshot. Prereleases continue to use `/docs/next` and release notes only; do not add patch, `-alpha`, `-beta`, or `-rc` entries to `website/versions.json`.
+Before merging the first stable `X.Y.0` release PR for a release line, snapshot the docs for that release line and commit the generated artifacts. Patch releases in the same line reuse the `X.Y.0` docs version, but user-facing docs fixes for that patch must refresh the existing `X.Y.0` snapshot from the release branch. Prereleases continue to use `/docs/next` and release notes only; do not add patch, `-alpha`, `-beta`, or `-rc` entries to `website/versions.json`.
 
 </Callout>
 
@@ -96,6 +96,16 @@ GitHub Actions runs workflow definitions from the branch that receives the push.
   code={`make docs-version DOCS_VERSION=X.Y.0`}
 >
   This updates `website/versioned_docs/`, `website/versioned_sidebars/`, and `website/versions.json`.
+</CommandBlock>
+
+<CommandBlock
+  language="bash"
+  label="configure"
+  title="Refresh docs for a patch release line"
+  code={`git switch release-X.Y
+make docs-refresh-version DOCS_VERSION=X.Y.0`}
+>
+  Run this from the release branch after backporting docs that apply to the patch release. This updates the existing release-line docs snapshot without adding a patch version to `website/versions.json`.
 </CommandBlock>
 
 <CommandBlock

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -389,6 +389,11 @@ docs-version: docs-deps ## Snapshot the current docs into a versioned Docusaurus
 	@test -n "$(DOCS_VERSION)" || { echo "DOCS_VERSION is required, for example: make docs-version DOCS_VERSION=1.2.3"; exit 1; }
 	@$(DOCS_NPM) --prefix "$(DOCS_DIR)" run version:docs -- "$(DOCS_VERSION)"
 
+.PHONY: docs-refresh-version
+docs-refresh-version: docs-deps ## Refresh an existing release-line docs snapshot from the checked-out docs. Set DOCS_VERSION=<X.Y.0>.
+	@test -n "$(DOCS_VERSION)" || { echo "DOCS_VERSION is required, for example: make docs-refresh-version DOCS_VERSION=1.2.0"; exit 1; }
+	@$(DOCS_NPM) --prefix "$(DOCS_DIR)" run refresh:docs-version -- "$(DOCS_VERSION)"
+
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -65,6 +65,12 @@ const config: Config = {
               label: 'next',
               path: 'next',
             },
+            '0.2.0': {
+              label: '0.2.x',
+            },
+            '0.1.0': {
+              label: '0.1.x',
+            },
           },
         },
         blog: false,

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "version:docs": "node ./scripts/snapshot-version.mjs",
+    "refresh:docs-version": "node ./scripts/refresh-version.mjs",
     "verify:docs-version": "node ./scripts/verify-docs-version.mjs",
     "typecheck": "tsc --noEmit",
     "test:e2e": "playwright test"

--- a/website/scripts/refresh-version.mjs
+++ b/website/scripts/refresh-version.mjs
@@ -1,0 +1,121 @@
+import {spawnSync} from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const version = process.argv[2];
+const websiteRoot = process.cwd();
+const versionsPath = path.join(websiteRoot, 'versions.json');
+
+if (!version) {
+  console.error('Usage: npm run refresh:docs-version -- <version>');
+  process.exit(1);
+}
+
+function isStableLineVersion(candidate) {
+  return /^\d+\.\d+\.0$/.test(candidate);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: websiteRoot,
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`${[command, ...args].join(' ')} failed with status ${result.status ?? 1}`);
+  }
+}
+
+async function pathExists(target) {
+  try {
+    await fs.access(target);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function moveIfExists(from, to) {
+  if (await pathExists(from)) {
+    await fs.mkdir(path.dirname(to), {recursive: true});
+    await fs.rename(from, to);
+    return true;
+  }
+  return false;
+}
+
+async function restoreIfMoved(from, to, moved) {
+  if (!moved) {
+    return;
+  }
+  await fs.rm(to, {recursive: true, force: true});
+  await fs.mkdir(path.dirname(to), {recursive: true});
+  await fs.rename(from, to);
+}
+
+if (!isStableLineVersion(version)) {
+  console.error(
+    `Release-line docs refresh only supports stable release-line versions (X.Y.0). Patch releases update the existing release-line snapshot: ${version}`,
+  );
+  process.exit(1);
+}
+
+const raw = await fs.readFile(versionsPath, 'utf8');
+const originalVersions = JSON.parse(raw);
+
+if (!Array.isArray(originalVersions)) {
+  throw new Error('versions.json is not an array');
+}
+
+const dedupedOriginalVersions = [...new Set(originalVersions)];
+if (!dedupedOriginalVersions.includes(version)) {
+  console.error(
+    `Docs version ${version} is not present in versions.json. Create the release-line snapshot first with: make docs-version DOCS_VERSION=${version}`,
+  );
+  process.exit(1);
+}
+
+const tempRoot = path.join(websiteRoot, `.tmp-refresh-version-${process.pid}`);
+const versionedDocsDir = path.join(websiteRoot, 'versioned_docs', `version-${version}`);
+const versionedSidebarPath = path.join(
+  websiteRoot,
+  'versioned_sidebars',
+  `version-${version}-sidebars.json`,
+);
+const backupDocsDir = path.join(tempRoot, 'versioned_docs', `version-${version}`);
+const backupSidebarPath = path.join(
+  tempRoot,
+  'versioned_sidebars',
+  `version-${version}-sidebars.json`,
+);
+
+let movedDocs = false;
+let movedSidebar = false;
+
+try {
+  await fs.rm(tempRoot, {recursive: true, force: true});
+  movedDocs = await moveIfExists(versionedDocsDir, backupDocsDir);
+  movedSidebar = await moveIfExists(versionedSidebarPath, backupSidebarPath);
+  await fs.writeFile(
+    versionsPath,
+    `${JSON.stringify(dedupedOriginalVersions.filter((candidate) => candidate !== version), null, 2)}\n`,
+  );
+
+  run(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['run', 'prepare:contribute']);
+  run(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['docusaurus', 'docs:version', version]);
+
+  await fs.writeFile(versionsPath, `${JSON.stringify(dedupedOriginalVersions, null, 2)}\n`);
+  await fs.rm(tempRoot, {recursive: true, force: true});
+} catch (error) {
+  await fs.rm(versionedDocsDir, {recursive: true, force: true});
+  await fs.rm(versionedSidebarPath, {force: true});
+  await restoreIfMoved(backupDocsDir, versionedDocsDir, movedDocs);
+  await restoreIfMoved(backupSidebarPath, versionedSidebarPath, movedSidebar);
+  await fs.writeFile(versionsPath, `${JSON.stringify(dedupedOriginalVersions, null, 2)}\n`);
+  await fs.rm(tempRoot, {recursive: true, force: true});
+  console.error(error.message);
+  process.exit(1);
+}

--- a/website/scripts/snapshot-version.mjs
+++ b/website/scripts/snapshot-version.mjs
@@ -33,6 +33,18 @@ async function dedupeVersions() {
   await fs.writeFile(versionsPath, `${JSON.stringify(deduped, null, 2)}\n`);
 }
 
+const prepareResult = spawnSync(
+  process.platform === 'win32' ? 'npm.cmd' : 'npm',
+  ['run', 'prepare:contribute'],
+  {
+    stdio: 'inherit',
+  },
+);
+
+if (prepareResult.status !== 0) {
+  process.exit(prepareResult.status ?? 1);
+}
+
 const result = spawnSync(
   process.platform === 'win32' ? 'npx.cmd' : 'npx',
   ['docusaurus', 'docs:version', version],

--- a/website/tests/behavior.spec.ts
+++ b/website/tests/behavior.spec.ts
@@ -42,7 +42,7 @@ test('version dropdown switches from next docs to the stable release line', asyn
   await versionDropdown.hover();
 
   const archivedRelease = page.locator('.dropdown__menu').getByRole('link', {
-    name: '0.2.0',
+    name: '0.2.x',
     exact: true,
   });
   await expect(archivedRelease).toBeVisible();
@@ -50,7 +50,7 @@ test('version dropdown switches from next docs to the stable release line', asyn
 
   await expect(page).toHaveURL(/\/openbao-operator\/docs\/get-started\/deployment-decision-guide$/);
   await expect(page.getByText('Published release documentation')).toBeVisible();
-  await expect(page.getByText('Version: 0.2.0')).toBeVisible();
+  await expect(page.getByText('Version: 0.2.x')).toBeVisible();
 });
 
 test.describe('curated legacy redirects stay alive', () => {

--- a/website/tests/smoke.spec.ts
+++ b/website/tests/smoke.spec.ts
@@ -46,7 +46,7 @@ test('stable docs expose the current release banner', async ({page}) => {
 
   await expect(page.getByRole('heading', {name: 'OpenBao Operator documentation'})).toBeVisible();
   await expect(page.getByText('Published release documentation')).toBeVisible();
-  await expect(page.getByText('Version: 0.2.0')).toBeVisible();
+  await expect(page.getByText('Version: 0.2.x')).toBeVisible();
 });
 
 test('architecture section exposes grouped local navigation', async ({page}) => {

--- a/website/versioned_docs/version-0.2.0/contribute/release-management.md
+++ b/website/versioned_docs/version-0.2.0/contribute/release-management.md
@@ -71,7 +71,7 @@ journey: contribute
 
 <Callout type="important" title="Stable release-line docs snapshots">
 
-Before merging the first stable `X.Y.0` release PR for a release line, snapshot the docs for that release line and commit the generated artifacts. Patch releases in the same line publish release notes and reuse the `X.Y.0` docs snapshot. Prereleases continue to use `/docs/next` and release notes only; do not add patch, `-alpha`, `-beta`, or `-rc` entries to `website/versions.json`.
+Before merging the first stable `X.Y.0` release PR for a release line, snapshot the docs for that release line and commit the generated artifacts. Patch releases in the same line reuse the `X.Y.0` docs version, but user-facing docs fixes for that patch must refresh the existing `X.Y.0` snapshot from the release branch. Prereleases continue to use `/docs/next` and release notes only; do not add patch, `-alpha`, `-beta`, or `-rc` entries to `website/versions.json`.
 
 </Callout>
 
@@ -82,6 +82,16 @@ Before merging the first stable `X.Y.0` release PR for a release line, snapshot 
   code={`make docs-version DOCS_VERSION=X.Y.0`}
 >
   This updates `website/versioned_docs/`, `website/versioned_sidebars/`, and `website/versions.json`.
+</CommandBlock>
+
+<CommandBlock
+  language="bash"
+  label="configure"
+  title="Refresh docs for a patch release line"
+  code={`git switch release-X.Y
+make docs-refresh-version DOCS_VERSION=X.Y.0`}
+>
+  Run this from the release branch after backporting docs that apply to the patch release. This updates the existing release-line docs snapshot without adding a patch version to `website/versions.json`.
 </CommandBlock>
 
 <CommandBlock

--- a/website/versioned_docs/version-0.2.0/reference/api.md
+++ b/website/versioned_docs/version-0.2.0/reference/api.md
@@ -1096,7 +1096,7 @@ _Appears in:_
 | `filePermissions` _string_ | FilePermissions are the file permissions for plugin files (e.g., "0755"). |  | Optional: \{\} <br /> |
 | `autoDownload` _boolean_ | AutoDownload controls automatic plugin downloads from OCI registries. |  | Optional: \{\} <br /> |
 | `autoRegister` _boolean_ | AutoRegister controls automatic plugin registration. |  | Optional: \{\} <br /> |
-| `downloadBehavior` _string_ | DownloadBehavior specifies how plugins are downloaded. |  | Enum: [standard direct] <br />Optional: \{\} <br /> |
+| `downloadBehavior` _string_ | DownloadBehavior controls whether OpenBao startup fails or continues when<br />declarative OCI plugin downloads fail. Valid values are "fail" and<br />"continue"; OpenBao defaults to "fail" when unset. |  | Enum: [fail continue] <br />Optional: \{\} <br /> |
 
 
 #### PodMetadataConfig

--- a/website/versioned_docs/version-0.2.0/user-guide/openbaocluster/configuration/server.md
+++ b/website/versioned_docs/version-0.2.0/user-guide/openbaocluster/configuration/server.md
@@ -145,15 +145,76 @@ description: Configure server-runtime defaults such as UI, listener behavior, au
   configuration:
     plugin:
       autoDownload: true
-      downloadBehavior: "direct"
+      downloadBehavior: "continue"
   plugins:
     - type: secret
       name: aws
       image: "ghcr.io/openbao/openbao-plugin-secrets-aws"
-      version: "v1.0.0"
+      version: "v0.0.1"
       binaryName: "openbao-plugin-secrets-aws"
+      sha256sum: "b98cb1cbfd0f567d7b614efb0621aaba10c4deda865f5e5b3d155609ada2482e"`}
+>
+  Use an `image` plugin when OpenBao should download the plugin from an OCI registry as part of server startup. The operator renders `plugin_directory = "/openbao/plugins"` and mounts a writable, pod-local volume at that path for OCI auto-download.
+</CommandBlock>
+
+<CommandBlock
+  language="yaml"
+  label="configure"
+  title="Register preinstalled plugins"
+  code={`spec:
+  plugins:
+    - type: secret
+      name: local-example
+      command: "openbao-plugin-secrets-example"
+      version: "v1.0.0"
+      binaryName: "openbao-plugin-secrets-example"
       sha256sum: "9fdd8be7947e4a4caf7cce4f0e02695081b6c85178aa912df5d37be97363144c"`}
+>
+  Use a `command` plugin when the binary is already available inside the OpenBao runtime image or another explicitly managed runtime path.
+</CommandBlock>
+
+<DecisionTable
+  kind="reference"
+  title="Plugin fields"
+  columns={["Surface", "Use it for", "Operational note"]}
+  rows={[
+    {
+      cells: [
+        "`spec.plugins[].image`",
+        "OCI-based plugin binaries that OpenBao downloads at startup.",
+        "Set `spec.configuration.plugin.autoDownload: true`; OpenBao pods need registry egress or access to a reachable mirror.",
+      ],
+      emphasis: "recommended",
+    },
+    {
+      cells: [
+        "`spec.plugins[].command`",
+        "Plugin binaries already present in the OpenBao runtime environment.",
+        "The operator does not create a plugin-download volume for command-only plugins.",
+      ],
+    },
+    {
+      cells: [
+        "`spec.configuration.plugin.autoRegister`",
+        "Automatic plugin catalog registration.",
+        "`args` and `env` on each plugin are only used when auto-register is enabled.",
+      ],
+    },
+    {
+      cells: [
+        "`spec.configuration.plugin.downloadBehavior`",
+        "Startup behavior when an OCI plugin download fails.",
+        "Use `fail` to stop startup or `continue` to log and keep starting; plugin auto-download settings require OpenBao 2.5.0 or newer.",
+      ],
+    },
+  ]}
 />
+
+<Callout type="note" title="Downloaded plugins are runtime cache">
+
+OCI-downloaded plugins are stored under `/openbao/plugins` on an ephemeral pod-local volume. Treat that directory as a writable startup cache, not durable storage. If the cluster runs in a private or disconnected environment, mirror the plugin image and make sure OpenBao's runtime OCI client can authenticate to that registry; Kubernetes `imagePullSecrets` only cover Kubernetes image pulls.
+
+</Callout>
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Adds the missing release-line docs workflow for patch releases. Patch releases still reuse the existing `X.Y.0` Docusaurus version, but docs fixes that apply to a patch release can now refresh that existing release-line snapshot with `make docs-refresh-version DOCS_VERSION=X.Y.0`.

This also updates the `0.2.x` versioned docs with the plugin behavior shipped in `0.2.1`, labels release-line docs as `0.2.x` and `0.1.x` in the version dropdown, and adds a CI guard for PRs targeting `release-*` branches that change source docs without touching the matching versioned snapshot.

## Related Issues

Related to the `0.2.1` release follow-up and #395.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low runtime risk; this only changes docs, docs tooling, and CI routing. The public docs paths remain stable: `0.2.x` still serves from `/docs`, and `0.1.x` still serves from `/docs/0.1.0`. Only the visible version labels change to represent release lines rather than exact patch versions.

## Verification

- `node --check website/scripts/snapshot-version.mjs && node --check website/scripts/refresh-version.mjs`
- `./bin/actionlint .github/workflows/*.yml`
- `npm --prefix website run typecheck`
- temp-tree execution of `website/scripts/refresh-version.mjs 0.2.0`, verifying `versions.json` order stays `0.2.0,0.1.0`
- `npm --prefix website run build`
- `npx --prefix website playwright install chromium`
- `npm --prefix website run test:e2e`
- `git diff --check`
- pre-push `make lint-ci`

## Reviewer Notes

The refresh command intentionally uses the currently checked-out docs as the source. For patch releases, run it from the relevant release branch, not from `main`, so `0.3.0`-only docs do not leak into the `0.2.x` snapshot.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.