### PR TITLE
fix(storage): enforce request-time endpoint guard

### DIFF
--- a/cmd/bao-backup/storage_config.go
+++ b/cmd/bao-backup/storage_config.go
@@ -22,9 +22,10 @@ func buildStorageConfig(cfg *backupconfig.ExecutorConfig) (storage.Config, error
 	}
 
 	storageConfig := storage.Config{
-		Provider: storage.ProviderType(provider),
-		Bucket:   cfg.BackupBucket,
-		Endpoint: cfg.BackupEndpoint,
+		Provider:                 storage.ProviderType(provider),
+		Bucket:                   cfg.BackupBucket,
+		Endpoint:                 cfg.BackupEndpoint,
+		ValidateEndpointRequests: true,
 	}
 
 	switch provider {

--- a/internal/adapter/storage/azure.go
+++ b/internal/adapter/storage/azure.go
@@ -44,6 +44,8 @@ type AzureClientConfig struct {
 	CACert []byte
 	// EnsureExists optionally creates the container if it does not exist.
 	EnsureExists bool
+	// ValidateEndpointRequests rejects request-time redirects or DNS results to local or metadata-adjacent destinations.
+	ValidateEndpointRequests bool
 }
 
 // OpenAzureContainer opens an Azure blob container using Go CDK.
@@ -118,14 +120,24 @@ func OpenAzureContainer(ctx context.Context, cfg AzureClientConfig) (blobstore.B
 		}
 
 		var cred azcore.TokenCredential
+		credentialHTTPClient, err := buildAzureHTTPClient(AzureClientConfig{
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
+			CACert:             cfg.CACert,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build Azure credential HTTP client: %w", err)
+		}
+		credentialClientOptions := azcore.ClientOptions{
+			Transport: credentialHTTPClient,
+		}
 		if cfg.ManagedIdentityClientID != "" {
 			cred, err = azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
 				ID:            azidentity.ClientID(cfg.ManagedIdentityClientID),
-				ClientOptions: clientOpts.ClientOptions,
+				ClientOptions: credentialClientOptions,
 			})
 		} else {
 			cred, err = azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
-				ClientOptions: clientOpts.ClientOptions,
+				ClientOptions: credentialClientOptions,
 			})
 		}
 		if err != nil {
@@ -185,10 +197,12 @@ func buildAzureHTTPClient(cfg AzureClientConfig) (*http.Client, error) {
 		MinVersion:         tls.VersionTLS12,
 	}
 
-	return &http.Client{
+	client := &http.Client{
 		Transport: transport,
 		Timeout:   DefaultUploadTimeout,
-	}, nil
+	}
+	applyStorageEndpointRequestGuard(client, transport, cfg.ValidateEndpointRequests)
+	return client, nil
 }
 
 func ensureAzureContainer(ctx context.Context, c *container.Client) error {

--- a/internal/adapter/storage/endpoint_request_guard.go
+++ b/internal/adapter/storage/endpoint_request_guard.go
@@ -1,0 +1,171 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type storageEndpointRequestResolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+type storageEndpointRequestGuard struct {
+	resolver    storageEndpointRequestResolver
+	dialContext func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+var storageAmbiguousNumericHostPattern = regexp.MustCompile(`(?i)^(0x[0-9a-f]+|[0-9]+)(\.(0x[0-9a-f]+|[0-9]+)){0,3}$`)
+
+func applyStorageEndpointRequestGuard(client *http.Client, transport *http.Transport, enabled bool) {
+	if !enabled {
+		return
+	}
+	guard := newStorageEndpointRequestGuard()
+	transport.DialContext = guard.guardedDialContext
+	client.CheckRedirect = guard.checkRedirect
+}
+
+func newStorageEndpointRequestGuard() storageEndpointRequestGuard {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return storageEndpointRequestGuard{
+		resolver:    net.DefaultResolver,
+		dialContext: dialer.DialContext,
+	}
+}
+
+func (g storageEndpointRequestGuard) guardedDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("storage request destination %q is invalid: %w", address, err)
+	}
+
+	addrs, err := g.resolveAllowedAddrs(ctx, network, host)
+	if err != nil {
+		return nil, err
+	}
+
+	dialErrs := make([]error, 0, len(addrs))
+	for _, addr := range addrs {
+		if !networkAllowsEndpointAddress(network, addr) {
+			continue
+		}
+		conn, err := g.dialContext(ctx, network, net.JoinHostPort(addr.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		dialErrs = append(dialErrs, err)
+	}
+
+	if len(dialErrs) == 0 {
+		return nil, fmt.Errorf("storage request destination %q has no addresses compatible with network %q", address, network)
+	}
+	return nil, fmt.Errorf("storage request destination %q could not be reached: %w", address, errors.Join(dialErrs...))
+}
+
+func (g storageEndpointRequestGuard) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after 10 redirects")
+	}
+	return g.validateURL(req.Context(), req.URL)
+}
+
+func (g storageEndpointRequestGuard) validateURL(ctx context.Context, u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("storage request redirect target is missing")
+	}
+	host := normalizeStorageEndpointRequestHost(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("storage request redirect target must include a host")
+	}
+	_, err := g.resolveAllowedAddrs(ctx, "ip", host)
+	return err
+}
+
+func (g storageEndpointRequestGuard) resolveAllowedAddrs(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	host = normalizeStorageEndpointRequestHost(host)
+	if host == "" {
+		return nil, fmt.Errorf("storage request destination must include a host")
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return nil, fmt.Errorf("storage request destination host %q is not allowed", host)
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		addr = addr.Unmap()
+		if isForbiddenStorageEndpointRequestAddress(addr) {
+			return nil, fmt.Errorf("storage request destination host %q is not allowed", host)
+		}
+		return []netip.Addr{addr}, nil
+	}
+	if storageAmbiguousNumericHostPattern.MatchString(host) {
+		return nil, fmt.Errorf("storage request destination host %q uses ambiguous numeric IP encoding", host)
+	}
+	if strings.Contains(host, ":") {
+		return nil, fmt.Errorf("storage request destination host %q uses ambiguous IP encoding", host)
+	}
+	if g.resolver == nil {
+		return nil, fmt.Errorf("storage request destination resolver is required")
+	}
+
+	addrs, err := g.resolver.LookupNetIP(ctx, resolverNetworkForEndpointDial(network), host)
+	if err != nil {
+		return nil, fmt.Errorf("storage request destination host %q could not be resolved: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("storage request destination host %q did not resolve to any IP addresses", host)
+	}
+	for _, addr := range addrs {
+		if isForbiddenStorageEndpointRequestAddress(addr) {
+			return nil, fmt.Errorf("storage request destination host %q resolves to forbidden address %s", host, addr)
+		}
+	}
+	return addrs, nil
+}
+
+func normalizeStorageEndpointRequestHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.TrimSuffix(host, ".")
+	return host
+}
+
+func isForbiddenStorageEndpointRequestAddress(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return !addr.IsValid() ||
+		addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsUnspecified() ||
+		addr.IsMulticast()
+}
+
+func networkAllowsEndpointAddress(network string, addr netip.Addr) bool {
+	addr = addr.Unmap()
+	switch {
+	case strings.HasSuffix(network, "4"):
+		return addr.Is4()
+	case strings.HasSuffix(network, "6"):
+		return addr.Is6()
+	default:
+		return true
+	}
+}
+
+func resolverNetworkForEndpointDial(network string) string {
+	switch {
+	case strings.HasSuffix(network, "4"):
+		return "ip4"
+	case strings.HasSuffix(network, "6"):
+		return "ip6"
+	default:
+		return "ip"
+	}
+}

