### PR TITLE
fix(security): harden backup and restore helper inputs

### DIFF
--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -353,6 +353,14 @@ spec:
         !has(object.spec.unseal.credentialsSecretRef) ||
         authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.unseal.credentialsSecretRef.name).check("get").allowed()
       message: "Users configuring unseal credentials must be authorized to get spec.unseal.credentialsSecretRef."
+    # Confused-deputy protection: users configuring backup Secret credentials must be able to read those Secrets.
+    - expression: >-
+        !has(object.spec.backup) ||
+        ((!has(object.spec.backup.target.credentialsSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.backup.target.credentialsSecretRef.name).check("get").allowed()) &&
+        (!has(object.spec.backup.tokenSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.backup.tokenSecretRef.name).check("get").allowed()))
+      message: "Users configuring backup credentials must be authorized to get referenced backup Secrets."
     # Block references to system secrets in unseal/backup/upgrade
     - expression: >-
         (!has(object.spec.unseal) || !has(object.spec.unseal.credentialsSecretRef) ||

--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -347,6 +347,18 @@ spec:
         object.spec.profile != "Hardened" ||
         object.spec.replicas >= 3
       message: "Hardened profile requires at least 3 replicas for Raft quorum HA. Use Profile=Development for non-HA deployments."
+    # Confused-deputy protection: custom backup helper images run with backup credentials.
+    - expression: >-
+        !has(object.spec.backup) ||
+        !has(object.spec.backup.image) ||
+        object.spec.backup.image == "" ||
+        (request.operation == "UPDATE" &&
+          oldObject != null &&
+          has(oldObject.spec.backup) &&
+          has(oldObject.spec.backup.image) &&
+          oldObject.spec.backup.image == object.spec.backup.image) ||
+        authorizer.group("openbao.org").resource("openbaoclusters").namespace(request.namespace).name(object.metadata.name).check("usehelperimages").allowed()
+      message: "Users configuring custom backup helper images must be authorized to use helper image overrides on this OpenBaoCluster."
     # Confused-deputy protection: users configuring unseal Secret credentials must be able to read that Secret.
     - expression: >-
         !has(object.spec.unseal) ||

--- a/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
@@ -50,6 +50,13 @@ spec:
         object.spec.source.target.endpoint.startsWith("s3://") ||
         object.spec.source.target.endpoint.matches("^http://[^/]+\\.svc(\\.|:|/|$).*")
       message: "Restore endpoint must use HTTPS or S3 scheme, unless it targets an in-cluster Service (*.svc)."
+    # Confused-deputy protection: users configuring restore Secret credentials must be able to read those Secrets.
+    - expression: >-
+        (!has(object.spec.source.target.credentialsSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.source.target.credentialsSecretRef.name).check("get").allowed()) &&
+        (!has(object.spec.tokenSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.tokenSecretRef.name).check("get").allowed())
+      message: "Users configuring restore credentials must be authorized to get referenced restore Secrets."
     # Confused-deputy protection: Block references to system secrets (restore auth + object store credentials)
     - expression: >-
         (!has(object.spec.source.target.credentialsSecretRef) ||

--- a/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
@@ -50,6 +50,16 @@ spec:
         object.spec.source.target.endpoint.startsWith("s3://") ||
         object.spec.source.target.endpoint.matches("^http://[^/]+\\.svc(\\.|:|/|$).*")
       message: "Restore endpoint must use HTTPS or S3 scheme, unless it targets an in-cluster Service (*.svc)."
+    # Confused-deputy protection: custom restore helper images run with restore credentials.
+    - expression: >-
+        !has(object.spec.image) ||
+        object.spec.image == "" ||
+        (request.operation == "UPDATE" &&
+          oldObject != null &&
+          has(oldObject.spec.image) &&
+          oldObject.spec.image == object.spec.image) ||
+        authorizer.group("openbao.org").resource("openbaoclusters").namespace(request.namespace).name(object.spec.cluster).check("usehelperimages").allowed()
+      message: "Users configuring custom restore helper images must be authorized to use helper image overrides on the target OpenBaoCluster."
     # Confused-deputy protection: users configuring restore Secret credentials must be able to read those Secrets.
     - expression: >-
         (!has(object.spec.source.target.credentialsSecretRef) ||

--- a/charts/openbao-operator/templates/rbac/aggregated-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/aggregated-clusterroles.yaml
@@ -52,6 +52,22 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
+  name: {{ include "openbao-operator.fullname" . }}-openbaocluster-helper-image
+rules:
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters
+    verbs:
+      - get
+      - usehelperimages
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "openbao-operator.labels" . | nindent 4 }}
   name: {{ include "openbao-operator.fullname" . }}-openbaocluster-viewer
 rules:
   - apiGroups:

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -350,6 +350,14 @@ spec:
         !has(object.spec.unseal.credentialsSecretRef) ||
         authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.unseal.credentialsSecretRef.name).check("get").allowed()
       message: "Users configuring unseal credentials must be authorized to get spec.unseal.credentialsSecretRef."
