### PR TITLE
fix(openbao): guard metrics-only listener configuration

### DIFF
--- a/internal/adapter/config/builder.go
+++ b/internal/adapter/config/builder.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	configUnsealKeyPath      = "file:///etc/bao/unseal/key"
-	configUnsealKeyID        = "operator-generated-v1"
-	configMaxRequestDuration = "90s"
-	configNodeIDTemplate     = "${HOSTNAME}"
+	configUnsealKeyPath         = "file:///etc/bao/unseal/key"
+	configUnsealKeyID           = "operator-generated-v1"
+	configMaxRequestDuration    = "90s"
+	configNodeIDTemplate        = "${HOSTNAME}"
+	configScrapeProfileAllNodes = "AllNodes"
 
 	jwtPolicyHealthStepDownAutopilot = `path "sys/health" { capabilities = ["read"] }
 path "sys/step-down" { capabilities = ["sudo", "update"] }
@@ -223,6 +224,11 @@ func validateConfigVersionCompatibility(cluster *openbaov1alpha1.OpenBaoCluster)
 	if cluster == nil {
 		return fmt.Errorf("cluster is required")
 	}
+
+	if err := validateMetricsOnlyListenerCompatibility(cluster); err != nil {
+		return err
+	}
+
 	if cluster.Spec.Configuration == nil || cluster.Spec.Configuration.Plugin == nil {
 		return nil
 	}
@@ -241,6 +247,34 @@ func validateConfigVersionCompatibility(cluster *openbaov1alpha1.OpenBaoCluster)
 	}
 
 	return fmt.Errorf("spec.configuration.plugin.{autoDownload,autoRegister,downloadBehavior} requires OpenBao >= 2.5.0 (spec.version=%q)", cluster.Spec.Version)
+}
+
+func validateMetricsOnlyListenerCompatibility(cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if !workloadMetricsEnabled(cluster) {
+		return nil
+	}
+
+	metrics := cluster.Spec.Observability.Metrics
+	allNodes := strings.TrimSpace(metrics.ScrapeProfile) == configScrapeProfileAllNodes
+	listener := metrics.MetricsOnlyListener
+	if allNodes && listener != nil && listener.Enabled != nil && !*listener.Enabled {
+		return fmt.Errorf("spec.observability.metrics.metricsOnlyListener.enabled cannot be false when scrapeProfile is AllNodes")
+	}
+
+	listenerExplicitlyEnabled := listener != nil && listener.Enabled != nil && *listener.Enabled
+	if !allNodes && !listenerExplicitlyEnabled {
+		return nil
+	}
+
+	ok, err := openBaoVersionAtLeast(cluster.Spec.Version, 2, 5, 0)
+	if err != nil {
+		return fmt.Errorf("failed to validate metrics-only listener version compatibility: %w", err)
+	}
+	if ok {
+		return nil
+	}
+
+	return fmt.Errorf("spec.observability.metrics.metricsOnlyListener requires OpenBao >= 2.5.0 (spec.version=%q)", cluster.Spec.Version)
 }
 
 func openBaoVersionAtLeast(version string, wantMajor, wantMinor, wantPatch int) (bool, error) {

--- a/internal/adapter/config/builder_fuzz_test.go
+++ b/internal/adapter/config/builder_fuzz_test.go
@@ -84,7 +84,7 @@ func FuzzRenderSelfInitHCL(f *testing.F) {
 			bootstrapOn:  false,
 			clusterName:  "demo",
 			clusterNS:    "default",
-			clusterVer:   "2.5.0",
+			clusterVer:   testOpenBaoVersion250,
 		},
 		{
 			name:         "policy",
@@ -96,7 +96,7 @@ func FuzzRenderSelfInitHCL(f *testing.F) {
 			bootstrapOn:  true,
 			clusterName:  "bootstrap",
 			clusterNS:    "operators",
-			clusterVer:   "2.5.0",
+			clusterVer:   testOpenBaoVersion250,
 		},
 		{
 			name:         "",
@@ -206,7 +206,7 @@ func sanitizeVersion(v string) string {
 	if _, err := platformsemver.Parse(v); err == nil {
 		return v
 	}
-	return "2.5.0"
+	return testOpenBaoVersion250
 }
 
 func FuzzRenderHCL(f *testing.F) {
@@ -228,7 +228,7 @@ func FuzzRenderHCL(f *testing.F) {
 		telemetryAddr string
 		enableObs     bool
 	}{
-		{"demo", "default", "2.5.0", "demo", "default", 8200, 8201, "info", "3600h", "7200h", "continue", "file", "stdout", `{"file_path":"stdout"}`, "127.0.0.1:8125", true},
+		{"demo", "default", testOpenBaoVersion250, "demo", "default", 8200, 8201, "info", "3600h", "7200h", "continue", "file", "stdout", `{"file_path":"stdout"}`, "127.0.0.1:8125", true},
 		{"acme", "operators", "2.4.4", "acme", "operators", 8200, 8201, "debug", "", "", "", "socket", "custom-socket", `{"address":"127.0.0.1:9000"}`, "", false},
 		{"broken", "default", "not-a-version", "", "", 0, -1, "", "", "", "", "", "", `{}`, "", false},
 	}

--- a/internal/adapter/config/builder_test.go
+++ b/internal/adapter/config/builder_test.go
@@ -13,6 +13,12 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
 
+const (
+	testOpenBaoVersion250          = "2.5.0"
+	testOpenBaoImage250            = "openbao/openbao:2.5.0"
+	testMetricsListenerVersionHint = "requires OpenBao >= 2.5.0"
+)
+
 func newMinimalCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 	return &openbaov1alpha1.OpenBaoCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -153,8 +159,8 @@ func TestRenderHCLIncludesCoreStanzas(t *testing.T) {
 
 func TestRenderHCLWithStructuredConfiguration(t *testing.T) {
 	cluster := newMinimalCluster("structured-config", "default")
-	cluster.Spec.Version = "2.5.0"
-	cluster.Spec.Image = "openbao/openbao:2.5.0"
+	cluster.Spec.Version = testOpenBaoVersion250
+	cluster.Spec.Image = testOpenBaoImage250
 	uiEnabled := true
 	autoDownload := true
 	autoRegister := false
@@ -230,7 +236,7 @@ func TestRenderHCLRejectsPluginAutoConfigForUnsupportedVersions(t *testing.T) {
 			if err == nil {
 				t.Fatalf("RenderHCL() expected error, got nil")
 			}
-			if !strings.Contains(err.Error(), "requires OpenBao >= 2.5.0") {
+			if !strings.Contains(err.Error(), testMetricsListenerVersionHint) {
 				t.Fatalf("RenderHCL() error = %v, want version gate error", err)
 			}
 		})
@@ -557,10 +563,12 @@ func TestRenderHCLWithObservabilityMetricsTelemetry(t *testing.T) {
 
 func TestRenderHCLWithAllNodeMetricsListener(t *testing.T) {
 	cluster := newMinimalCluster("metrics-listener", "default")
+	cluster.Spec.Version = testOpenBaoVersion250
+	cluster.Spec.Image = testOpenBaoImage250
 	cluster.Spec.Observability = &openbaov1alpha1.ObservabilityConfig{
 		Metrics: &openbaov1alpha1.MetricsConfig{
 			Enabled:       true,
-			ScrapeProfile: "AllNodes",
+			ScrapeProfile: configScrapeProfileAllNodes,
 		},
 	}
 
@@ -591,8 +599,69 @@ func TestRenderHCLWithAllNodeMetricsListener(t *testing.T) {
 	}
 }
 
+func TestRenderHCLWithMetricsOnlyListenerRejectsUnsupportedVersions(t *testing.T) {
+	tests := []struct {
+		name          string
+		configure     func(*openbaov1alpha1.MetricsConfig)
+		wantErrSubstr string
+	}{
+		{
+			name: "all nodes",
+			configure: func(metrics *openbaov1alpha1.MetricsConfig) {
+				metrics.ScrapeProfile = configScrapeProfileAllNodes
+			},
+			wantErrSubstr: testMetricsListenerVersionHint,
+		},
+		{
+			name: "explicit listener",
+			configure: func(metrics *openbaov1alpha1.MetricsConfig) {
+				enabled := true
+				metrics.MetricsOnlyListener = &openbaov1alpha1.MetricsOnlyListenerConfig{
+					Enabled: &enabled,
+				}
+			},
+			wantErrSubstr: testMetricsListenerVersionHint,
+		},
+		{
+			name: "all nodes disabled listener",
+			configure: func(metrics *openbaov1alpha1.MetricsConfig) {
+				enabled := false
+				metrics.ScrapeProfile = configScrapeProfileAllNodes
+				metrics.MetricsOnlyListener = &openbaov1alpha1.MetricsOnlyListenerConfig{
+					Enabled: &enabled,
+				}
+			},
+			wantErrSubstr: "cannot be false when scrapeProfile is AllNodes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newMinimalCluster("metrics-version", "default")
+			metrics := &openbaov1alpha1.MetricsConfig{Enabled: true}
+			tt.configure(metrics)
+			cluster.Spec.Observability = &openbaov1alpha1.ObservabilityConfig{Metrics: metrics}
+
+			_, err := RenderHCL(cluster, InfrastructureDetails{
+				HeadlessServiceName: cluster.Name,
+				Namespace:           cluster.Namespace,
+				APIPort:             8200,
+				ClusterPort:         8201,
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Fatalf("RenderHCL() error = %v, want containing %q", err, tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
 func TestRenderHCLWithMetricsOnlyListenerRejectsACME(t *testing.T) {
 	cluster := newMinimalCluster("metrics-acme", "default")
+	cluster.Spec.Version = testOpenBaoVersion250
+	cluster.Spec.Image = testOpenBaoImage250
 	cluster.Spec.TLS.Mode = openbaov1alpha1.TLSModeACME
 	cluster.Spec.TLS.ACME = &openbaov1alpha1.ACMEConfig{
 		Email:        "platform@example.com",
@@ -602,7 +671,7 @@ func TestRenderHCLWithMetricsOnlyListenerRejectsACME(t *testing.T) {
 	cluster.Spec.Observability = &openbaov1alpha1.ObservabilityConfig{
 		Metrics: &openbaov1alpha1.MetricsConfig{
 			Enabled:       true,
-			ScrapeProfile: "AllNodes",
+			ScrapeProfile: configScrapeProfileAllNodes,
 		},
 	}
 

--- a/internal/adapter/config/render_listener.go
+++ b/internal/adapter/config/render_listener.go
@@ -126,7 +126,7 @@ func metricsOnlyListenerEnabled(cluster *openbaov1alpha1.OpenBaoCluster) bool {
 	if listener != nil && listener.Enabled != nil {
 		return *listener.Enabled
 	}
-	return cluster.Spec.Observability.Metrics.ScrapeProfile == "AllNodes"
+	return cluster.Spec.Observability.Metrics.ScrapeProfile == configScrapeProfileAllNodes
 }
 
 func metricsOnlyListenerPort(cluster *openbaov1alpha1.OpenBaoCluster) int32 {
@@ -146,5 +146,5 @@ func metricsOnlyListenerUnauthenticatedAccess(cluster *openbaov1alpha1.OpenBaoCl
 			return *enabled
 		}
 	}
-	return cluster.Spec.Observability.Metrics.ScrapeProfile == "AllNodes"
+	return cluster.Spec.Observability.Metrics.ScrapeProfile == configScrapeProfileAllNodes
 }

--- a/internal/service/networking/policy_rules.go
+++ b/internal/service/networking/policy_rules.go
@@ -58,8 +58,12 @@ func buildNetworkPolicyIngressRules(
 	}
 
 	if cluster.Spec.Network != nil {
+		trustedIngressPorts := []intstr.IntOrString{apiPort}
+		if metricsOnlyListenerEnabled(cluster) {
+			trustedIngressPorts = append(trustedIngressPorts, intstr.FromInt(int(metricsOnlyListenerPort(cluster))))
+		}
 		for _, peer := range cluster.Spec.Network.TrustedIngressPeers {
-			rules = appendIngressPeerRule(rules, peer, apiPort)
+			rules = appendIngressPeerRule(rules, peer, trustedIngressPorts...)
 		}
 	}
 
@@ -103,16 +107,18 @@ func buildNetworkPolicyIngressRules(
 func appendIngressPeerRule(
 	rules []networkingv1.NetworkPolicyIngressRule,
 	peer networkingv1.NetworkPolicyPeer,
-	apiPort intstr.IntOrString,
+	ports ...intstr.IntOrString,
 ) []networkingv1.NetworkPolicyIngressRule {
+	networkPolicyPorts := make([]networkingv1.NetworkPolicyPort, 0, len(ports))
+	for _, port := range ports {
+		networkPolicyPorts = append(networkPolicyPorts, networkingv1.NetworkPolicyPort{
+			Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
+			Port:     &port,
+		})
+	}
 	return append(rules, networkingv1.NetworkPolicyIngressRule{
-		From: []networkingv1.NetworkPolicyPeer{peer},
-		Ports: []networkingv1.NetworkPolicyPort{
-			{
-				Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
-				Port:     &apiPort,
-			},
-		},
+		From:  []networkingv1.NetworkPolicyPeer{peer},
+		Ports: networkPolicyPorts,
 	})
 }
 

--- a/internal/service/networking/policy_test.go
+++ b/internal/service/networking/policy_test.go
@@ -609,6 +609,60 @@ func TestBuildNetworkPolicy_TrustedIngressPeers(t *testing.T) {
 	}
 }
 
+func TestBuildNetworkPolicy_TrustedIngressPeersAllowMetricsListenerPort(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "trusted-metrics",
+			Namespace: "openbao",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Observability: &openbaov1alpha1.ObservabilityConfig{
+				Metrics: &openbaov1alpha1.MetricsConfig{
+					Enabled:       true,
+					ScrapeProfile: metricsScrapeProfileAllNode,
+					MetricsOnlyListener: &openbaov1alpha1.MetricsOnlyListenerConfig{
+						Port: 9202,
+					},
+				},
+			},
+			Network: &openbaov1alpha1.NetworkConfig{
+				TrustedIngressPeers: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "monitoring",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	policy, err := buildNetworkPolicy(cluster, &apiServerInfo{ServiceNetworkCIDR: "10.96.0.0/12"}, "openbao-operator-system")
+	if err != nil {
+		t.Fatalf("buildNetworkPolicy() error: %v", err)
+	}
+
+	var foundMonitoringRule bool
+	for _, rule := range policy.Spec.Ingress {
+		if !networkPolicyRuleAllowsPort(rule.Ports, constants.PortAPI) ||
+			!networkPolicyRuleAllowsPort(rule.Ports, 9202) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil &&
+				peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == "monitoring" {
+				foundMonitoringRule = true
+			}
+		}
+	}
+
+	if !foundMonitoringRule {
+		t.Fatal("expected trusted monitoring peer to allow API and metrics listener ports")
+	}
+}
+
 func TestBuildNetworkPolicy_IngressEnabledDoesNotAllowUnrestrictedAPIIngress(t *testing.T) {
 	cluster := &openbaov1alpha1.OpenBaoCluster{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Adds guardrails around the dedicated metrics listener configuration:

- validate that the all-node scrape profile requires the dedicated metrics listener
- reject metrics-only listener configuration on OpenBao versions before 2.5.0
- allow configured trusted ingress peers to reach the metrics listener port when it is enabled
- keep the AllNodes scrape profile literal shared in config rendering code and tests

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This is validation and policy hardening. Invalid all-node telemetry combinations now fail config rendering earlier instead of producing an unsupported listener setup. When the metrics-only listener is enabled, NetworkPolicy ingress now also permits configured trusted peers to the metrics listener port.

No CRD, Helm, RBAC, or secret-handling changes are included.

## Verification

- `go test ./internal/adapter/config ./internal/service/networking`
- commit hook: whitespace check, gofmt on staged Go files, and golangci-lint on affected paths
- push hook: `make lint-ci` (golangci-lint plus ast-grep rules, 61/61 passing)
- local k3d observability gate in the operator test repo: `OPENBAO_OBSERVABILITY_REPO=../openbao-observability PROM_PORT=49090 GRAFANA_PORT=43000 LOKI_PORT=43100 bash environments/local/k3d-single/scripts/workload-observability-gate.sh`

## Reviewer Notes

GatewayClass readiness compatibility is intentionally excluded from this PR and will be handled on its own branch. Documentation updates are also intentionally deferred until the operator improvements settle, so the observability docs can point at the reference architecture cleanly.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
