### PR TITLE
docs(website): allow release-line snapshot refresh

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
@@ -11,6 +12,26 @@ const docsPluginDefaultExclude = [
   '**/*.test.{js,jsx,ts,tsx}',
   '**/__tests__/**',
 ];
+const releaseLineVersionLabels = {
+  '0.2.0': '0.2.x',
+  '0.1.0': '0.1.x',
+} as const;
+
+function readDocsVersions(): string[] {
+  try {
+    const versions = JSON.parse(fs.readFileSync(new URL('./versions.json', import.meta.url), 'utf8'));
+    return Array.isArray(versions) ? versions : [];
+  } catch {
+    return [];
+  }
+}
+
+const docsVersions = new Set(readDocsVersions());
+const releaseLineVersions = Object.fromEntries(
+  Object.entries(releaseLineVersionLabels)
+    .filter(([version]) => docsVersions.has(version))
+    .map(([version, label]) => [version, {label}]),
+);
 
 const config: Config = {
   title: 'OpenBao Operator',
@@ -65,12 +86,7 @@ const config: Config = {
               label: 'next',
               path: 'next',
             },
-            '0.2.0': {
-              label: '0.2.x',
-            },
-            '0.1.0': {
-              label: '0.1.x',
-            },
+            ...releaseLineVersions,
           },
         },
         blog: false,


### PR DESCRIPTION
## Summary

Fixes the release-line docs refresh command added in #458. During refresh, the script temporarily removes the target version from `website/versions.json` before rebuilding it. The Docusaurus config was still hard-coding labels for `0.2.0` and `0.1.0`, so Docusaurus could reject that transient state as an unknown version.

The config now reads `website/versions.json` and only applies release-line labels for versions that are currently present.

## Related Issues

Follow-up to #458.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low risk. Public docs routes and labels remain unchanged during normal builds. This only makes the config tolerate the temporary `versions.json` state used by `docs-refresh-version`.

## Verification

- `npm --prefix website run typecheck`
- temp-tree execution of `website/scripts/refresh-version.mjs 0.2.0`, verifying `versions.json` order stays `0.2.0,0.1.0`
- `npm --prefix website run build`
- `git diff --check`
- pre-push `make lint-ci`

## Reviewer Notes

This same fix is already included in the `release-0.2` backport PR #460 because the bug was found while validating that branch.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.