+    # Confused-deputy protection: users configuring backup Secret credentials must be able to read those Secrets.
+    - expression: >-
+        !has(object.spec.backup) ||
+        ((!has(object.spec.backup.target.credentialsSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.backup.target.credentialsSecretRef.name).check("get").allowed()) &&
+        (!has(object.spec.backup.tokenSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.backup.tokenSecretRef.name).check("get").allowed()))
+      message: "Users configuring backup credentials must be authorized to get referenced backup Secrets."
     # Block references to system secrets in unseal/backup/upgrade
     - expression: >-
         (!has(object.spec.unseal) || !has(object.spec.unseal.credentialsSecretRef) ||

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -344,6 +344,18 @@ spec:
         object.spec.profile != "Hardened" ||
         object.spec.replicas >= 3
       message: "Hardened profile requires at least 3 replicas for Raft quorum HA. Use Profile=Development for non-HA deployments."
+    # Confused-deputy protection: custom backup helper images run with backup credentials.
+    - expression: >-
+        !has(object.spec.backup) ||
+        !has(object.spec.backup.image) ||
+        object.spec.backup.image == "" ||
+        (request.operation == "UPDATE" &&
+          oldObject != null &&
+          has(oldObject.spec.backup) &&
+          has(oldObject.spec.backup.image) &&
+          oldObject.spec.backup.image == object.spec.backup.image) ||
+        authorizer.group("openbao.org").resource("openbaoclusters").namespace(request.namespace).name(object.metadata.name).check("usehelperimages").allowed()
+      message: "Users configuring custom backup helper images must be authorized to use helper image overrides on this OpenBaoCluster."
     # Confused-deputy protection: users configuring unseal Secret credentials must be able to read that Secret.
     - expression: >-
         !has(object.spec.unseal) ||

--- a/config/policy/openbao-validate-openbaorestore.yaml
+++ b/config/policy/openbao-validate-openbaorestore.yaml
@@ -47,6 +47,13 @@ spec:
         object.spec.source.target.endpoint.startsWith("s3://") ||
         object.spec.source.target.endpoint.matches("^http://[^/]+\\.svc(\\.|:|/|$).*")
       message: "Restore endpoint must use HTTPS or S3 scheme, unless it targets an in-cluster Service (*.svc)."
+    # Confused-deputy protection: users configuring restore Secret credentials must be able to read those Secrets.
+    - expression: >-
+        (!has(object.spec.source.target.credentialsSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.source.target.credentialsSecretRef.name).check("get").allowed()) &&
+        (!has(object.spec.tokenSecretRef) ||
+          authorizer.group("").resource("secrets").namespace(request.namespace).name(object.spec.tokenSecretRef.name).check("get").allowed())
+      message: "Users configuring restore credentials must be authorized to get referenced restore Secrets."
     # Confused-deputy protection: Block references to system secrets (restore auth + object store credentials)
     - expression: >-
         (!has(object.spec.source.target.credentialsSecretRef) ||

--- a/config/policy/openbao-validate-openbaorestore.yaml
+++ b/config/policy/openbao-validate-openbaorestore.yaml
@@ -47,6 +47,16 @@ spec:
         object.spec.source.target.endpoint.startsWith("s3://") ||
         object.spec.source.target.endpoint.matches("^http://[^/]+\\.svc(\\.|:|/|$).*")
       message: "Restore endpoint must use HTTPS or S3 scheme, unless it targets an in-cluster Service (*.svc)."
+    # Confused-deputy protection: custom restore helper images run with restore credentials.
+    - expression: >-
+        !has(object.spec.image) ||
+        object.spec.image == "" ||
+        (request.operation == "UPDATE" &&
+          oldObject != null &&
+          has(oldObject.spec.image) &&
+          oldObject.spec.image == object.spec.image) ||
+        authorizer.group("openbao.org").resource("openbaoclusters").namespace(request.namespace).name(object.spec.cluster).check("usehelperimages").allowed()
+      message: "Users configuring custom restore helper images must be authorized to use helper image overrides on the target OpenBaoCluster."
     # Confused-deputy protection: users configuring restore Secret credentials must be able to read those Secrets.
     - expression: >-
         (!has(object.spec.source.target.credentialsSecretRef) ||

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -35,5 +35,6 @@ resources:
   # if you do not want those helpers be installed with your Project.
   - openbaocluster_admin_role.yaml
   - openbaocluster_editor_role.yaml
+  - openbaocluster_helper_image_role.yaml
   - openbaocluster_maintenance_role.yaml
   - openbaocluster_viewer_role.yaml

--- a/config/rbac/namespace_scoped_example.yaml
+++ b/config/rbac/namespace_scoped_example.yaml
@@ -110,6 +110,47 @@ subjects:
     name: team-a-break-glass # Change to actual group name
     apiGroup: rbac.authorization.k8s.io
 ---
+# Example: Grant custom backup/restore helper image selection on one cluster
+#
+# This namespaced Role grants the custom `usehelperimages` verb only for a
+# single OpenBaoCluster object. Grant it only to operators trusted to choose
+# executor images, because those images run with backup/restore credentials.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openbaocluster-helper-image-team-a-example
+  namespace: team-a-prod # Change to target namespace
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters
+    resourceNames:
+      - example-cluster # Change to target OpenBaoCluster name
+    verbs:
+      - get
+      - usehelperimages
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbaocluster-helper-image-team-a-example
+  namespace: team-a-prod # Change to target namespace
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbaocluster-helper-image-team-a-example
+subjects:
+  - kind: Group
+    name: team-a-platform-operators # Change to actual group name
+    apiGroup: rbac.authorization.k8s.io
+---
 # Example: Grant admin permissions to platform team (cluster-wide)
 #
 # This ClusterRoleBinding grants platform administrators full access

--- a/config/rbac/openbaocluster_helper_image_role.yaml
+++ b/config/rbac/openbaocluster_helper_image_role.yaml
@@ -1,0 +1,24 @@
+# This rule is not used by the project openbao-operator itself.
+# It is provided to allow cluster administrators to delegate custom
+# backup/restore helper image selection without granting full
+# OpenBaoCluster admin permissions.
+#
+# Multi-tenancy: This ClusterRole can be bound via RoleBinding for
+# namespace-scoped helper image permissions, or copied into a namespaced
+# Role with resourceNames for one explicitly trusted OpenBaoCluster.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: openbao-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: openbaocluster-helper-image-role
+rules:
+  - apiGroups:
+      - openbao.org
+    resources:
+      - openbaoclusters
+    verbs:
+      - get
+      - usehelperimages

--- a/hack/helmchart/main.go
+++ b/hack/helmchart/main.go
@@ -664,16 +664,24 @@ subjects:
 
 // syncAggregatedRBAC syncs aggregated ClusterRoles.
 func syncAggregatedRBAC(opts options) error {
-	parts := make([]string, 0, 4) // 3 cluster roles + 1 tenant role
+	parts := make([]string, 0, 5) // 4 cluster roles + 1 tenant role
 
-	// OpenBaoCluster admin/editor/viewer roles
-	for _, suffix := range []string{"admin", "editor", "viewer"} {
-		filename := fmt.Sprintf("openbaocluster_%s_role.yaml", suffix)
+	// OpenBaoCluster admin/editor/viewer and helper-image delegation roles.
+	for _, role := range []struct {
+		filename   string
+		nameSuffix string
+	}{
+		{filename: "openbaocluster_admin_role.yaml", nameSuffix: "openbaocluster-admin"},
+		{filename: "openbaocluster_editor_role.yaml", nameSuffix: "openbaocluster-editor"},
+		{filename: "openbaocluster_helper_image_role.yaml", nameSuffix: "openbaocluster-helper-image"},
+		{filename: "openbaocluster_viewer_role.yaml", nameSuffix: "openbaocluster-viewer"},
+	} {
+		filename := role.filename
 		content, err := readFile(filepath.Join(opts.rbacInputDir, filename))
 		if err != nil {
 			return fmt.Errorf("read %s: %w", filename, err)
 		}
-		content = transformRBACToHelm(content, fmt.Sprintf("openbaocluster-%s", suffix), false)
+		content = transformRBACToHelm(content, role.nameSuffix, false)
 		parts = append(parts, content)
 	}
 

--- a/hack/helmchart/main_test.go
+++ b/hack/helmchart/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -63,6 +64,58 @@ rules:
 	}
 	if !strings.Contains(got, "app.kubernetes.io/component: controller") {
 		t.Fatalf("transformed RBAC dropped component label:\n%s", got)
+	}
+}
+
+func TestSyncAggregatedRBAC_IncludesHelperImageDelegationRole(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	writeRole := func(filename, name string, verbs ...string) {
+		t.Helper()
+
+		var builder strings.Builder
+		builder.WriteString("apiVersion: rbac.authorization.k8s.io/v1\n")
+		builder.WriteString("kind: ClusterRole\n")
+		builder.WriteString("metadata:\n")
+		builder.WriteString("  name: " + name + "\n")
+		builder.WriteString("rules:\n")
+		builder.WriteString("  - apiGroups:\n")
+		builder.WriteString("      - openbao.org\n")
+		builder.WriteString("    resources:\n")
+		builder.WriteString("      - openbaoclusters\n")
+		builder.WriteString("    verbs:\n")
+		for _, verb := range verbs {
+			builder.WriteString("      - " + verb + "\n")
+		}
+
+		if err := os.WriteFile(filepath.Join(inputDir, filename), []byte(builder.String()), 0o600); err != nil {
+			t.Fatalf("write %s: %v", filename, err)
+		}
+	}
+
+	writeRole("openbaocluster_admin_role.yaml", "openbaocluster-admin-role", "*")
+	writeRole("openbaocluster_editor_role.yaml", "openbaocluster-editor-role", "create", "update")
+	writeRole("openbaocluster_helper_image_role.yaml", "openbaocluster-helper-image-role", "get", "usehelperimages")
+	writeRole("openbaocluster_viewer_role.yaml", "openbaocluster-viewer-role", "get", "list")
+	writeRole("openbaotenant_editor_role.yaml", "openbaotenant-editor-role", "create", "update")
+
+	if err := syncAggregatedRBAC(options{rbacInputDir: inputDir, rbacOutputDir: outputDir}); err != nil {
+		t.Fatalf("syncAggregatedRBAC() failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outputDir, "aggregated-clusterroles.yaml"))
+	if err != nil {
+		t.Fatalf("read generated aggregated roles: %v", err)
+	}
+	output := string(got)
+	for _, want := range []string{
+		`{{ include "openbao-operator.fullname" . }}-openbaocluster-helper-image`,
+		"usehelperimages",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("generated aggregated RBAC missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/internal/service/backup/job_builder.go
+++ b/internal/service/backup/job_builder.go
@@ -254,8 +254,8 @@ func BuildBackupJobVolumeMounts(cluster *openbaov1alpha1.OpenBaoCluster, tlsTrus
 		})
 	}
 
-	// Mount token secret if provided (fallback method when JWT Auth is not used)
-	if cluster.Spec.Backup.TokenSecretRef != nil {
+	// Mount token secret only when static-token auth is effective.
+	if backupUsesStaticTokenAuth(cluster) {
 		mounts = append(mounts, corev1.VolumeMount{
 			Name:      backupTokenVolumeName,
 			MountPath: backupTokenMountPath,
@@ -344,7 +344,7 @@ func BuildBackupJobVolumes(cluster *openbaov1alpha1.OpenBaoCluster, tlsTrust por
 	}
 
 	// Token secret (fallback method when JWT Auth is not used)
-	if cluster.Spec.Backup.TokenSecretRef != nil {
+	if backupUsesStaticTokenAuth(cluster) {
 		secretName := cluster.Spec.Backup.TokenSecretRef.Name
 		tokenFileMode := int32(0400)
 		volumes = append(volumes, corev1.Volume{
@@ -359,6 +359,10 @@ func BuildBackupJobVolumes(cluster *openbaov1alpha1.OpenBaoCluster, tlsTrust por
 	}
 
 	return volumes
+}
+
+func backupUsesStaticTokenAuth(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return cluster.Spec.Backup.TokenSecretRef != nil && jobenv.EffectiveBackupJWTRole(cluster) == ""
 }
 
 // GetBackupExecutorImage returns the backup executor image to use.

--- a/internal/service/backup/job_test.go
+++ b/internal/service/backup/job_test.go
@@ -473,6 +473,36 @@ func TestBuildBackupJob_WithJWTAuth(t *testing.T) {
 	}
 }
 
+func TestBuildBackupJob_DoesNotMountTokenSecretWhenJWTAuthIsEffective(t *testing.T) {
+	cluster := newTestClusterWithBackup("test-cluster", "default")
+	cluster.Spec.Backup.JWTAuthRole = testBackupJWTAuthRole
+	cluster.Spec.Backup.TokenSecretRef = &corev1.LocalObjectReference{
+		Name: "backup-token",
+	}
+
+	job, err := BuildJob(cluster, JobOptions{
+		JobName:   testBackupJobName,
+		JobType:   JobTypeScheduled,
+		BackupKey: "test",
+		Platform:  "",
+	})
+	if err != nil {
+		t.Fatalf("buildBackupJob() error = %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == backupTokenVolumeName {
+			t.Fatalf("buildBackupJob() mounted %q even though JWT auth is effective", backupTokenVolumeName)
+		}
+	}
+	for _, volume := range job.Spec.Template.Spec.Volumes {
+		if volume.Name == backupTokenVolumeName {
+			t.Fatalf("buildBackupJob() added %q volume even though JWT auth is effective", backupTokenVolumeName)
+		}
+	}
+}
+
 func TestBuildBackupJob_WithRoleARN(t *testing.T) {
 	cluster := newTestClusterWithBackup("test-cluster", "default")
 	cluster.Spec.Backup.Target.RoleARN = "arn:aws:iam::123456789012:role/backup-role"

--- a/test/e2e/Security_Guardrails_test.go
+++ b/test/e2e/Security_Guardrails_test.go
@@ -952,6 +952,146 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 			Expect(err.Error()).To(ContainSubstring("References to system secrets"))
 		})
 
+		It("requires backup and restore credential Secret read authorization", func() {
+			const (
+				backupCredentialsSecretName  = "backup-creds-authz"
+				backupTokenSecretName        = "backup-token-authz"
+				restoreCredentialsSecretName = "restore-creds-authz"
+				restoreTokenSecretName       = "restore-token-authz"
+			)
+
+			for _, secretName := range []string{
+				backupCredentialsSecretName,
+				backupTokenSecretName,
+				restoreCredentialsSecretName,
+				restoreTokenSecretName,
+			} {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName,
+						Namespace: guardrailsNamespace,
+					},
+					StringData: map[string]string{
+						"token": "s.e2e",
+					},
+				}
+				err := admin.Create(ctx, secret)
+				if err != nil && !apierrors.IsAlreadyExists(err) {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+
+			newBackupCluster := func(name string) *openbaov1alpha1.OpenBaoCluster {
+				return &openbaov1alpha1.OpenBaoCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: guardrailsNamespace,
+					},
+					Spec: openbaov1alpha1.OpenBaoClusterSpec{
+						Profile:  openbaov1alpha1.ProfileDevelopment,
+						Version:  openBaoVersion,
+						Image:    openBaoImage,
+						Replicas: 1,
+						InitContainer: &openbaov1alpha1.InitContainerConfig{
+							Enabled: true,
+							Image:   configInitImage,
+						},
+						TLS: openbaov1alpha1.TLSConfig{
+							Enabled:        true,
+							RotationPeriod: "720h",
+						},
+						Storage: openbaov1alpha1.StorageConfig{
+							Size: "1Gi",
+						},
+						Network: &openbaov1alpha1.NetworkConfig{
+							APIServerCIDR: apiServerCIDR,
+						},
+						Backup: &openbaov1alpha1.BackupSchedule{
+							Image:          "attacker.example/backup-helper:dev",
+							Schedule:       "0 3 * * *",
+							TokenSecretRef: &corev1.LocalObjectReference{Name: backupTokenSecretName},
+							Target: openbaov1alpha1.BackupTarget{
+								Provider: constants.StorageProviderS3,
+								Endpoint: "https://s3.example.com",
+								Bucket:   "openbao-backups",
+								CredentialsSecretRef: &corev1.LocalObjectReference{
+									Name: backupCredentialsSecretName,
+								},
+							},
+						},
+					},
+				}
+			}
+
+			newRestore := func(name string) *openbaov1alpha1.OpenBaoRestore {
+				return &openbaov1alpha1.OpenBaoRestore{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: guardrailsNamespace,
+					},
+					Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+						Cluster: "valid-structured-config",
+						Source: openbaov1alpha1.RestoreSource{
+							Target: openbaov1alpha1.BackupTarget{
+								Provider: constants.StorageProviderS3,
+								Endpoint: "https://s3.example.com",
+								Bucket:   "openbao-backups",
+								CredentialsSecretRef: &corev1.LocalObjectReference{
+									Name: restoreCredentialsSecretName,
+								},
+							},
+							Key: "snapshots/test.snap",
+						},
+						Image:          "attacker.example/restore-helper:dev",
+						TokenSecretRef: &corev1.LocalObjectReference{Name: restoreTokenSecretName},
+					},
+				}
+			}
+
+			err := runAsE2EGroupMember(ctx, cfg, scheme, impersonatedUser, func(c client.Client) error {
+				return c.Create(ctx, newBackupCluster("backup-authz-denied"), client.DryRunAll)
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Users configuring backup credentials"))
+
+			err = runAsE2EGroupMember(ctx, cfg, scheme, impersonatedUser, func(c client.Client) error {
+				return c.Create(ctx, newRestore("restore-authz-denied"), client.DryRunAll)
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Users configuring restore credentials"))
+
+			secretReaderRole := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "e2e-helper-secret-reader",
+					Namespace: guardrailsNamespace,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"secrets"},
+						ResourceNames: []string{
+							backupCredentialsSecretName,
+							backupTokenSecretName,
+							restoreCredentialsSecretName,
+							restoreTokenSecretName,
+						},
+						Verbs: []string{"get"},
+					},
+				},
+			}
+			createRoleBindingForGroup(ctx, admin, guardrailsNamespace, secretReaderRole)
+
+			err = runAsE2EGroupMember(ctx, cfg, scheme, impersonatedUser, func(c client.Client) error {
+				return c.Create(ctx, newBackupCluster("backup-authz-allowed"), client.DryRunAll)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = runAsE2EGroupMember(ctx, cfg, scheme, impersonatedUser, func(c client.Client) error {
+				return c.Create(ctx, newRestore("restore-authz-allowed"), client.DryRunAll)
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("enforces digest-pinned images for managed workloads when digest enforcement is required", func() {
 			newManagedJob := func(name, image string) *batchv1.Job {
 				return &batchv1.Job{

--- a/test/e2e/Security_Guardrails_test.go
+++ b/test/e2e/Security_Guardrails_test.go
@@ -1007,7 +1007,6 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 							APIServerCIDR: apiServerCIDR,
 						},
 						Backup: &openbaov1alpha1.BackupSchedule{
-							Image:          "attacker.example/backup-helper:dev",
 							Schedule:       "0 3 * * *",
 							TokenSecretRef: &corev1.LocalObjectReference{Name: backupTokenSecretName},
 							Target: openbaov1alpha1.BackupTarget{
@@ -1042,7 +1041,6 @@ var _ = Describe("Security Guardrails", Label("security", "critical"), Ordered, 
 							},
 							Key: "snapshots/test.snap",
 						},
-						Image:          "attacker.example/restore-helper:dev",
 						TokenSecretRef: &corev1.LocalObjectReference{Name: restoreTokenSecretName},
 					},
 				}

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -12,7 +12,7 @@ Notes:
 ## Summary
 
 - Files: `19`
-- Specs: `80`
+- Specs: `81`
 - Explicit case IDs: `33`
 - Coverage tags: `44`
 
@@ -31,7 +31,7 @@ Notes:
 | [Manager Resilience](suites/Manager_Resilience_test.md) | 3 | 3 | 0 | `manager`, `cluster`, `e2e-anchor` | `test/e2e/Manager_Resilience_test.go` |
 | [Manager](suites/Operator_Manager_test.md) | 1 | 1 | 0 | `manager`, `critical`, `smoke` | `test/e2e/Operator_Manager_test.go` |
 | [OpenShift Platform](suites/Platform_OpenShift_test.md) | 2 | 0 | 0 | `openshift`, `platform` | `test/e2e/Platform_OpenShift_test.go` |
-| [Security Guardrails](suites/Security_Guardrails_test.md) | 21 | 2 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
+| [Security Guardrails](suites/Security_Guardrails_test.md) | 22 | 2 | 0 | `security`, `critical`, `admission`, `pentest`, `config`, `tokens`, `rbac`, `tamper` | `test/e2e/Security_Guardrails_test.go` |
 | [Tenant Data Isolation](suites/Tenant_Data_Isolation_test.md) | 1 | 1 | 0 | `security`, `tenant`, `tenancy` | `test/e2e/Tenant_Data_Isolation_test.go` |
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow`, `e2e-anchor` | `test/e2e/Upgrade_Operation_Lock_test.go` |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -1237,6 +1237,33 @@
     "suiteTitle": ""
   },
   {
+    "id": "security-guardrails-requires-backup-and-restore-credential-secret-aa243663",
+    "generatedId": "security-guardrails-requires-backup-and-restore-credential-secret-aa243663",
+    "file": "test/e2e/Security_Guardrails_test.go",
+    "type": "It",
+    "name": "requires backup and restore credential Secret read authorization",
+    "path": [
+      "Security Guardrails",
+      "Admission Policy Enforcement",
+      "requires backup and restore credential Secret read authorization"
+    ],
+    "labels": [
+      "security",
+      "critical",
+      "admission"
+    ],
+    "domainLabels": [
+      "security",
+      "critical",
+      "admission"
+    ],
+    "steps": null,
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539",
     "generatedId": "security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539",
     "file": "test/e2e/Security_Guardrails_test.go",

--- a/test/e2e/catalog/suites/Security_Guardrails_test.md
+++ b/test/e2e/catalog/suites/Security_Guardrails_test.md
@@ -13,6 +13,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `security-guardrails-blocks-cross-namespace-tenant-targeting-self-6a21b1fd` | blocks cross-namespace tenant targeting (self-service mode) | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-enforces-hardened-profile-invariants-446324b0` | enforces Hardened profile invariants | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-enforces-digest-pinned-images-for-managed-a108b1a3` | enforces digest-pinned images for managed workloads when digest enforcement is required | active | _none_ | `security`, `critical`, `admission` |
+| `security-guardrails-requires-backup-and-restore-credential-secret-aa243663` | requires backup and restore credential Secret read authorization | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-requires-transit-credential-secret-read-authorization-abe9d539` | requires transit credential Secret read authorization | active | _none_ | `security`, `critical`, `admission` |
 | `security-guardrails-reports-degraded-when-gateway-api-crds-d5cb95ff` | reports Degraded when Gateway API CRDs are missing | active | _none_ | `security`, `critical`, `config` |
 | `security-guardrails-applies-admission-guardrails-to-controller-rbac-7093e068` | applies admission guardrails to controller RBAC writes | active | _none_ | `security`, `critical`, `pentest`, `tokens`, `rbac` |
@@ -86,6 +87,17 @@ Labels: `security`, `critical`, `admission`
 ## `security-guardrails-enforces-digest-pinned-images-for-managed-a108b1a3`
 
 Path: `Security Guardrails > Admission Policy Enforcement > enforces digest-pinned images for managed workloads when digest enforcement is required`
+
+State: `active`
+
+Covers: _none_
+
+Labels: `security`, `critical`, `admission`
+
+
+## `security-guardrails-requires-backup-and-restore-credential-secret-aa243663`
+
+Path: `Security Guardrails > Admission Policy Enforcement > requires backup and restore credential Secret read authorization`
 
 State: `active`
 

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +49,148 @@ func requireInvalidRequest(t *testing.T, err error) {
 	}
 
 	t.Fatalf("expected invalid request error, got %T: %v", err, err)
+}
+
+func grantTenantOpenBaoWriteAccess(t *testing.T, namespace, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-openbao-writer",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"openbao.org"},
+				Resources: []string{"openbaoclusters", "openbaorestores"},
+				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create tenant writer role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-openbao-writer-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create tenant writer rolebinding: %v", err)
+	}
+}
+
+func grantClusterHelperImageAccess(t *testing.T, namespace, clusterName, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-helper-image-access",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"openbao.org"},
+				Resources:     []string{"openbaoclusters"},
+				ResourceNames: []string{clusterName},
+				Verbs:         []string{"get", "usehelperimages"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create helper image role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-helper-image-access-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create helper image rolebinding: %v", err)
+	}
+}
+
+func waitForOpenBaoRestoreAdmissionPolicies(t *testing.T, namespace string) {
+	t.Helper()
+
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	for attempt := 0; attempt < 25; attempt++ {
+		restore := &openbaov1alpha1.OpenBaoRestore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("restore-policy-probe-%d", attempt),
+				Namespace: namespace,
+			},
+			Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+				Cluster: "policy-probe",
+				Source: openbaov1alpha1.RestoreSource{
+					Target: openbaov1alpha1.BackupTarget{
+						Provider: "s3",
+						Endpoint: "http://example.com",
+						Bucket:   testBackupBucket,
+					},
+					Key: "clusters/probe/snapshot.snap",
+				},
+				JWTAuthRole: "restore-role",
+			},
+		}
+
+		err := k8sClient.Create(ctx, restore)
+		if err == nil {
+			_ = k8sClient.Delete(ctx, restore)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		return
+	}
+
+	t.Fatalf("expected OpenBaoRestore admission policies to become active after retries")
 }
 
 func TestCRD_OpenBaoRestore_RejectsMissingSpec(t *testing.T) {
@@ -248,6 +391,133 @@ func TestVAP_OpenBaoCluster_RequiresTrustedIngressPeersForManagedIngress(t *test
 
 	if err := k8sClient.Create(ctx, allowed); err != nil {
 		t.Fatalf("expected ingress with trusted ingress peers to succeed, got: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoCluster_DeniesCustomBackupImageWithoutHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	username := "backup-image-editor"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	cluster := newMinimalClusterObj(namespace, "cluster-custom-backup-image-denied")
+	cluster.Spec.Backup = &openbaov1alpha1.BackupSchedule{
+		Schedule:    "0 0 * * *",
+		Image:       "ghcr.io/attacker/backup-exfil:latest",
+		JWTAuthRole: "backup-role",
+		Target: openbaov1alpha1.BackupTarget{
+			Provider: "s3",
+			Endpoint: "https://objectstore.example.com",
+			Bucket:   testBackupBucket,
+		},
+	}
+
+	err := tenantClient.Create(ctx, cluster)
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "custom backup helper images") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoCluster_DeniesBackupImageChangeWithoutHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	cluster := newMinimalClusterObj(namespace, "cluster-custom-backup-image-update-denied")
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("create OpenBaoCluster: %v", err)
+	}
+
+	username := "backup-image-update-editor"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	var latest openbaov1alpha1.OpenBaoCluster
+	key := types.NamespacedName{Namespace: namespace, Name: cluster.Name}
+	if err := tenantClient.Get(ctx, key, &latest); err != nil {
+		t.Fatalf("get OpenBaoCluster as tenant editor: %v", err)
+	}
+	original := latest.DeepCopy()
+	latest.Spec.Backup = &openbaov1alpha1.BackupSchedule{
+		Schedule:    "0 0 * * *",
+		Image:       "ghcr.io/attacker/backup-exfil:latest",
+		JWTAuthRole: "backup-role",
+		Target: openbaov1alpha1.BackupTarget{
+			Provider: "s3",
+			Endpoint: "https://objectstore.example.com",
+			Bucket:   testBackupBucket,
+		},
+	}
+
+	err := tenantClient.Patch(ctx, &latest, client.MergeFrom(original))
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "custom backup helper images") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoCluster_AllowsCustomBackupImageWithHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	username := "backup-image-delegate"
+	clusterName := "cluster-custom-backup-image-allowed"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	grantClusterHelperImageAccess(t, namespace, clusterName, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	cluster := newMinimalClusterObj(namespace, clusterName)
+	cluster.Spec.Backup = &openbaov1alpha1.BackupSchedule{
+		Schedule:    "0 0 * * *",
+		Image:       "ghcr.io/platform/backup-helper:1.2.3",
+		JWTAuthRole: "backup-role",
+		Target: openbaov1alpha1.BackupTarget{
+			Provider: "s3",
+			Endpoint: "https://objectstore.example.com",
+			Bucket:   testBackupBucket,
+		},
+	}
+
+	if err := tenantClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("expected helper-image-authorized OpenBaoCluster create to succeed, got: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoCluster_AllowsUnchangedCustomBackupImageWithoutHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	cluster := newMinimalClusterObj(namespace, "cluster-custom-backup-image-unchanged")
+	cluster.Spec.Backup = &openbaov1alpha1.BackupSchedule{
+		Schedule:    "0 0 * * *",
+		Image:       "ghcr.io/platform/backup-helper:1.2.3",
+		JWTAuthRole: "backup-role",
+		Target: openbaov1alpha1.BackupTarget{
+			Provider: "s3",
+			Endpoint: "https://objectstore.example.com",
+			Bucket:   testBackupBucket,
+		},
+	}
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("create platform-authored OpenBaoCluster with custom helper image: %v", err)
+	}
+
+	username := "backup-image-standard-editor"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	var latest openbaov1alpha1.OpenBaoCluster
+	key := types.NamespacedName{Namespace: namespace, Name: cluster.Name}
+	if err := tenantClient.Get(ctx, key, &latest); err != nil {
+		t.Fatalf("get OpenBaoCluster as tenant editor: %v", err)
+	}
+	original := latest.DeepCopy()
+	latest.Spec.Backup.Schedule = "0 1 * * *"
+
+	if err := tenantClient.Patch(ctx, &latest, client.MergeFrom(original)); err != nil {
+		t.Fatalf("expected unchanged custom backup helper image update to succeed, got: %v", err)
 	}
 }
 
@@ -724,6 +994,124 @@ func TestVAP_OpenBaoCluster_RejectsNumericBackupEndpoint(t *testing.T) {
 	requireAdmissionDenied(t, err)
 	if !strings.Contains(err.Error(), "numeric IP encoding") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoRestore_DeniesCustomImageWithoutHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoRestoreAdmissionPolicies(t, namespace)
+
+	username := "restore-image-editor"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-custom-image-denied",
+			Namespace: namespace,
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "target-cluster",
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Endpoint: "https://objectstore.example.com",
+					Bucket:   testBackupBucket,
+				},
+				Key: "clusters/prod/snapshot.snap",
+			},
+			JWTAuthRole: "restore-role",
+			Image:       "ghcr.io/attacker/restore-exfil:latest",
+			Force:       true,
+		},
+	}
+
+	err := tenantClient.Create(ctx, restore)
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "custom restore helper images") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoRestore_AllowsCustomImageWithHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoRestoreAdmissionPolicies(t, namespace)
+
+	username := "restore-image-delegate"
+	clusterName := "target-cluster"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	grantClusterHelperImageAccess(t, namespace, clusterName, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-custom-image-allowed",
+			Namespace: namespace,
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: clusterName,
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Endpoint: "https://objectstore.example.com",
+					Bucket:   testBackupBucket,
+				},
+				Key: "clusters/prod/snapshot.snap",
+			},
+			JWTAuthRole: "restore-role",
+			Image:       "ghcr.io/platform/backup-helper:1.2.3",
+			Force:       true,
+		},
+	}
+
+	if err := tenantClient.Create(ctx, restore); err != nil {
+		t.Fatalf("expected helper-image-authorized OpenBaoRestore create to succeed, got: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoRestore_AllowsUnchangedCustomImageUpdateWithoutHelperImageVerb(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoRestoreAdmissionPolicies(t, namespace)
+
+	clusterName := "target-cluster"
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-custom-image-unchanged",
+			Namespace: namespace,
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: clusterName,
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Endpoint: "https://objectstore.example.com",
+					Bucket:   testBackupBucket,
+				},
+				Key: "clusters/prod/snapshot.snap",
+			},
+			JWTAuthRole: "restore-role",
+			Image:       "ghcr.io/platform/backup-helper:1.2.3",
+			Force:       true,
+		},
+	}
+	if err := k8sClient.Create(ctx, restore); err != nil {
+		t.Fatalf("create platform-authored OpenBaoRestore with custom helper image: %v", err)
+	}
+
+	username := "restore-image-standard-editor"
+	grantTenantOpenBaoWriteAccess(t, namespace, username)
+	tenantClient := newImpersonatedClient(t, username)
+
+	var latest openbaov1alpha1.OpenBaoRestore
+	key := types.NamespacedName{Namespace: namespace, Name: restore.Name}
+	if err := tenantClient.Get(ctx, key, &latest); err != nil {
+		t.Fatalf("get OpenBaoRestore as tenant editor: %v", err)
+	}
+	original := latest.DeepCopy()
+	latest.Annotations = map[string]string{"openbao.org/test": "metadata-update"}
+
+	if err := tenantClient.Patch(ctx, &latest, client.MergeFrom(original)); err != nil {
+		t.Fatalf("expected unchanged custom restore helper image update to succeed, got: %v", err)
 	}
 }
 

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -301,6 +301,7 @@ func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T
 	var foundHTTPS bool
 	var foundUnsafeURLComponents bool
 	var foundSecretAuthorizer bool
+	var foundBackupSecretAuthorizer bool
 	var foundSystemSecretBlock bool
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
@@ -324,6 +325,13 @@ func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T
 			strings.Contains(expression, `check("get")`) &&
 			!strings.Contains(expression, `object.spec.unseal.type != "transit"`):
 			foundSecretAuthorizer = true
+		case strings.Contains(message, "Users configuring backup credentials") &&
+			strings.Contains(expression, `authorizer.group("")`) &&
+			strings.Contains(expression, `resource("secrets")`) &&
+			strings.Contains(expression, `check("get")`) &&
+			strings.Contains(expression, `object.spec.backup.target.credentialsSecretRef`) &&
+			strings.Contains(expression, `object.spec.backup.tokenSecretRef`):
+			foundBackupSecretAuthorizer = true
 		case strings.Contains(message, "system secrets") &&
 			strings.Contains(expression, "object.spec.unseal.credentialsSecretRef") &&
 			strings.Contains(expression, "root-token"):
@@ -331,12 +339,65 @@ func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T
 		}
 	}
 
