### PR TITLE
chore(openbao): align validation baseline with 2.5.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: OpenBao version
       description: The version of the OpenBao container you are running (e.g., 2.4.4)
-      placeholder: 2.5.3
+      placeholder: 2.5.4
     validations:
       required: true
 

--- a/.github/actions/run-openbao-config-compat/action.yml
+++ b/.github/actions/run-openbao-config-compat/action.yml
@@ -5,7 +5,7 @@ inputs:
   versions:
     description: Space-delimited OpenBao versions to validate.
     required: false
-    default: 2.4.4 2.5.3
+    default: 2.4.4 2.5.4
   report-schema-drift:
     description: Whether to report upstream OpenBao schema drift across the version range.
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,7 @@ jobs:
       - name: Run OpenBao config compatibility
         uses: ./.github/actions/run-openbao-config-compat
         with:
-          versions: 2.4.4 2.5.3
+          versions: 2.4.4 2.5.4
 
   docs:
     name: Docs Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,9 +99,9 @@ jobs:
       - name: Run OpenBao config compatibility
         uses: ./.github/actions/run-openbao-config-compat
         with:
-          versions: 2.4.4 2.5.3
+          versions: 2.4.4 2.5.4
           report-schema-drift: "true"
-          operator-schema-drift-image-tag: 2.5.3
+          operator-schema-drift-image-tag: 2.5.4
 
   fuzz:
     name: Fuzz Nightly

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Recommended entry points:
 For full details, see the [Compatibility Matrix](https://dc-tec.github.io/openbao-operator/docs/reference/compatibility).
 
 - **Kubernetes**: requires `v1.33+`; release validation runs on `v1.34`–`v1.35`
-- **OpenBao**: primary validation on `2.5.3`, with config compatibility checks for `2.4.4` and `2.5.3`
+- **OpenBao**: primary validation on `2.5.4`, with config compatibility checks for `2.4.4` and `2.5.4`
 - **Support posture**: best-effort support for the latest stable release line
 
 ## CRDs (API Surface)
@@ -91,7 +91,7 @@ metadata:
   name: my-cluster
   namespace: openbao-demo
 spec:
-  version: "2.5.3"
+  version: "2.5.4"
   replicas: 1
   profile: Development
   tls:

--- a/charts/openbao-operator/Chart.yaml
+++ b/charts/openbao-operator/Chart.yaml
@@ -98,7 +98,7 @@ annotations:
       metadata:
         name: openbaocluster-sample
       spec:
-        version: "2.5.3"
+        version: "2.5.4"
         replicas: 3
         profile: Development
         tls:

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -92,17 +92,17 @@ The current stable release line is intended for real deployments, but it remains
   columns={['Workflow', 'Scope', 'Versions tested']}
   rows={[
     {
-      cells: ['PR Gate', 'Logic, manifests, and primary compatibility path', 'K8s 1.35.1 + OpenBao 2.5.3'],
+      cells: ['PR Gate', 'Logic, manifests, and primary compatibility path', 'K8s 1.35.1 + OpenBao 2.5.4'],
       emphasis: 'recommended',
     },
     {
-      cells: ['Release Gate E2E', 'Stable release lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.5.3'],
+      cells: ['Release Gate E2E', 'Stable release lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.5.4'],
     },
     {
-      cells: ['Nightly E2E', 'Full lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.5.3'],
+      cells: ['Nightly E2E', 'Full lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.5.4'],
     },
     {
-      cells: ['Nightly Config Compatibility', 'Render and config compatibility checks', 'OpenBao 2.4.4 and 2.5.3'],
+      cells: ['Nightly Config Compatibility', 'Render and config compatibility checks', 'OpenBao 2.4.4 and 2.5.4'],
     },
   ]}
 />

--- a/docs/user-guide/openbaocluster/configuration/unseal.md
+++ b/docs/user-guide/openbaocluster/configuration/unseal.md
@@ -241,7 +241,7 @@ metadata:
   name: bao-hsm
   namespace: openbao
 spec:
-  image: registry.example.com/openbao-hsm-vendor:2.5.3
+  image: registry.example.com/openbao-hsm-vendor:2.5.4
   unseal:
     type: pkcs11
     credentialsSecretRef:

--- a/hack/tools/e2e_manifest/main_test.go
+++ b/hack/tools/e2e_manifest/main_test.go
@@ -31,7 +31,7 @@ func testCILane(id string) ciLaneConfig {
 func testVersionPolicy() versionPolicy {
 	return versionPolicy{
 		OpenBao: openBaoVersionPolicy{
-			DefaultImage: "ghcr.io/openbao/openbao:2.5.3",
+			DefaultImage: "ghcr.io/openbao/openbao:2.5.4",
 		},
 		Kubernetes: kubernetesVersionPolicy{
 			Primary:       "1.35.1",

--- a/hack/tools/e2e_plan/main_test.go
+++ b/hack/tools/e2e_plan/main_test.go
@@ -16,7 +16,7 @@ const (
 func testVersionPolicy() versionPolicy {
 	return versionPolicy{
 		OpenBao: openBaoVersionPolicy{
-			DefaultImage: "ghcr.io/openbao/openbao:2.5.3",
+			DefaultImage: "ghcr.io/openbao/openbao:2.5.4",
 		},
 		StorageEmulators: storageEmulatorVersionPolicy{
 			RustFSImage:  "docker.io/rustfs/rustfs@sha256:test-rustfs",
@@ -73,7 +73,7 @@ func TestBuildGithubMatrixPreservesLaneConfiguration(t *testing.T) {
 	if row.ID != "backup-restore" {
 		t.Fatalf("id = %q, want backup-restore", row.ID)
 	}
-	if row.OpenBaoImage != "ghcr.io/openbao/openbao:2.5.3" {
+	if row.OpenBaoImage != "ghcr.io/openbao/openbao:2.5.4" {
 		t.Fatalf("openbao image = %q, want central default", row.OpenBaoImage)
 	}
 	if row.KindNodeImage != "kindest/node:v1.35.1" {

--- a/hack/tools/e2e_report/main_test.go
+++ b/hack/tools/e2e_report/main_test.go
@@ -106,7 +106,7 @@ func TestBuildSummaryCountsAndSlowestSpecs(t *testing.T) {
 		Lane:              "Backup & Restore",
 		Selector:          "restore",
 		KubernetesVersion: "kindest/node:v1.35.1",
-		OpenBAOVersion:    "ghcr.io/openbao/openbao:2.5.3",
+		OpenBAOVersion:    "ghcr.io/openbao/openbao:2.5.4",
 	})
 
 	if !s.SuiteSucceeded {

--- a/internal/service/workload/plugin_directory_test.go
+++ b/internal/service/workload/plugin_directory_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestStatefulSet_OCIPluginAutoDownloadMountsWritablePluginDirectory(t *testing.T) {
 	cluster := newMinimalCluster("oci-plugins", "default")
-	cluster.Spec.Version = "2.5.3"
+	cluster.Spec.Version = "2.5.4"
 	cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
 		Plugin: &openbaov1alpha1.PluginConfig{
 			AutoDownload: ptr.To(true),
@@ -89,7 +89,7 @@ func TestStatefulSet_OCIPluginDirectoryVolumeOmittedWhenAutoDownloadUnused(t *te
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster := newMinimalCluster("oci-plugins-unused", "default")
-			cluster.Spec.Version = "2.5.3"
+			cluster.Spec.Version = "2.5.4"
 			if tt.autoDownload != nil {
 				cluster.Spec.Configuration = &openbaov1alpha1.OpenBaoConfiguration{
 					Plugin: &openbaov1alpha1.PluginConfig{

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -67,7 +67,7 @@ docker-build-upgrade: ## Build docker image with the upgrade helper.
 docker-push-upgrade: ## Push docker image with the upgrade helper.
 	$(CONTAINER_TOOL) push ${IMG}
 
-OPENBAO_SOFTHSM_BASE_IMAGE ?= openbao/openbao-hsm:2.5.3
+OPENBAO_SOFTHSM_BASE_IMAGE ?= openbao/openbao-hsm:2.5.4
 OPENBAO_SOFTHSM_IMG ?= openbao-softhsm:dev
 PYKMIP_BASE_IMAGE ?= python:3.11-slim
 PYKMIP_VERSION ?= 0.10.0

--- a/test/e2e/e2e_versions.go
+++ b/test/e2e/e2e_versions.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const defaultOpenBaoVersion = "2.5.3"
+const defaultOpenBaoVersion = "2.5.4"
 
 // defaultUpgradeFromVersion is the version to start with for upgrade tests.
 // This should be set to a stable, known-good version.
@@ -18,7 +18,7 @@ const defaultUpgradeFromVersion = "2.4.4"
 // defaultUpgradeToVersion is the target version for upgrade tests.
 // This should be set to a newer version than defaultUpgradeFromVersion.
 // Update this when new OpenBao versions are released.
-const defaultUpgradeToVersion = "2.5.3"
+const defaultUpgradeToVersion = "2.5.4"
 
 var (
 	openBaoVersion string

--- a/test/e2e/hardened_signed_suite.go
+++ b/test/e2e/hardened_signed_suite.go
@@ -25,7 +25,7 @@ func requireHardenedSignedSuite() {
 	if !strings.EqualFold(strings.TrimSpace(os.Getenv(envEnableHardenedSignedSuite)), "true") {
 		ginkgo.Skip(fmt.Sprintf(
 			"requires signed hardened suite; set %s=true and provide %s and %s "+
-				"(for example ghcr.io/openbao/openbao:2.5.3 and ghcr.io/dc-tec/openbao-init:edge)",
+				"(for example ghcr.io/openbao/openbao:2.5.4 and ghcr.io/dc-tec/openbao-init:edge)",
 			envEnableHardenedSignedSuite,
 			envOpenBaoImage,
 			envHardenedConfigInitImage,

--- a/test/e2e/images/openbao-softhsm/Dockerfile
+++ b/test/e2e/images/openbao-softhsm/Dockerfile
@@ -1,4 +1,4 @@
-ARG OPENBAO_HSM_BASE_IMAGE=openbao/openbao-hsm:2.5.3
+ARG OPENBAO_HSM_BASE_IMAGE=openbao/openbao-hsm:2.5.4
 FROM ${OPENBAO_HSM_BASE_IMAGE}
 
 USER root

--- a/test/e2e/suites.yaml
+++ b/test/e2e/suites.yaml
@@ -1,7 +1,7 @@
 version: 1
 versions:
   openbao:
-    defaultImage: "ghcr.io/openbao/openbao:2.5.3"
+    defaultImage: "ghcr.io/openbao/openbao:2.5.4"
   storageEmulators:
     rustfsImage: "docker.io/rustfs/rustfs@sha256:3c2d55977829620284ece8593901bf776bcfc0fc9972784352de4dcffdb92416"
     fakeGCSImage: "docker.io/fsouza/fake-gcs-server@sha256:3730da0e31f7e5186a90ec4899dc2c336104e7599df400411392ef17e684c31f"


### PR DESCRIPTION
## Summary

Updates the repository's active OpenBao validation baseline from `2.5.3` to `2.5.4`.

This realigns E2E defaults, upgrade target defaults, config-compat workflow inputs, nightly schema drift checks, the SoftHSM test image base, chart/example references, and tests that assert the centralized OpenBao image value.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

No API, CRD, RBAC, or Helm chart behavior changes. The chart example OpenBao version changes to `2.5.4`, but chart `version` and `appVersion` are unchanged.

Operationally, CI and local E2E defaults now exercise OpenBao `2.5.4`; upgrade tests continue to start from `2.4.4` and now target `2.5.4`.

## Verification

- `go test ./hack/tools/e2e_manifest ./hack/tools/e2e_plan ./hack/tools/e2e_report ./internal/service/workload`
- `bash hack/ci/openbao-config-compat.sh 2.4.4 2.5.4`
- `go test ./...`
- `git diff --check`
- pre-commit hook: whitespace check, affected Go formatting, affected `golangci-lint`
- pre-push hook: `make lint-ci`

## Reviewer Notes

Historical `0.2.0` release-note artifacts still mention `2.5.3` because they describe the already-published release baseline. The remaining `website/package-lock.json` `2.5.3` entries are for npm `raw-body`, not OpenBao.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.