### PR TITLE
fix(security): harden backup restore endpoint validation

### DIFF
--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -26,6 +26,32 @@ spec:
       expression: has(object.spec.upgrade) && has(object.spec.upgrade.preUpgradeSnapshot) && object.spec.upgrade.preUpgradeSnapshot == true
     - name: has_bluegreen_pre_upgrade_snapshot
       expression: has(object.spec.upgrade) && has(object.spec.upgrade.blueGreen) && has(object.spec.upgrade.blueGreen.preUpgradeSnapshot) && object.spec.upgrade.blueGreen.preUpgradeSnapshot == true
+    - name: backup_endpoint
+      expression: >-
+        variables.has_backup && has(object.spec.backup.target.endpoint) ? object.spec.backup.target.endpoint.trim() : ""
+    - name: backup_endpoint_is_set
+      expression: variables.backup_endpoint != ""
+    - name: backup_endpoint_is_url
+      expression: >-
+        !variables.backup_endpoint_is_set || isURL(variables.backup_endpoint)
+    - name: backup_endpoint_scheme
+      expression: >-
+        variables.backup_endpoint_is_set && variables.backup_endpoint_is_url ? url(variables.backup_endpoint).getScheme().lowerAscii() : ""
+    - name: backup_endpoint_hostname
+      expression: >-
+        variables.backup_endpoint_is_set && variables.backup_endpoint_is_url ? url(variables.backup_endpoint).getHostname().lowerAscii() : ""
+    - name: backup_endpoint_hostname_normalized
+      expression: >-
+        variables.backup_endpoint_hostname.endsWith(".") ? variables.backup_endpoint_hostname.substring(0, size(variables.backup_endpoint_hostname) - 1) : variables.backup_endpoint_hostname
+    - name: backup_endpoint_host_is_ip
+      expression: >-
+        variables.backup_endpoint_hostname_normalized != "" && isIP(variables.backup_endpoint_hostname_normalized)
+    - name: backup_endpoint_host_is_ambiguous_ip
+      expression: >-
+        variables.backup_endpoint_hostname_normalized != "" &&
+        !variables.backup_endpoint_host_is_ip &&
+        (variables.backup_endpoint_hostname_normalized.matches("^(0x[0-9a-f]+|[0-9]+)(\\.(0x[0-9a-f]+|[0-9]+)){0,3}$") ||
+          variables.backup_endpoint_hostname_normalized.contains(":"))
     - name: spec_version_normalized
       expression: >-
         object.spec.version.startsWith("v") ? object.spec.version.substring(1) : object.spec.version
@@ -312,34 +338,35 @@ spec:
           has(object.spec.network.egressRules) &&
           size(object.spec.network.egressRules) > 0)
       message: Hardened profile requires non-empty spec.network.egressRules when backups or pre-upgrade snapshots are enabled.
+    # SSRF Protection: parse endpoint URL before host checks so userinfo,
+    # uppercase schemes, IPv6 brackets, and encoded numeric hosts cannot bypass
+    # raw string matching.
+    - expression: >-
+        !variables.backup_endpoint_is_set ||
+        (variables.backup_endpoint_is_url && variables.backup_endpoint_hostname_normalized != "")
+      message: "Backup endpoint must be a valid absolute URL with a host."
     # SSRF Protection: Block localhost endpoints (all profiles - localhost is never a valid backup target)
     - expression: >-