-	if !foundHTTPS || !foundUnsafeURLComponents || !foundSecretAuthorizer || !foundSystemSecretBlock {
+	if !foundHTTPS || !foundUnsafeURLComponents || !foundSecretAuthorizer || !foundBackupSecretAuthorizer || !foundSystemSecretBlock {
 		t.Fatalf(
-			"openbao-validate-openbaocluster transit protections missing: https=%v unsafeURL=%v authorizer=%v systemSecret=%v",
+			"openbao-validate-openbaocluster protections missing: https=%v unsafeURL=%v transitAuthorizer=%v backupAuthorizer=%v systemSecret=%v",
 			foundHTTPS,
 			foundUnsafeURLComponents,
 			foundSecretAuthorizer,
+			foundBackupSecretAuthorizer,
+			foundSystemSecretBlock,
+		)
+	}
+}
+
+func TestKustomizeDefault_OpenBaoRestorePolicyProtectsSecretRefs(t *testing.T) {
+	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
+	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {
+		gvk := u.GroupVersionKind()
+		return gvk.Group == testAdmissionRegistrationGroup &&
+			gvk.Kind == testKindVAP &&
+			strings.HasSuffix(u.GetName(), "openbao-validate-openbaorestore")
+	})
+
+	if len(objs) != 1 {
+		t.Fatalf("expected exactly one openbao-validate-openbaorestore policy, got %d", len(objs))
+	}
+
+	validations, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "validations")
+	if err != nil || !found {
+		t.Fatalf("read policy validations: found=%v err=%v", found, err)
+	}
+
+	var foundRestoreSecretAuthorizer bool
+	var foundSystemSecretBlock bool
+	for _, validation := range validations {
+		validationMap, ok := validation.(map[string]any)
+		if !ok {
+			continue
+		}
+		message, _ := validationMap["message"].(string)
+		expression, _ := validationMap["expression"].(string)
+		switch {
+		case strings.Contains(message, "Users configuring restore credentials") &&
+			strings.Contains(expression, `authorizer.group("")`) &&
+			strings.Contains(expression, `resource("secrets")`) &&
+			strings.Contains(expression, `check("get")`) &&
+			strings.Contains(expression, `object.spec.source.target.credentialsSecretRef`) &&
+			strings.Contains(expression, `object.spec.tokenSecretRef`):
+			foundRestoreSecretAuthorizer = true
+		case strings.Contains(message, "system secrets") &&
+			strings.Contains(expression, "object.spec.source.target.credentialsSecretRef") &&
+			strings.Contains(expression, "object.spec.tokenSecretRef") &&
+			strings.Contains(expression, "root-token"):
+			foundSystemSecretBlock = true
+		}
+	}
+
+	if !foundRestoreSecretAuthorizer || !foundSystemSecretBlock {
+		t.Fatalf(
+			"openbao-validate-openbaorestore protections missing: authorizer=%v systemSecret=%v",
+			foundRestoreSecretAuthorizer,
 			foundSystemSecretBlock,
 		)
 	}

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -302,6 +302,7 @@ func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T
 	var foundUnsafeURLComponents bool
 	var foundSecretAuthorizer bool
 	var foundBackupSecretAuthorizer bool
