### PR TITLE
fix(restore): validate static token secret identity

### DIFF
--- a/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
@@ -35,6 +35,7 @@ rules:
       - openbao.org
     resources:
       - openbaoclusters
+      - openbaorestores
     verbs:
       - get
       - list

--- a/config/rbac/provisioner_minimal_role.yaml
+++ b/config/rbac/provisioner_minimal_role.yaml
@@ -38,12 +38,13 @@ rules:
       - update
       - patch
 
-  # 2b. OpenBaoCluster read-only access
+  # 2b. OpenBaoCluster/OpenBaoRestore read-only access
   # Required for the tenant secrets RBAC sync controller to build per-namespace Secret allowlists.
   - apiGroups:
       - openbao.org
     resources:
       - openbaoclusters
+      - openbaorestores
     verbs:
       - get
       - list

--- a/docs/reference/status-and-events.md
+++ b/docs/reference/status-and-events.md
@@ -83,7 +83,7 @@ Condition types defined in `api/v1alpha1`:
 | Type | Meaning | Typical Reasons |
 | :--- | :--- | :--- |
 | `RestoreComplete` | Restore terminal state | `RestoreSucceeded`, `RestoreFailed`, `AuthenticationRequired` |
-| `RestoreConfigurationReady` | Operator-known restore prerequisites such as auth references, storage credential references, hardened-profile egress rules, and job-specific identity assumptions | `Ready`, `AuthenticationRequired`, `TokenSecretMissing`, `CredentialsSecretMissing`, `WorkloadIdentityConfigured`, `AmbientIdentityAssumed`, `NetworkEgressRulesRequired` |
+| `RestoreConfigurationReady` | Operator-known restore prerequisites such as auth references, storage credential references, hardened-profile egress rules, and job-specific identity assumptions | `Ready`, `AuthenticationRequired`, `TokenSecretMissing`, `TokenSecretInvalid`, `CredentialsSecretMissing`, `WorkloadIdentityConfigured`, `AmbientIdentityAssumed`, `NetworkEgressRulesRequired` |
 | `OperationLockOverride` | Break-glass lock override occurred | `OperationLockOverridden` |
 
 <Callout type="note" title="Ambient identity reasons">

--- a/docs/user-guide/openbaorestore/restore.md
+++ b/docs/user-guide/openbaorestore/restore.md
@@ -227,11 +227,22 @@ When the target cluster has steady read replicas enabled, restore first drains t
   language="yaml"
   label="configure"
   title="Use a static token Secret for restore"
