### PR TITLE
fix(security): harden transit unseal credential handling

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -1217,7 +1217,7 @@ type GatewayReference struct {
 // TransitSealConfig configures the Transit seal type.
 // See: https://openbao.org/docs/configuration/seal/transit/
 type TransitSealConfig struct {
-	// Address is the full address to the OpenBao cluster.
+	// Address is the full HTTPS address to the OpenBao cluster providing the Transit seal.
 	// +kubebuilder:validation:MinLength=1
 	Address string `json:"address"`
 

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -4314,7 +4314,8 @@ spec:
                       Required when Type is "transit".
                     properties:
                       address:
-                        description: Address is the full address to the OpenBao cluster.
+                        description: Address is the full HTTPS address to the OpenBao
+                          cluster providing the Transit seal.
                         minLength: 1
                         type: string
                       disableRenewal:

--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -157,13 +157,27 @@ spec:
         size(object.spec.unseal.transit.token) == 0
       message: Hardened profile does not allow spec.unseal.transit.token; use spec.unseal.credentialsSecretRef instead.
     - expression: >-
-        !has(object.spec.profile) ||
-        object.spec.profile != "Hardened" ||
         !has(object.spec.unseal) ||
         !has(object.spec.unseal.transit) ||
         !has(object.spec.unseal.transit.address) ||
         object.spec.unseal.transit.address.startsWith("https://")
-      message: Hardened profile requires spec.unseal.transit.address to use HTTPS.
+      message: Transit unseal address must use HTTPS.
+    - expression: >-
+        !has(object.spec.unseal) ||
+        !has(object.spec.unseal.transit) ||
+        !has(object.spec.unseal.transit.address) ||
+        !(
+          object.spec.unseal.transit.address.contains("@") ||
+          object.spec.unseal.transit.address.contains("?") ||
+          object.spec.unseal.transit.address.contains("#") ||
+          object.spec.unseal.transit.address.matches("^https://([^/?#@]*\\.)?localhost([:/?#].*)?$") ||
+          object.spec.unseal.transit.address.matches("^https://127\\.0\\.0\\.1([:/?#].*)?$") ||
+          object.spec.unseal.transit.address.contains("[::1]") ||
+          object.spec.unseal.transit.address.matches("^https://169\\.254\\..*") ||
+          object.spec.unseal.transit.address.contains("[fe80:") ||
+          object.spec.unseal.transit.address.matches("^https://[0-9]+([:/?#].*)?$")
+        )
+      message: Transit unseal address must not include userinfo, query, fragment, localhost, loopback, link-local, or numeric host forms.
     - expression: >-
         !has(object.spec.unseal) ||
         !has(object.spec.unseal.transit) ||
@@ -333,13 +347,21 @@ spec:
         object.spec.profile != "Hardened" ||
         object.spec.replicas >= 3
       message: "Hardened profile requires at least 3 replicas for Raft quorum HA. Use Profile=Development for non-HA deployments."
-    # Block references to system secrets in backup/upgrade
+    # Confused-deputy protection: users configuring unseal Secret credentials must be able to read that Secret.
     - expression: >-
+        !has(object.spec.unseal) ||
+        !has(object.spec.unseal.credentialsSecretRef) ||
+        authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.unseal.credentialsSecretRef.name).check("get").allowed()
+      message: "Users configuring unseal credentials must be authorized to get spec.unseal.credentialsSecretRef."
+    # Block references to system secrets in unseal/backup/upgrade
+    - expression: >-
+        (!has(object.spec.unseal) || !has(object.spec.unseal.credentialsSecretRef) ||
+          !object.spec.unseal.credentialsSecretRef.name.matches("^.*-(unseal-key|root-token|tls-ca|tls-server)$")) &&
         (!has(object.spec.backup) || !has(object.spec.backup.target.credentialsSecretRef) ||
           !object.spec.backup.target.credentialsSecretRef.name.matches("^.*-(unseal-key|root-token|tls-ca|tls-server)$")) &&
         (!has(object.spec.backup) || !has(object.spec.backup.tokenSecretRef) ||
           !object.spec.backup.tokenSecretRef.name.matches("^.*-(unseal-key|root-token|tls-ca|tls-server)$"))
-      message: "References to system secrets (unseal-key, root-token, tls-ca, tls-server) are prohibited in backup configurations to prevent confused deputy attacks."
+      message: "References to system secrets (unseal-key, root-token, tls-ca, tls-server) are prohibited in unseal and backup configurations to prevent confused deputy attacks."
     # Storage Immutability: Prevent storage class changes (immutable in StatefulSet)
     - expression: >-
         oldObject == null ||

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -4313,7 +4313,8 @@ spec:
                       Required when Type is "transit".
                     properties:
                       address:
-                        description: Address is the full address to the OpenBao cluster.
+                        description: Address is the full HTTPS address to the OpenBao
+                          cluster providing the Transit seal.
                         minLength: 1
                         type: string
                       disableRenewal:

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -154,13 +154,27 @@ spec:
         size(object.spec.unseal.transit.token) == 0
       message: Hardened profile does not allow spec.unseal.transit.token; use spec.unseal.credentialsSecretRef instead.
     - expression: >-
-        !has(object.spec.profile) ||
-        object.spec.profile != "Hardened" ||
         !has(object.spec.unseal) ||
         !has(object.spec.unseal.transit) ||
         !has(object.spec.unseal.transit.address) ||
         object.spec.unseal.transit.address.startsWith("https://")
-      message: Hardened profile requires spec.unseal.transit.address to use HTTPS.
+      message: Transit unseal address must use HTTPS.
+    - expression: >-
+        !has(object.spec.unseal) ||
+        !has(object.spec.unseal.transit) ||
+        !has(object.spec.unseal.transit.address) ||
+        !(
+          object.spec.unseal.transit.address.contains("@") ||
+          object.spec.unseal.transit.address.contains("?") ||
+          object.spec.unseal.transit.address.contains("#") ||
+          object.spec.unseal.transit.address.matches("^https://([^/?#@]*\\.)?localhost([:/?#].*)?$") ||
+          object.spec.unseal.transit.address.matches("^https://127\\.0\\.0\\.1([:/?#].*)?$") ||
+          object.spec.unseal.transit.address.contains("[::1]") ||
+          object.spec.unseal.transit.address.matches("^https://169\\.254\\..*") ||
+          object.spec.unseal.transit.address.contains("[fe80:") ||
+          object.spec.unseal.transit.address.matches("^https://[0-9]+([:/?#].*)?$")
+        )
+      message: Transit unseal address must not include userinfo, query, fragment, localhost, loopback, link-local, or numeric host forms.
     - expression: >-
         !has(object.spec.unseal) ||
         !has(object.spec.unseal.transit) ||
@@ -330,13 +344,21 @@ spec:
         object.spec.profile != "Hardened" ||
         object.spec.replicas >= 3
       message: "Hardened profile requires at least 3 replicas for Raft quorum HA. Use Profile=Development for non-HA deployments."
-    # Block references to system secrets in backup/upgrade
+    # Confused-deputy protection: users configuring unseal Secret credentials must be able to read that Secret.
     - expression: >-
+        !has(object.spec.unseal) ||
+        !has(object.spec.unseal.credentialsSecretRef) ||
+        authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.unseal.credentialsSecretRef.name).check("get").allowed()
+      message: "Users configuring unseal credentials must be authorized to get spec.unseal.credentialsSecretRef."
+    # Block references to system secrets in unseal/backup/upgrade
+    - expression: >-
+        (!has(object.spec.unseal) || !has(object.spec.unseal.credentialsSecretRef) ||
+          !object.spec.unseal.credentialsSecretRef.name.matches("^.*-(unseal-key|root-token|tls-ca|tls-server)$")) &&
         (!has(object.spec.backup) || !has(object.spec.backup.target.credentialsSecretRef) ||
           !object.spec.backup.target.credentialsSecretRef.name.matches("^.*-(unseal-key|root-token|tls-ca|tls-server)$")) &&
         (!has(object.spec.backup) || !has(object.spec.backup.tokenSecretRef) ||
           !object.spec.backup.tokenSecretRef.name.matches("^.*-(unseal-key|root-token|tls-ca|tls-server)$"))