-        !variables.has_backup ||
-        !has(object.spec.backup.target.endpoint) ||
-        object.spec.backup.target.endpoint == "" ||
-        !(
-          object.spec.backup.target.endpoint.contains("localhost") ||
-          object.spec.backup.target.endpoint.contains("127.0.0.1") ||
-          object.spec.backup.target.endpoint.contains("::1") ||
-          object.spec.backup.target.endpoint.matches("^https?://[0-9]+[:/].*")
+        !variables.backup_endpoint_is_set ||
+        !variables.backup_endpoint_is_url ||
+        (
+          !variables.backup_endpoint_hostname_normalized.matches("(^|.*\\.)localhost$") &&
+          !variables.backup_endpoint_host_is_ambiguous_ip &&
+          !(variables.backup_endpoint_host_is_ip && ip(variables.backup_endpoint_hostname_normalized).isLoopback())
         )
-      message: "Backup endpoint cannot point to localhost or use numeric IP encoding (SSRF protection)."
+      message: "Backup endpoint cannot point to localhost, loopback, or use ambiguous numeric IP encoding (SSRF protection)."
     # SSRF Protection: Block link-local addresses (all profiles - cloud metadata is always dangerous)
     - expression: >-
-        !variables.has_backup ||
-        !has(object.spec.backup.target.endpoint) ||
-        object.spec.backup.target.endpoint == "" ||
-        !object.spec.backup.target.endpoint.matches("^https?://169\\.254\\..*")
+        !variables.backup_endpoint_is_set ||
+        !variables.backup_endpoint_is_url ||
+        !(variables.backup_endpoint_host_is_ip && ip(variables.backup_endpoint_hostname_normalized).isLinkLocalUnicast())
       message: "Backup endpoint cannot point to link-local addresses (SSRF protection against cloud metadata services)."
     # SSRF Protection: Require HTTPS for Hardened profile
     - expression: >-
         !has(object.spec.profile) ||
         object.spec.profile != "Hardened" ||
-        !variables.has_backup ||
-        !has(object.spec.backup.target.endpoint) ||
-        object.spec.backup.target.endpoint == "" ||
-        object.spec.backup.target.endpoint.startsWith("https://") ||
-        object.spec.backup.target.endpoint.startsWith("s3://")
+        !variables.backup_endpoint_is_set ||
+        (variables.backup_endpoint_is_url && variables.backup_endpoint_scheme in ["https", "s3"])
       message: "Backup endpoint must use HTTPS or S3 scheme in Hardened profile."
     # HA Enforcement: Hardened profile requires 3+ replicas for Raft quorum
     - expression: >-

--- a/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
@@ -13,6 +13,36 @@ spec:
         apiVersions: ["v1alpha1"]
         operations: ["CREATE", "UPDATE"]
         resources: ["openbaorestores"]
+  variables:
+    - name: restore_endpoint
+      expression: >-
+        has(object.spec.source.target.endpoint) ? object.spec.source.target.endpoint.trim() : ""
+    - name: restore_endpoint_is_set
+      expression: variables.restore_endpoint != ""
+    - name: restore_endpoint_is_url
+      expression: >-
+        !variables.restore_endpoint_is_set || isURL(variables.restore_endpoint)
+    - name: restore_endpoint_scheme
+      expression: >-
+        variables.restore_endpoint_is_set && variables.restore_endpoint_is_url ? url(variables.restore_endpoint).getScheme().lowerAscii() : ""
+    - name: restore_endpoint_hostname
+      expression: >-
+        variables.restore_endpoint_is_set && variables.restore_endpoint_is_url ? url(variables.restore_endpoint).getHostname().lowerAscii() : ""
+    - name: restore_endpoint_hostname_normalized
+      expression: >-
+        variables.restore_endpoint_hostname.endsWith(".") ? variables.restore_endpoint_hostname.substring(0, size(variables.restore_endpoint_hostname) - 1) : variables.restore_endpoint_hostname
+    - name: restore_endpoint_host_is_ip
+      expression: >-
+        variables.restore_endpoint_hostname_normalized != "" && isIP(variables.restore_endpoint_hostname_normalized)
+    - name: restore_endpoint_host_is_ambiguous_ip
+      expression: >-
+        variables.restore_endpoint_hostname_normalized != "" &&
+        !variables.restore_endpoint_host_is_ip &&
+        (variables.restore_endpoint_hostname_normalized.matches("^(0x[0-9a-f]+|[0-9]+)(\\.(0x[0-9a-f]+|[0-9]+)){0,3}$") ||
+          variables.restore_endpoint_hostname_normalized.contains(":"))
+    - name: restore_endpoint_is_in_cluster_service
+      expression: >-
+        variables.restore_endpoint_hostname_normalized.matches("^.+\\.svc(\\..*)?$")
   validations:
     # API contract: restore specs are immutable after creation.
     - expression: >-
@@ -24,31 +54,36 @@ spec:
         object.spec.overrideOperationLock == false ||
         object.spec.force == true
       message: "spec.overrideOperationLock requires spec.force=true."
+    # SSRF Protection: parse endpoint URL before host checks so userinfo,
+    # uppercase schemes, IPv6 brackets, and encoded numeric hosts cannot bypass
+    # raw string matching.
+    - expression: >-
+        !variables.restore_endpoint_is_set ||
+        (variables.restore_endpoint_is_url && variables.restore_endpoint_hostname_normalized != "")
+      message: "Restore endpoint must be a valid absolute URL with a host."
     # SSRF Protection: Block localhost endpoints (all profiles - localhost is never a valid snapshot source)
     - expression: >-
-        !has(object.spec.source.target.endpoint) ||
-        object.spec.source.target.endpoint == "" ||
-        !(
-          object.spec.source.target.endpoint.contains("localhost") ||
-          object.spec.source.target.endpoint.contains("127.0.0.1") ||
-          object.spec.source.target.endpoint.contains("::1") ||
-          object.spec.source.target.endpoint.matches("^https?://[0-9]+[:/].*")
+        !variables.restore_endpoint_is_set ||
+        !variables.restore_endpoint_is_url ||
+        (
+          !variables.restore_endpoint_hostname_normalized.matches("(^|.*\\.)localhost$") &&
+          !variables.restore_endpoint_host_is_ambiguous_ip &&
+          !(variables.restore_endpoint_host_is_ip && ip(variables.restore_endpoint_hostname_normalized).isLoopback())
         )
-      message: "Restore endpoint cannot point to localhost or use numeric IP encoding (SSRF protection)."
+      message: "Restore endpoint cannot point to localhost, loopback, or use ambiguous numeric IP encoding (SSRF protection)."
     # SSRF Protection: Block link-local addresses (all profiles - cloud metadata is always dangerous)
     - expression: >-
-        !has(object.spec.source.target.endpoint) ||
-        object.spec.source.target.endpoint == "" ||
-        !object.spec.source.target.endpoint.matches("^https?://169\\.254\\..*")
+        !variables.restore_endpoint_is_set ||
+        !variables.restore_endpoint_is_url ||
+        !(variables.restore_endpoint_host_is_ip && ip(variables.restore_endpoint_hostname_normalized).isLinkLocalUnicast())
       message: "Restore endpoint cannot point to link-local addresses (SSRF protection against cloud metadata services)."
     # Safety: Require HTTPS for non-cluster endpoints.
     # We allow http:// only for in-cluster Service DNS names (useful for local dev emulators).
     - expression: >-
-        !has(object.spec.source.target.endpoint) ||
-        object.spec.source.target.endpoint == "" ||
-        object.spec.source.target.endpoint.startsWith("https://") ||
-        object.spec.source.target.endpoint.startsWith("s3://") ||
-        object.spec.source.target.endpoint.matches("^http://[^/]+\\.svc(\\.|:|/|$).*")
+        !variables.restore_endpoint_is_set ||
+        (variables.restore_endpoint_is_url &&
+          (variables.restore_endpoint_scheme in ["https", "s3"] ||
+            (variables.restore_endpoint_scheme == "http" && variables.restore_endpoint_is_in_cluster_service)))
       message: "Restore endpoint must use HTTPS or S3 scheme, unless it targets an in-cluster Service (*.svc)."
     # Confused-deputy protection: custom restore helper images run with restore credentials.
     - expression: >-

--- a/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaorestore.yaml
@@ -42,7 +42,7 @@ spec:
           variables.restore_endpoint_hostname_normalized.contains(":"))
     - name: restore_endpoint_is_in_cluster_service
       expression: >-
-        variables.restore_endpoint_hostname_normalized.matches("^.+\\.svc(\\..*)?$")
+        variables.restore_endpoint_hostname_normalized.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.svc(\\.cluster\\.local)?$")
   validations:
     # API contract: restore specs are immutable after creation.
     - expression: >-

--- a/cmd/bao-backup/storage_config.go
+++ b/cmd/bao-backup/storage_config.go
@@ -84,5 +84,9 @@ func openStorageClient(ctx context.Context, cfg *backupconfig.ExecutorConfig) (b
 		return nil, err
 	}
 
+	if err := backupconfig.ValidateStorageEndpointAccess(ctx, storageConfig); err != nil {
+		return nil, err
+	}
+
 	return storage.OpenBlobStore(ctx, storageConfig)
 }

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -23,6 +23,32 @@ spec:
       expression: has(object.spec.upgrade) && has(object.spec.upgrade.preUpgradeSnapshot) && object.spec.upgrade.preUpgradeSnapshot == true
     - name: has_bluegreen_pre_upgrade_snapshot
       expression: has(object.spec.upgrade) && has(object.spec.upgrade.blueGreen) && has(object.spec.upgrade.blueGreen.preUpgradeSnapshot) && object.spec.upgrade.blueGreen.preUpgradeSnapshot == true