--- a/internal/adapter/storage/endpoint_request_guard_test.go
+++ b/internal/adapter/storage/endpoint_request_guard_test.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStorageEndpointRequestResolver map[string][]netip.Addr
+
+func (r fakeStorageEndpointRequestResolver) LookupNetIP(_ context.Context, _ string, host string) ([]netip.Addr, error) {
+	if addrs, ok := r[host]; ok {
+		return addrs, nil
+	}
+	return nil, &net.DNSError{
+		Err:        "no such host",
+		Name:       host,
+		IsNotFound: true,
+	}
+}
+
+type recordingStorageEndpointRequestResolver struct {
+	network string
+	addrs   []netip.Addr
+}
+
+func (r *recordingStorageEndpointRequestResolver) LookupNetIP(_ context.Context, network, _ string) ([]netip.Addr, error) {
+	r.network = network
+	return r.addrs, nil
+}
+
+func TestStorageEndpointRequestGuardDialsResolvedAddress(t *testing.T) {
+	t.Parallel()
+
+	var dialedAddress string
+	resolver := &recordingStorageEndpointRequestResolver{
+		addrs: []netip.Addr{netip.MustParseAddr("203.0.113.10")},
+	}
+	guard := storageEndpointRequestGuard{
+		resolver: resolver,
+		dialContext: func(_ context.Context, _ string, address string) (net.Conn, error) {
+			dialedAddress = address
+			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() {
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			})
+			return clientConn, nil
+		},
+	}
+
+	conn, err := guard.guardedDialContext(context.Background(), "tcp4", "storage.example.test:443")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Equal(t, "ip4", resolver.network)
+	assert.Equal(t, "203.0.113.10:443", dialedAddress)
+}
+
+func TestStorageEndpointRequestGuardAllowsPrivateClusterAddress(t *testing.T) {
+	t.Parallel()
+
+	var dialedAddress string
+	guard := storageEndpointRequestGuard{
+		resolver: fakeStorageEndpointRequestResolver{},
+		dialContext: func(_ context.Context, _ string, address string) (net.Conn, error) {
+			dialedAddress = address
+			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() {
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			})
+			return clientConn, nil
+		},
+	}
+
+	conn, err := guard.guardedDialContext(context.Background(), "tcp", "10.96.12.34:9000")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Equal(t, "10.96.12.34:9000", dialedAddress)
+}
+
+func TestStorageEndpointRequestGuardRejectsForbiddenDNSAtDialTime(t *testing.T) {
+	t.Parallel()
+
+	dialed := false
+	guard := storageEndpointRequestGuard{
+		resolver: fakeStorageEndpointRequestResolver{
+			"storage.example.test": []netip.Addr{netip.MustParseAddr("169.254.169.254")},
+		},
+		dialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialed = true
+			return nil, nil
+		},
+	}
+
+	conn, err := guard.guardedDialContext(context.Background(), "tcp", "storage.example.test:443")
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.False(t, dialed)
+	assert.Contains(t, err.Error(), "resolves to forbidden address")
+}
+
+func TestStorageEndpointRequestGuardRejectsRedirectToForbiddenHost(t *testing.T) {
+	t.Parallel()
+
+	client, err := buildHTTPClient(nil, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, client.CheckRedirect)
+
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data", nil)
+	require.NoError(t, err)
+
+	err = client.CheckRedirect(req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}

--- a/internal/adapter/storage/gcs.go
+++ b/internal/adapter/storage/gcs.go
@@ -43,6 +43,8 @@ type GCSClientConfig struct {
 	CACert []byte
 	// EnsureExists optionally validates/creates the bucket (requires Project for create).
 	EnsureExists bool
+	// ValidateEndpointRequests rejects request-time redirects or DNS results to local or metadata-adjacent destinations.
+	ValidateEndpointRequests bool
 }
 
 // OpenGCSBucket opens a GCS bucket using Go CDK.
@@ -172,10 +174,12 @@ func buildGCSHTTPClient(cfg GCSClientConfig) (*http.Client, error) {
 	}
 	transport.TLSClientConfig = tlsConfig
 
-	return &http.Client{
+	client := &http.Client{
 		Transport: transport,
 		Timeout:   DefaultUploadTimeout,
-	}, nil
+	}
+	applyStorageEndpointRequestGuard(client, transport, cfg.ValidateEndpointRequests)
+	return client, nil
 }
 
 func ensureGCSBucket(ctx context.Context, cfg GCSClientConfig, b *Bucket) error {

--- a/internal/adapter/storage/s3.go
+++ b/internal/adapter/storage/s3.go
@@ -175,6 +175,8 @@ type S3ClientConfig struct {
 	InsecureSkipVerify bool
 	// EnsureExists checks if the bucket exists and tries to create it if not.
 	EnsureExists bool
+	// ValidateEndpointRequests rejects request-time redirects or DNS results to local or metadata-adjacent destinations.
+	ValidateEndpointRequests bool
 }
 
 // OpenS3Bucket opens an S3-compatible bucket using Go CDK.
@@ -346,8 +348,10 @@ func buildAWSConfig(ctx context.Context, cfg S3ClientConfig) (aws.Config, error)
 		opts = append(opts, config.WithCredentialsProvider(staticCreds))
 	}
 