-      message: "References to system secrets (unseal-key, root-token, tls-ca, tls-server) are prohibited in backup configurations to prevent confused deputy attacks."
+      message: "References to system secrets (unseal-key, root-token, tls-ca, tls-server) are prohibited in unseal and backup configurations to prevent confused deputy attacks."
     # Storage Immutability: Prevent storage class changes (immutable in StatefulSet)
     - expression: >-
         oldObject == null ||

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_transit.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_transit.yaml
@@ -81,10 +81,9 @@ spec:
 #   namespace: openbaocluster-transit
 # type: Opaque
 # stringData:
-#   VAULT_TOKEN: "s.Qf1s5zigZ4OX6akYjQXJC1jY"
+#   token: "s.Qf1s5zigZ4OX6akYjQXJC1jY"
 #   # Optional: CA certificate for TLS verification
 #   # ca.crt: |
 #   #   -----BEGIN CERTIFICATE-----
 #   #   ...
 #   #   -----END CERTIFICATE-----
-

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1830,7 +1830,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `address` _string_ | Address is the full address to the OpenBao cluster. |  | MinLength: 1 <br /> |
+| `address` _string_ | Address is the full HTTPS address to the OpenBao cluster providing the Transit seal. |  | MinLength: 1 <br /> |
 | `token` _string_ | Token is the OpenBao token to use for authentication.<br />Note: It is strongly recommended to use CredentialsSecretRef instead of setting this directly. |  | Optional: \{\} <br /> |
 | `keyName` _string_ | KeyName is the transit key to use for encryption and decryption. |  | MinLength: 1 <br /> |
 | `mountPath` _string_ | MountPath is the mount path to the transit secret engine. |  | MinLength: 1 <br /> |