+    - name: backup_endpoint
+      expression: >-
+        variables.has_backup && has(object.spec.backup.target.endpoint) ? object.spec.backup.target.endpoint.trim() : ""
+    - name: backup_endpoint_is_set
+      expression: variables.backup_endpoint != ""
+    - name: backup_endpoint_is_url
+      expression: >-
+        !variables.backup_endpoint_is_set || isURL(variables.backup_endpoint)
+    - name: backup_endpoint_scheme
+      expression: >-
+        variables.backup_endpoint_is_set && variables.backup_endpoint_is_url ? url(variables.backup_endpoint).getScheme().lowerAscii() : ""
+    - name: backup_endpoint_hostname
+      expression: >-
+        variables.backup_endpoint_is_set && variables.backup_endpoint_is_url ? url(variables.backup_endpoint).getHostname().lowerAscii() : ""
+    - name: backup_endpoint_hostname_normalized
+      expression: >-
+        variables.backup_endpoint_hostname.endsWith(".") ? variables.backup_endpoint_hostname.substring(0, size(variables.backup_endpoint_hostname) - 1) : variables.backup_endpoint_hostname
+    - name: backup_endpoint_host_is_ip
+      expression: >-
+        variables.backup_endpoint_hostname_normalized != "" && isIP(variables.backup_endpoint_hostname_normalized)
+    - name: backup_endpoint_host_is_ambiguous_ip
+      expression: >-
+        variables.backup_endpoint_hostname_normalized != "" &&
+        !variables.backup_endpoint_host_is_ip &&
+        (variables.backup_endpoint_hostname_normalized.matches("^(0x[0-9a-f]+|[0-9]+)(\\.(0x[0-9a-f]+|[0-9]+)){0,3}$") ||
+          variables.backup_endpoint_hostname_normalized.contains(":"))
     - name: spec_version_normalized
       expression: >-
         object.spec.version.startsWith("v") ? object.spec.version.substring(1) : object.spec.version
@@ -309,34 +335,35 @@ spec:
           has(object.spec.network.egressRules) &&
           size(object.spec.network.egressRules) > 0)
       message: Hardened profile requires non-empty spec.network.egressRules when backups or pre-upgrade snapshots are enabled.
+    # SSRF Protection: parse endpoint URL before host checks so userinfo,
+    # uppercase schemes, IPv6 brackets, and encoded numeric hosts cannot bypass
+    # raw string matching.
+    - expression: >-
+        !variables.backup_endpoint_is_set ||
+        (variables.backup_endpoint_is_url && variables.backup_endpoint_hostname_normalized != "")
+      message: "Backup endpoint must be a valid absolute URL with a host."
     # SSRF Protection: Block localhost endpoints (all profiles - localhost is never a valid backup target)
     - expression: >-
-        !variables.has_backup ||
-        !has(object.spec.backup.target.endpoint) ||
-        object.spec.backup.target.endpoint == "" ||
-        !(
-          object.spec.backup.target.endpoint.contains("localhost") ||
-          object.spec.backup.target.endpoint.contains("127.0.0.1") ||
-          object.spec.backup.target.endpoint.contains("::1") ||
-          object.spec.backup.target.endpoint.matches("^https?://[0-9]+[:/].*")
+        !variables.backup_endpoint_is_set ||
+        !variables.backup_endpoint_is_url ||
+        (
+          !variables.backup_endpoint_hostname_normalized.matches("(^|.*\\.)localhost$") &&
+          !variables.backup_endpoint_host_is_ambiguous_ip &&
+          !(variables.backup_endpoint_host_is_ip && ip(variables.backup_endpoint_hostname_normalized).isLoopback())
         )
-      message: "Backup endpoint cannot point to localhost or use numeric IP encoding (SSRF protection)."
+      message: "Backup endpoint cannot point to localhost, loopback, or use ambiguous numeric IP encoding (SSRF protection)."
     # SSRF Protection: Block link-local addresses (all profiles - cloud metadata is always dangerous)
     - expression: >-
-        !variables.has_backup ||
-        !has(object.spec.backup.target.endpoint) ||
-        object.spec.backup.target.endpoint == "" ||
-        !object.spec.backup.target.endpoint.matches("^https?://169\\.254\\..*")
+        !variables.backup_endpoint_is_set ||
+        !variables.backup_endpoint_is_url ||
+        !(variables.backup_endpoint_host_is_ip && ip(variables.backup_endpoint_hostname_normalized).isLinkLocalUnicast())
       message: "Backup endpoint cannot point to link-local addresses (SSRF protection against cloud metadata services)."
     # SSRF Protection: Require HTTPS for Hardened profile
     - expression: >-
         !has(object.spec.profile) ||
         object.spec.profile != "Hardened" ||
-        !variables.has_backup ||
-        !has(object.spec.backup.target.endpoint) ||
-        object.spec.backup.target.endpoint == "" ||
-        object.spec.backup.target.endpoint.startsWith("https://") ||
-        object.spec.backup.target.endpoint.startsWith("s3://")
+        !variables.backup_endpoint_is_set ||
+        (variables.backup_endpoint_is_url && variables.backup_endpoint_scheme in ["https", "s3"])
       message: "Backup endpoint must use HTTPS or S3 scheme in Hardened profile."
     # HA Enforcement: Hardened profile requires 3+ replicas for Raft quorum
     - expression: >-

--- a/config/policy/openbao-validate-openbaorestore.yaml
+++ b/config/policy/openbao-validate-openbaorestore.yaml
@@ -39,7 +39,7 @@ spec:
           variables.restore_endpoint_hostname_normalized.contains(":"))
     - name: restore_endpoint_is_in_cluster_service
       expression: >-
