### PR TITLE
fix(gateway): tolerate missing SupportedVersion condition

### DIFF
--- a/internal/controller/openbaocluster/status_gateway_test.go
+++ b/internal/controller/openbaocluster/status_gateway_test.go
@@ -115,6 +115,35 @@ func TestSetGatewayIntegrationReadyCondition_FastContract(t *testing.T) {
 			wantMessageIn: "prerequisites are satisfied",
 		},
 		{
+			name: "gateway integration ready when class omits SupportedVersion condition",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newOpenBaoClusterStatusTestObject()
+				cluster.Spec.Gateway = &openbaov1alpha1.GatewayConfig{
+					Enabled:  true,
+					Hostname: "bao.example.test",
+					GatewayRef: openbaov1alpha1.GatewayReference{
+						Name:      "shared-gateway",
+						Namespace: "gateway-system",
+					},
+				}
+				disabled := false
+				cluster.Spec.Gateway.BackendTLS = &openbaov1alpha1.BackendTLSConfig{Enabled: &disabled}
+				return cluster
+			}(),
+			objects: []client.Object{
+				newGateway([]gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+				}}, programmedTrue),
+				newGatewayClass([]string{"HTTPRoute"}, acceptedTrue),
+			},
+			wantPresent:   true,
+			wantStatus:    metav1.ConditionTrue,
+			wantReason:    ReasonGatewayIntegrationReady,
+			wantMessageIn: "prerequisites are satisfied",
+		},
+		{
 			name: "gateway capabilities unknown when class omits features",
 			cluster: func() *openbaov1alpha1.OpenBaoCluster {
 				cluster := newOpenBaoClusterStatusTestObject()

--- a/internal/service/networking/gateway_integration.go
+++ b/internal/service/networking/gateway_integration.go
@@ -178,7 +178,10 @@ func validateGatewayClassAccepted(gatewayClass *gatewayv1.GatewayClass) error {
 
 func validateGatewayClassSupportedVersion(gatewayClass *gatewayv1.GatewayClass) error {
 	supportedVersion := meta.FindStatusCondition(gatewayClass.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusSupportedVersion))
-	if supportedVersion == nil || supportedVersion.Status == metav1.ConditionUnknown {
+	if supportedVersion == nil {
+		return nil
+	}
+	if supportedVersion.Status == metav1.ConditionUnknown {
 		return fmt.Errorf("%w: GatewayClass %q has not yet reported SupportedVersion=True", ErrGatewayClassPending, gatewayClass.Name)
 	}
 	if supportedVersion.Status == metav1.ConditionFalse {

--- a/internal/service/networking/gateway_integration_test.go
+++ b/internal/service/networking/gateway_integration_test.go
@@ -103,6 +103,31 @@ func TestValidateGatewayIntegration(t *testing.T) {
 			},
 		},
 		{
+			name: "termination path tolerates class without SupportedVersion condition",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newMinimalCluster("example", "default")
+				cluster.Spec.Gateway = &openbaov1alpha1.GatewayConfig{
+					Enabled:  true,
+					Hostname: "bao.example.test",
+					GatewayRef: openbaov1alpha1.GatewayReference{
+						Name:      "shared-gateway",
+						Namespace: "gateway-system",
+					},
+				}
+				disabled := false
+				cluster.Spec.Gateway.BackendTLS = &openbaov1alpha1.BackendTLSConfig{Enabled: &disabled}
+				return cluster
+			}(),
+			objects: []client.Object{
+				newGateway([]gatewayv1.Listener{{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+				}}, programmedTrue),
+				newGatewayClass([]gatewayv1.FeatureName{gatewayFeatureHTTPRoute}, acceptedTrue),
+			},
+		},
+		{
 			name: "listener mismatch is explicit",
 			cluster: func() *openbaov1alpha1.OpenBaoCluster {
 				cluster := newMinimalCluster("example", "default")


### PR DESCRIPTION
## Summary

Gateway integration validation now treats an omitted GatewayClass `SupportedVersion` condition as acceptable instead of pending. Some Gateway API implementations do not report this condition, while still reporting `Accepted=True` and usable supported features. The change keeps explicit `SupportedVersion=False` and `SupportedVersion=Unknown` handling intact.

Status coverage and service-level validation coverage were added for the missing-condition case.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. This relaxes readiness validation only when `GatewayClass.status.conditions` omits `SupportedVersion`. Existing pending/failure behavior remains for `SupportedVersion=Unknown` and `SupportedVersion=False`. No API, CRD, Helm, RBAC, security, or upgrade behavior changes are expected.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/service/networking ./internal/controller/openbaocluster`
- Pre-push hook: `make lint-ci`

## Reviewer Notes

This is intended to land before the `0.3.0` release so Gateway implementations that omit `SupportedVersion` are not incorrectly held in pending readiness.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.