+	var foundBackupHelperImageAuthorizer bool
 	var foundSystemSecretBlock bool
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
@@ -332,6 +333,13 @@ func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T
 			strings.Contains(expression, `object.spec.backup.target.credentialsSecretRef`) &&
 			strings.Contains(expression, `object.spec.backup.tokenSecretRef`):
 			foundBackupSecretAuthorizer = true
+		case strings.Contains(message, "custom backup helper images") &&
+			strings.Contains(expression, `authorizer.group("openbao.org")`) &&
+			strings.Contains(expression, `resource("openbaoclusters")`) &&
+			strings.Contains(expression, `object.spec.backup.image`) &&
+			strings.Contains(expression, `oldObject.spec.backup.image`) &&
+			strings.Contains(expression, `check("usehelperimages")`):
+			foundBackupHelperImageAuthorizer = true
 		case strings.Contains(message, "system secrets") &&
 			strings.Contains(expression, "object.spec.unseal.credentialsSecretRef") &&
 			strings.Contains(expression, "root-token"):
@@ -339,13 +347,19 @@ func TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal(t *testing.T
 		}
 	}
 
-	if !foundHTTPS || !foundUnsafeURLComponents || !foundSecretAuthorizer || !foundBackupSecretAuthorizer || !foundSystemSecretBlock {
+	if !foundHTTPS ||
+		!foundUnsafeURLComponents ||
+		!foundSecretAuthorizer ||
+		!foundBackupSecretAuthorizer ||
+		!foundBackupHelperImageAuthorizer ||
+		!foundSystemSecretBlock {
 		t.Fatalf(
-			"openbao-validate-openbaocluster protections missing: https=%v unsafeURL=%v transitAuthorizer=%v backupAuthorizer=%v systemSecret=%v",
+			"openbao-validate-openbaocluster protections missing: https=%v unsafeURL=%v transitAuthorizer=%v backupAuthorizer=%v backupHelperImageAuthorizer=%v systemSecret=%v",
 			foundHTTPS,
 			foundUnsafeURLComponents,
 			foundSecretAuthorizer,
 			foundBackupSecretAuthorizer,
+			foundBackupHelperImageAuthorizer,
 			foundSystemSecretBlock,
 		)
 	}
@@ -370,6 +384,7 @@ func TestKustomizeDefault_OpenBaoRestorePolicyProtectsSecretRefs(t *testing.T) {
 	}
 
 	var foundRestoreSecretAuthorizer bool
+	var foundRestoreHelperImageAuthorizer bool
 	var foundSystemSecretBlock bool
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
@@ -386,6 +401,14 @@ func TestKustomizeDefault_OpenBaoRestorePolicyProtectsSecretRefs(t *testing.T) {
 			strings.Contains(expression, `object.spec.source.target.credentialsSecretRef`) &&
 			strings.Contains(expression, `object.spec.tokenSecretRef`):
 			foundRestoreSecretAuthorizer = true
+		case strings.Contains(message, "custom restore helper images") &&
+			strings.Contains(expression, `authorizer.group("openbao.org")`) &&
+			strings.Contains(expression, `resource("openbaoclusters")`) &&
+			strings.Contains(expression, `object.spec.image`) &&
+			strings.Contains(expression, `oldObject.spec.image`) &&
+			strings.Contains(expression, `object.spec.cluster`) &&
+			strings.Contains(expression, `check("usehelperimages")`):
+			foundRestoreHelperImageAuthorizer = true
 		case strings.Contains(message, "system secrets") &&
 			strings.Contains(expression, "object.spec.source.target.credentialsSecretRef") &&
 			strings.Contains(expression, "object.spec.tokenSecretRef") &&
@@ -394,10 +417,11 @@ func TestKustomizeDefault_OpenBaoRestorePolicyProtectsSecretRefs(t *testing.T) {
 		}
 	}
 
-	if !foundRestoreSecretAuthorizer || !foundSystemSecretBlock {
+	if !foundRestoreSecretAuthorizer || !foundRestoreHelperImageAuthorizer || !foundSystemSecretBlock {
 		t.Fatalf(
-			"openbao-validate-openbaorestore protections missing: authorizer=%v systemSecret=%v",
+			"openbao-validate-openbaorestore protections missing: authorizer=%v helperImageAuthorizer=%v systemSecret=%v",
 			foundRestoreSecretAuthorizer,
+			foundRestoreHelperImageAuthorizer,
 			foundSystemSecretBlock,
 		)
 	}


### PR DESCRIPTION
## Summary

Harden backup and restore helper inputs against confused-deputy abuse:

- require users configuring backup and restore Secret refs to be authorized for `get` on those Secrets
- require a separate `usehelperimages` authorization check before selecting custom backup or restore helper images
- add RBAC helper role examples for delegating custom helper image selection separately from broad OpenBaoCluster edit/admin access
- keep Helm RBAC generation in sync so the helper-image delegation ClusterRole is preserved by `helm-sync`
- realign integration and E2E guardrail tests around the separate Secret-read and helper-image permissions

## Related Issues

<!-- Closes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Security/RBAC impact: users with OpenBaoCluster or OpenBaoRestore write access now also need `get` on referenced backup/restore credential Secrets, and users selecting custom helper images need `usehelperimages` on the target OpenBaoCluster. Existing default helper-image flows are unchanged.

Helm impact: chart admission/RBAC templates are regenerated from config, including the helper-image delegation ClusterRole.

## Verification

- `go test ./hack/helmchart`
- `go test ./internal/service/backup`
- `KUBEBUILDER_ASSETS="/Users/roelc/projects/work/openbao-operator-transit-hardening/bin/k8s/1.36.0-darwin-arm64" GOFLAGS="-mod=vendor" go test -tags=integration ./test/integration -run 'TestVAP_OpenBaoCluster_.*HelperImage|TestVAP_OpenBaoRestore_.*HelperImage|TestKustomizeDefault_OpenBaoClusterPolicyProtectsTransitUnseal|TestKustomizeDefault_OpenBaoRestorePolicyProtectsSecretRefs' -count=1`
- `go test -tags=e2e ./test/e2e -run '^$'`
- `make helm-test`
- `make verify-helm`
- `make verify-e2e-manifest`
- pre-push: `make lint-ci`

## Reviewer Notes

This branch was rebased onto `origin/main` after the transit hardening PR landed as `fix(security): harden transit unseal credential handling (#473)`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