-        variables.restore_endpoint_hostname_normalized.matches("^.+\\.svc(\\..*)?$")
+        variables.restore_endpoint_hostname_normalized.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.svc(\\.cluster\\.local)?$")
   validations:
     # API contract: restore specs are immutable after creation.
     - expression: >-

--- a/config/policy/openbao-validate-openbaorestore.yaml
+++ b/config/policy/openbao-validate-openbaorestore.yaml
@@ -10,6 +10,36 @@ spec:
         apiVersions: ["v1alpha1"]
         operations: ["CREATE", "UPDATE"]
         resources: ["openbaorestores"]
+  variables:
+    - name: restore_endpoint
+      expression: >-
+        has(object.spec.source.target.endpoint) ? object.spec.source.target.endpoint.trim() : ""
+    - name: restore_endpoint_is_set
+      expression: variables.restore_endpoint != ""
+    - name: restore_endpoint_is_url
+      expression: >-
+        !variables.restore_endpoint_is_set || isURL(variables.restore_endpoint)
+    - name: restore_endpoint_scheme
+      expression: >-
+        variables.restore_endpoint_is_set && variables.restore_endpoint_is_url ? url(variables.restore_endpoint).getScheme().lowerAscii() : ""
+    - name: restore_endpoint_hostname
+      expression: >-
+        variables.restore_endpoint_is_set && variables.restore_endpoint_is_url ? url(variables.restore_endpoint).getHostname().lowerAscii() : ""
+    - name: restore_endpoint_hostname_normalized
+      expression: >-
+        variables.restore_endpoint_hostname.endsWith(".") ? variables.restore_endpoint_hostname.substring(0, size(variables.restore_endpoint_hostname) - 1) : variables.restore_endpoint_hostname
+    - name: restore_endpoint_host_is_ip
+      expression: >-
+        variables.restore_endpoint_hostname_normalized != "" && isIP(variables.restore_endpoint_hostname_normalized)
+    - name: restore_endpoint_host_is_ambiguous_ip
+      expression: >-
+        variables.restore_endpoint_hostname_normalized != "" &&
+        !variables.restore_endpoint_host_is_ip &&
+        (variables.restore_endpoint_hostname_normalized.matches("^(0x[0-9a-f]+|[0-9]+)(\\.(0x[0-9a-f]+|[0-9]+)){0,3}$") ||
+          variables.restore_endpoint_hostname_normalized.contains(":"))
+    - name: restore_endpoint_is_in_cluster_service
+      expression: >-
+        variables.restore_endpoint_hostname_normalized.matches("^.+\\.svc(\\..*)?$")
   validations:
     # API contract: restore specs are immutable after creation.
     - expression: >-
@@ -21,31 +51,36 @@ spec:
         object.spec.overrideOperationLock == false ||
         object.spec.force == true
       message: "spec.overrideOperationLock requires spec.force=true."
+    # SSRF Protection: parse endpoint URL before host checks so userinfo,
+    # uppercase schemes, IPv6 brackets, and encoded numeric hosts cannot bypass
+    # raw string matching.
+    - expression: >-
+        !variables.restore_endpoint_is_set ||
+        (variables.restore_endpoint_is_url && variables.restore_endpoint_hostname_normalized != "")
+      message: "Restore endpoint must be a valid absolute URL with a host."
     # SSRF Protection: Block localhost endpoints (all profiles - localhost is never a valid snapshot source)
     - expression: >-
-        !has(object.spec.source.target.endpoint) ||
-        object.spec.source.target.endpoint == "" ||
-        !(
-          object.spec.source.target.endpoint.contains("localhost") ||
-          object.spec.source.target.endpoint.contains("127.0.0.1") ||
-          object.spec.source.target.endpoint.contains("::1") ||
-          object.spec.source.target.endpoint.matches("^https?://[0-9]+[:/].*")
+        !variables.restore_endpoint_is_set ||
+        !variables.restore_endpoint_is_url ||
+        (
+          !variables.restore_endpoint_hostname_normalized.matches("(^|.*\\.)localhost$") &&
+          !variables.restore_endpoint_host_is_ambiguous_ip &&
+          !(variables.restore_endpoint_host_is_ip && ip(variables.restore_endpoint_hostname_normalized).isLoopback())
         )
-      message: "Restore endpoint cannot point to localhost or use numeric IP encoding (SSRF protection)."
+      message: "Restore endpoint cannot point to localhost, loopback, or use ambiguous numeric IP encoding (SSRF protection)."
     # SSRF Protection: Block link-local addresses (all profiles - cloud metadata is always dangerous)
     - expression: >-
-        !has(object.spec.source.target.endpoint) ||
-        object.spec.source.target.endpoint == "" ||
-        !object.spec.source.target.endpoint.matches("^https?://169\\.254\\..*")
+        !variables.restore_endpoint_is_set ||
+        !variables.restore_endpoint_is_url ||
+        !(variables.restore_endpoint_host_is_ip && ip(variables.restore_endpoint_hostname_normalized).isLinkLocalUnicast())
       message: "Restore endpoint cannot point to link-local addresses (SSRF protection against cloud metadata services)."
     # Safety: Require HTTPS for non-cluster endpoints.
     # We allow http:// only for in-cluster Service DNS names (useful for local dev emulators).
     - expression: >-
-        !has(object.spec.source.target.endpoint) ||
-        object.spec.source.target.endpoint == "" ||
-        object.spec.source.target.endpoint.startsWith("https://") ||
-        object.spec.source.target.endpoint.startsWith("s3://") ||
-        object.spec.source.target.endpoint.matches("^http://[^/]+\\.svc(\\.|:|/|$).*")
+        !variables.restore_endpoint_is_set ||
+        (variables.restore_endpoint_is_url &&
+          (variables.restore_endpoint_scheme in ["https", "s3"] ||
+            (variables.restore_endpoint_scheme == "http" && variables.restore_endpoint_is_in_cluster_service)))
       message: "Restore endpoint must use HTTPS or S3 scheme, unless it targets an in-cluster Service (*.svc)."
     # Confused-deputy protection: custom restore helper images run with restore credentials.
     - expression: >-

--- a/internal/service/backup/storage_client.go
+++ b/internal/service/backup/storage_client.go
@@ -50,6 +50,10 @@ func (m *Manager) openBackupStorageClient(ctx context.Context, cluster *openbaov
 		return nil, fmt.Errorf("unsupported backup storage provider %q", target.Provider)
 	}
 
+	if err := ValidateStorageEndpointAccess(ctx, storageConfig); err != nil {
+		return nil, err
+	}
+
 	return openBlobStoreFn(ctx, storageConfig)
 }
 