-  code={`spec:
+  code={`apiVersion: v1
+kind: Secret
+metadata:
+  name: restore-token
+  namespace: security
+  labels:
+    openbao.org/cluster: prod-cluster
+    openbao.org/credential-purpose: restore-token
+stringData:
+  token: <restore-token>
+---
+spec:
   tokenSecretRef:
     name: restore-token`}
 >
-  Use this path if JWT auth is not available. The Secret must be in the same namespace as the restore request.
+  Use this path if JWT auth is not available. The Secret must be in the same namespace as the restore request and must be labeled for the target cluster and restore-token purpose before the operator will launch the restore Job.
 </CommandBlock>
 
 </TabItem>

--- a/internal/controller/provisioner/tenant_secrets_rbac_controller.go
+++ b/internal/controller/provisioner/tenant_secrets_rbac_controller.go
@@ -12,7 +12,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appprovisioner "github.com/dc-tec/openbao-operator/internal/app/provisioner"
@@ -133,6 +135,20 @@ func (r *TenantSecretsRBACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
+		Watches(
+			&openbaov1alpha1.OpenBaoRestore{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, restore client.Object) []reconcile.Request {
+				if restore == nil {
+					return nil
+				}
+				return []reconcile.Request{{
+					NamespacedName: client.ObjectKey{
+						Namespace: restore.GetNamespace(),
+						Name:      restore.GetName(),
+					},
+				}}
+			}),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 3,
 			RateLimiter:             workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](1*time.Second, 60*time.Second),

--- a/internal/controller/provisioner/tenant_secrets_rbac_controller_test.go
+++ b/internal/controller/provisioner/tenant_secrets_rbac_controller_test.go
@@ -169,7 +169,24 @@ func TestTenantSecretsRBACReconcile_ProvisionedNamespaceSyncsAllowlists(t *testi
 			},
 		},
 	}
-	k8sClient := newTestClient(t, provisionedBinding, cluster)
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-a",
+			Namespace: "tenant-a",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "cluster-a",
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Bucket:               "restore-backups",
+					CredentialsSecretRef: &corev1.LocalObjectReference{Name: "restore-creds"},
+				},
+				Key: "snapshots/restore.snap",
+			},
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "restore-token"},
+		},
+	}
+	k8sClient := newTestClient(t, provisionedBinding, cluster, restore)
 	recorder := events.NewFakeRecorder(10)
 	reconciler := &TenantSecretsRBACReconciler{
 		Client:      k8sClient,
@@ -212,7 +229,7 @@ func TestTenantSecretsRBACReconcile_ProvisionedNamespaceSyncsAllowlists(t *testi
 	}, readerRole); err != nil {
 		t.Fatalf("expected reader role: %v", err)
 	}
-	wantReaderSecrets := []string{"backup-creds", "backup-token", "helper-registry-creds", "main-registry-creds", "unseal-creds"}
+	wantReaderSecrets := []string{"backup-creds", "backup-token", "helper-registry-creds", "main-registry-creds", "restore-creds", "restore-token", "unseal-creds"}
 	sort.Strings(wantReaderSecrets)
 	if gotReaderSecrets := extractSecretResourceNames(readerRole.Rules); !slices.Equal(gotReaderSecrets, wantReaderSecrets) {
 		t.Fatalf("reader secrets = %v, want %v", gotReaderSecrets, wantReaderSecrets)

--- a/internal/controller/provisioner/tenant_secrets_rbac_integration_test.go
+++ b/internal/controller/provisioner/tenant_secrets_rbac_integration_test.go
@@ -81,9 +81,27 @@ func TestTenantSecretsRBAC_SetupWithManager_SynchronizesSecretAllowlists(t *test
 		},
 	}
 	require.NoError(t, liveClient.Create(ctx, cluster))
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-a",
+			Namespace: "tenant-a",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "cluster-a",
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Bucket:               "restore-backups",
+					CredentialsSecretRef: &corev1.LocalObjectReference{Name: "restore-creds"},
+				},
+				Key: "snapshots/restore.snap",
+			},
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "restore-token"},
+		},
+	}
+	require.NoError(t, liveClient.Create(ctx, restore))
 
 	wantWriterSecrets := []string{"cluster-a-root-token", "cluster-a-tls-ca", "cluster-a-tls-server", "cluster-a-unseal-key"}
-	wantReaderSecrets := []string{"backup-creds", "backup-token", "unseal-creds"}
+	wantReaderSecrets := []string{"backup-creds", "backup-token", "restore-creds", "restore-token", "unseal-creds"}
 	sort.Strings(wantWriterSecrets)
 	sort.Strings(wantReaderSecrets)
 

--- a/internal/platform/constants/conditions.go
+++ b/internal/platform/constants/conditions.go
@@ -14,6 +14,9 @@ const (
 	ReasonAuthenticationRequired = "AuthenticationRequired"
 	// ReasonTokenSecretMissing indicates a referenced token Secret is missing.
 	ReasonTokenSecretMissing = "TokenSecretMissing"
+	// ReasonTokenSecretInvalid indicates a referenced token Secret does not satisfy
+	// the identity or purpose contract required for the operation.
+	ReasonTokenSecretInvalid = "TokenSecretInvalid"
 	// ReasonCredentialsSecretMissing indicates a referenced storage credentials Secret is missing.
 	ReasonCredentialsSecretMissing = "CredentialsSecretMissing"
 	// ReasonWorkloadIdentityConfigured indicates the operator can identify an

--- a/internal/platform/constants/labels.go
+++ b/internal/platform/constants/labels.go
@@ -14,6 +14,7 @@ const (
 	LabelOpenBaoRevision           = "openbao.org/revision"
 	LabelOpenBaoWorkloadPool       = "openbao.org/workload-pool"
 	LabelOpenBaoProfile            = "openbao.org/profile"
+	LabelOpenBaoCredentialPurpose  = "openbao.org/credential-purpose"
 	LabelOpenBaoServiceAccountRole = "openbao.org/service-account-role"
 	// LabelOpenBaoDigestEnforcement indicates whether digest-only image refs are required.
 	LabelOpenBaoDigestEnforcement = "openbao.org/digest-enforcement"
@@ -34,6 +35,7 @@ const (
 
 	LabelValueOpenBaoWorkloadPoolVoter       = "voter"
 	LabelValueOpenBaoWorkloadPoolReadReplica = "read-replica"
+	LabelValueCredentialPurposeRestoreToken  = "restore-token"
 )
 
 // ServiceAccount role label values for operator-managed ServiceAccounts.

--- a/internal/service/provisioner/manager_secret_rbac.go
+++ b/internal/service/provisioner/manager_secret_rbac.go
@@ -12,6 +12,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	clusterpkg "github.com/dc-tec/openbao-operator/internal/adapter/cluster"
+	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
 
 // EnsureTenantSecretRBAC ensures tenant Secret access is reduced to explicit allowlists.
@@ -31,10 +32,20 @@ func (m *Manager) EnsureTenantSecretRBAC(ctx context.Context, namespace string) 
 		return fmt.Errorf("failed to list OpenBaoClusters in namespace %s: %w", namespace, err)
 	}
 
+	restoreList := &openbaov1alpha1.OpenBaoRestoreList{}
+	if err := m.client.List(ctx, restoreList, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list OpenBaoRestores in namespace %s: %w", namespace, err)
+	}
+
 	writerNames := map[string]struct{}{}
 	readerNames := map[string]struct{}{}
+	clustersByName := map[string]*openbaov1alpha1.OpenBaoCluster{}
 	for i := range clusterList.Items {
 		accumulateTenantSecretNames(&clusterList.Items[i], writerNames, readerNames)
+		clustersByName[clusterList.Items[i].Name] = &clusterList.Items[i]
+	}
+	for i := range restoreList.Items {
+		accumulateRestoreTenantSecretNames(&restoreList.Items[i], clustersByName, readerNames)
 	}
 
 	type secretsRBACSpec struct {
@@ -87,6 +98,30 @@ func accumulateTenantSecretNames(cluster *openbaov1alpha1.OpenBaoCluster, writer
 	}
 }
 
+func accumulateRestoreTenantSecretNames(restore *openbaov1alpha1.OpenBaoRestore, clustersByName map[string]*openbaov1alpha1.OpenBaoCluster, reader map[string]struct{}) {
+	if restore == nil {
+		return
+	}
+	if ref := restore.Spec.Source.Target.CredentialsSecretRef; ref != nil {
+		reader[ref.Name] = struct{}{}
+	}
+	if restoreUsesStaticTokenAuth(restore, clustersByName[restore.Spec.Cluster]) {
+		reader[restore.Spec.TokenSecretRef.Name] = struct{}{}
+	}
+}
+
+func restoreUsesStaticTokenAuth(restore *openbaov1alpha1.OpenBaoRestore, cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if restore == nil || restore.Spec.TokenSecretRef == nil || restore.Spec.TokenSecretRef.Name == "" {
+		return false
+	}
+
+	return portauth.EffectiveJWTRole(
+		restore.Spec.JWTAuthRole,
+		cluster != nil && portauth.OperatorJWTBootstrapEnabled(cluster),
+		portauth.RoleNameRestore,
+	) == ""
+}
+
 func sortedUniqueSecretNames(names map[string]struct{}) []string {
 	if len(names) == 0 {
 		return nil
@@ -118,7 +153,7 @@ func (m *Manager) ensureSecretsRole(ctx context.Context, namespace string, roleN
 			}
 			return fmt.Errorf("failed to get Role %s/%s: %w", namespace, roleName, err)
 		}
-		m.logger.Info("Deleting tenant secrets Role (no clusters reference Secrets)", "namespace", namespace, "role", roleName)
+		m.logger.Info("Deleting tenant secrets Role (no tenant resources reference Secrets)", "namespace", namespace, "role", roleName)
 		if err := m.client.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete Role %s/%s: %w", namespace, roleName, err)
 		}
@@ -155,7 +190,7 @@ func (m *Manager) ensureSecretsRoleBinding(ctx context.Context, namespace string
 			}
 			return fmt.Errorf("failed to get RoleBinding %s/%s: %w", namespace, roleBindingName, err)
 		}
-		m.logger.Info("Deleting tenant secrets RoleBinding (no clusters reference Secrets)", "namespace", namespace, "rolebinding", roleBindingName)
+		m.logger.Info("Deleting tenant secrets RoleBinding (no tenant resources reference Secrets)", "namespace", namespace, "rolebinding", roleBindingName)
 		if err := m.client.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete RoleBinding %s/%s: %w", namespace, roleBindingName, err)
 		}

--- a/internal/service/provisioner/manager_test.go
+++ b/internal/service/provisioner/manager_test.go
@@ -695,8 +695,29 @@ func TestEnsureTenantSecretRBAC_CreatesRolesAndRoleBindings(t *testing.T) {
 			},
 		},
 	}
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-a",
+			Namespace: namespace,
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: clusterName,
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Bucket: "restore-bucket",
+					CredentialsSecretRef: &corev1.LocalObjectReference{
+						Name: "restore-creds",
+					},
+				},
+				Key: "snapshots/demo.snap",
+			},
+			TokenSecretRef: &corev1.LocalObjectReference{
+				Name: "restore-token",
+			},
+		},
+	}
 
-	k8sClient := newTestClient(t, cluster)
+	k8sClient := newTestClient(t, cluster, restore)
 	logger := logr.Discard()
 	manager, err := NewManager(k8sClient, logger)
 	if err != nil {
@@ -721,6 +742,8 @@ func TestEnsureTenantSecretRBAC_CreatesRolesAndRoleBindings(t *testing.T) {
 		"backup-token",
 		"helper-registry-creds",
 		"main-registry-creds",
+		"restore-creds",
+		"restore-token",
 		"unseal-creds",
 		"upgrade-token",
 	}
@@ -756,6 +779,30 @@ func TestEnsureTenantSecretRBAC_CreatesRolesAndRoleBindings(t *testing.T) {
 	}
 	if readerRoleBinding.RoleRef.Name != TenantSecretsReaderRoleName {
 		t.Errorf("reader RoleBinding RoleRef.Name = %v, want %v", readerRoleBinding.RoleRef.Name, TenantSecretsReaderRoleName)
+	}
+}
+
+func TestAccumulateRestoreTenantSecretNames_SkipsTokenSecretWhenJWTAuthConfigured(t *testing.T) {
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster:     "bao",
+			JWTAuthRole: "restore-role",
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					CredentialsSecretRef: &corev1.LocalObjectReference{Name: "restore-creds"},
+				},
+			},
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "restore-token"},
+		},
+	}
+	readerNames := map[string]struct{}{}
+
+	accumulateRestoreTenantSecretNames(restore, nil, readerNames)
+
+	got := sortedUniqueSecretNames(readerNames)
+	want := []string{"restore-creds"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("restore reader allowlist = %v, want %v", got, want)
 	}
 }
 

--- a/internal/service/restore/job.go
+++ b/internal/service/restore/job.go
@@ -238,7 +238,7 @@ func buildRestoreEnvVars(restore *openbaov1alpha1.OpenBaoRestore, cluster *openb
 
 	// JWT auth configuration
 	jwtRole := effectiveRestoreJWTRole(restore, cluster)
-	envVars = storageenv.AppendAuthEnvVars(envVars, jwtRole, restore.Spec.TokenSecretRef != nil)
+	envVars = storageenv.AppendAuthEnvVars(envVars, jwtRole, restoreUsesStaticTokenAuth(restore, cluster))
 
 	// Note: Credentials are mounted as a volume and read by the executor based on provider.
 	// S3-specific env vars (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) are not needed
@@ -302,7 +302,7 @@ func buildRestoreVolumes(restore *openbaov1alpha1.OpenBaoRestore, cluster *openb
 	}
 
 	// Static token volume (if using token auth)
-	if restore.Spec.TokenSecretRef != nil {
+	if restoreUsesStaticTokenAuth(restore, cluster) {
 		volumes = append(volumes, corev1.Volume{
 			Name: restoreTokenVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -372,7 +372,7 @@ func buildRestoreVolumeMounts(restore *openbaov1alpha1.OpenBaoRestore, cluster *
 	}
 
 	// Static token mount
-	if restore.Spec.TokenSecretRef != nil {
+	if restoreUsesStaticTokenAuth(restore, cluster) {
 		mounts = append(mounts, corev1.VolumeMount{
 			Name:      restoreTokenVolumeName,
 			MountPath: restoreTokenMountPath,
@@ -405,4 +405,8 @@ func effectiveRestoreJWTRole(restore *openbaov1alpha1.OpenBaoRestore, cluster *o
 		portauth.OperatorJWTBootstrapEnabled(cluster),
 		portauth.RoleNameRestore,
 	)
+}
+
+func restoreUsesStaticTokenAuth(restore *openbaov1alpha1.OpenBaoRestore, cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return restore.Spec.TokenSecretRef != nil && effectiveRestoreJWTRole(restore, cluster) == ""
 }

--- a/internal/service/restore/job_fuzz_test.go
+++ b/internal/service/restore/job_fuzz_test.go
@@ -91,6 +91,12 @@ func FuzzRestoreJWTEnvAndVolumeSelection(f *testing.F) {
 			if !containsRestoreMount(mounts, restoreJWTTokenVolumeName) {
 				t.Fatalf("expected JWT token mount for restore JWT auth")
 			}
+			if containsRestoreVolume(volumes, restoreTokenVolumeName) {
+				t.Fatalf("did not expect static token volume when restore JWT auth is configured")
+			}
+			if containsRestoreMount(mounts, restoreTokenVolumeName) {
+				t.Fatalf("did not expect static token mount when restore JWT auth is configured")
+			}
 		} else if hasTokenSecret {
 			if got[constants.EnvBackupAuthMethod] != constants.BackupAuthMethodToken {
 				t.Fatalf("expected token auth method when restore token secret is present")

--- a/internal/service/restore/job_test.go
+++ b/internal/service/restore/job_test.go
@@ -591,3 +591,59 @@ func TestBuildRestoreEnvVars_TokenAuth(t *testing.T) {
 	assert.Empty(t, envMap[constants.EnvBackupJWTAuthRole])
 	assert.Equal(t, constants.BackupAuthMethodToken, envMap[constants.EnvBackupAuthMethod])
 }
+
+func TestBuildRestoreJob_IgnoresTokenSecretRefWhenJWTAuthConfigured(t *testing.T) {
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "test-cluster",
+			Source: openbaov1alpha1.RestoreSource{
+				Key: "backup.snap",
+				Target: openbaov1alpha1.BackupTarget{
+					Endpoint: "https://s3.amazonaws.com",
+					Bucket:   "test-bucket",
+				},
+			},
+			Image:       "example.com/restore-executor:v1",
+			JWTAuthRole: "restore-role",
+			TokenSecretRef: &corev1.LocalObjectReference{
+				Name: "restore-token",
+			},
+		},
+	}
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 1,
+		},
+	}
+
+	mgr := &Manager{Platform: constants.PlatformKubernetes}
+	job, err := mgr.buildRestoreJob(restore, cluster, "")
+	require.NoError(t, err)
+
+	envMap := make(map[string]string)
+	for _, env := range job.Spec.Template.Spec.Containers[0].Env {
+		envMap[env.Name] = env.Value
+	}
+	assert.Equal(t, "restore-role", envMap[constants.EnvBackupJWTAuthRole])
+	assert.Equal(t, constants.BackupAuthMethodJWT, envMap[constants.EnvBackupAuthMethod])
+
+	volumeNames := make([]string, 0, len(job.Spec.Template.Spec.Volumes))
+	for _, volume := range job.Spec.Template.Spec.Volumes {
+		volumeNames = append(volumeNames, volume.Name)
+	}
+	assert.NotContains(t, volumeNames, restoreTokenVolumeName)
+
+	mountNames := make([]string, 0, len(job.Spec.Template.Spec.Containers[0].VolumeMounts))
+	for _, mount := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+		mountNames = append(mountNames, mount.Name)
+	}
+	assert.NotContains(t, mountNames, restoreTokenVolumeName)
+}

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -1152,6 +1152,156 @@ func TestValidatingNoAuthentication(t *testing.T) {
 	assert.Equal(t, constants.ReasonAuthenticationRequired, configuration.Reason)
 }
 
+func TestHandleValidating_RejectsUnlabeledStaticRestoreTokenSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile: openbaov1alpha1.ProfileDevelopment,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+	setTestResourceVersion(cluster)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster:        "test-cluster",
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "restore-token"},
+			Source: openbaov1alpha1.RestoreSource{
+				Key: "backup-key",
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Bucket:   "backups",
+				},
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseValidating,
+		},
+	}
+	setTestResourceVersion(restore)
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-token",
+			Namespace: "default",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, tokenSecret).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoRestore{}, &openbaov1alpha1.OpenBaoCluster{}).
+		WithReturnManagedFields().
+		Build()
+
+	mgr := NewManager(k8sClient, scheme, nil, security.NewImageVerifier(testLogger(), k8sClient, nil), "")
+
+	_, err := mgr.handleValidating(context.Background(), testLogger(), restore)
+	require.NoError(t, err)
+
+	updated := &openbaov1alpha1.OpenBaoRestore{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-restore", Namespace: "default"}, updated))
+	assert.Equal(t, openbaov1alpha1.RestorePhaseFailed, updated.Status.Phase)
+	assert.Contains(t, updated.Status.Message, constants.LabelOpenBaoCluster)
+	configuration := meta.FindStatusCondition(updated.Status.Conditions, RestoreConfigurationConditionType)
+	if configuration == nil {
+		t.Fatalf("expected %s condition", RestoreConfigurationConditionType)
+	}
+	assert.Equal(t, metav1.ConditionFalse, configuration.Status)
+	assert.Equal(t, constants.ReasonTokenSecretInvalid, configuration.Reason)
+}
+
+func TestHandleValidating_AcceptsLabeledStaticRestoreTokenSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile: openbaov1alpha1.ProfileDevelopment,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized: true,
+		},
+	}
+	setTestResourceVersion(cluster)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster:        "test-cluster",
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "restore-token"},
+			Source: openbaov1alpha1.RestoreSource{
+				Key: "backup-key",
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Bucket:   "backups",
+				},
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseValidating,
+		},
+	}
+	setTestResourceVersion(restore)
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-token",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.LabelOpenBaoCluster:           "test-cluster",
+				constants.LabelOpenBaoCredentialPurpose: constants.LabelValueCredentialPurposeRestoreToken,
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, tokenSecret).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoRestore{}, &openbaov1alpha1.OpenBaoCluster{}).
+		WithReturnManagedFields().
+		Build()
+
+	mgr := NewManager(k8sClient, scheme, nil, security.NewImageVerifier(testLogger(), k8sClient, nil), "")
+
+	_, err := mgr.handleValidating(context.Background(), testLogger(), restore)
+	require.NoError(t, err)
+
+	updated := &openbaov1alpha1.OpenBaoRestore{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-restore", Namespace: "default"}, updated))
+	assert.Equal(t, openbaov1alpha1.RestorePhaseRunning, updated.Status.Phase)
+	configuration := meta.FindStatusCondition(updated.Status.Conditions, RestoreConfigurationConditionType)
+	if configuration == nil {
+		t.Fatalf("expected %s condition", RestoreConfigurationConditionType)
+	}
+	assert.Equal(t, metav1.ConditionTrue, configuration.Status)
+	assert.Contains(t, configuration.Message, "token Secret default/restore-token")
+}
+
 func TestHandleValidating_SetsRestoreConfigurationConditionForAmbientIdentity(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))

--- a/internal/service/workloadidentity/readiness.go
+++ b/internal/service/workloadidentity/readiness.go
@@ -91,6 +91,7 @@ func EvaluateExecutionReadiness(ctx context.Context, reader client.Reader, input
 
 	hasJWTAuth := strings.TrimSpace(input.JWTAuthRole) != ""
 	hasTokenSecret := input.TokenSecretRef != nil && strings.TrimSpace(input.TokenSecretRef.Name) != ""
+	usesStaticTokenAuth := !hasJWTAuth && hasTokenSecret
 	if !hasJWTAuth && !hasTokenSecret {
 		return Readiness{
 			Status:  metav1.ConditionFalse,
@@ -99,7 +100,7 @@ func EvaluateExecutionReadiness(ctx context.Context, reader client.Reader, input
 		}, nil
 	}
 
-	if hasTokenSecret {
+	if usesStaticTokenAuth {
 		secret, err := getSecret(ctx, reader, input.Namespace, input.TokenSecretRef.Name)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -111,7 +112,7 @@ func EvaluateExecutionReadiness(ctx context.Context, reader client.Reader, input
 			}
 			return Readiness{}, fmt.Errorf("failed to read %s token Secret %s/%s: %w", input.Operation, input.Namespace, input.TokenSecretRef.Name, err)
 		}
-		if input.Operation == OperationRestore && !hasJWTAuth {
+		if input.Operation == OperationRestore {
 			if err := validateRestoreTokenSecretIdentity(secret, input.Cluster); err != nil {
 				return Readiness{
 					Status:  metav1.ConditionFalse,

--- a/internal/service/workloadidentity/readiness.go
+++ b/internal/service/workloadidentity/readiness.go
@@ -100,7 +100,8 @@ func EvaluateExecutionReadiness(ctx context.Context, reader client.Reader, input
 	}
 
 	if hasTokenSecret {
-		if err := ensureSecretExists(ctx, reader, input.Namespace, input.TokenSecretRef.Name); err != nil {
+		secret, err := getSecret(ctx, reader, input.Namespace, input.TokenSecretRef.Name)
+		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return Readiness{
 					Status:  metav1.ConditionFalse,
@@ -109,6 +110,15 @@ func EvaluateExecutionReadiness(ctx context.Context, reader client.Reader, input
 				}, nil
 			}
 			return Readiness{}, fmt.Errorf("failed to read %s token Secret %s/%s: %w", input.Operation, input.Namespace, input.TokenSecretRef.Name, err)
+		}
+		if input.Operation == OperationRestore && !hasJWTAuth {
+			if err := validateRestoreTokenSecretIdentity(secret, input.Cluster); err != nil {
+				return Readiness{
+					Status:  metav1.ConditionFalse,
+					Reason:  constants.ReasonTokenSecretInvalid,
+					Message: err.Error(),
+				}, nil
+			}
 		}
 	}
 
@@ -142,12 +152,54 @@ func EvaluateExecutionReadiness(ctx context.Context, reader client.Reader, input
 }
 
 func ensureSecretExists(ctx context.Context, reader client.Reader, namespace, name string) error {
+	_, err := getSecret(ctx, reader, namespace, name)
+	return err
+}
+
+func getSecret(ctx context.Context, reader client.Reader, namespace, name string) (*corev1.Secret, error) {
 	if reader == nil {
-		return fmt.Errorf("secret reader is required")
+		return nil, fmt.Errorf("secret reader is required")
 	}
 
 	secret := &corev1.Secret{}
-	return reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret)
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func validateRestoreTokenSecretIdentity(secret *corev1.Secret, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if secret == nil {
+		return fmt.Errorf("restore token Secret is required")
+	}
+	if cluster == nil || strings.TrimSpace(cluster.Name) == "" {
+		return fmt.Errorf("restore token Secret %s/%s cannot be validated because the target cluster identity is unknown", secret.Namespace, secret.Name)
+	}
+
+	clusterLabel := secret.Labels[constants.LabelOpenBaoCluster]
+	if clusterLabel != cluster.Name {
+		return fmt.Errorf(
+			"restore token Secret %s/%s must be labeled %s=%q for target cluster %q",
+			secret.Namespace,
+			secret.Name,
+			constants.LabelOpenBaoCluster,
+			cluster.Name,
+			cluster.Name,
+		)
+	}
+
+	purposeLabel := secret.Labels[constants.LabelOpenBaoCredentialPurpose]
+	if purposeLabel != constants.LabelValueCredentialPurposeRestoreToken {
+		return fmt.Errorf(
+			"restore token Secret %s/%s must be labeled %s=%q",
+			secret.Namespace,
+			secret.Name,
+			constants.LabelOpenBaoCredentialPurpose,
+			constants.LabelValueCredentialPurposeRestoreToken,
+		)
+	}
+
+	return nil
 }
 
 func buildAuthSummary(input Input) string {

--- a/internal/service/workloadidentity/readiness_test.go
+++ b/internal/service/workloadidentity/readiness_test.go
@@ -263,3 +263,42 @@ func TestEvaluateRestoreReadiness_RequiresTokenSecretIdentityLabels(t *testing.T
 		})
 	}
 }
+
+func TestEvaluateRestoreReadiness_IgnoresTokenSecretRefWhenJWTAuthConfigured(t *testing.T) {
+	scheme := testReadinessScheme(t)
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile: openbaov1alpha1.ProfileDevelopment,
+		},
+	}
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster:     "demo",
+			JWTAuthRole: "restore-role",
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Bucket:   "backups",
+				},
+			},
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "missing-token"},
+		},
+	}
+	reader := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	readiness, err := EvaluateRestoreReadiness(context.Background(), reader, restore, cluster)
+	if err != nil {
+		t.Fatalf("EvaluateRestoreReadiness() error = %v", err)
+	}
+	if readiness.Status != metav1.ConditionTrue {
+		t.Fatalf("readiness = %#v, want true", readiness)
+	}
+}

--- a/internal/service/workloadidentity/readiness_test.go
+++ b/internal/service/workloadidentity/readiness_test.go
@@ -164,3 +164,102 @@ func TestEvaluateExecutionReadiness_MissingCredentialsSecret(t *testing.T) {
 		t.Fatalf("message = %q, want missing Secret name", readiness.Message)
 	}
 }
+
+func TestEvaluateRestoreReadiness_RequiresTokenSecretIdentityLabels(t *testing.T) {
+	scheme := testReadinessScheme(t)
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Profile: openbaov1alpha1.ProfileDevelopment,
+		},
+	}
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster:        "demo",
+			TokenSecretRef: &corev1.LocalObjectReference{Name: "restore-token"},
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Bucket:   "backups",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		wantReady   bool
+		wantMessage string
+	}{
+		{
+			name:        "unlabeled token secret is rejected",
+			labels:      nil,
+			wantMessage: constants.LabelOpenBaoCluster,
+		},
+		{
+			name: "wrong cluster label is rejected",
+			labels: map[string]string{
+				constants.LabelOpenBaoCluster:           "other",
+				constants.LabelOpenBaoCredentialPurpose: constants.LabelValueCredentialPurposeRestoreToken,
+			},
+			wantMessage: `openbao.org/cluster="demo"`,
+		},
+		{
+			name: "wrong credential purpose is rejected",
+			labels: map[string]string{
+				constants.LabelOpenBaoCluster:           "demo",
+				constants.LabelOpenBaoCredentialPurpose: "backup-token",
+			},
+			wantMessage: `openbao.org/credential-purpose="restore-token"`,
+		},
+		{
+			name: "labeled restore token secret is accepted",
+			labels: map[string]string{
+				constants.LabelOpenBaoCluster:           "demo",
+				constants.LabelOpenBaoCredentialPurpose: constants.LabelValueCredentialPurposeRestoreToken,
+			},
+			wantReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "restore-token",
+					Namespace: "default",
+					Labels:    tt.labels,
+				},
+			}
+			reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			readiness, err := EvaluateRestoreReadiness(context.Background(), reader, restore, cluster)
+			if err != nil {
+				t.Fatalf("EvaluateRestoreReadiness() error = %v", err)
+			}
+
+			if tt.wantReady {
+				if readiness.Status != metav1.ConditionTrue {
+					t.Fatalf("readiness = %#v, want true", readiness)
+				}
+				return
+			}
+
+			if readiness.Status != metav1.ConditionFalse || readiness.Reason != constants.ReasonTokenSecretInvalid {
+				t.Fatalf("readiness = %#v, want false/%s", readiness, constants.ReasonTokenSecretInvalid)
+			}
+			if !strings.Contains(readiness.Message, tt.wantMessage) {
+				t.Fatalf("message = %q, want %q", readiness.Message, tt.wantMessage)
+			}
+		})
+	}
+}

--- a/test/e2e/Security_Guardrails_test.go
+++ b/test/e2e/Security_Guardrails_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/admission"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/service/provisioner"
+	restoresvc "github.com/dc-tec/openbao-operator/internal/service/restore"
 	"github.com/dc-tec/openbao-operator/test/e2e/framework"
 	e2ehelpers "github.com/dc-tec/openbao-operator/test/e2e/helpers"
 )
@@ -579,6 +580,141 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 				Resource: "clusterrolebindings",
 				Verb:     "create",
 			})).To(BeFalse())
+		})
+	})
+
+	// --- Restore Token Guardrails ---
+	Context("Restore Token Guardrails", Label("tokens", "pentest"), func() {
+		var (
+			tenantNamespace string
+			tenantFW        *framework.Framework
+		)
+
+		BeforeAll(func() {
+			var err error
+			tenantFW, err = framework.NewSetup(ctx, "tenant-restore-token-guardrails", operatorNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			tenantNamespace = tenantFW.Namespace
+		})
+
+		AfterAll(func() {
+			if tenantFW != nil {
+				_ = tenantFW.Cleanup(ctx)
+			}
+		})
+
+		It("rejects an unlabeled static restore token Secret before creating a restore Job", Label(
+			"case:restore-static-token-secret-labels",
+			"covers:restore-static-token-secret-identity",
+		), func() {
+			clusterName := "restore-token-guardrail"
+			tokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "restore-token-unlabeled",
+					Namespace: tenantNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"token": []byte("not-a-real-token"),
+				},
+			}
+			Expect(admin.Create(ctx, tokenSecret)).To(Succeed())
+
+			credentialsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "restore-storage-creds",
+					Namespace: tenantNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"accessKeyId":     []byte("test"),
+					"secretAccessKey": []byte("test"),
+				},
+			}
+			Expect(admin.Create(ctx, credentialsSecret)).To(Succeed())
+
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: tenantNamespace,
+				},
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Profile:  openbaov1alpha1.ProfileDevelopment,
+					Version:  openBaoVersion,
+					Image:    openBaoImage,
+					Replicas: 1,
+					Paused:   true,
+					InitContainer: &openbaov1alpha1.InitContainerConfig{
+						Enabled: true,
+						Image:   configInitImage,
+					},
+					TLS: openbaov1alpha1.TLSConfig{
+						Enabled:        true,
+						Mode:           openbaov1alpha1.TLSModeOperatorManaged,
+						RotationPeriod: "720h",
+					},
+					Storage: openbaov1alpha1.StorageConfig{
+						Size: "1Gi",
+					},
+					Network: &openbaov1alpha1.NetworkConfig{
+						APIServerCIDR: apiServerCIDR,
+					},
+					DeletionPolicy: openbaov1alpha1.DeletionPolicyDeleteAll,
+				},
+			}
+			Expect(admin.Create(ctx, cluster)).To(Succeed())
+
+			restore := &openbaov1alpha1.OpenBaoRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-token-unlabeled",
+					Namespace: tenantNamespace,
+				},
+				Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+					Cluster: clusterName,
+					Source: openbaov1alpha1.RestoreSource{
+						Target: openbaov1alpha1.BackupTarget{
+							Provider:     constants.StorageProviderS3,
+							Endpoint:     fmt.Sprintf("http://restore-store.%s.svc.cluster.local:9000", tenantNamespace),
+							Bucket:       "openbao-backups",
+							UsePathStyle: true,
+							CredentialsSecretRef: &corev1.LocalObjectReference{
+								Name: credentialsSecret.Name,
+							},
+						},
+						Key: "clusters/restore-token-guardrail/snapshot.snap",
+					},
+					TokenSecretRef: &corev1.LocalObjectReference{
+						Name: tokenSecret.Name,
+					},
+					Image: backupExecutorImage,
+					Force: true,
+				},
+			}
+			Expect(admin.Create(ctx, restore)).To(Succeed())
+
+			By("waiting for restore validation to reject the unlabeled static token Secret")
+			Eventually(func(g Gomega) {
+				updated := &openbaov1alpha1.OpenBaoRestore{}
+				g.Expect(admin.Get(ctx, types.NamespacedName{
+					Name:      restore.Name,
+					Namespace: tenantNamespace,
+				}, updated)).To(Succeed())
+				g.Expect(updated.Status.Phase).To(Equal(openbaov1alpha1.RestorePhaseFailed))
+
+				configuration := meta.FindStatusCondition(updated.Status.Conditions, restoresvc.RestoreConfigurationConditionType)
+				g.Expect(configuration).NotTo(BeNil())
+				g.Expect(configuration.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(configuration.Reason).To(Equal(constants.ReasonTokenSecretInvalid))
+				g.Expect(configuration.Message).To(ContainSubstring(constants.LabelOpenBaoCluster))
+			}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+			By("ensuring no restore Job was created")
+			job := &batchv1.Job{}
+			err := admin.Get(ctx, types.NamespacedName{
+				Name:      restoresvc.RestoreJobNamePrefix + restore.Name,
+				Namespace: tenantNamespace,
+			}, job)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected no restore Job, got error: %v", err)
 		})
 	})
 

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,9 +12,9 @@ Notes:
 ## Summary
 
 - Files: `19`
-- Specs: `78`
-- Explicit case IDs: `32`
-- Coverage tags: `43`
+- Specs: `79`
+- Explicit case IDs: `33`
+- Coverage tags: `44`
 
 ## Suites
 
@@ -31,7 +31,7 @@ Notes:
 | [Manager Resilience](suites/Manager_Resilience_test.md) | 3 | 3 | 0 | `manager`, `cluster`, `e2e-anchor` | `test/e2e/Manager_Resilience_test.go` |
 | [Manager](suites/Operator_Manager_test.md) | 1 | 1 | 0 | `manager`, `critical`, `smoke` | `test/e2e/Operator_Manager_test.go` |
 | [OpenShift Platform](suites/Platform_OpenShift_test.md) | 2 | 0 | 0 | `openshift`, `platform` | `test/e2e/Platform_OpenShift_test.go` |
-| [Security Guardrails](suites/Security_Guardrails_test.md) | 19 | 1 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
+| [Security Guardrails](suites/Security_Guardrails_test.md) | 20 | 2 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
 | [Tenant Data Isolation](suites/Tenant_Data_Isolation_test.md) | 1 | 1 | 0 | `security`, `tenant`, `tenancy` | `test/e2e/Tenant_Data_Isolation_test.go` |
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow`, `e2e-anchor` | `test/e2e/Upgrade_Operation_Lock_test.go` |
@@ -75,6 +75,7 @@ Notes:
 | `pvc-retention` | 1 |
 | `recoverability-secret-retention` | 1 |
 | `restart-at` | 1 |
+| `restore-static-token-secret-identity` | 1 |
 | `rolling-upgrade` | 1 |
 | `scale-reconcile` | 1 |
 | `secret-regeneration` | 1 |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -1658,6 +1658,44 @@
     "suiteTitle": ""
   },
   {
+    "id": "restore-static-token-secret-labels",
+    "generatedId": "security-guardrails-rejects-an-unlabeled-static-restore-token-191fbffe",
+    "caseLabel": "restore-static-token-secret-labels",
+    "coverage": [
+      "restore-static-token-secret-identity"
+    ],
+    "file": "test/e2e/Security_Guardrails_test.go",
+    "type": "It",
+    "name": "rejects an unlabeled static restore token Secret before creating a restore Job",
+    "path": [
+      "Security Guardrails",
+      "Restore Token Guardrails",
+      "rejects an unlabeled static restore token Secret before creating a restore Job"
+    ],
+    "labels": [
+      "security",
+      "critical",
+      "tokens",
+      "pentest",
+      "case:restore-static-token-secret-labels",
+      "covers:restore-static-token-secret-identity"
+    ],
+    "domainLabels": [
+      "security",
+      "critical",
+      "tokens",
+      "pentest"
+    ],
+    "steps": [
+      "waiting for restore validation to reject the unlabeled static token Secret",
+      "ensuring no restore Job was created"
+    ],
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "tenant-data-plane-isolation",
     "generatedId": "tenant-data-isolation-isolates-tenant-data-plane-access-across-eb142963",
     "caseLabel": "tenant-data-plane-isolation",

--- a/test/e2e/catalog/suites/Security_Guardrails_test.md
+++ b/test/e2e/catalog/suites/Security_Guardrails_test.md
@@ -27,6 +27,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `security-guardrails-prevents-sidecar-injection-via-statefulset-updates-145c71ee` | prevents sidecar injection via StatefulSet updates | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-unauthorized-deletion-of-the-tls-9e011135` | prevents unauthorized deletion of the TLS CA secret | active | _none_ | `security`, `critical`, `tamper` |
 | `security-guardrails-prevents-unauthorized-deletion-of-the-unseal-2ea235de` | prevents unauthorized deletion of the unseal Secret | active | _none_ | `security`, `critical`, `tamper` |
+| `restore-static-token-secret-labels` | rejects an unlabeled static restore token Secret before creating a restore Job | active | `restore-static-token-secret-identity` | `security`, `critical`, `tokens`, `pentest` |
 
 ## `admission-runtime-binding-loss`
 
@@ -271,3 +272,20 @@ State: `active`
 Covers: _none_
 
 Labels: `security`, `critical`, `tamper`
+
+
+## `restore-static-token-secret-labels`
+
+Path: `Security Guardrails > Restore Token Guardrails > rejects an unlabeled static restore token Secret before creating a restore Job`
+
+State: `active`
+
+Generated fallback ID: `security-guardrails-rejects-an-unlabeled-static-restore-token-191fbffe`
+
+Covers: `restore-static-token-secret-identity`
+
+Labels: `security`, `critical`, `tokens`, `pentest`
+
+Recorded checkpoints:
+- waiting for restore validation to reject the unlabeled static token Secret
+- ensuring no restore Job was created

--- a/test/e2e/suites.yaml
+++ b/test/e2e/suites.yaml
@@ -574,6 +574,7 @@ suites:
     coverage:
       - admission-runtime-recheck
       - managed-resource-pause-on-policy-loss
+      - restore-static-token-secret-identity
     runtime:
       observed: 2m17.926s
       budget: 4m


### PR DESCRIPTION
## Summary

- Require static restore token Secrets to be labeled for the target OpenBaoCluster and restore-token purpose before restore validation can pass.
- Keep `tokenSecretRef` fallback-only by ignoring the static token Secret when an effective restore JWT/OIDC role is configured.
- Document the static restore token label contract and add `TokenSecretInvalid` to restore status reason guidance.
- Add a security guardrails e2e case that verifies an unlabeled static restore token Secret fails validation before a restore Job is created.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This tightens the static restore token fallback path. Restore requests that rely on `spec.tokenSecretRef` without JWT/OIDC auth now require the referenced Secret to be in the same namespace and labeled with `openbao.org/cluster=<target-cluster>` and `openbao.org/credential-purpose=restore-token`.

JWT/OIDC restore auth remains preferred and ignores `tokenSecretRef`; static token volumes and mounts are no longer rendered when an effective restore JWT role is present.

No CRD, Helm, RBAC, or generated artifact changes are included.

## Verification

- `GOFLAGS='-mod=vendor' go test ./internal/service/workloadidentity ./internal/service/restore`
- `GOFLAGS='-mod=vendor' go test -tags=e2e ./test/e2e -run '^$'`
- `make e2e-manifest-validate`
- `make verify-e2e-manifest`
- `git diff --check`
- `make docs-build`
- pre-push hook: `make lint-ci`

`make docs-build` succeeded. During dependency install, npm reported existing audit warnings: 3 moderate severity vulnerabilities.

Full `make ci-core` was not run locally because it includes the broader image scan, Helm, fuzz, and generated checks; the scoped checks above cover this slice and CI will run the full gate.

## Reviewer Notes

The label validation is intentionally controller-side because admission cannot look up Secret labels. Admission still blocks obvious system Secret references by name, while restore validation now verifies the referenced Secret identity before launching the restore Job.

The added e2e guardrail uses a paused non-OIDC cluster and `force: true` so it validates the static-token rejection without exercising object-store restore execution.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
