### PR TITLE
test(perf): fix rolling availability probe service

### DIFF
--- a/hack/perf/v2/baselines/lifecycle-convergence/kind-v1.34.3.json
+++ b/hack/perf/v2/baselines/lifecycle-convergence/kind-v1.34.3.json
@@ -1,32 +1,396 @@
 {
   "version": "v2",
   "scenario": "lifecycle-convergence",
-  "capturedAt": "2026-02-10T22:35:20Z",
-  "commit": "a6950686fd43dc5384590f7fd22abf410ad082a4",
+  "capturedAt": "2026-06-01T13:07:15.027512526Z",
+  "commit": "6975e81fff7b910ea7c95cbc2815809216c8b43e",
   "environment": {
-    "runner": "github-hosted",
-    "runnerImage": "ubuntu-24.04",
+    "runner": "kind",
+    "kindVersion": "kind v0.31.0 go1.25.5 linux/amd64",
     "nodeImage": "kindest/node:v1.34.3",
-    "commit": "a6950686fd43dc5384590f7fd22abf410ad082a4"
+    "goVersion": "go1.26.3",
+    "commit": "6975e81fff7b910ea7c95cbc2815809216c8b43e",
+    "context": "kind-perf-lifecycle-convergence-1"
   },
   "samples": {
-    "sample_total_seconds": [763.960618155, 205.172085171, 223.664860869, 217.768277506, 232.562866534],
-    "reconcile_duration_bucket_p95": [0.5, 0.5, 0.5, 0.5, 0.5],
-    "reconcile_error_ratio": [0.29545454545454547, 0.30434782608695654, 0.32727272727272727, 0.3269230769230769, 0.32142857142857145],
-    "workqueue_retries_delta": [42, 43, 52, 49, 53],
-    "kubernetes_writes": [0, 0, 0, 0, 0],
-    "openbao_auth_logins": [0, 0, 0, 0, 0],
-    "openbao_auth_login_errors": [0, 0, 0, 0, 0],
-    "openbao_api_requests": [0, 0, 0, 0, 0]
+    "all_pods_ready_seconds": [
+      30,
+      29,
+      30,
+      30,
+      30
+    ],
+    "cluster_available_seconds": [
+      30,
+      30,
+      31,
+      31,
+      31
+    ],
+    "first_pod_ready_seconds": [
+      30,
+      29,
+      30,
+      30,
+      30
+    ],
+    "kubernetes_writes": [
+      15,
+      16,
+      16,
+      16,
+      16
+    ],
+    "observed_kubernetes_writes": [
+      15,
+      16,
+      16,
+      16,
+      16
+    ],
+    "openbao_api_requests": [
+      2,
+      2,
+      2,
+      2,
+      2
+    ],
+    "openbao_auth_cache_hits_total": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_cache_misses_total": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_inline_requests": [
+      2,
+      2,
+      2,
+      2,
+      2
+    ],
+    "openbao_auth_login_errors": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_logins": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_workload_audit_request_failures": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_workload_audit_response_failures": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_workload_in_flight_requests_max": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_workload_login_request_avg_seconds": [
+      1.4374679625034332,
+      1.4602515548467636,
+      1.5535384714603424,
+      1.4633379578590393,
+      1.433114543557167
+    ],
+    "openbao_workload_login_request_count": [
+      2,
+      2,
+      2,
+      2,
+      2
+    ],
+    "openbao_workload_request_avg_seconds": [
+      1.5298707740647453,
+      1.4348947618688856,
+      1.378911350454603,
+      1.4917559283120292,
+      1.6498039535113744
+    ],
+    "openbao_workload_request_count": [
+      14,
+      14,
+      14,
+      14,
+      14
+    ],
+    "openbao_workload_token_check_avg_seconds": [
+      0.12535118765663356,
+      0.14357312710490078,
+      0.13154206454055384,
+      0.19619281380437315,
+      0.16881699970690534
+    ],
+    "openbao_workload_token_check_count": [
+      16,
+      16,
+      16,
+      16,
+      16
+    ],
+    "openbao_workload_token_creation_count": [
+      2,
+      2,
+      2,
+      2,
+      2
+    ],
+    "reconcile_duration_bucket_p95": [
+      0.5,
+      0.5,
+      0.5,
+      0.5,
+      0.5
+    ],
+    "reconcile_error_ratio": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "sample_total_seconds": [
+      105.092151689,
+      104.925089618,
+      105.173130553,
+      105.347978254,
+      108.111874086
+    ],
+    "scenario_run_seconds": [
+      34.041181643,
+      34.039624768,
+      34.045337155,
+      34.040726647,
+      34.043384432
+    ],
+    "statefulset_created_seconds": [
+      0,
+      0,
+      1,
+      1,
+      1
+    ],
+    "workqueue_retries_delta": [
+      16,
+      16,
+      16,
+      16,
+      16
+    ]
   },
   "summary": {
-    "sample_total_seconds": {"median": 223.664860869, "upperSample": 763.960618155, "min": 205.172085171, "max": 763.960618155, "count": 5},
-    "reconcile_duration_bucket_p95": {"median": 0.5, "upperSample": 0.5, "min": 0.5, "max": 0.5, "count": 5},
-    "reconcile_error_ratio": {"median": 0.32142857142857145, "upperSample": 0.32727272727272727, "min": 0.29545454545454547, "max": 0.32727272727272727, "count": 5},
-    "workqueue_retries_delta": {"median": 49, "upperSample": 53, "min": 42, "max": 53, "count": 5},
-    "kubernetes_writes": {"median": 0, "upperSample": 0, "min": 0, "max": 0, "count": 5},
-    "openbao_auth_logins": {"median": 0, "upperSample": 0, "min": 0, "max": 0, "count": 5},
-    "openbao_auth_login_errors": {"median": 0, "upperSample": 0, "min": 0, "max": 0, "count": 5},
-    "openbao_api_requests": {"median": 0, "upperSample": 0, "min": 0, "max": 0, "count": 5}
+    "all_pods_ready_seconds": {
+      "median": 30,
+      "upperSample": 30,
+      "min": 29,
+      "max": 30,
+      "count": 5
+    },
+    "cluster_available_seconds": {
+      "median": 31,
+      "upperSample": 31,
+      "min": 30,
+      "max": 31,
+      "count": 5
+    },
+    "first_pod_ready_seconds": {
+      "median": 30,
+      "upperSample": 30,
+      "min": 29,
+      "max": 30,
+      "count": 5
+    },
+    "kubernetes_writes": {
+      "median": 16,
+      "upperSample": 16,
+      "min": 15,
+      "max": 16,
+      "count": 5
+    },
+    "observed_kubernetes_writes": {
+      "median": 16,
+      "upperSample": 16,
+      "min": 15,
+      "max": 16,
+      "count": 5
+    },
+    "openbao_api_requests": {
+      "median": 2,
+      "upperSample": 2,
+      "min": 2,
+      "max": 2,
+      "count": 5
+    },
+    "openbao_auth_cache_hits_total": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_cache_misses_total": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_inline_requests": {
+      "median": 2,
+      "upperSample": 2,
+      "min": 2,
+      "max": 2,
+      "count": 5
+    },
+    "openbao_auth_login_errors": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_logins": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_workload_audit_request_failures": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_workload_audit_response_failures": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_workload_in_flight_requests_max": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_workload_login_request_avg_seconds": {
+      "median": 1.4602515548467636,
+      "upperSample": 1.5535384714603424,
+      "min": 1.433114543557167,
+      "max": 1.5535384714603424,
+      "count": 5
+    },
+    "openbao_workload_login_request_count": {
+      "median": 2,
+      "upperSample": 2,
+      "min": 2,
+      "max": 2,
+      "count": 5
+    },
+    "openbao_workload_request_avg_seconds": {
+      "median": 1.4917559283120292,
+      "upperSample": 1.6498039535113744,
+      "min": 1.378911350454603,
+      "max": 1.6498039535113744,
+      "count": 5
+    },
+    "openbao_workload_request_count": {
+      "median": 14,
+      "upperSample": 14,
+      "min": 14,
+      "max": 14,
+      "count": 5
+    },
+    "openbao_workload_token_check_avg_seconds": {
+      "median": 0.14357312710490078,
+      "upperSample": 0.19619281380437315,
+      "min": 0.12535118765663356,
+      "max": 0.19619281380437315,
+      "count": 5
+    },
+    "openbao_workload_token_check_count": {
+      "median": 16,
+      "upperSample": 16,
+      "min": 16,
+      "max": 16,
+      "count": 5
+    },
+    "openbao_workload_token_creation_count": {
+      "median": 2,
+      "upperSample": 2,
+      "min": 2,
+      "max": 2,
+      "count": 5
+    },
+    "reconcile_duration_bucket_p95": {
+      "median": 0.5,
+      "upperSample": 0.5,
+      "min": 0.5,
+      "max": 0.5,
+      "count": 5
+    },
+    "reconcile_error_ratio": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "sample_total_seconds": {
+      "median": 105.173130553,
+      "upperSample": 108.111874086,
+      "min": 104.925089618,
+      "max": 108.111874086,
+      "count": 5
+    },
+    "scenario_run_seconds": {
+      "median": 34.041181643,
+      "upperSample": 34.045337155,
+      "min": 34.039624768,
+      "max": 34.045337155,
+      "count": 5
+    },
+    "statefulset_created_seconds": {
+      "median": 1,
+      "upperSample": 1,
+      "min": 0,
+      "max": 1,
+      "count": 5
+    },
+    "workqueue_retries_delta": {
+      "median": 16,
+      "upperSample": 16,
+      "min": 16,
+      "max": 16,
+      "count": 5
+    }
   }
 }