--- a/internal/service/backup/storage_endpoint_guard.go
+++ b/internal/service/backup/storage_endpoint_guard.go
@@ -1,0 +1,207 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/dc-tec/openbao-operator/internal/adapter/storage"
+)
+
+type endpointResolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+var defaultStorageEndpointResolver endpointResolver = net.DefaultResolver
+
+var ambiguousNumericHostPattern = regexp.MustCompile(`(?i)^(0x[0-9a-f]+|[0-9]+)(\.(0x[0-9a-f]+|[0-9]+)){0,3}$`)
+
+// ValidateStorageEndpointAccess rejects storage endpoints that resolve to local or metadata-adjacent addresses.
+func ValidateStorageEndpointAccess(ctx context.Context, cfg storage.Config) error {
+	return validateStorageEndpointAccessWithResolver(ctx, cfg, defaultStorageEndpointResolver)
+}
+
+func validateStorageEndpointAccessWithResolver(ctx context.Context, cfg storage.Config, resolver endpointResolver) error {
+	if err := validateEndpointURLAccess(ctx, resolver, "storage endpoint", cfg.Endpoint); err != nil {
+		return err
+	}
+	if s3VirtualHostedEndpointShouldBeChecked(cfg) {
+		endpoint, err := s3VirtualHostedEndpoint(cfg.Endpoint, cfg.Bucket)
+		if err != nil {
+			return err
+		}
+		if err := validateEndpointURLAccess(ctx, resolver, "s3 virtual-hosted endpoint", endpoint); err != nil {
+			return err
+		}
+	}
+
+	if cfg.Azure != nil {
+		for _, endpoint := range azureConnectionStringEndpointCandidates(cfg.Azure.ConnectionString) {
+			if err := validateEndpointURLAccess(ctx, resolver, endpoint.description, endpoint.url); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func s3VirtualHostedEndpointShouldBeChecked(cfg storage.Config) bool {
+	if cfg.Endpoint == "" || cfg.Bucket == "" {
+		return false
+	}
+	if cfg.Provider != "" && cfg.Provider != storage.ProviderS3 {
+		return false
+	}
+	if cfg.S3 != nil && cfg.S3.UsePathStyle {
+		return false
+	}
+	return true
+}
+
+func s3VirtualHostedEndpoint(endpoint, bucket string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		if err != nil {
+			return "", fmt.Errorf("storage endpoint must be an absolute URL with host: %w", err)
+		}
+		return "", fmt.Errorf("storage endpoint must be an absolute URL with host")
+	}
+
+	host := normalizeEndpointHost(parsed.Hostname())
+	if host == "" || net.ParseIP(host) != nil || strings.Contains(host, ":") {
+		return "", nil
+	}
+
+	parsed.User = nil
+	virtualHost := bucket + "." + host
+	if port := parsed.Port(); port != "" {
+		virtualHost = net.JoinHostPort(virtualHost, port)
+	}
+	parsed.Host = virtualHost
+	return parsed.String(), nil
+}
+
+func validateEndpointURLAccess(ctx context.Context, resolver endpointResolver, description, rawEndpoint string) error {
+	rawEndpoint = strings.TrimSpace(rawEndpoint)
+	if rawEndpoint == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(rawEndpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		if err != nil {
+			return fmt.Errorf("%s must be an absolute URL with host: %w", description, err)
+		}
+		return fmt.Errorf("%s must be an absolute URL with host", description)
+	}
+
+	host := normalizeEndpointHost(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("%s must include a host", description)
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return fmt.Errorf("%s host %q is not allowed", description, host)
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		if isForbiddenEndpointAddress(addr) {
+			return fmt.Errorf("%s host %q is not allowed", description, host)
+		}
+		return nil
+	}
+	if ambiguousNumericHostPattern.MatchString(host) {
+		return fmt.Errorf("%s host %q uses ambiguous numeric IP encoding", description, host)
+	}
+	if strings.Contains(host, ":") {
+		return fmt.Errorf("%s host %q uses ambiguous IP encoding", description, host)
+	}
+
+	if resolver == nil {
+		return fmt.Errorf("%s resolver is required", description)
+	}
+	addrs, err := resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return fmt.Errorf("%s host %q could not be resolved: %w", description, host, err)
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("%s host %q did not resolve to any IP addresses", description, host)
+	}
+	for _, addr := range addrs {
+		if isForbiddenEndpointAddress(addr) {
+			return fmt.Errorf("%s host %q resolves to forbidden address %s", description, host, addr)
+		}
+	}
+
+	return nil
+}
+
+func normalizeEndpointHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.TrimSuffix(host, ".")
+	return host
+}
+
+func isForbiddenEndpointAddress(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return !addr.IsValid() ||
+		addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsUnspecified() ||
+		addr.IsMulticast()
+}
+
+type storageEndpointCandidate struct {
+	description string
+	url         string
+}
+
+func azureConnectionStringEndpointCandidates(connectionString string) []storageEndpointCandidate {
+	connectionString = strings.TrimSpace(connectionString)
+	if connectionString == "" {
+		return nil
+	}
+
+	values := parseAzureConnectionString(connectionString)
+	if blobEndpoint := values["blobendpoint"]; blobEndpoint != "" {
+		return []storageEndpointCandidate{{
+			description: "azure connection string BlobEndpoint",
+			url:         blobEndpoint,
+		}}
+	}
+
+	accountName := values["accountname"]
+	endpointSuffix := strings.TrimPrefix(values["endpointsuffix"], ".")
+	if accountName == "" || endpointSuffix == "" {
+		return nil
+	}
+
+	protocol := values["defaultendpointsprotocol"]
+	if protocol == "" {
+		protocol = "https"
+	}
+
+	return []storageEndpointCandidate{{
+		description: "azure connection string EndpointSuffix",
+		url:         fmt.Sprintf("%s://%s.blob.%s", protocol, accountName, endpointSuffix),
+	}}
+}
+
+func parseAzureConnectionString(connectionString string) map[string]string {
+	values := make(map[string]string)
+	for _, part := range strings.Split(connectionString, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		values[strings.ToLower(strings.TrimSpace(key))] = strings.TrimSpace(value)
+	}
+	return values
+}

