### PR TITLE
fix(rbac): permit managed ServiceMonitor reconciliation

### DIFF
--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -144,6 +144,55 @@ spec:
     - name: is_service_request
       expression: >-
         request.kind.group == "" && request.kind.kind == "Service"
+    - name: is_service_monitor_request
+      expression: >-
+        request.kind.group == "monitoring.coreos.com" && request.kind.kind == "ServiceMonitor"
+    - name: current_service_monitor_is_operator_owned
+      expression: >-
+        object != null &&
+        has(object.metadata) &&
+        request.namespace != "" &&
+        object.metadata.name.endsWith("-metrics") &&
+        has(object.metadata.labels) &&
+        ("app.kubernetes.io/managed-by" in object.metadata.labels) &&
+        object.metadata.labels["app.kubernetes.io/managed-by"] == "openbao-operator" &&
+        ("app.kubernetes.io/component" in object.metadata.labels) &&
+        object.metadata.labels["app.kubernetes.io/component"] == "metrics" &&
+        ("openbao.org/component" in object.metadata.labels) &&
+        object.metadata.labels["openbao.org/component"] == "metrics" &&
+        ("openbao.org/cluster" in object.metadata.labels) &&
+        object.metadata.labels["openbao.org/cluster"] != "" &&
+        object.metadata.name == object.metadata.labels["openbao.org/cluster"] + "-metrics" &&
+        has(object.metadata.ownerReferences) &&
+        object.metadata.ownerReferences.exists(ref,
+          ref.apiVersion == "openbao.org/v1alpha1" &&
+          ref.kind == "OpenBaoCluster" &&
+          ref.name == object.metadata.labels["openbao.org/cluster"] &&
+          has(ref.controller) &&
+          ref.controller == true)
+    - name: old_service_monitor_is_operator_owned
+      expression: >-
+        oldObject != null &&
+        has(oldObject.metadata) &&
+        request.namespace != "" &&
+        oldObject.metadata.name.endsWith("-metrics") &&
+        has(oldObject.metadata.labels) &&
+        ("app.kubernetes.io/managed-by" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["app.kubernetes.io/managed-by"] == "openbao-operator" &&
+        ("app.kubernetes.io/component" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["app.kubernetes.io/component"] == "metrics" &&
+        ("openbao.org/component" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["openbao.org/component"] == "metrics" &&
+        ("openbao.org/cluster" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["openbao.org/cluster"] != "" &&
+        oldObject.metadata.name == oldObject.metadata.labels["openbao.org/cluster"] + "-metrics" &&
+        has(oldObject.metadata.ownerReferences) &&
+        oldObject.metadata.ownerReferences.exists(ref,
+          ref.apiVersion == "openbao.org/v1alpha1" &&
+          ref.kind == "OpenBaoCluster" &&
+          ref.name == oldObject.metadata.labels["openbao.org/cluster"] &&
+          has(ref.controller) &&
+          ref.controller == true)
     - name: is_kubelet_node
       expression: >-
         request.userInfo.username.startsWith("system:node:")
@@ -295,6 +344,15 @@ spec:
           check("maintenance").
           allowed()
   validations:
+    - expression: >-
+        !(variables.is_operator_controller || variables.is_operator_provisioner) ||
+        !variables.is_service_monitor_request ||
+        (
+          (request.operation == "CREATE" && variables.current_service_monitor_is_operator_owned) ||
+          (request.operation == "UPDATE" && variables.current_service_monitor_is_operator_owned && variables.old_service_monitor_is_operator_owned) ||
+          (request.operation == "DELETE" && variables.old_service_monitor_is_operator_owned)
+        )
+      message: The operator can only create, update, or delete ServiceMonitors that match the OpenBao metrics ownership shape.
     - expression: >-
         !variables.is_managed ||
         variables.is_operator_controller ||

--- a/charts/openbao-operator/templates/admission/provisioner-rbac.yaml
+++ b/charts/openbao-operator/templates/admission/provisioner-rbac.yaml
@@ -196,6 +196,15 @@ spec:
             ) ||
             (
               rule.apiGroups.size() == 1 &&
+              rule.apiGroups[0] == 'monitoring.coreos.com' &&
+              rule.resources != null &&
+              rule.resources.size() == 1 &&
+              rule.resources[0] == 'servicemonitors' &&
+              rule.verbs != null &&
+              rule.verbs.all(v, v in ['create', 'delete', 'get', 'patch'])
+            ) ||
+            (
+              rule.apiGroups.size() == 1 &&
               rule.apiGroups[0] == 'rbac.authorization.k8s.io' &&
               rule.resources != null &&
               rule.resources.size() > 0 &&

--- a/charts/openbao-operator/templates/rbac/single-tenant-clusterrole.yaml
+++ b/charts/openbao-operator/templates/rbac/single-tenant-clusterrole.yaml
@@ -165,6 +165,15 @@ rules:
       - watch{{- end }}
 
   - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - roles

--- a/config/overlays/single-tenant-custom-identity/single_tenant_clusterrole.yaml
+++ b/config/overlays/single-tenant-custom-identity/single_tenant_clusterrole.yaml
@@ -23,10 +23,7 @@ rules:
       - create
       - delete
       - get
-      - list
       - patch
-      - update
-      - watch
   - apiGroups:
       - openbao.org
     resources:
@@ -168,6 +165,15 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/config/overlays/single-tenant/single_tenant_clusterrole.yaml
+++ b/config/overlays/single-tenant/single_tenant_clusterrole.yaml
@@ -23,10 +23,7 @@ rules:
       - create
       - delete
       - get
-      - list
       - patch
-      - update
-      - watch
   - apiGroups:
       - openbao.org
     resources:
@@ -168,6 +165,15 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -141,6 +141,55 @@ spec:
     - name: is_service_request
       expression: >-
         request.kind.group == "" && request.kind.kind == "Service"
+    - name: is_service_monitor_request
+      expression: >-
+        request.kind.group == "monitoring.coreos.com" && request.kind.kind == "ServiceMonitor"
+    - name: current_service_monitor_is_operator_owned
+      expression: >-
+        object != null &&
+        has(object.metadata) &&
+        request.namespace != "" &&
+        object.metadata.name.endsWith("-metrics") &&
+        has(object.metadata.labels) &&
+        ("app.kubernetes.io/managed-by" in object.metadata.labels) &&
+        object.metadata.labels["app.kubernetes.io/managed-by"] == "openbao-operator" &&
+        ("app.kubernetes.io/component" in object.metadata.labels) &&
+        object.metadata.labels["app.kubernetes.io/component"] == "metrics" &&
+        ("openbao.org/component" in object.metadata.labels) &&
+        object.metadata.labels["openbao.org/component"] == "metrics" &&
+        ("openbao.org/cluster" in object.metadata.labels) &&
+        object.metadata.labels["openbao.org/cluster"] != "" &&
+        object.metadata.name == object.metadata.labels["openbao.org/cluster"] + "-metrics" &&
+        has(object.metadata.ownerReferences) &&
+        object.metadata.ownerReferences.exists(ref,
+          ref.apiVersion == "openbao.org/v1alpha1" &&
+          ref.kind == "OpenBaoCluster" &&
+          ref.name == object.metadata.labels["openbao.org/cluster"] &&
+          has(ref.controller) &&
+          ref.controller == true)
+    - name: old_service_monitor_is_operator_owned
+      expression: >-
+        oldObject != null &&
+        has(oldObject.metadata) &&
+        request.namespace != "" &&
+        oldObject.metadata.name.endsWith("-metrics") &&
+        has(oldObject.metadata.labels) &&
+        ("app.kubernetes.io/managed-by" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["app.kubernetes.io/managed-by"] == "openbao-operator" &&
+        ("app.kubernetes.io/component" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["app.kubernetes.io/component"] == "metrics" &&
+        ("openbao.org/component" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["openbao.org/component"] == "metrics" &&
+        ("openbao.org/cluster" in oldObject.metadata.labels) &&
+        oldObject.metadata.labels["openbao.org/cluster"] != "" &&
+        oldObject.metadata.name == oldObject.metadata.labels["openbao.org/cluster"] + "-metrics" &&
+        has(oldObject.metadata.ownerReferences) &&
+        oldObject.metadata.ownerReferences.exists(ref,
+          ref.apiVersion == "openbao.org/v1alpha1" &&
+          ref.kind == "OpenBaoCluster" &&
+          ref.name == oldObject.metadata.labels["openbao.org/cluster"] &&
+          has(ref.controller) &&
+          ref.controller == true)
     - name: is_kubelet_node
       expression: >-
         request.userInfo.username.startsWith("system:node:")
@@ -292,6 +341,15 @@ spec:
           check("maintenance").
           allowed()
   validations:
+    - expression: >-
+        !(variables.is_operator_controller || variables.is_operator_provisioner) ||
+        !variables.is_service_monitor_request ||
+        (
+          (request.operation == "CREATE" && variables.current_service_monitor_is_operator_owned) ||
+          (request.operation == "UPDATE" && variables.current_service_monitor_is_operator_owned && variables.old_service_monitor_is_operator_owned) ||
+          (request.operation == "DELETE" && variables.old_service_monitor_is_operator_owned)
+        )
+      message: The operator can only create, update, or delete ServiceMonitors that match the OpenBao metrics ownership shape.
     - expression: >-
         !variables.is_managed ||
         variables.is_operator_controller ||

--- a/config/policy/openbao-restrict-provisioner-rbac.yaml
+++ b/config/policy/openbao-restrict-provisioner-rbac.yaml
@@ -193,6 +193,15 @@ spec:
             ) ||
             (
               rule.apiGroups.size() == 1 &&
+              rule.apiGroups[0] == 'monitoring.coreos.com' &&
+              rule.resources != null &&
+              rule.resources.size() == 1 &&
+              rule.resources[0] == 'servicemonitors' &&
+              rule.verbs != null &&
+              rule.verbs.all(v, v in ['create', 'delete', 'get', 'patch'])
+            ) ||
+            (
+              rule.apiGroups.size() == 1 &&
               rule.apiGroups[0] == 'rbac.authorization.k8s.io' &&
               rule.resources != null &&
               rule.resources.size() > 0 &&

--- a/config/rbac/single_tenant_clusterrole.yaml
+++ b/config/rbac/single_tenant_clusterrole.yaml
@@ -190,6 +190,16 @@ rules:
       - patch
       - update
       - watch
+  # Observability
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
   # RBAC for OpenBao pod discovery
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/docs/security/infrastructure/rbac.md
+++ b/docs/security/infrastructure/rbac.md
@@ -150,7 +150,7 @@ The provisioner writes the RBAC that grants the controller access, but it does n
     {
       cells: [
         'Manage tenant-scoped workload resources',
-        'StatefulSets, Services, ConfigMaps, Jobs, and related resources are the normal lifecycle surface.',
+        'StatefulSets, Services, ConfigMaps, Jobs, ServiceMonitors, and related resources are the normal lifecycle surface.',
         'This access only exists where the provisioner already introduced the controller via RoleBinding.',
       ],
     },

--- a/docs/user-guide/openbaocluster/configuration/observability.md
+++ b/docs/user-guide/openbaocluster/configuration/observability.md
@@ -303,6 +303,12 @@ spec:
   Keep the first alert set small. Availability, backup freshness, sustained read-pool degradation, and sustained reconcile failure are the highest-value starting signals.
 </CommandBlock>
 
+<Callout type="note" title="Alert rules are not operator-managed">
+
+The OpenBaoCluster controller manages the workload `ServiceMonitor` when `spec.observability.metrics` enables it. `PrometheusRule` resources are user-applied observability objects, so the ServiceAccount or GitOps controller applying the alert rules needs `monitoring.coreos.com` `prometheusrules` permissions in that namespace.
+
+</Callout>
+
 ## Dashboards, logs, and health
 
 <CommandBlock

--- a/internal/service/networking/metrics.go
+++ b/internal/service/networking/metrics.go
@@ -113,10 +113,14 @@ func buildWorkloadServiceMonitor(cluster *openbaov1alpha1.OpenBaoCluster) (*unst
 
 	serviceMonitor := cluster.Spec.Observability.Metrics.ServiceMonitor
 	labels := metricsResourceLabels(cluster)
+	requiredLabels := metricsResourceLabels(cluster)
 	if serviceMonitor != nil {
 		for key, value := range serviceMonitor.Labels {
 			labels[key] = value
 		}
+	}
+	for key, value := range requiredLabels {
+		labels[key] = value
 	}
 
 	endpoint, err := buildServiceMonitorEndpoint(cluster, serviceMonitor)

--- a/internal/service/networking/metrics_test.go
+++ b/internal/service/networking/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
 
 func TestBuildWorkloadServiceMonitor_IncludesAuthTLSAndSelector(t *testing.T) {
@@ -103,6 +104,42 @@ func TestBuildWorkloadServiceMonitor_IncludesAuthTLSAndSelector(t *testing.T) {
 	}
 	if got := selector[metricsScrapeProfileLabel]; got != metricsScrapeProfileActive {
 		t.Fatalf("selector scrape profile = %q", got)
+	}
+}
+
+func TestBuildWorkloadServiceMonitor_PreservesOperatorIdentityLabels(t *testing.T) {
+	cluster := newMinimalCluster("metrics-cluster", "security")
+	cluster.Spec.Observability = &openbaov1alpha1.ObservabilityConfig{
+		Metrics: &openbaov1alpha1.MetricsConfig{
+			Enabled: true,
+			ServiceMonitor: &openbaov1alpha1.ServiceMonitorConfig{
+				Enabled: true,
+				Labels: map[string]string{
+					constants.LabelAppManagedBy:   "user",
+					constants.LabelOpenBaoCluster: "other-cluster",
+					constants.LabelAppComponent:   "custom",
+					"release":                     "kube-prometheus-stack",
+				},
+			},
+		},
+	}
+
+	monitor, err := buildWorkloadServiceMonitor(cluster)
+	if err != nil {
+		t.Fatalf("buildWorkloadServiceMonitor() error = %v", err)
+	}
+	labels := monitor.GetLabels()
+	if got := labels[constants.LabelAppManagedBy]; got != constants.LabelValueAppManagedByOpenBaoOperator {
+		t.Fatalf("managed-by label = %q, want %q", got, constants.LabelValueAppManagedByOpenBaoOperator)
+	}
+	if got := labels[constants.LabelOpenBaoCluster]; got != cluster.Name {
+		t.Fatalf("cluster label = %q, want %q", got, cluster.Name)
+	}
+	if got := labels[constants.LabelAppComponent]; got != metricsComponentLabelValue {
+		t.Fatalf("component label = %q, want %q", got, metricsComponentLabelValue)
+	}
+	if got := labels["release"]; got != "kube-prometheus-stack" {
+		t.Fatalf("user label = %q", got)
 	}
 }
 

--- a/internal/service/provisioner/manager_test.go
+++ b/internal/service/provisioner/manager_test.go
@@ -328,8 +328,9 @@ func TestEnsureTenantRBAC_UpdatesRoleWhenRulesChange(t *testing.T) {
 	}
 
 	// Verify rules were updated
-	if len(role.Rules) != 15 {
-		t.Errorf("Role rules count = %v, want 15", len(role.Rules))
+	expectedRules := len(GenerateTenantRole(namespace).Rules)
+	if len(role.Rules) != expectedRules {
+		t.Errorf("Role rules count = %v, want %v", len(role.Rules), expectedRules)
 	}
 
 	// Verify at least one rule has the expected OpenBaoCluster permissions

--- a/internal/service/provisioner/rbac.go
+++ b/internal/service/provisioner/rbac.go
@@ -8,13 +8,14 @@ import (
 )
 
 var (
-	verbsReadOnly     = []string{"get", "list", "watch"}
-	verbsManage       = []string{"create", "delete", "get", "list", "patch", "update", "watch"}
-	verbsEventWrite   = []string{"create", "patch"}
-	verbsPodManage    = []string{"delete", "get", "list", "patch", "update", "watch"}
-	verbsSecretRead   = []string{"get"}
-	verbsSecretCreate = []string{"create"}
-	verbsSecretMutate = []string{"delete", "get", "patch", "update"}
+	verbsReadOnly             = []string{"get", "list", "watch"}
+	verbsManage               = []string{"create", "delete", "get", "list", "patch", "update", "watch"}
+	verbsEventWrite           = []string{"create", "patch"}
+	verbsPodManage            = []string{"delete", "get", "list", "patch", "update", "watch"}
+	verbsServiceMonitorManage = []string{"create", "delete", "get", "patch"}
+	verbsSecretRead           = []string{"get"}
+	verbsSecretCreate         = []string{"create"}
+	verbsSecretMutate         = []string{"delete", "get", "patch", "update"}
 )
 
 func cloneStrings(in []string) []string {
@@ -109,6 +110,11 @@ func GenerateTenantRole(namespace string) *rbacv1.Role {
 			APIGroups: []string{"gateway.networking.k8s.io"},
 			Resources: []string{"httproutes", "tlsroutes", "backendtlspolicies"},
 			Verbs:     cloneStrings(verbsManage),
+		},
+		{
+			APIGroups: []string{"monitoring.coreos.com"},
+			Resources: []string{"servicemonitors"},
+			Verbs:     cloneStrings(verbsServiceMonitorManage),
 		},
 		{
 			APIGroups: []string{"rbac.authorization.k8s.io"},

--- a/internal/service/provisioner/rbac_test.go
+++ b/internal/service/provisioner/rbac_test.go
@@ -20,19 +20,19 @@ func TestGenerateTenantRole(t *testing.T) {
 			name:      "default namespace",
 			namespace: "default",
 			wantName:  TenantRoleName,
-			wantRules: 15, // Expected number of PolicyRules
+			wantRules: 16, // Expected number of PolicyRules
 		},
 		{
 			name:      "custom namespace",
 			namespace: "tenant-1",
 			wantName:  TenantRoleName,
-			wantRules: 15,
+			wantRules: 16,
 		},
 		{
 			name:      "namespace with special characters",
 			namespace: "my-namespace-123",
 			wantName:  TenantRoleName,
-			wantRules: 15,
+			wantRules: 16,
 		},
 	}
 
@@ -74,6 +74,8 @@ func TestGenerateTenantRole(t *testing.T) {
 			hasStatefulSetRule := false
 			hasPodRule := false
 			hasEventsK8sRule := false
+			hasServiceMonitorRule := false
+			hasPrometheusRuleRule := false
 			hasQuotaOrLimitRangeRule := false
 
 			for _, rule := range role.Rules {
@@ -110,6 +112,25 @@ func TestGenerateTenantRole(t *testing.T) {
 					hasEventsK8sRule = true
 				}
 
+				if slices.Contains(rule.APIGroups, "monitoring.coreos.com") &&
+					slices.Contains(rule.Resources, "servicemonitors") &&
+					slices.Contains(rule.Verbs, "get") &&
+					slices.Contains(rule.Verbs, "create") &&
+					slices.Contains(rule.Verbs, "patch") &&
+					slices.Contains(rule.Verbs, "delete") {
+					for _, forbiddenVerb := range []string{"list", "update", "watch"} {
+						if slices.Contains(rule.Verbs, forbiddenVerb) {
+							t.Errorf("GenerateTenantRole() ServiceMonitor rule unexpectedly grants %q", forbiddenVerb)
+						}
+					}
+					hasServiceMonitorRule = true
+				}
+
+				if slices.Contains(rule.APIGroups, "monitoring.coreos.com") &&
+					slices.Contains(rule.Resources, "prometheusrules") {
+					hasPrometheusRuleRule = true
+				}
+
 				if slices.Contains(rule.Resources, "resourcequotas") || slices.Contains(rule.Resources, "limitranges") {
 					hasQuotaOrLimitRangeRule = true
 				}
@@ -126,6 +147,12 @@ func TestGenerateTenantRole(t *testing.T) {
 			}
 			if !hasEventsK8sRule {
 				t.Error("GenerateTenantRole() missing events.k8s.io Events rule")
+			}
+			if !hasServiceMonitorRule {
+				t.Error("GenerateTenantRole() missing monitoring.coreos.com ServiceMonitor rule")
+			}
+			if hasPrometheusRuleRule {
+				t.Error("GenerateTenantRole() unexpectedly includes PrometheusRule permissions")
 			}
 			if hasQuotaOrLimitRangeRule {
 				t.Error("GenerateTenantRole() unexpectedly includes ResourceQuota/LimitRange permissions")

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -183,6 +183,9 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	var maintenanceAuthorizedExpression string
 	var maintenanceClusterNameExpression string
 	var isManagedExpression string
+	var isServiceMonitorRequestExpression string
+	var currentServiceMonitorOwnedExpression string
+	var oldServiceMonitorOwnedExpression string
 	for _, variable := range variables {
 		variableMap, ok := variable.(map[string]any)
 		if !ok {
@@ -199,6 +202,12 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			maintenanceClusterNameExpression = expression
 		case "is_managed":
 			isManagedExpression = expression
+		case "is_service_monitor_request":
+			isServiceMonitorRequestExpression = expression
+		case "current_service_monitor_is_operator_owned":
+			currentServiceMonitorOwnedExpression = expression
+		case "old_service_monitor_is_operator_owned":
+			oldServiceMonitorOwnedExpression = expression
 		}
 	}
 
@@ -231,6 +240,48 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			"maintenance_authorized expression does not check the custom maintenance verb: %q",
 			maintenanceAuthorizedExpression,
 		)
+	}
+	if !strings.Contains(isServiceMonitorRequestExpression, `request.kind.group == "monitoring.coreos.com"`) ||
+		!strings.Contains(isServiceMonitorRequestExpression, `request.kind.kind == "ServiceMonitor"`) {
+		t.Fatalf("is_service_monitor_request expression does not target ServiceMonitors: %q", isServiceMonitorRequestExpression)
+	}
+	if !strings.Contains(currentServiceMonitorOwnedExpression, `object.metadata.name.endsWith("-metrics")`) ||
+		!strings.Contains(currentServiceMonitorOwnedExpression, `"app.kubernetes.io/managed-by"`) ||
+		!strings.Contains(currentServiceMonitorOwnedExpression, `"openbao.org/cluster"`) ||
+		!strings.Contains(currentServiceMonitorOwnedExpression, `ref.kind == "OpenBaoCluster"`) ||
+		!strings.Contains(currentServiceMonitorOwnedExpression, `has(ref.controller)`) {
+		t.Fatalf("current ServiceMonitor ownership expression is incomplete: %q", currentServiceMonitorOwnedExpression)
+	}
+	if !strings.Contains(oldServiceMonitorOwnedExpression, `oldObject.metadata.name.endsWith("-metrics")`) ||
+		!strings.Contains(oldServiceMonitorOwnedExpression, `"app.kubernetes.io/managed-by"`) ||
+		!strings.Contains(oldServiceMonitorOwnedExpression, `"openbao.org/cluster"`) ||
+		!strings.Contains(oldServiceMonitorOwnedExpression, `ref.kind == "OpenBaoCluster"`) ||
+		!strings.Contains(oldServiceMonitorOwnedExpression, `has(ref.controller)`) {
+		t.Fatalf("old ServiceMonitor ownership expression is incomplete: %q", oldServiceMonitorOwnedExpression)
+	}
+
+	validations, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "validations")
+	if err != nil || !found {
+		t.Fatalf("read policy validations: found=%v err=%v", found, err)
+	}
+	var foundServiceMonitorOwnershipGuard bool
+	for _, validation := range validations {
+		validationMap, ok := validation.(map[string]any)
+		if !ok {
+			continue
+		}
+		message, _ := validationMap["message"].(string)
+		expression, _ := validationMap["expression"].(string)
+		if strings.Contains(message, "ServiceMonitors that match the OpenBao metrics ownership shape") &&
+			strings.Contains(expression, "variables.is_operator_controller") &&
+			strings.Contains(expression, "variables.current_service_monitor_is_operator_owned") &&
+			strings.Contains(expression, "variables.old_service_monitor_is_operator_owned") {
+			foundServiceMonitorOwnershipGuard = true
+			break
+		}
+	}
+	if !foundServiceMonitorOwnershipGuard {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy missing ServiceMonitor ownership guard")
 	}
 }
 
@@ -677,6 +728,7 @@ func TestKustomizeSingleTenantOverlay_BakesInNamespaceScopeAndRemovesProvisioner
 	objs := parseYAMLToUnstructured(t, yamlBytes, nil)
 
 	var controller *unstructured.Unstructured
+	var singleTenantRole *unstructured.Unstructured
 	var singleTenantBinding *unstructured.Unstructured
 	var hasOperatorNamespace bool
 
@@ -692,6 +744,10 @@ func TestKustomizeSingleTenantOverlay_BakesInNamespaceScopeAndRemovesProvisioner
 			if obj.GetName() == testControllerSAName {
 				controller = obj
 			}
+		case "ClusterRole":
+			if obj.GetName() == "openbao-operator-single-tenant" {
+				singleTenantRole = obj
+			}
 		case "RoleBinding":
 			if obj.GetName() == "openbao-operator-single-tenant" {
 				singleTenantBinding = obj
@@ -704,6 +760,9 @@ func TestKustomizeSingleTenantOverlay_BakesInNamespaceScopeAndRemovesProvisioner
 	}
 	if controller == nil {
 		t.Fatal("single-tenant overlay missing controller deployment")
+	}
+	if singleTenantRole == nil {
+		t.Fatal("single-tenant overlay missing controller ClusterRole")
 	}
 	if singleTenantBinding == nil {
 		t.Fatal("single-tenant overlay missing target namespace rolebinding")
@@ -719,6 +778,13 @@ func TestKustomizeSingleTenantOverlay_BakesInNamespaceScopeAndRemovesProvisioner
 	if got := kustomizeEnvVarValue(t, controller, "WATCH_NAMESPACE"); got != testSingleTenantTargetNS {
 		t.Fatalf("WATCH_NAMESPACE = %q, want %q", got, testSingleTenantTargetNS)
 	}
+	assertClusterRoleHasResourceRule(
+		t,
+		singleTenantRole,
+		"monitoring.coreos.com",
+		"servicemonitors",
+		[]string{"create", "delete", "get", "patch"},
+	)
 
 	subjects, found, err := unstructured.NestedSlice(singleTenantBinding.Object, "subjects")
 	if err != nil || !found || len(subjects) != 1 {
@@ -734,6 +800,45 @@ func TestKustomizeSingleTenantOverlay_BakesInNamespaceScopeAndRemovesProvisioner
 	if got, _ := subject["namespace"].(string); got != testDefaultOperatorNS {
 		t.Fatalf("rolebinding subject namespace = %q, want %q", got, testDefaultOperatorNS)
 	}
+}
+
+func assertClusterRoleHasResourceRule(
+	t *testing.T,
+	role *unstructured.Unstructured,
+	apiGroup string,
+	resource string,
+	verbs []string,
+) {
+	t.Helper()
+
+	rules, found, err := unstructured.NestedSlice(role.Object, "rules")
+	if err != nil || !found {
+		t.Fatalf("read %s rules: found=%v err=%v", role.GetName(), found, err)
+	}
+
+	for _, rule := range rules {
+		ruleMap, ok := rule.(map[string]any)
+		if !ok {
+			continue
+		}
+		apiGroups, _ := ruleMap["apiGroups"].([]any)
+		resources, _ := ruleMap["resources"].([]any)
+		ruleVerbs, _ := ruleMap["verbs"].([]any)
+		if !containsAny(apiGroups, apiGroup) || !containsAny(resources, resource) {
+			continue
+		}
+		if len(ruleVerbs) != len(verbs) {
+			t.Fatalf("%s rule for %s/%s verbs = %#v, want exactly %#v", role.GetName(), apiGroup, resource, ruleVerbs, verbs)
+		}
+		for _, verb := range verbs {
+			if !containsAny(ruleVerbs, verb) {
+				t.Fatalf("%s rule for %s/%s missing verb %q: %#v", role.GetName(), apiGroup, resource, verb, ruleMap)
+			}
+		}
+		return
+	}
+
+	t.Fatalf("%s missing rule for %s/%s", role.GetName(), apiGroup, resource)
 }
 
 func failIfProvisionerObject(t *testing.T, obj *unstructured.Unstructured) {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -49,6 +49,7 @@ func TestMain(m *testing.M) {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "config", "crd", "bases"),
 			filepath.Join("..", "manifests", "gateway-api", "v1.5.1", "crds"),
+			filepath.Join("..", "manifests", "prometheus-operator", "v0.91.0", "crds"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -11,10 +11,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	provisionerpkg "github.com/dc-tec/openbao-operator/internal/service/provisioner"
 )
 
@@ -184,6 +186,67 @@ func grantClusterMaintenanceAccess(t *testing.T, namespace, clusterName, usernam
 	}
 }
 
+func createClusterForServiceMonitorGuard(t *testing.T, namespace, clusterName string) *openbaov1alpha1.OpenBaoCluster {
+	t.Helper()
+
+	cluster := newMinimalClusterObj(namespace, clusterName)
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("create OpenBaoCluster %s/%s: %v", namespace, clusterName, err)
+	}
+	var persisted openbaov1alpha1.OpenBaoCluster
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, &persisted); err != nil {
+		t.Fatalf("get OpenBaoCluster %s/%s: %v", namespace, clusterName, err)
+	}
+	return &persisted
+}
+
+func newServiceMonitorObject(namespace, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("monitoring.coreos.com/v1")
+	obj.SetKind("ServiceMonitor")
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	obj.Object["spec"] = map[string]interface{}{
+		"endpoints": []interface{}{
+			map[string]interface{}{
+				"port": "metrics",
+				"path": "/v1/sys/metrics",
+			},
+		},
+		"namespaceSelector": map[string]interface{}{
+			"matchNames": []interface{}{namespace},
+		},
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				constants.LabelAppName: constants.LabelValueAppNameOpenBao,
+			},
+		},
+	}
+	return obj
+}
+
+func newOwnedServiceMonitorObject(cluster *openbaov1alpha1.OpenBaoCluster) *unstructured.Unstructured {
+	obj := newServiceMonitorObject(cluster.Namespace, cluster.Name+"-metrics")
+	obj.SetLabels(map[string]string{
+		constants.LabelAppName:          constants.LabelValueAppNameOpenBao,
+		constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelAppComponent:     "metrics",
+		constants.LabelOpenBaoComponent: "metrics",
+		constants.LabelOpenBaoCluster:   cluster.Name,
+	})
+	controller := true
+	obj.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: "openbao.org/v1alpha1",
+			Kind:       "OpenBaoCluster",
+			Name:       cluster.Name,
+			UID:        cluster.UID,
+			Controller: &controller,
+		},
+	})
+	return obj
+}
+
 func createManagedMaintenancePod(t *testing.T, c client.Client, namespace, clusterName, podName string) {
 	t.Helper()
 
@@ -226,6 +289,87 @@ func createManagedMaintenancePod(t *testing.T, c client.Client, namespace, clust
 	}
 	if err := c.Create(ctx, pod); err != nil {
 		t.Fatalf("create managed maintenance pod: %v", err)
+	}
+}
+
+func TestVAP_LockManagedRBAC_RestrictsOperatorServiceMonitorOwnership(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	controllerClient := newPrivilegedImpersonatedClient(t, controllerUsername)
+
+	rogue := newServiceMonitorObject(namespace, "rogue-monitor")
+	var rogueDenied bool
+	for attempt := 0; attempt < 25; attempt++ {
+		err := controllerClient.Create(ctx, rogue.DeepCopy())
+		if err == nil {
+			_ = k8sClient.Delete(ctx, rogue)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		if !strings.Contains(err.Error(), "ServiceMonitors that match the OpenBao metrics ownership shape") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+		rogueDenied = true
+		break
+	}
+	if !rogueDenied {
+		t.Fatalf("expected VAP to deny operator-created rogue ServiceMonitor after retries")
+	}
+
+	ownedCluster := createClusterForServiceMonitorGuard(t, namespace, "owned")
+	ownedMonitor := newOwnedServiceMonitorObject(ownedCluster)
+	if err := controllerClient.Create(ctx, ownedMonitor); err != nil {
+		t.Fatalf("expected owned ServiceMonitor create to succeed, got: %v", err)
+	}
+
+	var latestOwned unstructured.Unstructured
+	latestOwned.SetAPIVersion("monitoring.coreos.com/v1")
+	latestOwned.SetKind("ServiceMonitor")
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ownedMonitor.GetName()}, &latestOwned); err != nil {
+		t.Fatalf("get owned ServiceMonitor: %v", err)
+	}
+	originalOwned := latestOwned.DeepCopy()
+	latestOwned.SetAnnotations(map[string]string{"example.com/reconcile": "true"})
+	if err := controllerClient.Patch(ctx, &latestOwned, client.MergeFrom(originalOwned)); err != nil {
+		t.Fatalf("expected owned ServiceMonitor update to succeed, got: %v", err)
+	}
+
+	takeoverCluster := createClusterForServiceMonitorGuard(t, namespace, "takeover")
+	userOwned := newServiceMonitorObject(namespace, "takeover-metrics")
+	userOwned.SetLabels(map[string]string{
+		"release": "kube-prometheus-stack",
+	})
+	if err := k8sClient.Create(ctx, userOwned); err != nil {
+		t.Fatalf("create user-owned ServiceMonitor: %v", err)
+	}
+
+	var latestUserOwned unstructured.Unstructured
+	latestUserOwned.SetAPIVersion("monitoring.coreos.com/v1")
+	latestUserOwned.SetKind("ServiceMonitor")
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: userOwned.GetName()}, &latestUserOwned); err != nil {
+		t.Fatalf("get user-owned ServiceMonitor: %v", err)
+	}
+	originalUserOwned := latestUserOwned.DeepCopy()
+	ownedShape := newOwnedServiceMonitorObject(takeoverCluster)
+	latestUserOwned.SetLabels(ownedShape.GetLabels())
+	latestUserOwned.SetOwnerReferences(ownedShape.GetOwnerReferences())
+	err := controllerClient.Patch(ctx, &latestUserOwned, client.MergeFrom(originalUserOwned))
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "ServiceMonitors that match the OpenBao metrics ownership shape") {
+		t.Fatalf("unexpected takeover error message: %v", err)
+	}
+
+	err = controllerClient.Delete(ctx, userOwned)
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "ServiceMonitors that match the OpenBao metrics ownership shape") {
+		t.Fatalf("unexpected delete error message: %v", err)
+	}
+
+	if err := controllerClient.Delete(ctx, ownedMonitor); err != nil {
+		t.Fatalf("expected owned ServiceMonitor delete to succeed, got: %v", err)
 	}
 }
 