--- a/docs/user-guide/openbaocluster/configuration/unseal.md
+++ b/docs/user-guide/openbaocluster/configuration/unseal.md
@@ -63,6 +63,9 @@ For production-oriented clusters, use an external trust source such as cloud KMS
 <Callout type="note" title="What the operator validates before Pods can use Secret-backed credentials">
 
 - `spec.unseal.credentialsSecretRef` must reference a Secret in the same namespace as the `OpenBaoCluster`.
+- Transit unseal addresses must use HTTPS and must not include userinfo, query, fragment, localhost, loopback, link-local, or numeric host forms.
+- Users configuring transit `credentialsSecretRef` must also be authorized to `get` the referenced Secret.
+- Transit unseal credentials cannot reference operator-managed system Secrets such as `<cluster>-root-token`, `<cluster>-unseal-key`, `<cluster>-tls-ca`, or `<cluster>-tls-server`.
 - Any unseal field that points to a mounted credential file must use a path under `/etc/bao/seal-creds`.
 - The Secret key name must match the filename used in the mounted path.
 - When you use private ACME trust rooted under `/etc/bao/seal-creds`, include `pki-ca.crt` in the same Secret so probes and day-2 operations can trust the ACME issuer too.
@@ -111,7 +114,7 @@ For production-oriented clusters, use an external trust source such as cloud KMS
         "Transit",
         "Needed whenever you do not rely only on an inline token and Secret-backed files are referenced.",
         "`token`, plus any mounted files referenced by `tlsCACert`, `tlsClientCert`, and `tlsClientKey`.",
-        "If client cert auth is used, the certificate and key must both be present and form a valid key pair.",
+        "Use an orphan or periodic token with only update permissions on the transit encrypt/decrypt paths. If client cert auth is used, the certificate and key must both be present and form a valid key pair.",
       ],
       emphasis: "recommended",
     },

--- a/internal/service/bootstrap/unseal_validation.go
+++ b/internal/service/bootstrap/unseal_validation.go
@@ -15,21 +15,24 @@ func (m *Manager) validateUnsealPrerequisites(ctx context.Context, cluster *open
 	if cluster == nil || cluster.Spec.Unseal == nil {
 		return nil
 	}
+	if err := validateUnsealCredentialsSecretRef(cluster); err != nil {
+		return providerPrerequisitesError(err)
+	}
 
 	switch cluster.Spec.Unseal.Type {
-	case "", "static":
+	case "", portopenbao.SealTypeStatic:
 		return nil
 	case unsealTypeTransit:
 		return m.validateTransitUnsealPrerequisites(ctx, cluster)
-	case "awskms":
+	case portopenbao.SealTypeAWSKMS:
 		return m.validateAWSKMSUnsealPrerequisites(ctx, cluster)
-	case "azurekeyvault":
+	case portopenbao.SealTypeAzureKeyVault:
 		return m.validateAzureKeyVaultUnsealPrerequisites(ctx, cluster)
-	case "gcpckms":
+	case portopenbao.SealTypeGCPCKMS:
 		return m.validateGCPCKMSUnsealPrerequisites(ctx, cluster)
-	case "kmip":
+	case portopenbao.SealTypeKMIP:
 		return m.validateKMIPUnsealPrerequisites(ctx, cluster)
-	case "ocikms":
+	case portopenbao.SealTypeOCIKMS:
 		return m.validateOCIKMSUnsealPrerequisites(ctx, cluster)
 	case portopenbao.SealTypePKCS11:
 		return m.validatePKCS11UnsealPrerequisites(ctx, cluster)

--- a/internal/service/bootstrap/unseal_validation_test.go
+++ b/internal/service/bootstrap/unseal_validation_test.go
@@ -41,6 +41,104 @@ func TestValidateTransitUnsealPrerequisites(t *testing.T) {
 		}
 	})
 