--- a/hack/perf/v2/baselines/tenant-churn/kind-v1.34.3.json
+++ b/hack/perf/v2/baselines/tenant-churn/kind-v1.34.3.json
@@ -1,20 +1,18 @@
 {
   "version": "v2",
   "scenario": "tenant-churn",
-  "capturedAt": "2026-05-29T13:33:46.803259Z",
-  "commit": "abeb8ae0da5dc2ae462c409113e87cf899f314fb",
+  "capturedAt": "2026-06-01T13:04:26.802243985Z",
+  "commit": "6975e81fff7b910ea7c95cbc2815809216c8b43e",
   "environment": {
     "runner": "kind",
-    "kindVersion": "kind v0.31.0 go1.26.1 darwin/arm64",
+    "kindVersion": "kind v0.31.0 go1.25.5 linux/amd64",
     "nodeImage": "kindest/node:v1.34.3",
     "goVersion": "go1.26.3",
-    "commit": "abeb8ae0da5dc2ae462c409113e87cf899f314fb",
+    "commit": "6975e81fff7b910ea7c95cbc2815809216c8b43e",
     "context": "kind-perf-tenant-churn-1"
   },
   "samples": {
     "kubernetes_writes": [
-      20,
-      20,
       20,
       20,
       20,
@@ -26,13 +24,51 @@
       20,
       20,
       20,
-      20,
-      20,
       20
     ],
+    "openbao_api_requests": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_cache_hits_total": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_cache_misses_total": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_inline_requests": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_login_errors": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "openbao_auth_logins": [
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
     "reconcile_error_ratio": [
-      0,
-      0,
       0,
       0,
       0,
@@ -40,35 +76,27 @@
       0
     ],
     "sample_total_seconds": [
-      84.276625,
-      85.661945,
-      89.133417,
-      86.974676,
-      90.473159,
-      79.071795,
-      84.286532
+      77.614400602,
+      76.371074965,
+      74.83896946,
+      77.202904433,
+      73.953908403
     ],
     "scenario_run_seconds": [
-      4.230708,
-      4.229871,
-      4.22459,
-      4.2425180000000005,
-      4.238781,
-      4.227292,
-      4.236788
+      4.223459452,
+      4.221319936,
+      4.223273456,
+      4.222374609,
+      4.223999803
     ],
     "tenant_churn_complete_seconds": [
-      2.20967,
-      2.196297,
-      2.201606,
-      2.209044,
-      2.201308,
-      2.194498,
-      2.207178
+      2.20219617,
+      2.201667133,
+      2.202180179,
+      2.201514448,
+      2.20324104
     ],
     "tenant_kubernetes_writes": [
-      20,
-      20,
       20,
       20,
       20,
@@ -76,26 +104,20 @@
       20
     ],
     "tenant_ready_p50_seconds": [
-      1.209534,
-      1.206938,
-      1.207181,
-      1.403176,
-      1.200399,
-      1.20136,
-      1.217855
+      1.202468805,
+      1.201839359,
+      1.202308735,
+      1.20199211,
+      1.2022632739999999
     ],
     "tenant_ready_p95_seconds": [
-      2.209667,
-      2.19629,
-      2.201604,
-      2.209036,
-      2.201305,
-      2.194495,
-      2.207175
+      2.202193916,
+      2.201661064,
+      2.202177636,
+      2.201511624,
+      2.203238757
     ],
     "workqueue_retries_delta": [
-      0,
-      0,
       0,
       0,
       0,
@@ -109,70 +131,112 @@
       "upperSample": 20,
       "min": 20,
       "max": 20,
-      "count": 7
+      "count": 5
     },
     "observed_kubernetes_writes": {
       "median": 20,
       "upperSample": 20,
       "min": 20,
       "max": 20,
-      "count": 7
+      "count": 5
+    },
+    "openbao_api_requests": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_cache_hits_total": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_cache_misses_total": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_inline_requests": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_login_errors": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
+    },
+    "openbao_auth_logins": {
+      "median": 0,
+      "upperSample": 0,
+      "min": 0,
+      "max": 0,
+      "count": 5
     },
     "reconcile_error_ratio": {
       "median": 0,
       "upperSample": 0,
       "min": 0,
       "max": 0,
-      "count": 7
+      "count": 5
     },
     "sample_total_seconds": {
-      "median": 85.661945,
-      "upperSample": 90.473159,
-      "min": 79.071795,
-      "max": 90.473159,
-      "count": 7
+      "median": 76.371074965,
+      "upperSample": 77.614400602,
+      "min": 73.953908403,
+      "max": 77.614400602,
+      "count": 5
     },
     "scenario_run_seconds": {
-      "median": 4.230708,
-      "upperSample": 4.2425180000000005,
-      "min": 4.22459,
-      "max": 4.2425180000000005,
-      "count": 7
+      "median": 4.223273456,
+      "upperSample": 4.223999803,
+      "min": 4.221319936,
+      "max": 4.223999803,
+      "count": 5
     },
     "tenant_churn_complete_seconds": {
-      "median": 2.201606,
-      "upperSample": 2.20967,
-      "min": 2.194498,
-      "max": 2.20967,
-      "count": 7
+      "median": 2.202180179,
+      "upperSample": 2.20324104,
+      "min": 2.201514448,
+      "max": 2.20324104,
+      "count": 5
     },
     "tenant_kubernetes_writes": {
       "median": 20,
       "upperSample": 20,
       "min": 20,
       "max": 20,
-      "count": 7
+      "count": 5
     },
     "tenant_ready_p50_seconds": {
-      "median": 1.207181,
-      "upperSample": 1.403176,
-      "min": 1.200399,
-      "max": 1.403176,
-      "count": 7
+      "median": 1.2022632739999999,
+      "upperSample": 1.202468805,
+      "min": 1.201839359,
+      "max": 1.202468805,
+      "count": 5
     },
     "tenant_ready_p95_seconds": {
-      "median": 2.201604,
-      "upperSample": 2.209667,
-      "min": 2.194495,
-      "max": 2.209667,
-      "count": 7
+      "median": 2.202177636,
+      "upperSample": 2.203238757,
+      "min": 2.201511624,
+      "max": 2.203238757,
+      "count": 5
     },
     "workqueue_retries_delta": {
       "median": 0,
       "upperSample": 0,
       "min": 0,
       "max": 0,
-      "count": 7
+      "count": 5
     }
   }
 }