--- a/test/manifests/prometheus-operator/v0.91.0/README.md
+++ b/test/manifests/prometheus-operator/v0.91.0/README.md
@@ -1,0 +1,19 @@
+# Prometheus Operator manifests (v0.91.0)
+
+This directory vendors the Prometheus Operator ServiceMonitor CRD for use in local and CI testing.
+
+- Version: `v0.91.0`
+- Source: https://github.com/prometheus-operator/prometheus-operator/blob/v0.91.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+- Used by: `envtest` suites that validate operator-managed ServiceMonitor admission behavior
+
+## Contents
+
+- `crds/monitoring.coreos.com_servicemonitors.yaml`: ServiceMonitor CRD copied from the upstream Prometheus Operator release.
+
+## Updating
+
+If you bump the Prometheus Operator CRD version:
+
+1. Replace `crds/monitoring.coreos.com_servicemonitors.yaml` with the matching upstream release file.
+2. Update envtest suites that reference this path.
+3. Run `go test -tags=integration ./test/integration` to validate envtest still boots and ServiceMonitor resources can be created.

--- a/test/manifests/prometheus-operator/v0.91.0/crds/monitoring.coreos.com_servicemonitors.yaml
+++ b/test/manifests/prometheus-operator/v0.91.0/crds/monitoring.coreos.com_servicemonitors.yaml
@@ -1,0 +1,1412 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    shortNames:
+    - smon
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The `ServiceMonitor` custom resource definition (CRD) defines how `Prometheus` and `PrometheusAgent` can scrape metrics from a group of services.
+          Among other things, it allows to specify:
+          * The services to scrape via label selectors.
+          * The container ports to scrape.
+          * Authentication credentials to use.
+          * Target and metric relabeling.
+
+          `Prometheus` and `PrometheusAgent` objects select `ServiceMonitor` objects using label and namespace selectors.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              spec defines the specification of desired Service selection for target discovery by
+              Prometheus.
+            properties:
+              attachMetadata:
+                description: |-
+                  attachMetadata defines additional metadata which is added to the
+                  discovered targets.
+
+                  It requires Prometheus >= v2.37.0.
+                properties:
+                  node:
+                    description: |-
+                      node when set to true, Prometheus attaches node metadata to the discovered
+                      targets.
+
+                      The Prometheus service account must have the `list` and `watch`
+                      permissions on the `Nodes` objects.
+                    type: boolean
+                type: object
+              bodySizeLimit:
+                description: |-
+                  bodySizeLimit when defined, bodySizeLimit specifies a job level limit on the size
+                  of uncompressed response body that will be accepted by Prometheus.
+
+                  It requires Prometheus >= v2.28.0.
+                pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                type: string
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
+              endpoints:
+                description: |-
+                  endpoints defines the list of endpoints part of this ServiceMonitor.
+                  Defines how to scrape metrics from Kubernetes [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) objects.
+                  In most cases, an Endpoints object is backed by a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object with the same name and labels.
+                items:
+                  description: |-
+                    Endpoint defines an endpoint serving Prometheus metrics to be scraped by
+                    Prometheus.
+                  properties:
+                    authorization:
+                      description: |-
+                        authorization configures the Authorization header credentials used by
+                        the client.
+
+                        Cannot be set at the same time as `basicAuth`, `bearerTokenSecret` or `oauth2`.
+                      properties:
+                        credentials:
+                          description: credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: |-
+                        basicAuth defines the Basic Authentication credentials used by the
+                        client.
+
+                        Cannot be set at the same time as `authorization`, `bearerTokenSecret` or `oauth2`.
+                      properties:
+                        password:
+                          description: |-
+                            password defines a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            username defines a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    bearerTokenFile:
+                      description: |-
+                        bearerTokenFile defines the file to read bearer token for scraping the target.
+
+                        Deprecated: use `authorization` instead.
+                      type: string
+                    bearerTokenSecret:
+                      description: |-
+                        bearerTokenSecret defines a key of a Secret containing the bearer token
+                        used by the client for authentication. The secret needs to be in the
+                        same namespace as the custom resource and readable by the Prometheus
+                        Operator.
+
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `oauth2`.
+
+                        Deprecated: use `authorization` instead.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    enableHttp2:
+                      description: enableHttp2 can be used to disable HTTP2.
+                      type: boolean
+                    filterRunning:
+                      description: |-
+                        filterRunning when true, the pods which are not running (e.g. either in Failed or
+                        Succeeded state) are dropped during the target discovery.
+
+                        If unset, the filtering is enabled.
+
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+                      type: boolean
+                    followRedirects:
+                      description: |-
+                        followRedirects defines whether the client should follow HTTP 3xx
+                        redirects.
+                      type: boolean
+                    honorLabels:
+                      description: |-
+                        honorLabels defines when true the metric's labels when they collide
+                        with the target's labels.
+                      type: boolean
+                    honorTimestamps:
+                      description: |-
+                        honorTimestamps defines whether Prometheus preserves the timestamps
+                        when exposed by the target.
+                      type: boolean
+                    interval:
+                      description: |-
+                        interval at which Prometheus scrapes the metrics from the target.
+
+                        If empty, Prometheus uses the global scrape interval.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    metricRelabelings:
+                      description: |-
+                        metricRelabelings defines the relabeling rules to apply to the
+                        samples before ingestion.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against
+                              which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated
+                              SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description: |-
+                        oauth2 defines the OAuth2 settings used by the client.
+
+                        It requires Prometheus >= 2.27.0.
+
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `bearerTokenSecret`.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description: configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description: scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description: ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description: configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description: secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description: cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description: configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description: secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description: insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description: keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                              type: string
+                            serverName:
+                              description: serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description: tokenUrl defines the URL to fetch the token
+                            from.
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
+                    params:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: params define optional HTTP URL parameters.
+                      type: object
+                    path:
+                      description: |-
+                        path defines the HTTP path from which to scrape for metrics.
+
+                        If empty, Prometheus uses the default value (e.g. `/metrics`).
+                      type: string
+                    port:
+                      description: |-
+                        port defines the name of the Service port which this endpoint refers to.
+
+                        It takes precedence over `targetPort`.
+                      type: string
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    relabelings:
+                      description: |-
+                        relabelings defines the relabeling rules to apply the target's
+                        metadata labels.
+
+                        The Operator automatically adds relabelings for a few standard Kubernetes fields.
+
+                        The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against
+                              which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated
+                              SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    scheme:
+                      description: scheme defines the HTTP scheme to use when scraping
+                        the metrics.
+                      enum:
+                      - http
+                      - https
+                      - HTTP
+                      - HTTPS
+                      type: string
+                    scrapeTimeout:
+                      description: |-
+                        scrapeTimeout defines the timeout after which Prometheus considers the scrape to be failed.
+
+                        If empty, Prometheus uses the global scrape timeout unless it is less
+                        than the target's scrape interval value in which the latter is used.
+                        The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    targetPort:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        targetPort defines the name or number of the target port of the `Pod` object behind the
+                        Service. The port must be specified with the container's port property.
+                      x-kubernetes-int-or-string: true
+                    tlsConfig:
+                      description: tlsConfig defines TLS configuration used by the
+                        client.
+                      properties:
+                        ca:
+                          description: ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description: configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        caFile:
+                          description: caFile defines the path to the CA cert in the
+                            Prometheus container to use for the targets.
+                          type: string
+                        cert:
+                          description: cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        certFile:
+                          description: certFile defines the path to the client cert
+                            file in the Prometheus container for the targets.
+                          type: string
+                        insecureSkipVerify:
+                          description: insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keyFile:
+                          description: keyFile defines the path to the client key
+                            file in the Prometheus container for the targets.
+                          type: string
+                        keySecret:
+                          description: keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        serverName:
+                          description: serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                    trackTimestampsStaleness:
+                      description: |-
+                        trackTimestampsStaleness defines whether Prometheus tracks staleness of
+                        the metrics that have an explicit timestamp present in scraped data.
+                        Has no effect if `honorTimestamps` is false.
+
+                        It requires Prometheus >= v2.48.0.
+                      type: boolean
+                  type: object
+                type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
+              jobLabel:
+                description: |-
+                  jobLabel selects the label from the associated Kubernetes `Service`
+                  object which will be used as the `job` label for all metrics.
+
+                  For example if `jobLabel` is set to `foo` and the Kubernetes `Service`
+                  object is labeled with `foo: bar`, then Prometheus adds the `job="bar"`
+                  label to all ingested metrics.
+
+                  If the value of this field is empty or if the label doesn't exist for
+                  the given Service, the `job` label of the metrics defaults to the name
+                  of the associated Kubernetes `Service`.
+                type: string
+              keepDroppedTargets:
+                description: |-
+                  keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
+                  that will be kept in memory. 0 means no limit.
+
+                  It requires Prometheus >= v2.47.0.
+                format: int64
+                type: integer
+              labelLimit:
+                description: |-
+                  labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
+
+                  It requires Prometheus >= v2.27.0.
+                format: int64
+                type: integer
+              labelNameLengthLimit:
+                description: |-
+                  labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
+
+                  It requires Prometheus >= v2.27.0.
+                format: int64
+                type: integer
+              labelValueLengthLimit:
+                description: |-
+                  labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
+
+                  It requires Prometheus >= v2.27.0.
+                format: int64
+                type: integer
+              namespaceSelector:
+                description: |-
+                  namespaceSelector defines in which namespace(s) Prometheus should discover the services.
+                  By default, the services are discovered in the same namespace as the `ServiceMonitor` object but it is possible to select pods across different/all namespaces.
+                properties:
+                  any:
+                    description: |-
+                      any defines the boolean describing whether all namespaces are selected in contrast to a
+                      list restricting them.
+                    type: boolean
+                  matchNames:
+                    description: matchNames defines the list of namespace names to
+                      select from.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              nativeHistogramBucketLimit:
+                description: |-
+                  nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
+                  buckets will be merged to stay within the limit.
+                  It requires Prometheus >= v2.45.0.
+                format: int64
+                type: integer
+              nativeHistogramMinBucketFactor:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
+                  buckets will be merged to increase the factor sufficiently.
+                  It requires Prometheus >= v2.50.0.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              podTargetLabels:
+                description: |-
+                  podTargetLabels defines the labels which are transferred from the
+                  associated Kubernetes `Pod` object onto the ingested metrics.
+                items:
+                  type: string
+                type: array
+              sampleLimit:
+                description: |-
+                  sampleLimit defines a per-scrape limit on the number of scraped samples
+                  that will be accepted.
+                format: int64
+                type: integer
+              scrapeClass:
+                description: scrapeClass defines the scrape class to apply.
+                minLength: 1
+                type: string
+              scrapeClassicHistograms:
+                description: |-
+                  scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.
+                  It requires Prometheus >= v2.45.0.
+
+                  Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
+                type: boolean
+              scrapeNativeHistograms:
+                description: |-
+                  scrapeNativeHistograms defines whether to enable scraping of native histograms.
+                  It requires Prometheus >= v3.8.0.
+                type: boolean
+              scrapeProtocols:
+                description: |-
+                  scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
+                  protocols supported by Prometheus in order of preference (from most to least preferred).
+
+                  If unset, Prometheus uses its default value.
+
+                  It requires Prometheus >= v2.49.0.
+                items:
+                  description: |-
+                    ScrapeProtocol represents a protocol used by Prometheus for scraping metrics.
+                    Supported values are:
+                    * `OpenMetricsText0.0.1`
+                    * `OpenMetricsText1.0.0`
+                    * `PrometheusProto`
+                    * `PrometheusText0.0.4`
+                    * `PrometheusText1.0.0`
+                  enum:
+                  - PrometheusProto
+                  - OpenMetricsText0.0.1
+                  - OpenMetricsText1.0.0
+                  - PrometheusText0.0.4
+                  - PrometheusText1.0.0
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              selector:
+                description: selector defines the label selector to select the Kubernetes
+                  `Endpoints` objects to scrape metrics from.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              selectorMechanism:
+                description: |-
+                  selectorMechanism defines the mechanism used to select the endpoints to scrape.
+                  By default, the selection process relies on relabel configurations to filter the discovered targets.
+                  Alternatively, you can opt in for role selectors, which may offer better efficiency in large clusters.
+                  Which strategy is best for your use case needs to be carefully evaluated.
+
+                  It requires Prometheus >= v2.17.0.
+                enum:
+                - RelabelConfig
+                - RoleSelector
+                type: string
+              serviceDiscoveryRole:
+                description: |-
+                  serviceDiscoveryRole defines the service discovery role used to discover targets.
+
+                  If set, the value should be either "Endpoints" or "EndpointSlice".
+                  Otherwise it defaults to the value defined in the
+                  Prometheus/PrometheusAgent resource.
+                enum:
+                - Endpoints
+                - EndpointSlice
+                type: string
+              targetLabels:
+                description: |-
+                  targetLabels defines the labels which are transferred from the
+                  associated Kubernetes `Service` object onto the ingested metrics.
+                items:
+                  type: string
+                type: array
+              targetLimit:
+                description: |-
+                  targetLimit defines a limit on the number of scraped targets that will
+                  be accepted.
+                format: int64
+                type: integer
+            required:
+            - endpoints
+            - selector
+            type: object
+          status:
+            description: |-
+              status defines the status subresource. It is under active development and is updated only when the
+              "StatusForConfigurationResources" feature gate is enabled.
+
+              Most recent observed status of the ServiceMonitor. Read-only.
+              More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bindings:
+                description: bindings defines the list of workload resources (Prometheus,
+                  PrometheusAgent, ThanosRuler or Alertmanager) which select the configuration
+                  resource.
+                items:
+                  description: WorkloadBinding is a link between a configuration resource
+                    and a workload resource.
+                  properties:
+                    conditions:
+                      description: conditions defines the current state of the configuration
+                        resource when bound to the referenced Workload object.
+                      items:
+                        description: ConfigResourceCondition describes the status
+                          of configuration resources linked to Prometheus, PrometheusAgent,
+                          Alertmanager or ThanosRuler.
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime defines the time of the
+                              last update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message defines the human-readable message
+                              indicating details for the condition's last transition.
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration defines the .metadata.generation that the
+                              condition was set based upon. For instance, if `.metadata.generation` is
+                              currently 12, but the `.status.conditions[].observedGeneration` is 9, the
+                              condition is out of date with respect to the current state of the object.
+                            format: int64
+                            type: integer
+                          reason:
+                            description: reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: status of the condition.
+                            minLength: 1
+                            type: string
+                          type:
+                            description: |-
+                              type of the condition being reported.
+                              Currently, only "Accepted" is supported.
+                            enum:
+                            - Accepted
+                            minLength: 1
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    group:
+                      description: group defines the group of the referenced resource.
+                      enum:
+                      - monitoring.coreos.com
+                      type: string
+                    name:
+                      description: name defines the name of the referenced object.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: namespace defines the namespace of the referenced
+                        object.
+                      minLength: 1
+                      type: string
+                    resource:
+                      description: resource defines the type of resource being referenced
+                        (e.g. Prometheus, PrometheusAgent, ThanosRuler or Alertmanager).
+                      enum:
+                      - prometheuses
+                      - prometheusagents
+                      - thanosrulers
+                      - alertmanagers
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/utils/policy_restrict_provisioner_rbac_test.go
+++ b/test/utils/policy_restrict_provisioner_rbac_test.go
@@ -47,6 +47,30 @@ func TestRestrictProvisionerRBACPolicyContainsSecretsRoleGuards(t *testing.T) {
 	}
 }
 
