### PR TITLE
fix(deps): update x/net for vulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/vendor/golang.org/x/net/html/parse.go
+++ b/vendor/golang.org/x/net/html/parse.go
@@ -5,9 +5,11 @@
 package html
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	a "golang.org/x/net/html/atom"
@@ -328,6 +330,14 @@ func (p *parser) addText(text string) {
 	})
 }
 
+func attrCompare(a, b Attribute) int {
+	return cmp.Or(
+		cmp.Compare(a.Namespace, b.Namespace),
+		cmp.Compare(a.Key, b.Key),
+		cmp.Compare(a.Val, b.Val),
+	)
+}
+
 // addElement adds a child element based on the current token.
 func (p *parser) addElement() {
 	p.addChild(&Node{
@@ -342,6 +352,10 @@ func (p *parser) addElement() {
 func (p *parser) addFormattingElement() {
 	tagAtom, attr := p.tok.DataAtom, p.tok.Attr
 	p.addElement()
+
+	// In order to optimize the search, we need the attributes to be sorted, so we
+	// can just use slices.Equal.
+	slices.SortFunc(attr, attrCompare)
 
 	// Implement the Noah's Ark clause, but with three per family instead of two.
 	identicalElements := 0
@@ -360,19 +374,7 @@ findIdenticalElements:
 		if n.DataAtom != tagAtom {
 			continue
 		}
-		if len(n.Attr) != len(attr) {
-			continue
-		}
-	compareAttributes:
-		for _, t0 := range n.Attr {
-			for _, t1 := range attr {
-				if t0.Key == t1.Key && t0.Namespace == t1.Namespace && t0.Val == t1.Val {
-					// Found a match for this attribute, continue with the next attribute.
-					continue compareAttributes
-				}
-			}
-			// If we get here, there is no attribute that matches a.
-			// Therefore the element is not identical to the new one.
+		if !slices.Equal(n.Attr, attr) {
 			continue findIdenticalElements
 		}
 
@@ -382,7 +384,11 @@ findIdenticalElements:
 		}
 	}
 
-	p.afe = append(p.afe, p.top())
+	// Sort the attributes to optimize future identical-element searches.
+	top := p.top()
+	slices.SortFunc(top.Attr, attrCompare)
+
+	p.afe = append(p.afe, top)
 }
 
 // Section 12.2.4.3.
@@ -1372,8 +1378,6 @@ func (p *parser) inBodyEndTagFormatting(tagAtom a.Atom, tagName string) {
 }
 
 // inBodyEndTagOther performs the "any other end tag" algorithm for inBodyIM.
-// "Any other end tag" handling from 12.2.6.5 The rules for parsing tokens in foreign content
-// https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inforeign
 func (p *parser) inBodyEndTagOther(tagAtom a.Atom, tagName string) {
 	for i := len(p.oe) - 1; i >= 0; i-- {
 		// Two element nodes have the same tag if they have the same Data (a
@@ -1383,7 +1387,7 @@ func (p *parser) inBodyEndTagOther(tagAtom a.Atom, tagName string) {
 		// Uncommon (custom) tags get a zero DataAtom.
 		//
 		// The if condition here is equivalent to (p.oe[i].Data == tagName).
-		if (p.oe[i].DataAtom == tagAtom) &&
+		if p.oe[i].Namespace == "" && (p.oe[i].DataAtom == tagAtom) &&
 			((tagAtom != 0) || (p.oe[i].Data == tagName)) {
 			p.oe = p.oe[:i]
 			break

--- a/vendor/golang.org/x/net/html/render.go
+++ b/vendor/golang.org/x/net/html/render.go
@@ -113,14 +113,14 @@ func render1(w writer, n *Node) error {
 				if _, err := w.WriteString(" PUBLIC "); err != nil {
 					return err
 				}
-				if err := writeQuoted(w, p); err != nil {
+				if err := writeDoctypeQuoted(w, p); err != nil {
 					return err
 				}
 				if s != "" {
 					if err := w.WriteByte(' '); err != nil {
 						return err
 					}
-					if err := writeQuoted(w, s); err != nil {
+					if err := writeDoctypeQuoted(w, s); err != nil {
 						return err
 					}
 				}
@@ -128,7 +128,7 @@ func render1(w writer, n *Node) error {
 				if _, err := w.WriteString(" SYSTEM "); err != nil {
 					return err
 				}
-				if err := writeQuoted(w, s); err != nil {
+				if err := writeDoctypeQuoted(w, s); err != nil {
 					return err
 				}
 			}
@@ -243,27 +243,50 @@ func childTextNodesAreLiteral(n *Node) bool {
 	if n.Namespace != "" {
 		return false
 	}
+
 	switch n.Data {
 	case "iframe", "noembed", "noframes", "noscript", "plaintext", "script", "style", "xmp":
+		// We need to check if n is a node that was fostered from a HTML namespace
+		// into a non-HTML namespace (in which case, different rules apply to it).
+		// We do this by walking up the tree until we find a node with a non-empty
+		// namespace. If we find such a node, we also have to check if it's
+		// an HTML integration point. If it isn't, then the node we're currently
+		// looking at is foster-parented and we should return false.
+		for p := n.Parent; p != nil; p = p.Parent {
+			if p.Namespace != "" {
+				if !htmlIntegrationPoint(p) {
+					return false
+				}
+				break
+			}
+		}
+
 		return true
 	default:
 		return false
 	}
 }
 
-// writeQuoted writes s to w surrounded by quotes. Normally it will use double
+// writeDoctypeQuoted writes s to w surrounded by quotes. Normally it will use double
 // quotes, but if s contains a double quote, it will use single quotes.
+// If s contains any '>' characters, they are replaced with &gt; in order
+// to prevent triggering an abrupt-doctype-system-identifier parse error.
 // It is used for writing the identifiers in a doctype declaration.
 // In valid HTML, they can't contain both types of quotes.
-func writeQuoted(w writer, s string) error {
+func writeDoctypeQuoted(w writer, s string) error {
 	var q byte = '"'
 	if strings.Contains(s, `"`) {
+		// parseDoctype will never produce a Node with both quote types, but a user
+		// can construct their own Node that violates this assumption.
+		if strings.Contains(s, `'`) {
+			return errors.New("doctype contains both quote types, cannot be safely rendered")
+		}
 		q = '\''
 	}
 	if err := w.WriteByte(q); err != nil {
 		return err
 	}
-	if _, err := w.WriteString(s); err != nil {
+	if _, err := w.WriteString(strings.ReplaceAll(s, ">", "&gt;")); err != nil {
 		return err
 	}
 	if err := w.WriteByte(q); err != nil {

--- a/vendor/golang.org/x/net/html/token.go
+++ b/vendor/golang.org/x/net/html/token.go
@@ -156,6 +156,7 @@ type Tokenizer struct {
 	// incremented on each call to TagAttr.
 	pendingAttr   [2]span
 	attr          [][2]span
+	attrNames     map[string]bool
 	nAttrReturned int
 	// rawTag is the "script" in "</script>" that closes the next token. If
 	// non-empty, the subsequent call to Next will return a raw or RCDATA text
@@ -867,6 +868,7 @@ func (z *Tokenizer) readStartTag() TokenType {
 func (z *Tokenizer) readTag(saveAttr bool) {
 	z.attr = z.attr[:0]
 	z.nAttrReturned = 0
+	clear(z.attrNames)
 	// Read the tag name and attribute key/value pairs.
 	z.readTagName()
 	if z.skipWhiteSpace(); z.err != nil {
@@ -880,9 +882,11 @@ func (z *Tokenizer) readTag(saveAttr bool) {
 		z.raw.end--
 		z.readTagAttrKey()
 		z.readTagAttrVal()
-		// Save pendingAttr if saveAttr and that attribute has a non-empty key.
-		if saveAttr && z.pendingAttr[0].start != z.pendingAttr[0].end {
+		// Save pendingAttr if saveAttr and that attribute has a non-empty key, and the key hasn't been seen before.
+		key := strings.ToLower(string(z.buf[z.pendingAttr[0].start:z.pendingAttr[0].end]))
+		if saveAttr && z.pendingAttr[0].start != z.pendingAttr[0].end && !z.attrNames[key] {
 			z.attr = append(z.attr, z.pendingAttr)
+			z.attrNames[key] = true
 		}
 		if z.skipWhiteSpace(); z.err != nil {
 			break
@@ -1273,8 +1277,9 @@ func NewTokenizer(r io.Reader) *Tokenizer {
 // The input is assumed to be UTF-8 encoded.
 func NewTokenizerFragment(r io.Reader, contextTag string) *Tokenizer {
 	z := &Tokenizer{
-		r:   r,
-		buf: make([]byte, 0, 4096),
+		r:         r,
+		buf:       make([]byte, 0, 4096),
+		attrNames: make(map[string]bool),
 	}
 	if contextTag != "" {
 		switch s := strings.ToLower(contextTag); s {

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -2657,21 +2657,6 @@ func (rws *responseWriterState) writeChunk(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// TrailerPrefix is a magic prefix for ResponseWriter.Header map keys
-// that, if present, signals that the map entry is actually for
-// the response trailers, and not the response headers. The prefix
-// is stripped after the ServeHTTP call finishes and the values are
-// sent in the trailers.
-//
-// This mechanism is intended only for trailers that are not known
-// prior to the headers being written. If the set of trailers is fixed
-// or known before the header is written, the normal Go trailers mechanism
-// is preferred:
-//
-//	https://golang.org/pkg/net/http/#ResponseWriter
-//	https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
-const TrailerPrefix = "Trailer:"
-
 // promoteUndeclaredTrailers permits http.Handlers to set trailers
 // after the header has already been flushed. Because the Go
 // ResponseWriter interface has no way to set Trailers (only the
@@ -2947,12 +2932,6 @@ func (w *responseWriter) handlerDone() {
 	w.rws = nil
 	responseWriterStatePool.Put(rws)
 }
-
-// Push errors.
-var (
-	ErrRecursivePush    = errors.New("http2: recursive push not allowed")
-	ErrPushLimitReached = errors.New("http2: push would exceed peer's SETTINGS_MAX_CONCURRENT_STREAMS")
-)
 
 var _ http.Pusher = (*responseWriter)(nil)
 

--- a/vendor/golang.org/x/net/http2/server_common.go
+++ b/vendor/golang.org/x/net/http2/server_common.go
@@ -6,9 +6,31 @@ package http2
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"time"
+)
+
+// TrailerPrefix is a magic prefix for ResponseWriter.Header map keys
+// that, if present, signals that the map entry is actually for
+// the response trailers, and not the response headers. The prefix
+// is stripped after the ServeHTTP call finishes and the values are
+// sent in the trailers.
+//
+// This mechanism is intended only for trailers that are not known
+// prior to the headers being written. If the set of trailers is fixed
+// or known before the header is written, the normal Go trailers mechanism
+// is preferred:
+//
+//	https://golang.org/pkg/net/http/#ResponseWriter
+//	https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
+const TrailerPrefix = "Trailer:"
+
+// Push errors.
+var (
+	ErrRecursivePush    = errors.New("http2: recursive push not allowed")
+	ErrPushLimitReached = errors.New("http2: push would exceed peer's SETTINGS_MAX_CONCURRENT_STREAMS")
 )
 
 // ConfigureServer adds HTTP/2 support to a net/http Server.

--- a/vendor/golang.org/x/net/http2/server_wrap.go
+++ b/vendor/golang.org/x/net/http2/server_wrap.go
@@ -159,3 +159,43 @@ type FrameWriteRequest struct {
 	// to avoid duplicating an exported symbol across two files,
 	// but the changes required to make this work are fairly large.
 }
+
+func (wr FrameWriteRequest) StreamID() uint32 {
+	return 0
+}
+
+func (wr FrameWriteRequest) DataSize() int {
+	return 0
+}
+
+func (wr FrameWriteRequest) Consume(n int32) (FrameWriteRequest, FrameWriteRequest, int) {
+	return FrameWriteRequest{}, FrameWriteRequest{}, 0
+}
+
+func (wr FrameWriteRequest) String() string {
+	return ""
+}
+
+// NewPriorityWriteScheduler is deprecated.
+//
+// Deprecated: User-provided write schedulers are deprecated.
+func NewPriorityWriteScheduler(cfg *PriorityWriteSchedulerConfig) WriteScheduler {
+	return unsupportedWriteScheduler{}
+}
+
+// NewRandomWriteScheduler is deprecated.
+//
+// Deprecated: User-provided write schedulers are deprecated.
+func NewRandomWriteScheduler() WriteScheduler {
+	return unsupportedWriteScheduler{}
+}
+
+type unsupportedWriteScheduler struct{}
+
+func (unsupportedWriteScheduler) OpenStream(streamID uint32, options OpenStreamOptions) {}
+func (unsupportedWriteScheduler) CloseStream(streamID uint32)                           {}
+func (unsupportedWriteScheduler) AdjustStream(streamID uint32, priority PriorityParam)  {}
+func (unsupportedWriteScheduler) Push(wr FrameWriteRequest)                             {}
+func (unsupportedWriteScheduler) Pop() (wr FrameWriteRequest, ok bool) {
+	return FrameWriteRequest{}, false
+}

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -399,27 +399,6 @@ func (sew stickyErrWriter) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-// noCachedConnError is the concrete type of ErrNoCachedConn, which
-// needs to be detected by net/http regardless of whether it's its
-// bundled version (in h2_bundle.go with a rewritten type name) or
-// from a user's x/net/http2. As such, as it has a unique method name
-// (IsHTTP2NoCachedConnError) that net/http sniffs for via func
-// isNoCachedConnError.
-type noCachedConnError struct{}
-
-func (noCachedConnError) IsHTTP2NoCachedConnError() {}
-func (noCachedConnError) Error() string             { return "http2: no cached connection was available" }
-
-// isNoCachedConnError reports whether err is of type noCachedConnError
-// or its equivalent renamed type in net/http2's h2_bundle.go. Both types
-// may coexist in the same running program.
-func isNoCachedConnError(err error) bool {
-	_, ok := err.(interface{ IsHTTP2NoCachedConnError() })
-	return ok
-}
-
-var ErrNoCachedConn error = noCachedConnError{}
-
 func (t *Transport) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
 	switch req.URL.Scheme {
 	case "https":
@@ -1784,19 +1763,6 @@ func (cc *ClientConn) readLoop() {
 		cc.fr.WriteGoAway(0, ErrCode(ce), nil)
 		cc.wmu.Unlock()
 	}
-}
-
-// GoAwayError is returned by the Transport when the server closes the
-// TCP connection after sending a GOAWAY frame.
-type GoAwayError struct {
-	LastStreamID uint32
-	ErrCode      ErrCode
-	DebugData    string
-}
-
-func (e GoAwayError) Error() string {
-	return fmt.Sprintf("http2: server sent GOAWAY and closed the connection; LastStreamID=%v, ErrCode=%v, debug=%q",
-		e.LastStreamID, e.ErrCode, e.DebugData)
 }
 
 func isEOFOrNetReadError(err error) bool {

--- a/vendor/golang.org/x/net/http2/transport_common.go
+++ b/vendor/golang.org/x/net/http2/transport_common.go
@@ -411,3 +411,37 @@ func (t *Transport) dialTLSWithContext(ctx context.Context, network, addr string
 	tlsCn := cn.(*tls.Conn) // DialContext comment promises this will always succeed
 	return tlsCn, nil
 }
+
+// GoAwayError is returned by the Transport when the server closes the
+// TCP connection after sending a GOAWAY frame.
+type GoAwayError struct {
+	LastStreamID uint32
+	ErrCode      ErrCode
+	DebugData    string
+}
+
+func (e GoAwayError) Error() string {
+	return fmt.Sprintf("http2: server sent GOAWAY and closed the connection; LastStreamID=%v, ErrCode=%v, debug=%q",
+		e.LastStreamID, e.ErrCode, e.DebugData)
+}
+
+// noCachedConnError is the concrete type of ErrNoCachedConn, which
+// needs to be detected by net/http regardless of whether it's its
+// bundled version (in h2_bundle.go with a rewritten type name) or
+// from a user's x/net/http2. As such, as it has a unique method name
+// (IsHTTP2NoCachedConnError) that net/http sniffs for via func
+// isNoCachedConnError.
+type noCachedConnError struct{}
+
+func (noCachedConnError) IsHTTP2NoCachedConnError() {}
+func (noCachedConnError) Error() string             { return "http2: no cached connection was available" }
+
+// isNoCachedConnError reports whether err is of type noCachedConnError
+// or its equivalent renamed type in net/http2's h2_bundle.go. Both types
+// may coexist in the same running program.
+func isNoCachedConnError(err error) bool {
+	_, ok := err.(interface{ IsHTTP2NoCachedConnError() })
+	return ok
+}
+
+var ErrNoCachedConn error = noCachedConnError{}

--- a/vendor/golang.org/x/net/http2/writesched_common.go
+++ b/vendor/golang.org/x/net/http2/writesched_common.go
@@ -47,3 +47,44 @@ type OpenStreamOptions struct {
 	// priority is used to set the priority of the newly opened stream.
 	priority PriorityParam
 }
+
+// PriorityWriteSchedulerConfig configures a priorityWriteScheduler.
+//
+// Deprecated: User-provided write schedulers are deprecated.
+type PriorityWriteSchedulerConfig struct {
+	// MaxClosedNodesInTree controls the maximum number of closed streams to
+	// retain in the priority tree. Setting this to zero saves a small amount
+	// of memory at the cost of performance.
+	//
+	// See RFC 7540, Section 5.3.4:
+	//   "It is possible for a stream to become closed while prioritization
+	//   information ... is in transit. ... This potentially creates suboptimal
+	//   prioritization, since the stream could be given a priority that is
+	//   different from what is intended. To avoid these problems, an endpoint
+	//   SHOULD retain stream prioritization state for a period after streams
+	//   become closed. The longer state is retained, the lower the chance that
+	//   streams are assigned incorrect or default priority values."
+	MaxClosedNodesInTree int
+
+	// MaxIdleNodesInTree controls the maximum number of idle streams to
+	// retain in the priority tree. Setting this to zero saves a small amount
+	// of memory at the cost of performance.
+	//
+	// See RFC 7540, Section 5.3.4:
+	//   Similarly, streams that are in the "idle" state can be assigned
+	//   priority or become a parent of other streams. This allows for the
+	//   creation of a grouping node in the dependency tree, which enables
+	//   more flexible expressions of priority. Idle streams begin with a
+	//   default priority (Section 5.3.5).
+	MaxIdleNodesInTree int
+
+	// ThrottleOutOfOrderWrites enables write throttling to help ensure that
+	// data is delivered in priority order. This works around a race where
+	// stream B depends on stream A and both streams are about to call Write
+	// to queue DATA frames. If B wins the race, a naive scheduler would eagerly
+	// write as much data from B as possible, but this is suboptimal because A
+	// is a higher-priority stream. With throttling enabled, we write a small
+	// amount of data from B to minimize the amount of bandwidth that B can
+	// steal from A.
+	ThrottleOutOfOrderWrites bool
+}

--- a/vendor/golang.org/x/net/http2/writesched_priority_rfc7540.go
+++ b/vendor/golang.org/x/net/http2/writesched_priority_rfc7540.go
@@ -15,47 +15,6 @@ import (
 // RFC 7540, Section 5.3.5: the default weight is 16.
 const priorityDefaultWeightRFC7540 = 15 // 16 = 15 + 1
 
-// PriorityWriteSchedulerConfig configures a priorityWriteScheduler.
-//
-// Deprecated: User-provided write schedulers are deprecated.
-type PriorityWriteSchedulerConfig struct {
-	// MaxClosedNodesInTree controls the maximum number of closed streams to
-	// retain in the priority tree. Setting this to zero saves a small amount
-	// of memory at the cost of performance.
-	//
-	// See RFC 7540, Section 5.3.4:
-	//   "It is possible for a stream to become closed while prioritization
-	//   information ... is in transit. ... This potentially creates suboptimal
-	//   prioritization, since the stream could be given a priority that is
-	//   different from what is intended. To avoid these problems, an endpoint
-	//   SHOULD retain stream prioritization state for a period after streams
-	//   become closed. The longer state is retained, the lower the chance that
-	//   streams are assigned incorrect or default priority values."
-	MaxClosedNodesInTree int
-
-	// MaxIdleNodesInTree controls the maximum number of idle streams to
-	// retain in the priority tree. Setting this to zero saves a small amount
-	// of memory at the cost of performance.
-	//
-	// See RFC 7540, Section 5.3.4:
-	//   Similarly, streams that are in the "idle" state can be assigned
-	//   priority or become a parent of other streams. This allows for the
-	//   creation of a grouping node in the dependency tree, which enables
-	//   more flexible expressions of priority. Idle streams begin with a
-	//   default priority (Section 5.3.5).
-	MaxIdleNodesInTree int
-
-	// ThrottleOutOfOrderWrites enables write throttling to help ensure that
-	// data is delivered in priority order. This works around a race where
-	// stream B depends on stream A and both streams are about to call Write
-	// to queue DATA frames. If B wins the race, a naive scheduler would eagerly
-	// write as much data from B as possible, but this is suboptimal because A
-	// is a higher-priority stream. With throttling enabled, we write a small
-	// amount of data from B to minimize the amount of bandwidth that B can
-	// steal from A.
-	ThrottleOutOfOrderWrites bool
-}
-
 // NewPriorityWriteScheduler constructs a WriteScheduler that schedules
 // frames by following HTTP/2 priorities as described in RFC 7540 Section 5.3.
 // If cfg is nil, default options are used.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1213,7 +1213,7 @@ golang.org/x/exp/slices
 ## explicit; go 1.25.0
 golang.org/x/mod/semver
 golang.org/x/mod/sumdb/note
-# golang.org/x/net v0.54.0
+# golang.org/x/net v0.55.0
 ## explicit; go 1.25.0
 golang.org/x/net/html
 golang.org/x/net/html/atom


### PR DESCRIPTION
## Summary

Updates `golang.org/x/net` from `v0.54.0` to `v0.55.0` and refreshes vendored sources.

This addresses the PR CI `vulncheck` failure for `GO-2026-5026`, where `govulncheck` reported the issue in `golang.org/x/net/idna` and identified `v0.55.0` as the fixed version.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, upgrade, or operational behavior changes are intended. Runtime impact is limited to consuming the patched `golang.org/x/net` release and corresponding vendored sources.

## Verification

- `make verify-tidy`
- `make verify-vendor`
- `make vulncheck`
- `make security-ci`
- `make test-ci`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

This is split out from the inline-auth feature branch so that the security dependency fix can merge independently. After this lands, the inline-auth branch can be rebased onto `main`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.