--- a/test/perf/native.go
+++ b/test/perf/native.go
@@ -421,13 +421,7 @@ func (n *nativeScenarioContext) runRollingUpgrade(ctx context.Context) (Result, 
 			n.opts.UpgradeFromVersion,
 		)
 	}
-	cluster := n.buildCluster(
-		n.resourceName("perf-up"),
-		n.opts.UpgradeFromVersion,
-		n.opts.UpgradeFromImage,
-		3,
-	)
-	cluster.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{Image: n.opts.UpgradeExecutorImage}
+	cluster := n.buildRollingUpgradeCluster()
 	tracker := newResourceWriteTracker()
 	if err := n.client.Create(ctx, cluster); err != nil {
 		return Result{}, fmt.Errorf("create OpenBaoCluster: %w", err)
@@ -706,6 +700,18 @@ func (n *nativeScenarioContext) buildCluster(
 			DeletionPolicy: openbaov1alpha1.DeletionPolicyDeleteAll,
 		},
 	}
+}
+
+func (n *nativeScenarioContext) buildRollingUpgradeCluster() *openbaov1alpha1.OpenBaoCluster {
+	cluster := n.buildCluster(
+		n.resourceName("perf-up"),
+		n.opts.UpgradeFromVersion,
+		n.opts.UpgradeFromImage,
+		3,
+	)
+	cluster.Spec.Service = &openbaov1alpha1.ServiceConfig{}
+	cluster.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{Image: n.opts.UpgradeExecutorImage}
+	return cluster
 }
 
 func (n *nativeScenarioContext) workloadObservability(version string) *openbaov1alpha1.ObservabilityConfig {

--- a/test/perf/native_test.go
+++ b/test/perf/native_test.go
@@ -159,6 +159,35 @@ func TestWorkloadObservabilityMetricsOnlyListenerIsVersionAware(t *testing.T) {
 	}
 }
 