+func TestRestrictProvisionerRBACPolicyAllowsTenantServiceMonitorRule(t *testing.T) {
+	const policyPath = "../../config/policy/openbao-restrict-provisioner-rbac.yaml"
+
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatalf("failed to read policy %s: %v", policyPath, err)
+	}
+
+	policy := string(data)
+	required := []string{
+		"rule.apiGroups[0] == 'monitoring.coreos.com'",
+		"rule.resources[0] == 'servicemonitors'",
+		"rule.verbs.all(v, v in ['create', 'delete', 'get', 'patch'])",
+	}
+	for _, needle := range required {
+		if !containsString(policy, needle) {
+			t.Fatalf("policy %s does not allow the tenant ServiceMonitor rule; missing %q", policyPath, needle)
+		}
+	}
+	if containsString(policy, "prometheusrules") {
+		t.Fatalf("policy %s unexpectedly allows tenant PrometheusRule management", policyPath)
+	}
+}
+
 // containsString performs a simple substring check without introducing extra
 // dependencies. Kept private and local to avoid over-abstracting.
 func containsString(haystack, needle string) bool {


### PR DESCRIPTION
## Summary

Adds narrowly scoped tenant RBAC for operator-managed `ServiceMonitor` reconciliation and hardens the admission path around those mutations.

This change:

- grants the tenant Role only `create`, `delete`, `get`, and `patch` on `monitoring.coreos.com/servicemonitors`
- keeps `PrometheusRule` out of the operator tenant Role because alerting rules remain user/GitOps-applier managed
- adds admission validation so operator/provisioner ServiceMonitor mutations must match the expected OpenBao-owned metrics resource shape
- preserves required operator identity labels when merging user-provided ServiceMonitor labels
- vendors the Prometheus Operator `ServiceMonitor` CRD for envtest-only coverage
- updates RBAC, observability, policy, kustomize, Helm, and integration test coverage

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

RBAC impact is intentionally narrow: tenant-managed OpenBao workloads gain access only to `ServiceMonitor` resources and only with `create`, `delete`, `get`, and `patch`. The operator still does not receive `PrometheusRule` permissions.

Admission impact is restrictive for operator/provisioner principals: managed ServiceMonitor create/update/delete requests must match the expected OpenBao metrics ownership shape, including labels, owner reference, and `<cluster>-metrics` naming. This is intended to prevent accidental or malicious mutation of unrelated ServiceMonitor resources.

No CRD install surface changes are introduced. The vendored Prometheus Operator CRD is used only by envtest integration tests.

## Verification

- `git diff --check origin/main...HEAD`
- `go test ./internal/service/networking ./internal/service/provisioner ./test/utils`
- `go test -tags=integration ./test/integration -run 'TestKustomize|TestVAP_' -count=1`
- `make helm-test`
- pre-push hook: `make lint-ci`

## Reviewer Notes

Please focus review on the ServiceMonitor verb set, the admission ownership predicate, and the decision to keep `PrometheusRule` out of the operator tenant Role. The Prometheus Operator CRD is vendored under `test/manifests/prometheus-operator/v0.91.0` for integration testing only.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