--- a/internal/service/backup/storage_endpoint_guard_test.go
+++ b/internal/service/backup/storage_endpoint_guard_test.go
@@ -1,0 +1,265 @@
+package backup
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dc-tec/openbao-operator/internal/adapter/storage"
+)
+
+func TestMain(m *testing.M) {
+	defaultStorageEndpointResolver = permissiveEndpointResolver{}
+	os.Exit(m.Run())
+}
+
+type permissiveEndpointResolver struct{}
+
+func (permissiveEndpointResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return []netip.Addr{netip.MustParseAddr("203.0.113.10")}, nil
+}
+
+type fakeEndpointResolver map[string][]netip.Addr
+
+func (r fakeEndpointResolver) LookupNetIP(_ context.Context, _ string, host string) ([]netip.Addr, error) {
+	if addrs, ok := r[host]; ok {
+		return addrs, nil
+	}
+	return nil, &net.DNSError{
+		Err:         "no such host",
+		Name:        host,
+		IsNotFound:  true,
+		IsTemporary: false,
+	}
+}
+
+func TestValidateStorageEndpointAccessRejectsUnsafeEndpointHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  string
+	}{
+		{
+			name:     "userinfo before link local host",
+			endpoint: "https://s3.example.test@169.254.169.254/latest/meta-data",
+			wantErr:  "not allowed",
+		},
+		{
+			name:     "ipv4 mapped link local",
+			endpoint: "https://[::ffff:169.254.169.254]/latest/meta-data",
+			wantErr:  "not allowed",
+		},
+		{
+			name:     "single integer loopback",
+			endpoint: "http://2130706433",
+			wantErr:  "ambiguous numeric IP encoding",
+		},
+		{
+			name:     "hex loopback",
+			endpoint: "http://0x7f000001",
+			wantErr:  "ambiguous numeric IP encoding",
+		},
+		{
+			name:     "localhost name",
+			endpoint: "http://localhost:9000",
+			wantErr:  "not allowed",
+		},
+		{
+			name:     "subdomain localhost name",
+			endpoint: "http://object.localhost:9000",
+			wantErr:  "not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateStorageEndpointAccessWithResolver(
+				context.Background(),
+				storage.Config{Endpoint: tt.endpoint},
+				fakeEndpointResolver{},
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidateStorageEndpointAccessChecksDNSAnswers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		addrs    []netip.Addr
+		wantErr  string
+	}{
+		{
+			name:     "dns resolves to link local",
+			endpoint: "https://object-store.example.test",
+			addrs:    []netip.Addr{netip.MustParseAddr("169.254.169.254")},
+			wantErr:  "resolves to forbidden address",
+		},
+		{
+			name:     "dns resolves to loopback",
+			endpoint: "https://object-store.example.test",
+			addrs:    []netip.Addr{netip.MustParseAddr("::1")},
+			wantErr:  "resolves to forbidden address",
+		},
+		{
+			name:     "dns resolves to public address",
+			endpoint: "https://object-store.example.test",
+			addrs:    []netip.Addr{netip.MustParseAddr("203.0.113.10")},
+		},
+		{
+			name:     "dns resolves to private in cluster address",
+			endpoint: "http://minio.team-a.svc.cluster.local:9000",
+			addrs:    []netip.Addr{netip.MustParseAddr("10.96.12.34")},
+		},
+		{
+			name:     "private literal endpoint",
+			endpoint: "https://10.0.0.15:9000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolver := fakeEndpointResolver{}
+			if len(tt.addrs) > 0 {
+				parsed, err := urlHost(tt.endpoint)
+				require.NoError(t, err)
+				resolver[parsed] = tt.addrs
+			}
+
+			err := validateStorageEndpointAccessWithResolver(
+				context.Background(),
+				storage.Config{Endpoint: tt.endpoint},
+				resolver,
+			)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateStorageEndpointAccessChecksS3VirtualHostedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	resolver := fakeEndpointResolver{
+		"storage.example.test":               []netip.Addr{netip.MustParseAddr("203.0.113.10")},
+		"tenant-bucket.storage.example.test": []netip.Addr{netip.MustParseAddr("169.254.169.254")},
+	}
+
+	err := validateStorageEndpointAccessWithResolver(
+		context.Background(),
+		storage.Config{
+			Provider: storage.ProviderS3,
+			Bucket:   "tenant-bucket",
+			Endpoint: "https://storage.example.test",
+			S3:       &storage.S3Options{},
+		},
+		resolver,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "s3 virtual-hosted endpoint")
+	assert.Contains(t, err.Error(), "resolves to forbidden address")
+
+	err = validateStorageEndpointAccessWithResolver(
+		context.Background(),
+		storage.Config{
+			Provider: storage.ProviderS3,
+			Bucket:   "tenant-bucket",
+			Endpoint: "https://storage.example.test",
+			S3: &storage.S3Options{
+				UsePathStyle: true,
+			},
+		},
+		resolver,
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateStorageEndpointAccessChecksAzureConnectionStringEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		connectionString string
+		resolver         fakeEndpointResolver
+		wantErr          string
+	}{
+		{
+			name:             "blob endpoint link local literal",
+			connectionString: "DefaultEndpointsProtocol=http;AccountName=tenant;AccountKey=key;BlobEndpoint=http://169.254.169.254/devstoreaccount1",
+			wantErr:          "azure connection string BlobEndpoint",
+		},
+		{
+			name:             "blob endpoint dns resolves to link local",
+			connectionString: "DefaultEndpointsProtocol=https;AccountName=tenant;AccountKey=key;BlobEndpoint=https://blob.example.test/devstoreaccount1",
+			resolver: fakeEndpointResolver{
+				"blob.example.test": []netip.Addr{netip.MustParseAddr("169.254.169.254")},
+			},
+			wantErr: "resolves to forbidden address",
+		},
+		{
+			name:             "custom suffix dns resolves to link local",
+			connectionString: "DefaultEndpointsProtocol=https;AccountName=tenant;AccountKey=key;EndpointSuffix=metadata.example.test",
+			resolver: fakeEndpointResolver{
+				"tenant.blob.metadata.example.test": []netip.Addr{netip.MustParseAddr("169.254.169.254")},
+			},
+			wantErr: "azure connection string EndpointSuffix",
+		},
+		{
+			name:             "blob endpoint dns resolves to public address",
+			connectionString: "DefaultEndpointsProtocol=https;AccountName=tenant;AccountKey=key;BlobEndpoint=https://blob.example.test/devstoreaccount1",
+			resolver: fakeEndpointResolver{
+				"blob.example.test": []netip.Addr{netip.MustParseAddr("203.0.113.10")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateStorageEndpointAccessWithResolver(
+				context.Background(),
+				storage.Config{
+					Azure: &storage.AzureOptions{
+						ConnectionString: tt.connectionString,
+					},
+				},
+				tt.resolver,
+			)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func urlHost(endpoint string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	return normalizeEndpointHost(parsed.Hostname()), nil
+}

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -1017,6 +1017,11 @@ func TestVAP_OpenBaoCluster_RejectsBackupEndpointSSRFBypasses(t *testing.T) {
 			wantMessage: "Backup endpoint cannot point to link-local addresses",
 		},
 		{
+			name:        "ipv4-mapped-ipv6-link-local",
+			endpoint:    "HTTP://[::ffff:169.254.169.254]/latest/meta-data",
+			wantMessage: "numeric IP encoding",
+		},
+		{
 			name:        "shorthand-loopback",
 			endpoint:    "http://127.1:9000",
 			wantMessage: "numeric IP encoding",
@@ -1196,6 +1201,11 @@ func TestVAP_OpenBaoRestore_RejectsUnsafeEndpoints(t *testing.T) {
 			wantMessage: "Restore endpoint cannot point to link-local addresses",
 		},
 		{
+			name:        "ipv4-mapped-ipv6-link-local",
+			endpoint:    "HTTPS://[::ffff:169.254.169.254]/latest/meta-data",
+			wantMessage: "numeric IP encoding",
+		},
+		{
 			name:        "shorthand-loopback",
 			endpoint:    "https://127.1:9000",
 			wantMessage: "numeric IP encoding",
@@ -1208,6 +1218,11 @@ func TestVAP_OpenBaoRestore_RejectsUnsafeEndpoints(t *testing.T) {
 		{
 			name:        "plain-http-external",
 			endpoint:    "http://example.com",
+			wantMessage: "Restore endpoint must use HTTPS or S3 scheme",
+		},
+		{
+			name:        "plain-http-fake-svc-external-domain",
+			endpoint:    "http://storage.namespace.svc.evil.example:9000",
 			wantMessage: "Restore endpoint must use HTTPS or S3 scheme",
 		},
 	}

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -997,6 +997,62 @@ func TestVAP_OpenBaoCluster_RejectsNumericBackupEndpoint(t *testing.T) {
 	}
 }
 
+func TestVAP_OpenBaoCluster_RejectsBackupEndpointSSRFBypasses(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	tests := []struct {
+		name        string
+		endpoint    string
+		wantMessage string
+	}{
+		{
+			name:        "uppercase-scheme-link-local",
+			endpoint:    "HTTP://169.254.169.254/latest/meta-data",
+			wantMessage: "Backup endpoint cannot point to link-local addresses",
+		},
+		{
+			name:        "userinfo-link-local",
+			endpoint:    "http://storage.example.com@169.254.169.254/latest/meta-data",
+			wantMessage: "Backup endpoint cannot point to link-local addresses",
+		},
+		{
+			name:        "shorthand-loopback",
+			endpoint:    "http://127.1:9000",
+			wantMessage: "numeric IP encoding",
+		},
+		{
+			name:        "hex-loopback",
+			endpoint:    "http://0x7f000001:9000",
+			wantMessage: "numeric IP encoding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newMinimalClusterObj(namespace, "cluster-backup-ssrf-"+tt.name)
+			cluster.Spec.Backup = &openbaov1alpha1.BackupSchedule{
+				Schedule:    "0 0 * * *",
+				Image:       "ghcr.io/dc-tec/openbao-backup:1.0.0",
+				JWTAuthRole: "backup-role",
+				Target: openbaov1alpha1.BackupTarget{
+					Endpoint: tt.endpoint,
+					Bucket:   testBackupBucket,
+					CredentialsSecretRef: &corev1.LocalObjectReference{
+						Name: "backup-creds",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, cluster)
+			requireAdmissionDenied(t, err)
+			if !strings.Contains(err.Error(), tt.wantMessage) {
+				t.Fatalf("unexpected error message: %v", err)
+			}
+		})
+	}
+}
+
 func TestVAP_OpenBaoRestore_DeniesCustomImageWithoutHelperImageVerb(t *testing.T) {
 	namespace := newTestNamespace(t)
 	waitForOpenBaoRestoreAdmissionPolicies(t, namespace)
@@ -1130,6 +1186,26 @@ func TestVAP_OpenBaoRestore_RejectsUnsafeEndpoints(t *testing.T) {
 			wantMessage: "Restore endpoint cannot point to link-local addresses",
 		},
 		{
+			name:        "uppercase-scheme-link-local",
+			endpoint:    "HTTPS://169.254.169.254/latest/meta-data",
+			wantMessage: "Restore endpoint cannot point to link-local addresses",
+		},
+		{
+			name:        "userinfo-link-local",
+			endpoint:    "https://storage.example.com@169.254.169.254/latest/meta-data",
+			wantMessage: "Restore endpoint cannot point to link-local addresses",
+		},
+		{
+			name:        "shorthand-loopback",
+			endpoint:    "https://127.1:9000",
+			wantMessage: "numeric IP encoding",
+		},
+		{
+			name:        "hex-loopback",
+			endpoint:    "https://0x7f000001:9000",
+			wantMessage: "numeric IP encoding",
+		},
+		{
 			name:        "plain-http-external",
 			endpoint:    "http://example.com",
 			wantMessage: "Restore endpoint must use HTTPS or S3 scheme",
@@ -1179,6 +1255,35 @@ func TestVAP_OpenBaoRestore_RejectsUnsafeEndpoints(t *testing.T) {
 
 			t.Fatalf("expected VAP to deny OpenBaoRestore endpoint %q after retries", tt.endpoint)
 		})
+	}
+}
+
+func TestVAP_OpenBaoRestore_AllowsInClusterHTTPServiceEndpoint(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoRestoreAdmissionPolicies(t, namespace)
+
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-in-cluster-http-service",
+			Namespace: namespace,
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{
+			Cluster: "target-cluster",
+			Source: openbaov1alpha1.RestoreSource{
+				Target: openbaov1alpha1.BackupTarget{
+					Provider: "s3",
+					Endpoint: "http://rustfs-svc.rustfs.svc.cluster.local:9000",
+					Bucket:   testBackupBucket,
+				},
+				Key: "clusters/prod/snapshot.snap",
+			},
+			JWTAuthRole: "restore",
+			Force:       true,
+		},
+	}
+
+	if err := k8sClient.Create(ctx, restore); err != nil {
+		t.Fatalf("expected in-cluster HTTP restore endpoint to be allowed, got: %v", err)
 	}
 }
 

--- a/test/integration/restore_manager_test.go
+++ b/test/integration/restore_manager_test.go
@@ -44,7 +44,7 @@ func TestRestoreManager_TransitionsAndCreatesJob(t *testing.T) {
 			Source: openbaov1alpha1.RestoreSource{
 				Key: "backup.enc",
 				Target: openbaov1alpha1.BackupTarget{
-					Endpoint: "http://minio.svc",
+					Endpoint: "http://minio." + namespace + ".svc",
 					Bucket:   testBackupBucket,
 				},
 			},
@@ -406,7 +406,7 @@ func TestRestoreManager_ValidatingLockContention_RequeuesWithWaitingMessage(t *t
 			Source: openbaov1alpha1.RestoreSource{
 				Key: "backup.enc",
 				Target: openbaov1alpha1.BackupTarget{
-					Endpoint: "http://minio.svc",
+					Endpoint: "http://minio." + namespace + ".svc",
 					Bucket:   testBackupBucket,
 				},
 			},
@@ -485,7 +485,7 @@ func TestRestoreManager_RunningLockTaken_FailsDeterministically(t *testing.T) {
 			Source: openbaov1alpha1.RestoreSource{
 				Key: "backup.enc",
 				Target: openbaov1alpha1.BackupTarget{
-					Endpoint: "http://minio.svc",
+					Endpoint: "http://minio." + namespace + ".svc",
 					Bucket:   testBackupBucket,
 				},
 			},
@@ -568,7 +568,7 @@ func TestRestoreManager_FailedJob_RemainsTerminalAcrossReconcileRetries(t *testi
 			Source: openbaov1alpha1.RestoreSource{
 				Key: "backup.enc",
 				Target: openbaov1alpha1.BackupTarget{
-					Endpoint: "http://minio.svc",
+					Endpoint: "http://minio." + namespace + ".svc",
 					Bucket:   testBackupBucket,
 				},
 			},


### PR DESCRIPTION
## Summary

- Harden backup and restore storage endpoint validation against raw-string SSRF bypasses by parsing URLs and rejecting local, link-local, unspecified, multicast, IPv4-mapped, and ambiguous numeric hosts.
- Add runtime storage endpoint guards before controller/helper blob clients are opened, including DNS-answer checks plus S3 virtual-hosted and Azure connection-string derived endpoint checks.
- Tighten the restore admission HTTP exception to actual in-cluster Service DNS names (`service.namespace.svc[.cluster.local]`).
- Realign restore manager envtest fixtures to namespace-qualified Service hosts; E2E restore/backup endpoints already use namespace-qualified Service DNS names, so no E2E fixture realignment was needed.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This is a security hardening change for backup/restore endpoints. Existing valid HTTPS/S3 object storage endpoints and namespace-qualified in-cluster Service HTTP endpoints remain supported.

Operationally, backup/restore storage clients now fail before opening a blob store when a configured or provider-derived endpoint resolves to local, link-local, unspecified, or multicast addresses, or when the host uses ambiguous numeric IP encoding. This may reject previously accepted unsafe or malformed endpoints.

No CRD schema, RBAC, or Secret data exposure changes are introduced.

## Verification

- `env GOCACHE=/private/tmp/openbao-operator-gocache KUBEBUILDER_ASSETS=/Users/roelc/projects/work/openbao-operator-transit-hardening/bin/k8s/1.36.0-darwin-arm64 GOFLAGS=-mod=vendor go test -tags=integration ./test/integration -run 'TestVAP_OpenBao(Cluster_RejectsNumericBackupEndpoint|Cluster_RejectsBackupEndpointSSRFBypasses|Restore_RejectsUnsafeEndpoints|Restore_AllowsInClusterHTTPServiceEndpoint)$|TestRestoreManager_' -count=1`
- `go test ./internal/service/backup ./cmd/bao-backup`
- `GOFLAGS=-mod=vendor go test -tags=e2e ./test/e2e -run '^$'`
- `make helm-test`
- `git diff --check`
- `make bootstrap`
- `make doctor`
- `make ci-core`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

Focus areas:

- The CEL restore HTTP exception now requires `service.namespace.svc` or `service.namespace.svc.cluster.local`.
- The runtime guard intentionally allows private IP ranges so in-cluster object stores continue to work, but blocks local, link-local, unspecified, multicast, ambiguous numeric, and forbidden DNS-resolved destinations.
- S3 virtual-hosted and Azure connection-string derived endpoints are validated because those can change the actual network destination beyond the raw configured endpoint string.

E2E tests did not need fixture realignment; envtest restore manager fixtures were updated from `http://minio.svc` to namespace-qualified Service hosts.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

Docs were not changed because this tightens existing endpoint validation behavior without adding new user-facing fields or workflows. Generated Helm admission policy output was synchronized and verified.