+func TestRollingUpgradeClusterEnablesPublicService(t *testing.T) {
+	t.Parallel()
+
+	native := &nativeScenarioContext{
+		namespace: "perf-test",
+		runID:     "rolling-probe",
+		opts: Config{
+			UpgradeFromVersion:   "2.5.3",
+			UpgradeFromImage:     "ghcr.io/openbao/openbao:2.5.3",
+			UpgradeExecutorImage: "ghcr.io/dc-tec/openbao-operator-upgrade:dev",
+			ConfigInitImage:      "ghcr.io/dc-tec/openbao-operator-config-init:dev",
+		},
+	}
+
+	cluster := native.buildRollingUpgradeCluster()
+	if cluster.Spec.Service == nil {
+		t.Fatalf("rolling upgrade cluster should enable public service for availability probe")
+	}
+	if cluster.Spec.Service.Type != "" {
+		t.Fatalf("public service type = %q, want operator default", cluster.Spec.Service.Type)
+	}
+	if cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Image != native.opts.UpgradeExecutorImage {
+		t.Fatalf("upgrade config = %#v, want executor image %q", cluster.Spec.Upgrade, native.opts.UpgradeExecutorImage)
+	}
+	if cluster.Spec.Replicas != 3 {
+		t.Fatalf("replicas = %d, want 3", cluster.Spec.Replicas)
+	}
+}
+
 func TestPhaseMeasurements(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes the perfcheck v2 rolling-upgrade availability probe setup. The rolling scenario was probing the `<cluster>-public` Service but created an OpenBaoCluster without `spec.service`, so the operator correctly did not create that Service and every 2s probe was counted as a failure.

This change makes the rolling-upgrade scenario explicitly request the public ClusterIP Service and adds a regression test for that scenario setup. It also updates the usable baseline captures from the successful main run for `lifecycle-convergence` and `tenant-churn`; the rolling-upgrade baseline from that run is intentionally excluded because it contains the false availability-probe failures.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

Low. This only changes the native performance harness scenario definition and checked-in perf baselines. It does not change CRD schema, Helm output, RBAC, or runtime operator behavior outside perf tests.

## Verification

- `GOFLAGS=-mod=vendor go test ./test/perf`
- `jq empty hack/perf/v2/baselines/lifecycle-convergence/kind-v1.34.3.json hack/perf/v2/baselines/tenant-churn/kind-v1.34.3.json`
- `git diff --check`
- pre-commit hook: whitespace check, Go formatting, golangci-lint on affected Go paths
- pre-push hook: `make lint-ci`

## Reviewer Notes

The rolling-upgrade baseline should be recaptured after this merges or after this branch's workflow proves the probe path is healthy. The baseline from run `26755972133` was not committed for rolling-upgrade because it recorded `upgrade_availability_probe_failures` with upper sample `52` from the broken probe target.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [ ] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
