### PR TITLE
chore(samples): align logging examples with stdout

### DIFF
--- a/config/samples/basics/openbao_v1alpha1_openbaocluster.yaml
+++ b/config/samples/basics/openbao_v1alpha1_openbaocluster.yaml
@@ -7,7 +7,6 @@ metadata:
   name: openbaocluster-sample
 spec:
   version: "2.4.4"
-  version: "2.4.4"
   # image: "openbao/openbao:2.4.4" # Optional: inferred from version
   # Optional: Supply chain security (Cosign image verification + digest pinning).
   # When enabled, verification applies to all operator-managed images for this cluster

--- a/config/samples/basics/openbao_v1alpha1_openbaocluster_selfinit.yaml
+++ b/config/samples/basics/openbao_v1alpha1_openbaocluster_selfinit.yaml
@@ -30,8 +30,7 @@ spec:
     logLevel: "info"
     ui: true
     logging:
-      format: "standard"
-      file: "/var/log/openbao/openbao.log"
+      format: "json"
   # Self-initialization configuration
   selfInit:
     enabled: true

--- a/config/samples/integrations/openbao_v1alpha1_openbaocluster_gateway.yaml
+++ b/config/samples/integrations/openbao_v1alpha1_openbaocluster_gateway.yaml
@@ -63,8 +63,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # Gateway API configuration
   gateway:
     enabled: true

--- a/config/samples/integrations/openbao_v1alpha1_openbaocluster_ingress.yaml
+++ b/config/samples/integrations/openbao_v1alpha1_openbaocluster_ingress.yaml
@@ -40,5 +40,3 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_acme.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_acme.yaml
@@ -66,10 +66,6 @@ spec:
     # Structured logging
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
-      rotateBytes: 10485760 # 10MB
-      rotateMaxFiles: 7
     # UI enabled
     ui: true
   # External access for ACME mode must be TLS passthrough.

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_awskms.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_awskms.yaml
@@ -33,8 +33,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # Optional: annotate the OpenBao ServiceAccount for IAM-based workload identity
   # serviceAccount:
   #   annotations:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_azure.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_azure.yaml
@@ -34,8 +34,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # Optional: configure Azure Workload Identity metadata for the OpenBao Pods
   # serviceAccount:
   #   annotations:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_backup.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_backup.yaml
@@ -39,10 +39,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
-      rotateBytes: 10485760 # 10MB
-      rotateMaxFiles: 7
   # Self-initialization with backup policy (for JWT Auth)
   # Note: For Hardened profile clusters, backup and upgrade policies/roles are
   # automatically created when spec.backup.jwtAuthRole and spec.upgrade.jwtAuthRole

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_external_tls.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_external_tls.yaml
@@ -59,8 +59,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
 ---
 # Example: Create TLS Secrets using cert-manager
 # The operator expects these Secrets to exist before deployment

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_full.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_full.yaml
@@ -99,10 +99,6 @@ spec:
     # Structured logging configuration
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
-      rotateBytes: 10485760 # 10MB
-      rotateMaxFiles: 7
       pidFile: "/var/run/openbao/openbao.pid"
     # Plugin configuration
     plugin:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_gcp.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_gcp.yaml
@@ -34,8 +34,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # Optional: annotate the OpenBao ServiceAccount for GKE Workload Identity
   # serviceAccount:
   #   annotations:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_hardened.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_hardened.yaml
@@ -57,10 +57,6 @@ spec:
     # Structured logging for better log aggregation
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
-      rotateBytes: 10485760 # 10MB
-      rotateMaxFiles: 7
     # Lease/TTL configuration for production
     defaultLeaseTTL: "720h" # 30 days
     maxLeaseTTL: "8760h" # 1 year

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_kmip.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_kmip.yaml
@@ -32,8 +32,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # KMIP seal configuration
   unseal:
     type: kmip

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_oci.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_oci.yaml
@@ -32,8 +32,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # OCI KMS seal configuration
   unseal:
     type: ocikms

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_pkcs11.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_pkcs11.yaml
@@ -34,8 +34,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # PKCS#11 seal configuration
   unseal:
     type: pkcs11

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_structured_config.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_structured_config.yaml
@@ -35,10 +35,6 @@ spec:
     # Logging configuration
     logging:
       format: "json" # json or standard
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
-      rotateBytes: 10485760 # 10MB
-      rotateMaxFiles: 7
       pidFile: "/var/run/openbao/openbao.pid"
     # Listener configuration
     listener:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_transit.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_transit.yaml
@@ -34,8 +34,6 @@ spec:
     ui: true
     logging:
       format: "json"
-      file: "/var/log/openbao/openbao.log"
-      rotateDuration: "24h"
   # Transit seal configuration
   unseal:
     type: transit


### PR DESCRIPTION
## Summary

Aligns operator-managed OpenBao samples with Kubernetes stdout logging conventions.

The samples now keep structured JSON logging but no longer configure `logging.file` under `/var/log/openbao`, which is not writable in the hardened/read-only OpenBao pod shape unless a dedicated writable volume is explicitly mounted. File-log rotation settings were removed from the same samples because rotation belongs to the container/platform log collector for stdout logging. This also removes a duplicate `version` key from the basic OpenBaoCluster sample that prevented `kubectl kustomize config/samples` from rendering.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, or runtime controller behavior changes.

Operational impact: sample manifests no longer recommend file logging to an unwritable path. Users who need file logging or file audit storage should add an explicit writable volume contract before configuring file paths.

## Verification

- `kubectl kustomize config/samples >/tmp/openbao-samples-rendered.yaml && wc -l /tmp/openbao-samples-rendered.yaml`
- `ruby -e 'require "psych"; files = Dir["config/samples/**/*.yaml"]; files.each { |f| Psych.load_stream(File.read(f)) }; puts "parsed #{files.size} yaml files"'`
- `rg -n 'file: "?/var/log/openbao/openbao\\.log"?|rotate(Duration|Bytes|MaxFiles):|format: "standard"' config/samples docs/user-guide/validated-deployments -S`
- `git diff --check -- config/samples`
- `make lint-ci` via pre-push hook

## Reviewer Notes

This intentionally does not add an audit PVC or file-log volume contract. File-based logging/audit storage should be introduced separately with explicit writable mounts, retention, and collection semantics.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