-	// Configure custom HTTP client for TLS
-	httpClient, err := buildHTTPClient(cfg.CACert, cfg.InsecureSkipVerify)
+	// Configure an HTTP client for config loading and credential discovery. This
+	// path must not apply the storage endpoint guard because ambient credential
+	// providers may legitimately use their own metadata or identity endpoints.
+	httpClient, err := buildHTTPClient(cfg.CACert, cfg.InsecureSkipVerify, false)
 	if err != nil {
 		if operatorerrors.IsTransientConnection(err) {
 			return aws.Config{}, operatorerrors.WrapTransientConnection(fmt.Errorf("failed to create HTTP client: %w", err))
@@ -365,11 +369,20 @@ func buildAWSConfig(ctx context.Context, cfg S3ClientConfig) (aws.Config, error)
 		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
+	storageHTTPClient, err := buildHTTPClient(cfg.CACert, cfg.InsecureSkipVerify, cfg.ValidateEndpointRequests)
+	if err != nil {
+		if operatorerrors.IsTransientConnection(err) {
+			return aws.Config{}, operatorerrors.WrapTransientConnection(fmt.Errorf("failed to create storage HTTP client: %w", err))
+		}
+		return aws.Config{}, fmt.Errorf("failed to create storage HTTP client: %w", err)
+	}
+	awsCfg.HTTPClient = storageHTTPClient
+
 	return awsCfg, nil
 }
 
 // buildHTTPClient creates an HTTP client with optional custom CA certificate.
-func buildHTTPClient(caCert []byte, insecureSkipVerify bool) (*http.Client, error) {
+func buildHTTPClient(caCert []byte, insecureSkipVerify, validateEndpointRequests bool) (*http.Client, error) {
 	transport := &http.Transport{
 		TLSHandshakeTimeout: 10 * time.Second,
 		DisableKeepAlives:   false,
@@ -396,8 +409,10 @@ func buildHTTPClient(caCert []byte, insecureSkipVerify bool) (*http.Client, erro
 		MinVersion:         tls.VersionTLS12,
 	}
 
-	return &http.Client{
+	client := &http.Client{
 		Transport: transport,
 		Timeout:   DefaultUploadTimeout,
-	}, nil
+	}
+	applyStorageEndpointRequestGuard(client, transport, validateEndpointRequests)
+	return client, nil
 }

--- a/internal/adapter/storage/storage.go
+++ b/internal/adapter/storage/storage.go
@@ -65,6 +65,11 @@ type Config struct {
 
 	// Azure contains Azure-specific configuration.
 	Azure *AzureOptions
+
+	// ValidateEndpointRequests rejects storage HTTP requests and redirects to
+	// local or metadata-adjacent destinations. Backup and restore paths enable
+	// this after admission/preflight endpoint validation.
+	ValidateEndpointRequests bool
 }
 
 // S3Options holds S3-specific options.
@@ -148,25 +153,27 @@ func openS3(ctx context.Context, cfg Config) (blobstore.BlobStore, error) {
 	}
 
 	return OpenS3Bucket(ctx, S3ClientConfig{
-		Endpoint:           cfg.Endpoint,
-		Bucket:             cfg.Bucket,
-		Region:             cfg.Region,
-		AccessKeyID:        accessKeyID,
-		SecretAccessKey:    secretAccessKey,
-		SessionToken:       sessionToken,
-		CACert:             caCert,
-		UsePathStyle:       usePathStyle,
-		InsecureSkipVerify: insecureSkipVerify,
-		EnsureExists:       ensureExists,
+		Endpoint:                 cfg.Endpoint,
+		Bucket:                   cfg.Bucket,
+		Region:                   cfg.Region,
+		AccessKeyID:              accessKeyID,
+		SecretAccessKey:          secretAccessKey,
+		SessionToken:             sessionToken,
+		CACert:                   caCert,
+		UsePathStyle:             usePathStyle,
+		InsecureSkipVerify:       insecureSkipVerify,
+		EnsureExists:             ensureExists,
+		ValidateEndpointRequests: cfg.ValidateEndpointRequests,
 	})
 }
 
 // openGCS opens a GCS bucket using the unified Config.
 func openGCS(ctx context.Context, cfg Config) (blobstore.BlobStore, error) {
 	gcsCfg := GCSClientConfig{
-		Bucket:       cfg.Bucket,
-		Endpoint:     cfg.Endpoint,
-		EnsureExists: cfg.EnsureExists,
+		Bucket:                   cfg.Bucket,
+		Endpoint:                 cfg.Endpoint,
+		EnsureExists:             cfg.EnsureExists,
+		ValidateEndpointRequests: cfg.ValidateEndpointRequests,
 	}
 
 	if cfg.GCS != nil {
@@ -183,9 +190,10 @@ func openGCS(ctx context.Context, cfg Config) (blobstore.BlobStore, error) {
 // openAzure opens an Azure blob container using the unified Config.
 func openAzure(ctx context.Context, cfg Config) (blobstore.BlobStore, error) {
 	azureCfg := AzureClientConfig{
-		Container:    cfg.Bucket,
-		Endpoint:     cfg.Endpoint,
-		EnsureExists: cfg.EnsureExists,
+		Container:                cfg.Bucket,
+		Endpoint:                 cfg.Endpoint,
+		EnsureExists:             cfg.EnsureExists,
+		ValidateEndpointRequests: cfg.ValidateEndpointRequests,
 	}
 
 	if cfg.Azure != nil {

--- a/internal/service/backup/storage_client.go
+++ b/internal/service/backup/storage_client.go
@@ -28,10 +28,11 @@ func (m *Manager) openBackupStorageClient(ctx context.Context, cluster *openbaov
 	}
 
 	storageConfig := storage.Config{
-		Provider:     provider,
-		Bucket:       target.Bucket,
-		Endpoint:     target.Endpoint,
-		EnsureExists: ensureExists,
+		Provider:                 provider,
+		Bucket:                   target.Bucket,
+		Endpoint:                 target.Endpoint,
+		EnsureExists:             ensureExists,
+		ValidateEndpointRequests: true,
 	}
 
 	credsSecret, err := m.loadBackupCredentialsSecret(ctx, cluster)


### PR DESCRIPTION
## Summary

Adds request-time storage endpoint enforcement for backup and restore object storage clients.

The existing endpoint validation rejected unsafe configured endpoints before opening a storage client, but the provider SDKs still performed request-time DNS resolution and followed redirects with their default HTTP clients. This change wires an opt-in `ValidateEndpointRequests` flag through the backup/restore storage config into the S3, GCS, and Azure HTTP clients, then guards both `DialContext` and `CheckRedirect` so requests cannot be redirected or rebound to loopback, link-local, unspecified, multicast, localhost, or ambiguous numeric destinations.

## Related Issues

Follow-up to #475.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, or generated artifact changes.

Operational impact: backup and restore storage HTTP requests now fail closed if the final request destination or redirect target resolves to a forbidden local or metadata-adjacent address. Private in-cluster storage endpoints remain allowed. S3 and Azure credential discovery keep separate unguarded credential transports so ambient cloud identity metadata access is not conflated with storage endpoint requests.

## Verification

- `go test -count=1 ./internal/adapter/storage ./internal/service/backup ./cmd/bao-backup`
- Pre-push hook ran `make lint-ci` successfully, including `golangci-lint` and the AST rule suite.

## Reviewer Notes

The request guard is intentionally opt-in at the storage adapter boundary and enabled by the backup/restore entry points. This keeps unrelated direct adapter usage unchanged while closing the backup/restore SSRF bypass path.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.