+	t.Run("transit address rejects insecure and ambiguous destinations", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			address string
+			want    string
+		}{
+			{
+				name:    "plain http",
+				address: "http://infra-bao.example",
+				want:    "must use HTTPS",
+			},
+			{
+				name:    "userinfo",
+				address: "https://token@infra-bao.example",
+				want:    "must not include userinfo",
+			},
+			{
+				name:    "localhost",
+				address: "https://localhost:8200",
+				want:    "must not point to localhost",
+			},
+			{
+				name:    "loopback ip",
+				address: "https://127.0.0.1:8200",
+				want:    "must not point to loopback",
+			},
+			{
+				name:    "link local ip",
+				address: "https://169.254.169.254/latest/meta-data",
+				want:    "must not point to loopback",
+			},
+			{
+				name:    "query",
+				address: "https://infra-bao.example?token=leak",
+				want:    "must not include query or fragment",
+			},
+			{
+				name:    "numeric host",
+				address: "https://2130706433:8200",
+				want:    "must not use numeric host forms",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cluster := newMinimalCluster("transit-address-"+tt.name, "default")
+				cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+					Type: "transit",
+					Transit: &openbaov1alpha1.TransitSealConfig{
+						Address:   tt.address,
+						KeyName:   "autounseal",
+						MountPath: "transit/",
+						Token:     "inline-token",
+					},
+				}
+
+				mgr := NewManager(newTestClient(t), testScheme, "operator-system")
+				err := mgr.validateUnsealPrerequisites(context.Background(), cluster)
+				if err == nil {
+					t.Fatal("validateUnsealPrerequisites() error = nil, want error")
+				}
+				if !errors.Is(err, operatorerrors.ErrPermanentPrerequisitesMissing) {
+					t.Fatalf("expected permanent prerequisites missing error, got %v", err)
+				}
+				if !strings.Contains(err.Error(), tt.want) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("transit credentials Secret cannot reference operator managed system Secrets", func(t *testing.T) {
+		cluster := newMinimalCluster("transit-system-secret", "default")
+		cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+			Type: "transit",
+			CredentialsSecretRef: &corev1.LocalObjectReference{
+				Name: "transit-system-secret-root-token",
+			},
+			Transit: &openbaov1alpha1.TransitSealConfig{
+				Address:   "https://infra-bao.example",
+				KeyName:   "autounseal",
+				MountPath: "transit/",
+			},
+		}
+
+		mgr := NewManager(newTestClient(t), testScheme, "operator-system")
+		err := mgr.validateUnsealPrerequisites(context.Background(), cluster)
+		if err == nil {
+			t.Fatal("validateUnsealPrerequisites() error = nil, want error")
+		}
+		if !errors.Is(err, operatorerrors.ErrPermanentPrerequisitesMissing) {
+			t.Fatalf("expected permanent prerequisites missing error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "operator-managed system Secret") {
+			t.Fatalf("error = %q, want operator-managed system Secret", err.Error())
+		}
+	})
+
 	t.Run("secret-backed transit files require credentials Secret", func(t *testing.T) {
 		cluster := newMinimalCluster("transit-missing-secret-ref", "default")
 		cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
@@ -349,6 +447,30 @@ func TestValidateAWSKMSUnsealPrerequisites(t *testing.T) {
 		mgr := NewManager(newTestClient(t), testScheme, "operator-system")
 		if err := mgr.validateUnsealPrerequisites(context.Background(), cluster); err != nil {
 			t.Fatalf("validateUnsealPrerequisites() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("credentials Secret cannot reference operator managed system Secrets", func(t *testing.T) {
+		cluster := newMinimalCluster("awskms-system-secret", "default")
+		cluster.Spec.Unseal = &openbaov1alpha1.UnsealConfig{
+			Type:                 "awskms",
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "awskms-system-secret-root-token"},
+			AWSKMS: &openbaov1alpha1.AWSKMSSealConfig{
+				Region:   "eu-central-1",
+				KMSKeyID: "alias/openbao",
+			},
+		}
+
+		mgr := NewManager(newTestClient(t), testScheme, "operator-system")
+		err := mgr.validateUnsealPrerequisites(context.Background(), cluster)
+		if err == nil {
+			t.Fatal("validateUnsealPrerequisites() error = nil, want error")
+		}
+		if !errors.Is(err, operatorerrors.ErrPermanentPrerequisitesMissing) {
+			t.Fatalf("expected permanent prerequisites missing error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "operator-managed system Secret") {
+			t.Fatalf("error = %q, want operator-managed system Secret", err.Error())
 		}
 	})
 

--- a/internal/service/bootstrap/unseal_validation_transit.go
+++ b/internal/service/bootstrap/unseal_validation_transit.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net/netip"
 	"net/url"
 	"slices"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
 
 func (m *Manager) validateTransitUnsealPrerequisites(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) error {
@@ -82,14 +84,99 @@ func (m *Manager) validateTransitUnsealPrerequisites(ctx context.Context, cluste
 }
 
 func validateTransitAddress(address string) error {
-	u, err := url.Parse(strings.TrimSpace(address))
+	trimmed := strings.TrimSpace(address)
+	u, err := url.Parse(trimmed)
 	if err != nil {
 		return fmt.Errorf("spec.unseal.transit.address must be a valid absolute URL: %w", err)
 	}
 	if strings.TrimSpace(u.Scheme) == "" || strings.TrimSpace(u.Host) == "" {
 		return fmt.Errorf("spec.unseal.transit.address must be a valid absolute URL")
 	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("spec.unseal.transit.address must use HTTPS")
+	}
+	if u.User != nil {
+		return fmt.Errorf("spec.unseal.transit.address must not include userinfo")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("spec.unseal.transit.address must not include query or fragment components")
+	}
+
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("spec.unseal.transit.address must include a host")
+	}
+	if isLocalhostName(host) {
+		return fmt.Errorf("spec.unseal.transit.address must not point to localhost")
+	}
+	if isNumericHostname(host) {
+		return fmt.Errorf("spec.unseal.transit.address must not use numeric host forms")
+	}
+	if strings.Contains(host, "%") {
+		return fmt.Errorf("spec.unseal.transit.address must not include scoped IP zone identifiers")
+	}
+	if addr, err := netip.ParseAddr(host); err == nil && isForbiddenTransitAddress(addr) {
+		return fmt.Errorf("spec.unseal.transit.address must not point to loopback, link-local, or unspecified addresses")
+	}
 	return nil
+}
+
+func isLocalhostName(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	return host == "localhost" || strings.HasSuffix(host, ".localhost")
+}
+
+func isForbiddenTransitAddress(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() ||
+		addr.IsUnspecified()
+}
+
+func isNumericHostname(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	for _, r := range host {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func validateUnsealCredentialsSecretRef(cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if cluster == nil || cluster.Spec.Unseal == nil || cluster.Spec.Unseal.CredentialsSecretRef == nil {
+		return nil
+	}
+
+	name := strings.TrimSpace(cluster.Spec.Unseal.CredentialsSecretRef.Name)
+	if name == "" {
+		return fmt.Errorf("spec.unseal.credentialsSecretRef.name must not be empty")
+	}
+	if isOperatorManagedSystemSecretName(name) {
+		return fmt.Errorf(
+			"spec.unseal.credentialsSecretRef must not reference operator-managed system Secret %q",
+			name,
+		)
+	}
+	return nil
+}
+
+func isOperatorManagedSystemSecretName(name string) bool {
+	for _, suffix := range []string{
+		constants.SuffixUnsealKey,
+		constants.SuffixRootToken,
+		constants.SuffixTLSCA,
+		constants.SuffixTLSServer,
+	} {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateTransitClientTLSPair(cfg *openbaov1alpha1.TransitSealConfig) error {

--- a/test/e2e/Security_Guardrails_test.go
+++ b/test/e2e/Security_Guardrails_test.go
@@ -923,7 +923,7 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 				return c.Create(ctx, newTransitCluster("transit-authz-denied", transitSecretName), client.DryRunAll)
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Users configuring transit credentials"))
+			Expect(err.Error()).To(ContainSubstring("Users configuring unseal credentials"))
 
 			secretReaderRole := &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/Security_Guardrails_test.go
+++ b/test/e2e/Security_Guardrails_test.go
@@ -862,6 +862,96 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 			Expect(err.Error()).To(ContainSubstring("Hardened profile requires"))
 		})
 
+		It("requires transit credential Secret read authorization", func() {
+			const transitSecretName = "transit-creds-authz"
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      transitSecretName,
+					Namespace: guardrailsNamespace,
+				},
+				StringData: map[string]string{
+					"token": "s.e2e",
+				},
+			}
+			err := admin.Create(ctx, secret)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			newTransitCluster := func(name, secretName string) *openbaov1alpha1.OpenBaoCluster {
+				return &openbaov1alpha1.OpenBaoCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: guardrailsNamespace,
+					},
+					Spec: openbaov1alpha1.OpenBaoClusterSpec{
+						Profile:  openbaov1alpha1.ProfileDevelopment,
+						Version:  openBaoVersion,
+						Image:    openBaoImage,
+						Replicas: 1,
+						InitContainer: &openbaov1alpha1.InitContainerConfig{
+							Enabled: true,
+							Image:   configInitImage,
+						},
+						TLS: openbaov1alpha1.TLSConfig{
+							Enabled:        true,
+							RotationPeriod: "720h",
+						},
+						Storage: openbaov1alpha1.StorageConfig{
+							Size: "1Gi",
+						},
+						Network: &openbaov1alpha1.NetworkConfig{
+							APIServerCIDR: apiServerCIDR,
+						},
+						Unseal: &openbaov1alpha1.UnsealConfig{
+							Type: "transit",
+							Transit: &openbaov1alpha1.TransitSealConfig{
+								Address:   "https://transit-provider.example.com:8200",
+								KeyName:   "openbao-unseal",
+								MountPath: "transit",
+							},
+							CredentialsSecretRef: &corev1.LocalObjectReference{
+								Name: secretName,
+							},
+						},
+					},
+				}
+			}
+
+			err = runAsE2EGroupMember(ctx, cfg, scheme, impersonatedUser, func(c client.Client) error {
+				return c.Create(ctx, newTransitCluster("transit-authz-denied", transitSecretName), client.DryRunAll)
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Users configuring transit credentials"))
+
+			secretReaderRole := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "e2e-transit-secret-reader",
+					Namespace: guardrailsNamespace,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Resources:     []string{"secrets"},
+						ResourceNames: []string{transitSecretName},
+						Verbs:         []string{"get"},
+					},
+				},
+			}
+			createRoleBindingForGroup(ctx, admin, guardrailsNamespace, secretReaderRole)
+
+			err = runAsE2EGroupMember(ctx, cfg, scheme, impersonatedUser, func(c client.Client) error {
+				return c.Create(ctx, newTransitCluster("transit-authz-allowed", transitSecretName), client.DryRunAll)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			systemSecretCluster := newTransitCluster("transit-system-secret-denied", "transit-root-token")
+			err = admin.Create(ctx, systemSecretCluster, client.DryRunAll)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("References to system secrets"))
+		})
+
 		It("enforces digest-pinned images for managed workloads when digest enforcement is required", func() {
 			newManagedJob := func(name, image string) *batchv1.Job {
 				return &batchv1.Job{

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,7 +12,7 @@ Notes:
 ## Summary
 
 - Files: `19`
-- Specs: `79`
+- Specs: `80`
 - Explicit case IDs: `33`
 - Coverage tags: `44`
 
@@ -31,7 +31,7 @@ Notes:
 | [Manager Resilience](suites/Manager_Resilience_test.md) | 3 | 3 | 0 | `manager`, `cluster`, `e2e-anchor` | `test/e2e/Manager_Resilience_test.go` |
 | [Manager](suites/Operator_Manager_test.md) | 1 | 1 | 0 | `manager`, `critical`, `smoke` | `test/e2e/Operator_Manager_test.go` |
 | [OpenShift Platform](suites/Platform_OpenShift_test.md) | 2 | 0 | 0 | `openshift`, `platform` | `test/e2e/Platform_OpenShift_test.go` |
-| [Security Guardrails](suites/Security_Guardrails_test.md) | 20 | 2 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
+| [Security Guardrails](suites/Security_Guardrails_test.md) | 21 | 2 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
 | [Tenant Data Isolation](suites/Tenant_Data_Isolation_test.md) | 1 | 1 | 0 | `security`, `tenant`, `tenancy` | `test/e2e/Tenant_Data_Isolation_test.go` |
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow`, `e2e-anchor` | `test/e2e/Upgrade_Operation_Lock_test.go` |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -1237,6 +1237,33 @@
     "suiteTitle": ""
   },
   {
+    "id": "security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539",
+    "generatedId": "security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539",
+    "file": "test/e2e/Security_Guardrails_test.go",
+    "type": "It",
+    "name": "requires transit credential Secret read authorization",
+    "path": [
+      "Security Guardrails",
+      "Admission Policy Enforcement",
+      "requires transit credential Secret read authorization"
+    ],
+    "labels": [
+      "security",
+      "critical",
+      "admission"
+    ],
+    "domainLabels": [
+      "security",
+      "critical",
+      "admission"
+    ],
+    "steps": null,
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "security-guardrails-reports-degraded-when-gateway-api-crds-d5cb95ff",
     "generatedId": "security-guardrails-reports-degraded-when-gateway-api-crds-d5cb95ff",
     "file": "test/e2e/Security_Guardrails_test.go",

--- a/test/e2e/catalog/suites/Security_Guardrails_test.md
+++ b/test/e2e/catalog/suites/Security_Guardrails_test.md
@@ -13,6 +13,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `security-guardrails-blocks-cross-namespace-tenant-targeting-self-6a21b1fd` | blocks cross-namespace tenant targeting (self-service mode) | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-enforces-hardened-profile-invariants-446324b0` | enforces Hardened profile invariants | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-enforces-digest-pinned-images-for-managed-a108b1a3` | enforces digest-pinned images for managed workloads when digest enforcement is required | active | _none_ | `security`, `critical`, `admission` |
+| `security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539` | requires transit credential Secret read authorization | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-reports-degraded-when-gateway-api-crds-d5cb95ff` | reports Degraded when Gateway API CRDs are missing | active | _none_ | `security`, `critical`, `config` |
 | `security-guardrails-applies-admission-guardrails-to-controller-rbac-7093e068` | applies admission guardrails to controller RBAC writes | active | _none_ | `security`, `critical`, `pentest`, `tokens`, `rbac` |
 | `security-guardrails-applies-admission-guardrails-to-provisioner-namespace-451d674f` | applies admission guardrails to provisioner Namespace mutations | active | _none_ | `security`, `critical`, `pentest`, `tokens`, `rbac` |
@@ -85,6 +86,17 @@ Labels: `security`, `critical`, `admission`
 ## `security-guardrails-enforces-digest-pinned-images-for-managed-a108b1a3`
 
 Path: `Security Guardrails > Admission Policy Enforcement > enforces digest-pinned images for managed workloads when digest enforcement is required`
+
+State: `active`
+
+Covers: _none_
+
+Labels: `security`, `critical`, `admission`
+
+
+## `security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539`
+
+Path: `Security Guardrails > Admission Policy Enforcement > requires transit credential Secret read authorization`
 
 State: `active`
 

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -395,7 +395,7 @@ func TestVAP_OpenBaoCluster_RejectsHardenedTransitAddressWithoutHTTPS(t *testing
 
 	err := k8sClient.Create(ctx, cluster)
 	requireAdmissionDenied(t, err)
-	if !strings.Contains(err.Error(), "Hardened profile requires spec.unseal.transit.address to use HTTPS") {
+	if !strings.Contains(err.Error(), "Transit unseal address must use HTTPS") {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -280,6 +280,68 @@ func TestKustomizeDefault_OpenBaoClusterPolicyBlocksUpgradeStrategySwitches(t *t
 	}
 }
 
+func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T) {
+	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
+	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {
+		gvk := u.GroupVersionKind()
+		return gvk.Group == testAdmissionRegistrationGroup &&
+			gvk.Kind == testKindVAP &&
+			strings.HasSuffix(u.GetName(), "openbao-validate-openbaocluster")
+	})
+
+	if len(objs) != 1 {
+		t.Fatalf("expected exactly one openbao-validate-openbaocluster policy, got %d", len(objs))
+	}
+
+	validations, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "validations")
+	if err != nil || !found {
+		t.Fatalf("read policy validations: found=%v err=%v", found, err)
+	}
+
+	var foundHTTPS bool
+	var foundUnsafeURLComponents bool
+	var foundSecretAuthorizer bool
+	var foundSystemSecretBlock bool
+	for _, validation := range validations {
+		validationMap, ok := validation.(map[string]any)
+		if !ok {
+			continue
+		}
+		message, _ := validationMap["message"].(string)
+		expression, _ := validationMap["expression"].(string)
+		switch {
+		case message == "Transit unseal address must use HTTPS." &&
+			strings.Contains(expression, `object.spec.unseal.transit.address.startsWith("https://")`):
+			foundHTTPS = true
+		case strings.Contains(message, "must not include userinfo") &&
+			strings.Contains(expression, `contains("@")`) &&
+			strings.Contains(expression, `169\\.254`) &&
+			strings.Contains(expression, `[fe80:`):
+			foundUnsafeURLComponents = true
+		case strings.Contains(message, "Users configuring unseal credentials") &&
+			strings.Contains(expression, `authorizer.group("")`) &&
+			strings.Contains(expression, `resource("secrets")`) &&
+			strings.Contains(expression, `check("get")`) &&
+			!strings.Contains(expression, `object.spec.unseal.type != "transit"`):
+			foundSecretAuthorizer = true
+		case strings.Contains(message, "system secrets") &&
+			strings.Contains(expression, "object.spec.unseal.credentialsSecretRef") &&
+			strings.Contains(expression, "root-token"):
+			foundSystemSecretBlock = true
+		}
+	}
+
+	if !foundHTTPS || !foundUnsafeURLComponents || !foundSecretAuthorizer || !foundSystemSecretBlock {
+		t.Fatalf(
+			"openbao-validate-openbaocluster transit protections missing: https=%v unsafeURL=%v authorizer=%v systemSecret=%v",
+			foundHTTPS,
+			foundUnsafeURLComponents,
+			foundSecretAuthorizer,
+			foundSystemSecretBlock,
+		)
+	}
+}
+
 func TestKustomizeDefault_OpenBaoClusterCRDRejectsUpgradeStrategySwitches(t *testing.T) {
 	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
 	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {


### PR DESCRIPTION
## Summary

Hardens Transit auto-unseal handling against confused-deputy Secret access and unsafe transit endpoint configuration.

This change:
- Requires Transit seal addresses to use HTTPS and rejects userinfo, query/fragment, localhost, loopback, link-local, scoped-IP, unspecified, and numeric host forms.
- Blocks `spec.unseal.credentialsSecretRef` from referencing operator-managed system Secrets.
- Adds an admission `authorizer` check requiring the OpenBaoCluster author to have `get` on the referenced Transit credentials Secret.
- Updates CRDs, Helm chart CRDs/policies, API reference, unseal docs, and the Transit sample Secret key.
- Adds unit, integration, and E2E guardrail coverage for the new behavior.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Security-impacting admission and reconciliation hardening.

This may reject existing Transit unseal configurations that use non-HTTPS addresses, localhost/link-local/numeric hosts, URL userinfo/query/fragment components, operator-managed system Secrets as unseal credentials, or credentials Secrets the submitting user cannot `get`.

Generated CRDs, Helm CRDs/policies, and API reference were updated.

## Verification

```sh
go test ./internal/service/bootstrap
go test ./internal/service/bootstrap ./internal/service/workload ./internal/adapter/config
go test -tags=integration ./test/integration -run TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal
go test -tags=e2e ./test/e2e -run TestNonExistent
make manifests
make helm-sync
make api-reference
make helm-template
make verify-generated
make verify-helm
make e2e-catalog
make e2e-manifest-validate
git diff --check
git push -u origin fix/transit-unseal-hardening
```

Pre-push also ran `make lint-ci` successfully.

## Reviewer Notes

Please focus on the admission `authorizer` expression and the runtime/admission parity for Transit URL validation.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
