### PR TITLE
fix(security): require provenance for managed resources

### DIFF
--- a/.ast-grep/policy/architecture-boundaries.yml
+++ b/.ast-grep/policy/architecture-boundaries.yml
@@ -48,6 +48,7 @@ layerCoverage:
       - platform/reconcile
       - platform/resourceapply
       - platform/resourceidentity
+      - platform/resourceownership
       - platform/semver
       - platform/statusapply
       - platform/statuspatch

--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -12,7 +12,7 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]
-        resources: ["secrets", "configmaps", "services", "pods", "endpoints", "persistentvolumeclaims"]
+        resources: ["secrets", "configmaps", "services", "serviceaccounts", "pods", "endpoints", "persistentvolumeclaims"]
       - apiGroups: ["discovery.k8s.io"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]

--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -12,7 +12,7 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]
-        resources: ["secrets", "configmaps", "services", "pods", "endpoints"]
+        resources: ["secrets", "configmaps", "services", "pods", "endpoints", "persistentvolumeclaims"]
       - apiGroups: ["discovery.k8s.io"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]
@@ -144,6 +144,25 @@ spec:
     - name: is_service_request
       expression: >-
         request.kind.group == "" && request.kind.kind == "Service"
+    - name: has_current_owner_uid_annotation
+      expression: >-
+        object != null &&
+        has(object.metadata) &&
+        has(object.metadata.annotations) &&
+        ("openbao.org/owner-uid" in object.metadata.annotations)
+    - name: has_old_owner_uid_annotation
+      expression: >-
+        oldObject != null &&
+        has(oldObject.metadata) &&
+        has(oldObject.metadata.annotations) &&
+        ("openbao.org/owner-uid" in oldObject.metadata.annotations)
+    - name: owner_uid_annotation_allowed
+      expression: >-
+        variables.is_operator_controller ||
+        variables.is_operator_provisioner ||
+        variables.is_kube_controller_manager ||
+        variables.is_system_controller ||
+        variables.is_kube_system_controller
     - name: is_service_monitor_request
       expression: >-
         request.kind.group == "monitoring.coreos.com" && request.kind.kind == "ServiceMonitor"
@@ -319,19 +338,15 @@ spec:
         (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.labels)) ? oldObject.metadata.labels : {}
     - name: maintenance_cluster_name
       expression: >-
-        request.operation == "DELETE" ?
+        request.operation == "CREATE" ?
+          ("openbao.org/cluster" in variables.maintenance_current_labels ?
+            variables.maintenance_current_labels["openbao.org/cluster"] :
+            ("app.kubernetes.io/instance" in variables.maintenance_current_labels ?
+              variables.maintenance_current_labels["app.kubernetes.io/instance"] : "")) :
           ("openbao.org/cluster" in variables.maintenance_old_labels ?
             variables.maintenance_old_labels["openbao.org/cluster"] :
             ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
-              variables.maintenance_old_labels["app.kubernetes.io/instance"] : "")) :
-          ("openbao.org/cluster" in variables.maintenance_current_labels ?
-            variables.maintenance_current_labels["openbao.org/cluster"] :
-            ("openbao.org/cluster" in variables.maintenance_old_labels ?
-              variables.maintenance_old_labels["openbao.org/cluster"] :
-              ("app.kubernetes.io/instance" in variables.maintenance_current_labels ?
-                variables.maintenance_current_labels["app.kubernetes.io/instance"] :
-                ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
-                  variables.maintenance_old_labels["app.kubernetes.io/instance"] : ""))))
+              variables.maintenance_old_labels["app.kubernetes.io/instance"] : ""))
     - name: maintenance_authorized
       expression: >-
         variables.maintenance_enabled &&
@@ -344,6 +359,19 @@ spec:
           check("maintenance").
           allowed()
   validations:
+    - expression: >-
+        variables.owner_uid_annotation_allowed ||
+        (
+          !variables.has_current_owner_uid_annotation &&
+          !variables.has_old_owner_uid_annotation
+        ) ||
+        (
+          request.operation == "UPDATE" &&
+          variables.has_current_owner_uid_annotation &&
+          variables.has_old_owner_uid_annotation &&
+          object.metadata.annotations["openbao.org/owner-uid"] == oldObject.metadata.annotations["openbao.org/owner-uid"]
+        )
+      message: The openbao.org/owner-uid annotation is reserved for OpenBao Operator managed-resource provenance.
     - expression: >-
         !(variables.is_operator_controller || variables.is_operator_provisioner) ||
         !variables.is_service_monitor_request ||

--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -107,9 +107,26 @@ spec:
       expression: >-
         request.userInfo.username == "system:kube-controller-manager" ||
         request.userInfo.username == "system:serviceaccount:kube-system:kube-controller-manager"
+    - name: is_kube_scheduler
+      expression: >-
+        request.userInfo.username == "system:kube-scheduler" ||
+        request.userInfo.username == "system:serviceaccount:kube-system:kube-scheduler"
+    - name: is_storage_provisioner_serviceaccount
+      expression: >-
+        request.userInfo.username.matches("^system:serviceaccount:[^:]+:.*(csi|provisioner).*$")
+    - name: is_persistent_volume_binder
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:persistent-volume-binder"
+    - name: is_pvc_protection_controller
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:pvc-protection-controller"
     - name: is_system_controller
       expression: >-
         request.userInfo.username.startsWith("system:controller:")
+    - name: is_statefulset_controller
+      expression: >-
+        request.userInfo.username == "system:controller:statefulset-controller" ||
+        request.userInfo.username == "system:serviceaccount:kube-system:statefulset-controller"
     # K3s/K3d and some distributions use service accounts for GC instead of system:controller:*
     - name: is_garbage_collector_sa
       expression: >-
@@ -144,6 +161,9 @@ spec:
     - name: is_service_request
       expression: >-
         request.kind.group == "" && request.kind.kind == "Service"
+    - name: is_pvc_request
+      expression: >-
+        request.kind.group == "" && request.kind.kind == "PersistentVolumeClaim"
     - name: has_current_owner_uid_annotation
       expression: >-
         object != null &&
@@ -296,6 +316,18 @@ spec:
     - name: service_old_annotations
       expression: >-
         (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.annotations)) ? oldObject.metadata.annotations : {}
+    - name: pvc_new_annotations
+      expression: >-
+        (object != null && has(object.metadata) && has(object.metadata.annotations)) ? object.metadata.annotations : {}
+    - name: pvc_old_annotations
+      expression: >-
+        (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.annotations)) ? oldObject.metadata.annotations : {}
+    - name: pvc_new_finalizers
+      expression: >-
+        (object != null && has(object.metadata) && has(object.metadata.finalizers)) ? object.metadata.finalizers : []
+    - name: pvc_old_finalizers
+      expression: >-
+        (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.finalizers)) ? oldObject.metadata.finalizers : []
     - name: is_kube_system_service_metadata_update
       expression: >-
         variables.is_service_request &&
@@ -312,6 +344,53 @@ spec:
         variables.service_old_annotations.all(k, v,
           !k.startsWith("openbao.org/") ||
           (k in variables.service_new_annotations && variables.service_new_annotations[k] == v))
+    - name: is_storage_pvc_binding_update
+      expression: >-
+        variables.is_pvc_request &&
+        request.operation == "UPDATE" &&
+        (variables.is_kube_scheduler ||
+          variables.is_kube_controller_manager ||
+          variables.is_persistent_volume_binder ||
+          variables.is_pvc_protection_controller ||
+          variables.is_storage_provisioner_serviceaccount) &&
+        object != null &&
+        oldObject != null &&
+        object.metadata.name == oldObject.metadata.name &&
+        object.metadata.namespace == oldObject.metadata.namespace &&
+        object.status == oldObject.status &&
+        (has(object.metadata.labels) == has(oldObject.metadata.labels) &&
+          (!has(object.metadata.labels) || object.metadata.labels == oldObject.metadata.labels)) &&
+        (has(object.metadata.ownerReferences) == has(oldObject.metadata.ownerReferences) &&
+          (!has(object.metadata.ownerReferences) || object.metadata.ownerReferences == oldObject.metadata.ownerReferences)) &&
+        variables.pvc_new_finalizers.all(f,
+          f in variables.pvc_old_finalizers ||
+          f in ["kubernetes.io/pvc-protection", "external-provisioner.volume.kubernetes.io/finalizer"]) &&
+        variables.pvc_old_finalizers.all(f,
+          f in variables.pvc_new_finalizers ||
+          f in ["kubernetes.io/pvc-protection", "external-provisioner.volume.kubernetes.io/finalizer"]) &&
+        variables.pvc_new_annotations.all(k, v,
+          !k.startsWith("openbao.org/") ||
+          (k in variables.pvc_old_annotations && variables.pvc_old_annotations[k] == v)) &&
+        variables.pvc_old_annotations.all(k, v,
+          !k.startsWith("openbao.org/") ||
+          (k in variables.pvc_new_annotations && variables.pvc_new_annotations[k] == v)) &&
+        object.spec.accessModes == oldObject.spec.accessModes &&
+        object.spec.resources == oldObject.spec.resources &&
+        (has(object.spec.storageClassName) == has(oldObject.spec.storageClassName) &&
+          (!has(object.spec.storageClassName) || object.spec.storageClassName == oldObject.spec.storageClassName)) &&
+        (has(object.spec.volumeMode) == has(oldObject.spec.volumeMode) &&
+          (!has(object.spec.volumeMode) || object.spec.volumeMode == oldObject.spec.volumeMode)) &&
+        (has(object.spec.selector) == has(oldObject.spec.selector) &&
+          (!has(object.spec.selector) || object.spec.selector == oldObject.spec.selector)) &&
+        (has(object.spec.dataSource) == has(oldObject.spec.dataSource) &&
+          (!has(object.spec.dataSource) || object.spec.dataSource == oldObject.spec.dataSource)) &&
+        (has(object.spec.dataSourceRef) == has(oldObject.spec.dataSourceRef) &&
+          (!has(object.spec.dataSourceRef) || object.spec.dataSourceRef == oldObject.spec.dataSourceRef)) &&
+        (
+          (!has(object.spec.volumeName) && !has(oldObject.spec.volumeName)) ||
+          (has(object.spec.volumeName) && has(oldObject.spec.volumeName) && object.spec.volumeName == oldObject.spec.volumeName) ||
+          (has(object.spec.volumeName) && object.spec.volumeName != "" && (!has(oldObject.spec.volumeName) || oldObject.spec.volumeName == ""))
+        )
     - name: maintenance_enabled
       expression: >-
         request.operation == "DELETE" ?
@@ -360,6 +439,7 @@ spec:
           allowed()
   validations:
     - expression: >-
+        request.operation == "DELETE" ||
         variables.owner_uid_annotation_allowed ||
         (
           !variables.has_current_owner_uid_annotation &&
@@ -391,6 +471,8 @@ spec:
         (variables.is_system_controller && request.resource.resource == "pods") ||
         (variables.is_system_controller && variables.is_endpoints_controller_request) ||
         (variables.is_kube_system_controller && request.resource.resource == "pods" && (request.operation == "CREATE" || request.operation == "DELETE")) ||
+        (variables.is_statefulset_controller && request.resource.resource == "persistentvolumeclaims" && request.operation == "CREATE") ||
+        variables.is_storage_pvc_binding_update ||
         (variables.is_kube_system_controller && variables.is_endpoints_controller_request) ||
         variables.is_kube_system_service_metadata_update ||
         variables.is_cert_manager_secret_request ||

--- a/cmd/controller/run_test.go
+++ b/cmd/controller/run_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Note: OIDC/JWKS tests have been moved to internal/adapter/auth/oidc_test.go
@@ -56,4 +58,19 @@ func TestUnavailableHelperImageDefaultFields(t *testing.T) {
 			t.Fatalf("unavailableHelperImageDefaultFields() = %v, want empty", fields)
 		}
 	})
+}
+
+func TestNewManagerOptions_DisablesPDBCacheInMultiTenantMode(t *testing.T) {
+	opts := newManagerOptions(runtime.NewScheme(), buildMetricsServerOptions(runConfig{}), "0", false, "")
+	if opts.Client.Cache == nil {
+		t.Fatal("expected client cache options")
+	}
+
+	for _, obj := range opts.Client.Cache.DisableFor {
+		if _, ok := obj.(*policyv1.PodDisruptionBudget); ok {
+			return
+		}
+	}
+
+	t.Fatalf("expected PodDisruptionBudget reads to bypass the shared cache, got %T", opts.Client.Cache.DisableFor)
 }

--- a/cmd/controller/startup_helpers.go
+++ b/cmd/controller/startup_helpers.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -99,6 +100,7 @@ func newManagerOptions(
 		&corev1.Service{},
 		&corev1.ConfigMap{},
 		&corev1.Namespace{},
+		&policyv1.PodDisruptionBudget{},
 		&networkingv1.Ingress{},
 		&networkingv1.NetworkPolicy{},
 		&rbacv1.Role{},

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -9,7 +9,7 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]
-        resources: ["secrets", "configmaps", "services", "pods", "endpoints"]
+        resources: ["secrets", "configmaps", "services", "pods", "endpoints", "persistentvolumeclaims"]
       - apiGroups: ["discovery.k8s.io"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]
@@ -141,6 +141,25 @@ spec:
     - name: is_service_request
       expression: >-
         request.kind.group == "" && request.kind.kind == "Service"
+    - name: has_current_owner_uid_annotation
+      expression: >-
+        object != null &&
+        has(object.metadata) &&
+        has(object.metadata.annotations) &&
+        ("openbao.org/owner-uid" in object.metadata.annotations)
+    - name: has_old_owner_uid_annotation
+      expression: >-
+        oldObject != null &&
+        has(oldObject.metadata) &&
+        has(oldObject.metadata.annotations) &&
+        ("openbao.org/owner-uid" in oldObject.metadata.annotations)
+    - name: owner_uid_annotation_allowed
+      expression: >-
+        variables.is_operator_controller ||
+        variables.is_operator_provisioner ||
+        variables.is_kube_controller_manager ||
+        variables.is_system_controller ||
+        variables.is_kube_system_controller
     - name: is_service_monitor_request
       expression: >-
         request.kind.group == "monitoring.coreos.com" && request.kind.kind == "ServiceMonitor"
@@ -316,19 +335,15 @@ spec:
         (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.labels)) ? oldObject.metadata.labels : {}
     - name: maintenance_cluster_name
       expression: >-
-        request.operation == "DELETE" ?
+        request.operation == "CREATE" ?
+          ("openbao.org/cluster" in variables.maintenance_current_labels ?
+            variables.maintenance_current_labels["openbao.org/cluster"] :
+            ("app.kubernetes.io/instance" in variables.maintenance_current_labels ?
+              variables.maintenance_current_labels["app.kubernetes.io/instance"] : "")) :
           ("openbao.org/cluster" in variables.maintenance_old_labels ?
             variables.maintenance_old_labels["openbao.org/cluster"] :
             ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
-              variables.maintenance_old_labels["app.kubernetes.io/instance"] : "")) :
-          ("openbao.org/cluster" in variables.maintenance_current_labels ?
-            variables.maintenance_current_labels["openbao.org/cluster"] :
-            ("openbao.org/cluster" in variables.maintenance_old_labels ?
-              variables.maintenance_old_labels["openbao.org/cluster"] :
-              ("app.kubernetes.io/instance" in variables.maintenance_current_labels ?
-                variables.maintenance_current_labels["app.kubernetes.io/instance"] :
-                ("app.kubernetes.io/instance" in variables.maintenance_old_labels ?
-                  variables.maintenance_old_labels["app.kubernetes.io/instance"] : ""))))
+              variables.maintenance_old_labels["app.kubernetes.io/instance"] : ""))
     - name: maintenance_authorized
       expression: >-
         variables.maintenance_enabled &&
@@ -341,6 +356,19 @@ spec:
           check("maintenance").
           allowed()
   validations:
+    - expression: >-
+        variables.owner_uid_annotation_allowed ||
+        (
+          !variables.has_current_owner_uid_annotation &&
+          !variables.has_old_owner_uid_annotation
+        ) ||
+        (
+          request.operation == "UPDATE" &&
+          variables.has_current_owner_uid_annotation &&
+          variables.has_old_owner_uid_annotation &&
+          object.metadata.annotations["openbao.org/owner-uid"] == oldObject.metadata.annotations["openbao.org/owner-uid"]
+        )
+      message: The openbao.org/owner-uid annotation is reserved for OpenBao Operator managed-resource provenance.
     - expression: >-
         !(variables.is_operator_controller || variables.is_operator_provisioner) ||
         !variables.is_service_monitor_request ||

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -104,9 +104,26 @@ spec:
       expression: >-
         request.userInfo.username == "system:kube-controller-manager" ||
         request.userInfo.username == "system:serviceaccount:kube-system:kube-controller-manager"
+    - name: is_kube_scheduler
+      expression: >-
+        request.userInfo.username == "system:kube-scheduler" ||
+        request.userInfo.username == "system:serviceaccount:kube-system:kube-scheduler"
+    - name: is_storage_provisioner_serviceaccount
+      expression: >-
+        request.userInfo.username.matches("^system:serviceaccount:[^:]+:.*(csi|provisioner).*$")
+    - name: is_persistent_volume_binder
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:persistent-volume-binder"
+    - name: is_pvc_protection_controller
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:pvc-protection-controller"
     - name: is_system_controller
       expression: >-
         request.userInfo.username.startsWith("system:controller:")
+    - name: is_statefulset_controller
+      expression: >-
+        request.userInfo.username == "system:controller:statefulset-controller" ||
+        request.userInfo.username == "system:serviceaccount:kube-system:statefulset-controller"
     # K3s/K3d and some distributions use service accounts for GC instead of system:controller:*
     - name: is_garbage_collector_sa
       expression: >-
@@ -141,6 +158,9 @@ spec:
     - name: is_service_request
       expression: >-
         request.kind.group == "" && request.kind.kind == "Service"
+    - name: is_pvc_request
+      expression: >-
+        request.kind.group == "" && request.kind.kind == "PersistentVolumeClaim"
     - name: has_current_owner_uid_annotation
       expression: >-
         object != null &&
@@ -293,6 +313,18 @@ spec:
     - name: service_old_annotations
       expression: >-
         (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.annotations)) ? oldObject.metadata.annotations : {}
+    - name: pvc_new_annotations
+      expression: >-
+        (object != null && has(object.metadata) && has(object.metadata.annotations)) ? object.metadata.annotations : {}
+    - name: pvc_old_annotations
+      expression: >-
+        (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.annotations)) ? oldObject.metadata.annotations : {}
+    - name: pvc_new_finalizers
+      expression: >-
+        (object != null && has(object.metadata) && has(object.metadata.finalizers)) ? object.metadata.finalizers : []
+    - name: pvc_old_finalizers
+      expression: >-
+        (oldObject != null && has(oldObject.metadata) && has(oldObject.metadata.finalizers)) ? oldObject.metadata.finalizers : []
     - name: is_kube_system_service_metadata_update
       expression: >-
         variables.is_service_request &&
@@ -309,6 +341,53 @@ spec:
         variables.service_old_annotations.all(k, v,
           !k.startsWith("openbao.org/") ||
           (k in variables.service_new_annotations && variables.service_new_annotations[k] == v))
+    - name: is_storage_pvc_binding_update
+      expression: >-
+        variables.is_pvc_request &&
+        request.operation == "UPDATE" &&
+        (variables.is_kube_scheduler ||
+          variables.is_kube_controller_manager ||
+          variables.is_persistent_volume_binder ||
+          variables.is_pvc_protection_controller ||
+          variables.is_storage_provisioner_serviceaccount) &&
+        object != null &&
+        oldObject != null &&
+        object.metadata.name == oldObject.metadata.name &&
+        object.metadata.namespace == oldObject.metadata.namespace &&
+        object.status == oldObject.status &&
+        (has(object.metadata.labels) == has(oldObject.metadata.labels) &&
+          (!has(object.metadata.labels) || object.metadata.labels == oldObject.metadata.labels)) &&
+        (has(object.metadata.ownerReferences) == has(oldObject.metadata.ownerReferences) &&
+          (!has(object.metadata.ownerReferences) || object.metadata.ownerReferences == oldObject.metadata.ownerReferences)) &&
+        variables.pvc_new_finalizers.all(f,
+          f in variables.pvc_old_finalizers ||
+          f in ["kubernetes.io/pvc-protection", "external-provisioner.volume.kubernetes.io/finalizer"]) &&
+        variables.pvc_old_finalizers.all(f,
+          f in variables.pvc_new_finalizers ||
+          f in ["kubernetes.io/pvc-protection", "external-provisioner.volume.kubernetes.io/finalizer"]) &&
+        variables.pvc_new_annotations.all(k, v,
+          !k.startsWith("openbao.org/") ||
+          (k in variables.pvc_old_annotations && variables.pvc_old_annotations[k] == v)) &&
+        variables.pvc_old_annotations.all(k, v,
+          !k.startsWith("openbao.org/") ||
+          (k in variables.pvc_new_annotations && variables.pvc_new_annotations[k] == v)) &&
+        object.spec.accessModes == oldObject.spec.accessModes &&
+        object.spec.resources == oldObject.spec.resources &&
+        (has(object.spec.storageClassName) == has(oldObject.spec.storageClassName) &&
+          (!has(object.spec.storageClassName) || object.spec.storageClassName == oldObject.spec.storageClassName)) &&
+        (has(object.spec.volumeMode) == has(oldObject.spec.volumeMode) &&
+          (!has(object.spec.volumeMode) || object.spec.volumeMode == oldObject.spec.volumeMode)) &&
+        (has(object.spec.selector) == has(oldObject.spec.selector) &&
+          (!has(object.spec.selector) || object.spec.selector == oldObject.spec.selector)) &&
+        (has(object.spec.dataSource) == has(oldObject.spec.dataSource) &&
+          (!has(object.spec.dataSource) || object.spec.dataSource == oldObject.spec.dataSource)) &&
+        (has(object.spec.dataSourceRef) == has(oldObject.spec.dataSourceRef) &&
+          (!has(object.spec.dataSourceRef) || object.spec.dataSourceRef == oldObject.spec.dataSourceRef)) &&
+        (
+          (!has(object.spec.volumeName) && !has(oldObject.spec.volumeName)) ||
+          (has(object.spec.volumeName) && has(oldObject.spec.volumeName) && object.spec.volumeName == oldObject.spec.volumeName) ||
+          (has(object.spec.volumeName) && object.spec.volumeName != "" && (!has(oldObject.spec.volumeName) || oldObject.spec.volumeName == ""))
+        )
     - name: maintenance_enabled
       expression: >-
         request.operation == "DELETE" ?
@@ -388,6 +467,8 @@ spec:
         (variables.is_system_controller && request.resource.resource == "pods") ||
         (variables.is_system_controller && variables.is_endpoints_controller_request) ||
         (variables.is_kube_system_controller && request.resource.resource == "pods" && (request.operation == "CREATE" || request.operation == "DELETE")) ||
+        (variables.is_statefulset_controller && request.resource.resource == "persistentvolumeclaims" && request.operation == "CREATE") ||
+        variables.is_storage_pvc_binding_update ||
         (variables.is_kube_system_controller && variables.is_endpoints_controller_request) ||
         variables.is_kube_system_service_metadata_update ||
         variables.is_cert_manager_secret_request ||

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -9,7 +9,7 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]
-        resources: ["secrets", "configmaps", "services", "pods", "endpoints", "persistentvolumeclaims"]
+        resources: ["secrets", "configmaps", "services", "serviceaccounts", "pods", "endpoints", "persistentvolumeclaims"]
       - apiGroups: ["discovery.k8s.io"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE", "DELETE"]

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -436,6 +436,7 @@ spec:
           allowed()
   validations:
     - expression: >-
+        request.operation == "DELETE" ||
         variables.owner_uid_annotation_allowed ||
         (
           !variables.has_current_owner_uid_annotation &&

--- a/docs/contribute/standards/project-conventions.md
+++ b/docs/contribute/standards/project-conventions.md
@@ -64,7 +64,7 @@ Reserve `any` and `interface{}` for external API boundaries. Helpers that only w
 - Use defined types for enum-like status and phase values instead of raw strings.
 - Avoid junk-drawer package names such as `util`, `common`, or `shared`.
 - Prefer package names that describe the actual boundary or job, such as `k8sutil`, `config`, or `schema`.
-- Reuse shared platform contracts such as `internal/platform/resourceidentity` and `internal/platform/resourceapply` instead of copying names, labels, selectors, or generic apply flow into another service.
+- Reuse shared platform contracts such as `internal/platform/resourceidentity`, `internal/platform/resourceapply`, and `internal/platform/resourceownership` instead of copying names, labels, selectors, provenance checks, or generic apply flow into another service.
 - Keep `config.hcl` semantics behind `internal/service/configuration` instead of letting workload bootstrap and upgrade flows render around each other.
 
 ## Review hygiene

--- a/docs/security/infrastructure/admission-policies.md
+++ b/docs/security/infrastructure/admission-policies.md
@@ -197,8 +197,8 @@ For Hardened clusters, admission rejects TLS disablement, TLS skip-verify, backe
     {
       cells: [
         'Managed-resource mutation',
-        'Drift on operator-managed StatefulSets, Services, Pods, and other objects is denied.',
-        'This protects the reconciliation contract and keeps GitOps or manual edits from undermining the lifecycle model.',
+        'Drift on operator-managed StatefulSets, Services, Pods, PVCs, and other objects is denied. The `openbao.org/owner-uid` provenance annotation is reserved for the operator and Kubernetes controllers.',
+        'This protects the reconciliation contract, prevents forged ownership proof, and keeps GitOps or manual edits from undermining the lifecycle model.',
       ],
     },
   ]}
@@ -216,6 +216,7 @@ Admission policy is one of the reasons the operator can separate user intent fro
 
 - user-owned surfaces stay in the CR where customization is supported
 - operator-owned networking, seal, listener identity, and lifecycle wiring stay protected
+- deterministic child resources must already carry an OpenBaoCluster controller owner reference or operator-written owner UID provenance before the operator mutates or deletes them
 - CR-selected helper images, hooks, plugin executables, restore images, and Hardened image-verification trust roots require explicit delegated RBAC before they can be persisted
 - unsafe or drifted changes are rejected before they have to be repaired later
 

--- a/docs/user-guide/openbaocluster/operations/deletion.md
+++ b/docs/user-guide/openbaocluster/operations/deletion.md
@@ -102,6 +102,8 @@ Once the PVCs are deleted, the underlying volume data is gone unless you have an
 
 </Callout>
 
+The operator only deletes PVCs that carry OpenBao ownership proof, either through the `OpenBaoCluster` controller owner reference or the operator-written `openbao.org/owner-uid` annotation. Label-matched PVCs without that proof are left behind for manual review instead of being adopted or deleted by name.
+
 </TabItem>
 
 <TabItem value="delete-all" label="DeleteAll">

--- a/internal/app/openbaocluster/deletionops/cleanup.go
+++ b/internal/app/openbaocluster/deletionops/cleanup.go
@@ -11,6 +11,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -34,7 +35,7 @@ func Cleanup(
 	)
 
 	if policy == openbaov1alpha1.DeletionPolicyDeletePVCs || policy == openbaov1alpha1.DeletionPolicyDeleteAll {
-		if err := deletePVCs(ctx, kubeClient, cluster); err != nil {
+		if err := deletePVCs(ctx, logger, kubeClient, cluster); err != nil {
 			return fmt.Errorf("failed to delete PVCs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 		}
 		logger.Info("PVCs deleted per deletion policy")
@@ -45,7 +46,7 @@ func Cleanup(
 	return nil
 }
 
-func deletePVCs(ctx context.Context, kubeClient client.Client, cluster *openbaov1alpha1.OpenBaoCluster) error {
+func deletePVCs(ctx context.Context, logger logr.Logger, kubeClient client.Client, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	var pvcList corev1.PersistentVolumeClaimList
 	if err := kubeClient.List(
 		ctx,
@@ -62,6 +63,10 @@ func deletePVCs(ctx context.Context, kubeClient client.Client, cluster *openbaov
 			continue
 		}
 		if portopenbao.UsesExistingAuditFileStorage(cluster) && pvc.Name == portopenbao.AuditFileStorageClaimName(cluster) {
+			continue
+		}
+		if !resourceownership.HasOwnerProof(pvc, cluster) {
+			logger.Info("Skipping PVC cleanup because owner proof is missing", "pvc", pvc.Name)
 			continue
 		}
 		if len(pvc.Finalizers) > 0 {

--- a/internal/app/openbaocluster/deletionops/cleanup_test.go
+++ b/internal/app/openbaocluster/deletionops/cleanup_test.go
@@ -139,6 +139,27 @@ func TestDeletePVCsPreservesExistingACMESharedCachePVC(t *testing.T) {
 	}
 }
 
+func TestDeletePVCsSkipsLabelMatchedPVCWithoutOwnerProof(t *testing.T) {
+	cluster := newCleanupTestCluster("cleanup-unowned")
+	pvc := newCleanupTestPVC(cluster.Namespace, cluster.Name, "data-cleanup-unowned-0")
+	delete(pvc.Annotations, constants.AnnotationOpenBaoOwnerUID)
+	kubeClient := newCleanupTestClient(t, cluster, pvc)
+
+	err := Cleanup(context.Background(), logr.Discard(), kubeClient, cluster, openbaov1alpha1.DeletionPolicyDeletePVCs)
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	err = kubeClient.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: cluster.Namespace, Name: pvc.Name},
+		&corev1.PersistentVolumeClaim{},
+	)
+	if err != nil {
+		t.Fatalf("expected unproven PVC to be preserved, got error: %v", err)
+	}
+}
+
 func newCleanupTestClient(t *testing.T, objs ...runtime.Object) client.Client {
 	t.Helper()
 
@@ -161,6 +182,7 @@ func newCleanupTestCluster(name string) *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
+			UID:       types.UID(name + "-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -183,6 +205,9 @@ func newCleanupTestPVC(namespace, clusterName, name string) *corev1.PersistentVo
 			Namespace: namespace,
 			Labels: map[string]string{
 				constants.LabelOpenBaoCluster: clusterName,
+			},
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: clusterName + "-uid",
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{

--- a/internal/app/openbaocluster/infra_test.go
+++ b/internal/app/openbaocluster/infra_test.go
@@ -369,13 +369,15 @@ func TestReconcileDisabledReadReplicas_DeletesDrainedResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 	}
 	readReplicas := int32(0)
 	readSTS := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceidentity.ReadReplicaStatefulSetName(cluster),
-			Namespace: cluster.Namespace,
+			Name:            resourceidentity.ReadReplicaStatefulSetName(cluster),
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{infraOwnerRef(cluster)},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &readReplicas,
@@ -391,6 +393,9 @@ func TestReconcileDisabledReadReplicas_DeletesDrainedResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceidentity.ReadReplicaConfigMapName(cluster),
 			Namespace: cluster.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: string(cluster.UID),
+			},
 		},
 	}
 
@@ -434,13 +439,15 @@ func TestReconcileDisabledReadReplicas_RequeuesUntilDrained(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 	}
 	currentReplicas := int32(1)
 	readSTS := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceidentity.ReadReplicaStatefulSetName(cluster),
-			Namespace: cluster.Namespace,
+			Name:            resourceidentity.ReadReplicaStatefulSetName(cluster),
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{infraOwnerRef(cluster)},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &currentReplicas,
@@ -738,6 +745,7 @@ func TestInfraReconciler_Reconcile_MapsAPIServerNetworkConfigurationError(t *tes
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example",
 			Namespace: "default",
+			UID:       types.UID("example-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile: openbaov1alpha1.ProfileDevelopment,
@@ -1104,4 +1112,15 @@ func assertOIDCBootstrapConfigurationError(t *testing.T, err error) {
 func malformedJSONError() error {
 	var payload map[string]any
 	return json.Unmarshal([]byte("{"), &payload)
+}
+
+func infraOwnerRef(cluster *openbaov1alpha1.OpenBaoCluster) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}
 }

--- a/internal/app/openbaocluster/storage.go
+++ b/internal/app/openbaocluster/storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 const (
@@ -179,6 +180,7 @@ func ReconcileStorageResizeRestart(
 		}
 		return recon.Result{}, fmt.Errorf("failed to list PVCs for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 	}
+	pvcList.Items = filterPVCsByOwnerProof(pvcList.Items, cluster)
 
 	if cluster.Spec.Maintenance == nil || !cluster.Spec.Maintenance.Enabled {
 		if anyPVCFileSystemResizePending(pvcList.Items) {
@@ -246,4 +248,15 @@ func ReconcileStorageResizeRestart(
 	}
 
 	return recon.Result{RequeueAfter: storageRequeueShort}, nil
+}
+
+func filterPVCsByOwnerProof(pvcs []corev1.PersistentVolumeClaim, cluster *openbaov1alpha1.OpenBaoCluster) []corev1.PersistentVolumeClaim {
+	owned := pvcs[:0]
+	for i := range pvcs {
+		pvc := pvcs[i]
+		if resourceownership.HasOwnerProof(&pvc, cluster) {
+			owned = append(owned, pvc)
+		}
+	}
+	return owned
 }

--- a/internal/app/openbaocluster/storage_pvc.go
+++ b/internal/app/openbaocluster/storage_pvc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 func desiredStorageSpec(cluster *openbaov1alpha1.OpenBaoCluster) (resource.Quantity, string, error) {
@@ -88,6 +89,9 @@ func listClusterPVCs(ctx context.Context, c client.Client, cluster *openbaov1alp
 	}
 	for i := range pvcList.Items {
 		pvc := pvcList.Items[i]
+		if !resourceownership.HasOwnerProof(&pvc, cluster) {
+			continue
+		}
 		if !isManagedDataPVC(cluster.Name, pvc.Name) {
 			continue
 		}

--- a/internal/app/openbaocluster/storage_test.go
+++ b/internal/app/openbaocluster/storage_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +56,8 @@ func TestStorageReconciler_ExpandsPVCs(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, pvc)
+	markStorageTestPVC(cluster, pvc)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
 	r := NewStorageReconciler(
@@ -105,6 +108,8 @@ func TestStorageReconciler_RejectsShrink(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, pvc)
+	markStorageTestPVC(cluster, pvc)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
 	r := NewStorageReconciler(
@@ -154,6 +159,8 @@ func TestStorageReconciler_RejectsStorageClassChangeWhenPVCClassIsUnset(t *testi
 			},
 		},
 	}
+	markStorageTestPVC(cluster, pvc)
+	markStorageTestPVC(cluster, pvc)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
 	r := NewStorageReconciler(
@@ -204,6 +211,7 @@ func TestStorageReconciler_IgnoresACMECachePVCForStorageClassValidation(t *testi
 			},
 		},
 	}
+	markStorageTestPVC(cluster, dataPVC)
 
 	acmeClass := "efs-acme"
 	acmeCachePVC := &corev1.PersistentVolumeClaim{
@@ -277,6 +285,7 @@ func TestStorageReconciler_ExpandsReadReplicaPVCsUsingReadReplicaStorageSpec(t *
 			},
 		},
 	}
+	markStorageTestPVC(cluster, voterPVC)
 	readPVC := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "data-" + resourceidentity.ReadReplicaStatefulSetName(cluster) + "-0",
@@ -294,6 +303,7 @@ func TestStorageReconciler_ExpandsReadReplicaPVCsUsingReadReplicaStorageSpec(t *
 			},
 		},
 	}
+	markStorageTestPVC(cluster, readPVC)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(voterPVC, readPVC).Build()
 	r := NewStorageReconciler(
@@ -380,6 +390,7 @@ func TestStorageResizeRestartReconciler_RestartsFollowerPod(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, pvc)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -448,6 +459,7 @@ func TestStorageResizeRestartReconciler_StepsDownLeaderFirst(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, pvc)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -520,6 +532,7 @@ func TestStorageResizeRestartReconciler_RequiresMaintenance(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, pvc)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, pvc).Build()
 
@@ -567,6 +580,7 @@ func TestStorageResizeRestartReconciler_PrefersReadReplicaPods(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, voterPVC)
 	readPVC := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "data-" + resourceidentity.ReadReplicaStatefulSetName(cluster) + "-0",
@@ -581,6 +595,7 @@ func TestStorageResizeRestartReconciler_PrefersReadReplicaPods(t *testing.T) {
 			},
 		},
 	}
+	markStorageTestPVC(cluster, readPVC)
 	voterPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-0", Namespace: "default"},
 		Status: corev1.PodStatus{
@@ -619,4 +634,14 @@ func TestStorageResizeRestartReconciler_PrefersReadReplicaPods(t *testing.T) {
 
 func quantityPtr(q resource.Quantity) *resource.Quantity {
 	return &q
+}
+
+func markStorageTestPVC(cluster *openbaov1alpha1.OpenBaoCluster, pvc *corev1.PersistentVolumeClaim) {
+	if cluster.UID == "" {
+		cluster.UID = types.UID(cluster.Name + "-uid")
+	}
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	pvc.Annotations[constants.AnnotationOpenBaoOwnerUID] = string(cluster.UID)
 }

--- a/internal/platform/constants/annotations.go
+++ b/internal/platform/constants/annotations.go
@@ -12,4 +12,6 @@ const (
 	AnnotationMaintenanceAllowed = "openbao.org/maintenance-allowed"
 	// AnnotationRestartAt is the annotation key used to trigger a rolling restart via Pod template updates.
 	AnnotationRestartAt = "openbao.org/restart-at"
+	// AnnotationOpenBaoOwnerUID ties retained operator-managed resources to the owning OpenBaoCluster UID.
+	AnnotationOpenBaoOwnerUID = "openbao.org/owner-uid"
 )

--- a/internal/platform/resourceapply/apply.go
+++ b/internal/platform/resourceapply/apply.go
@@ -12,17 +12,84 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 func ApplyOwned(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj client.Object) error {
-	if err := PrepareOwned(obj, owner, scheme); err != nil {
+	resolvedOwner, err := ResolveOwnerIdentity(ctx, c, owner)
+	if err != nil {
+		return err
+	}
+	if err := resourceownership.RequireOwnerUID(resolvedOwner); err != nil {
+		return err
+	}
+	if err := EnsureOwnedResourceManageable(ctx, c, resolvedOwner, obj); err != nil {
+		return err
+	}
+	if err := PrepareOwned(obj, resolvedOwner, scheme); err != nil {
 		return err
 	}
 	applyConfig, err := kube.ToApplyConfiguration(obj, c)
 	if err != nil {
 		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
 	}
-	return ApplyConfiguration(ctx, c, obj, applyConfig)
+	if err := ApplyConfiguration(ctx, c, obj, applyConfig); err != nil {
+		return err
+	}
+	return EnsureOwnedResourceProofStamped(ctx, c, scheme, resolvedOwner, obj)
+}
+
+func ResolveOwnerIdentity(ctx context.Context, c client.Client, owner client.Object) (client.Object, error) {
+	if owner == nil || owner.GetUID() != "" || c == nil {
+		return owner, nil
+	}
+	liveOwner, ok := owner.DeepCopyObject().(client.Object)
+	if !ok {
+		return owner, nil
+	}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(owner), liveOwner); err != nil {
+		if apierrors.IsNotFound(err) {
+			return owner, nil
+		}
+		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
+			return nil, operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to resolve owner identity %s/%s: %w", owner.GetNamespace(), owner.GetName(), err))
+		}
+		return nil, fmt.Errorf("failed to resolve owner identity %s/%s: %w", owner.GetNamespace(), owner.GetName(), err)
+	}
+	if liveOwner.GetUID() == "" {
+		return owner, nil
+	}
+	return liveOwner, nil
+}
+
+func EnsureOwnedResourceManageable(ctx context.Context, c client.Client, owner client.Object, obj client.Object) error {
+	if c == nil {
+		return fmt.Errorf("client is required")
+	}
+	if owner == nil {
+		return fmt.Errorf("owner is required")
+	}
+	if obj == nil {
+		return fmt.Errorf("object is required")
+	}
+	existing, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("object %T does not implement client.Object", obj)
+	}
+	prepareObjectForGet(existing, obj)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
+			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to check existing resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+		}
+		return fmt.Errorf("failed to check existing resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	if err := resourceownership.RequireOwnerProof("manage", existing, owner); err != nil {
+		return err
+	}
+	return nil
 }
 
 func ApplyUnowned(ctx context.Context, c client.Client, obj client.Object) error {
@@ -33,14 +100,124 @@ func ApplyUnowned(ctx context.Context, c client.Client, obj client.Object) error
 	return ApplyConfiguration(ctx, c, obj, applyConfig)
 }
 
+func ApplyRetained(ctx context.Context, c client.Client, owner client.Object, obj client.Object) error {
+	resolvedOwner, err := ResolveOwnerIdentity(ctx, c, owner)
+	if err != nil {
+		return err
+	}
+	if err := resourceownership.RequireOwnerUID(resolvedOwner); err != nil {
+		return err
+	}
+	if err := resourceownership.SetOwnerUIDAnnotation(obj, resolvedOwner); err != nil {
+		return err
+	}
+	if err := EnsureOwnedResourceManageable(ctx, c, resolvedOwner, obj); err != nil {
+		return err
+	}
+	if err := ApplyUnowned(ctx, c, obj); err != nil {
+		return err
+	}
+	return EnsureRetainedResourceProofStamped(ctx, c, resolvedOwner, obj)
+}
+
 func PrepareOwned(obj client.Object, owner client.Object, scheme *runtime.Scheme) error {
 	if scheme == nil {
 		return fmt.Errorf("scheme is required")
 	}
+	if err := resourceownership.RequireOwnerUID(owner); err != nil {
+		return err
+	}
 	if err := controllerutil.SetControllerReference(owner, obj, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}
+	if err := resourceownership.SetOwnerUIDAnnotation(obj, owner); err != nil {
+		return err
+	}
 	return nil
+}
+
+func EnsureOwnedResourceProofStamped(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj client.Object) error {
+	existing, err := getExistingObject(ctx, c, obj)
+	if err != nil {
+		return err
+	}
+	if resourceownership.HasOwnerProof(existing, owner) {
+		return nil
+	}
+
+	before, ok := existing.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("object %T does not implement client.Object", existing)
+	}
+	if err := PrepareOwned(existing, owner, scheme); err != nil {
+		return err
+	}
+	if err := c.Patch(ctx, existing, client.MergeFrom(before)); err != nil {
+		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
+			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to stamp owner proof on resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+		}
+		return fmt.Errorf("failed to stamp owner proof on resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	return nil
+}
+
+func EnsureRetainedResourceProofStamped(ctx context.Context, c client.Client, owner client.Object, obj client.Object) error {
+	existing, err := getExistingObject(ctx, c, obj)
+	if err != nil {
+		return err
+	}
+	if resourceownership.HasOwnerProof(existing, owner) {
+		return nil
+	}
+
+	before, ok := existing.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("object %T does not implement client.Object", existing)
+	}
+	if err := resourceownership.SetOwnerUIDAnnotation(existing, owner); err != nil {
+		return err
+	}
+	if err := c.Patch(ctx, existing, client.MergeFrom(before)); err != nil {
+		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
+			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to stamp retained owner proof on resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+		}
+		return fmt.Errorf("failed to stamp retained owner proof on resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	return nil
+}
+
+func getExistingObject(ctx context.Context, c client.Client, obj client.Object) (client.Object, error) {
+	if c == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("object is required")
+	}
+	existing, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("object %T does not implement client.Object", obj)
+	}
+	prepareObjectForGet(existing, obj)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
+		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
+			return nil, operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to get resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err))
+		}
+		return nil, fmt.Errorf("failed to get resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+	return existing, nil
+}
+
+func prepareObjectForGet(existing client.Object, obj client.Object) {
+	gvk := existing.GetObjectKind().GroupVersionKind()
+	existing.SetName(obj.GetName())
+	existing.SetNamespace(obj.GetNamespace())
+	existing.SetLabels(nil)
+	existing.SetAnnotations(nil)
+	existing.SetOwnerReferences(nil)
+	existing.SetManagedFields(nil)
+	existing.SetUID("")
+	existing.SetResourceVersion("")
+	existing.GetObjectKind().SetGroupVersionKind(gvk)
 }
 
 func ApplyConfiguration(ctx context.Context, c client.Client, obj client.Object, applyConfig runtime.ApplyConfiguration) error {

--- a/internal/platform/resourceapply/apply_test.go
+++ b/internal/platform/resourceapply/apply_test.go
@@ -8,10 +8,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
 
 func TestApplyOwnedSetsOwnerReference(t *testing.T) {
@@ -32,6 +34,30 @@ func TestApplyOwnedSetsOwnerReference(t *testing.T) {
 	if len(stored.OwnerReferences) != 1 || stored.OwnerReferences[0].Name != owner.Name {
 		t.Fatalf("expected controller owner reference for %q, got %#v", owner.Name, stored.OwnerReferences)
 	}
+	if got := stored.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != string(owner.UID) {
+		t.Fatalf("owner UID annotation = %q, want %q", got, owner.UID)
+	}
+}
+
+func TestApplyOwnedResolvesLiveOwnerUID(t *testing.T) {
+	scheme := newTestScheme(t)
+	liveOwner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: types.UID("live-owner-uid")}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(liveOwner).WithReturnManagedFields().Build()
+
+	staleOwner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+
+	if err := ApplyOwned(context.Background(), k8sClient, scheme, staleOwner, obj); err != nil {
+		t.Fatalf("ApplyOwned() error = %v", err)
+	}
+
+	stored := &corev1.ConfigMap{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(stored.OwnerReferences) != 1 || stored.OwnerReferences[0].UID != liveOwner.UID {
+		t.Fatalf("expected controller owner reference UID %q, got %#v", liveOwner.UID, stored.OwnerReferences)
+	}
 }
 
 func TestApplyUnownedDoesNotSetOwnerReference(t *testing.T) {
@@ -50,6 +76,86 @@ func TestApplyUnownedDoesNotSetOwnerReference(t *testing.T) {
 	}
 	if len(stored.OwnerReferences) != 0 {
 		t.Fatalf("expected no owner references, got %#v", stored.OwnerReferences)
+	}
+}
+
+func TestApplyRetainedSetsOwnerUIDAnnotation(t *testing.T) {
+	scheme := newTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithReturnManagedFields().Build()
+
+	owner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: types.UID("owner-uid")}}
+	obj := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-test-0", Namespace: "default"}}
+
+	if err := ApplyRetained(context.Background(), k8sClient, owner, obj); err != nil {
+		t.Fatalf("ApplyRetained() error = %v", err)
+	}
+
+	stored := &corev1.PersistentVolumeClaim{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := stored.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != string(owner.UID) {
+		t.Fatalf("owner UID annotation = %q, want %q", got, owner.UID)
+	}
+	if len(stored.OwnerReferences) != 0 {
+		t.Fatalf("expected no owner references for retained resource, got %#v", stored.OwnerReferences)
+	}
+}
+
+func TestApplyRetainedRejectsUnownedExistingResource(t *testing.T) {
+	scheme := newTestScheme(t)
+	existing := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-test-0", Namespace: "default"}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(existing).WithReturnManagedFields().Build()
+
+	owner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: types.UID("owner-uid")}}
+	obj := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-test-0", Namespace: "default"}}
+
+	err := ApplyRetained(context.Background(), k8sClient, owner, obj)
+	if err == nil {
+		t.Fatal("ApplyRetained() expected error")
+	}
+	if !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("ApplyRetained() error = %q, want owner proof error", err.Error())
+	}
+}
+
+func TestApplyOwnedRejectsUnownedExistingResource(t *testing.T) {
+	scheme := newTestScheme(t)
+	existing := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(existing).WithReturnManagedFields().Build()
+
+	owner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: types.UID("owner-uid")}}
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+
+	err := ApplyOwned(context.Background(), k8sClient, scheme, owner, obj)
+	if err == nil {
+		t.Fatal("ApplyOwned() expected error")
+	}
+	if !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("ApplyOwned() error = %q, want owner proof error", err.Error())
+	}
+}
+
+func TestApplyOwnedAllowsExistingOwnedResource(t *testing.T) {
+	scheme := newTestScheme(t)
+	controller := true
+	owner := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: types.UID("owner-uid")}}
+	existing := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      "cfg",
+		Namespace: "default",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: openbaov1alpha1.GroupVersion.String(),
+			Kind:       "OpenBaoCluster",
+			Name:       owner.Name,
+			UID:        owner.UID,
+			Controller: &controller,
+		}},
+	}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(owner, existing).WithReturnManagedFields().Build()
+
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+	if err := ApplyOwned(context.Background(), k8sClient, scheme, owner, obj); err != nil {
+		t.Fatalf("ApplyOwned() error = %v", err)
 	}
 }
 

--- a/internal/platform/resourceownership/ownership.go
+++ b/internal/platform/resourceownership/ownership.go
@@ -1,0 +1,103 @@
+package resourceownership
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+// HasOwnerProof reports whether obj is provably owned by owner.
+//
+// Controller owner references are preferred. The owner UID annotation is used
+// for retained resources, such as PVCs, that must survive owner deletion.
+func HasOwnerProof(obj client.Object, owner client.Object) bool {
+	return HasControllerOwnerReference(obj, owner) || HasOwnerUIDAnnotation(obj, owner)
+}
+
+// HasControllerOwnerReference reports whether obj has a controller owner
+// reference for owner.
+func HasControllerOwnerReference(obj client.Object, owner client.Object) bool {
+	if obj == nil || owner == nil {
+		return false
+	}
+	ownerUID := owner.GetUID()
+	if ownerUID == "" {
+		return false
+	}
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Controller == nil || !*ref.Controller {
+			continue
+		}
+		if ref.UID == ownerUID {
+			return true
+		}
+	}
+	return false
+}
+
+// HasOwnerUIDAnnotation reports whether obj carries the retained-resource
+// provenance annotation for owner.
+func HasOwnerUIDAnnotation(obj client.Object, owner client.Object) bool {
+	if obj == nil || owner == nil || owner.GetUID() == "" {
+		return false
+	}
+	return obj.GetAnnotations()[constants.AnnotationOpenBaoOwnerUID] == string(owner.GetUID())
+}
+
+// SetOwnerUIDAnnotation records the owning resource UID on obj.
+func SetOwnerUIDAnnotation(obj client.Object, owner client.Object) error {
+	if obj == nil {
+		return fmt.Errorf("object is required")
+	}
+	if owner == nil {
+		return fmt.Errorf("owner is required")
+	}
+	uid := owner.GetUID()
+	if uid == "" {
+		return nil
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[constants.AnnotationOpenBaoOwnerUID] = string(uid)
+	obj.SetAnnotations(annotations)
+	return nil
+}
+
+func RequireOwnerUID(owner client.Object) error {
+	if owner == nil {
+		return fmt.Errorf("owner is required")
+	}
+	if owner.GetUID() == "" {
+		return fmt.Errorf("owner UID is required")
+	}
+	return nil
+}
+
+// RequireOwnerProof returns an error when obj exists but is not proven to
+// belong to owner.
+func RequireOwnerProof(action string, obj client.Object, owner client.Object) error {
+	if HasOwnerProof(obj, owner) {
+		return nil
+	}
+	namespace, name := "", ""
+	if obj != nil {
+		namespace = obj.GetNamespace()
+		name = obj.GetName()
+	}
+	return fmt.Errorf("%s %s %s/%s requires OpenBaoCluster owner proof", strings.TrimSpace(action), kindOf(obj), namespace, name)
+}
+
+func kindOf(obj client.Object) string {
+	if obj == nil {
+		return "resource"
+	}
+	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != "" {
+		return kind
+	}
+	return "resource"
+}

--- a/internal/platform/resourceownership/ownership_test.go
+++ b/internal/platform/resourceownership/ownership_test.go
@@ -1,0 +1,95 @@
+package resourceownership
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+func TestHasOwnerProof(t *testing.T) {
+	owner := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default", UID: types.UID("cluster-uid")},
+	}
+
+	controller := true
+	tests := []struct {
+		name string
+		obj  *corev1.ConfigMap
+		want bool
+	}{
+		{
+			name: "controller owner reference",
+			obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      "owned",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: openbaov1alpha1.GroupVersion.String(),
+					Kind:       "OpenBaoCluster",
+					Name:       owner.Name,
+					UID:        owner.UID,
+					Controller: &controller,
+				}},
+			}},
+			want: true,
+		},
+		{
+			name: "owner uid annotation",
+			obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:        "retained",
+				Namespace:   "default",
+				Annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: string(owner.UID)},
+			}},
+			want: true,
+		},
+		{
+			name: "non-controller owner reference is insufficient",
+			obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      "weak",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: openbaov1alpha1.GroupVersion.String(),
+					Kind:       "OpenBaoCluster",
+					Name:       owner.Name,
+					UID:        owner.UID,
+				}},
+			}},
+			want: false,
+		},
+		{
+			name: "wrong uid is rejected",
+			obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:        "wrong",
+				Namespace:   "default",
+				Annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: "other"},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasOwnerProof(tt.obj, owner); got != tt.want {
+				t.Fatalf("HasOwnerProof() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetOwnerUIDAnnotation(t *testing.T) {
+	owner := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default", UID: types.UID("cluster-uid")},
+	}
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+
+	if err := SetOwnerUIDAnnotation(obj, owner); err != nil {
+		t.Fatalf("SetOwnerUIDAnnotation() error = %v", err)
+	}
+	if got := obj.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != string(owner.UID) {
+		t.Fatalf("owner UID annotation = %q, want %q", got, owner.UID)
+	}
+}

--- a/internal/service/backup/job_test.go
+++ b/internal/service/backup/job_test.go
@@ -59,6 +59,7 @@ func newTestClusterWithBackup(name, namespace string) *openbaov1alpha1.OpenBaoCl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",

--- a/internal/service/bootstrap/acme_cache.go
+++ b/internal/service/bootstrap/acme_cache.go
@@ -13,6 +13,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -26,7 +27,7 @@ func (m *Manager) ensureACMESharedCachePVC(ctx context.Context, logger logr.Logg
 		return err
 	}
 
-	if err := m.applyResourceWithoutOwnerRef(ctx, pvc); err != nil {
+	if err := m.applyRetainedResource(ctx, pvc, cluster); err != nil {
 		return fmt.Errorf("failed to ensure ACME shared cache PVC %s/%s: %w", pvc.Namespace, pvc.Name, err)
 	}
 
@@ -66,9 +67,12 @@ func buildManagedACMESharedCachePVC(cluster *openbaov1alpha1.OpenBaoCluster) (*c
 		className := *sc
 		pvc.Spec.StorageClassName = &className
 	}
+	if err := resourceownership.SetOwnerUIDAnnotation(pvc, cluster); err != nil {
+		return nil, err
+	}
 	return pvc, nil
 }
 
-func (m *Manager) applyResourceWithoutOwnerRef(ctx context.Context, obj client.Object) error {
-	return resourceapply.ApplyUnowned(ctx, m.client, obj)
+func (m *Manager) applyRetainedResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	return resourceapply.ApplyRetained(ctx, m.client, cluster, obj)
 }

--- a/internal/service/bootstrap/audit_file_storage.go
+++ b/internal/service/bootstrap/audit_file_storage.go
@@ -12,6 +12,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -25,7 +26,7 @@ func (m *Manager) ensureAuditFileStoragePVC(ctx context.Context, logger logr.Log
 		return err
 	}
 
-	if err := m.applyResourceWithoutOwnerRef(ctx, pvc); err != nil {
+	if err := m.applyRetainedResource(ctx, pvc, cluster); err != nil {
 		return fmt.Errorf("failed to ensure audit file storage PVC %s/%s: %w", pvc.Namespace, pvc.Name, err)
 	}
 
@@ -67,6 +68,9 @@ func buildManagedAuditFileStoragePVC(cluster *openbaov1alpha1.OpenBaoCluster) (*
 	if sc := cluster.Spec.AuditFileStorage.StorageClassName; sc != nil && *sc != "" {
 		className := *sc
 		pvc.Spec.StorageClassName = &className
+	}
+	if err := resourceownership.SetOwnerUIDAnnotation(pvc, cluster); err != nil {
+		return nil, err
 	}
 	return pvc, nil
 }

--- a/internal/service/bootstrap/config.go
+++ b/internal/service/bootstrap/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/auth"
 	configbuilder "github.com/dc-tec/openbao-operator/internal/adapter/config"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
 
@@ -35,10 +36,9 @@ func usesStaticSeal(cluster *openbaov1alpha1.OpenBaoCluster) bool {
 }
 
 // ensureUnsealSecret manages the static auto-unseal Secret for the OpenBaoCluster.
-// This function implements a "blind create" pattern: it generates the key in memory
-// and attempts to create the Secret, ignoring AlreadyExists errors. This ensures
-// the operator never needs GET permission on the unseal key Secret after creation,
-// improving security by preventing the operator from reading root keys.
+// This function implements a "blind create" pattern: it generates the key in
+// memory and attempts to create the Secret without reading Secret data. If a
+// Secret already exists, only metadata ownership proof is accepted.
 func (m *Manager) ensureUnsealSecret(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	secretName := resourceidentity.UnsealSecretName(cluster)
 
@@ -65,11 +65,17 @@ func (m *Manager) ensureUnsealSecret(ctx context.Context, logger logr.Logger, cl
 	if err := controllerutil.SetControllerReference(cluster, secret, m.scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on unseal Secret %s/%s: %w", cluster.Namespace, secretName, err)
 	}
+	if err := resourceownership.SetOwnerUIDAnnotation(secret, cluster); err != nil {
+		return err
+	}
 
-	// Attempt CREATE - ignore AlreadyExists errors (blind create pattern)
+	// Attempt CREATE first. Existing Secrets are accepted only when metadata
+	// proves they already belong to this OpenBaoCluster.
 	if err := m.client.Create(ctx, secret); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			// Secret already exists - this is fine, we don't need to read it
+			if proofErr := m.requireExistingSecretOwnerProof(ctx, cluster, secretName, "use existing unseal Secret"); proofErr != nil {
+				return proofErr
+			}
 			logger.Info("Unseal Secret already exists; skipping creation", "secret", secretName)
 			return nil
 		}
@@ -78,6 +84,15 @@ func (m *Manager) ensureUnsealSecret(ctx context.Context, logger logr.Logger, cl
 
 	logger.Info("Created unseal Secret", "secret", secretName)
 	return nil
+}
+
+func (m *Manager) requireExistingSecretOwnerProof(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, secretName, action string) error {
+	metadata := &metav1.PartialObjectMetadata{}
+	metadata.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: secretName}, metadata); err != nil {
+		return fmt.Errorf("failed to verify existing Secret %s/%s owner proof: %w", cluster.Namespace, secretName, err)
+	}
+	return resourceownership.RequireOwnerProof(action, metadata, cluster)
 }
 
 // generateUnsealKey generates a 32-byte random key for the static unseal Secret.
@@ -146,6 +161,9 @@ func (m *Manager) ensureSelfInitConfigMap(ctx context.Context, logger logr.Logge
 		}
 
 		logger.Info("Self-init disabled; deleting self-init ConfigMap", "configmap", cmName)
+		if err := resourceownership.RequireOwnerProof("delete self-init ConfigMap", configMap, cluster); err != nil {
+			return err
+		}
 		if err := m.client.Delete(ctx, configMap); err != nil {
 			return fmt.Errorf("failed to delete self-init ConfigMap %s/%s: %w", cluster.Namespace, cmName, err)
 		}
@@ -217,6 +235,9 @@ func (m *Manager) ensureSelfInitConfigMap(ctx context.Context, logger logr.Logge
 		}
 
 		logger.Info("No self-init requests; deleting self-init ConfigMap", "configmap", cmName)
+		if err := resourceownership.RequireOwnerProof("delete self-init ConfigMap", configMap, cluster); err != nil {
+			return err
+		}
 		if err := m.client.Delete(ctx, configMap); err != nil {
 			return fmt.Errorf("failed to delete self-init ConfigMap %s/%s: %w", cluster.Namespace, cmName, err)
 		}

--- a/internal/service/bootstrap/config_test.go
+++ b/internal/service/bootstrap/config_test.go
@@ -144,8 +144,9 @@ func TestEnsureUnsealSecret_CreatesSecret(t *testing.T) {
 	}
 }
 
-func TestEnsureUnsealSecret_HandlesAlreadyExists(t *testing.T) {
+func TestEnsureUnsealSecret_RejectsUnownedAlreadyExists(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.UID = types.UID("test-cluster-uid")
 	secretName := resourceidentity.UnsealSecretName(cluster)
 
 	existingSecret := &corev1.Secret{
@@ -164,10 +165,36 @@ func TestEnsureUnsealSecret_HandlesAlreadyExists(t *testing.T) {
 	k8sClient := newTestClientWithObjects(t, existingSecret)
 	manager := NewManager(k8sClient, testScheme, "openbao-operator-system")
 
-	// Should not error when secret already exists (blind create pattern)
 	err := manager.ensureUnsealSecret(ctx, logger, cluster)
-	if err != nil {
-		t.Fatalf("ensureUnsealSecret() with existing secret should not error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("ensureUnsealSecret() error = %v, want owner proof error", err)
+	}
+}
+
+func TestEnsureUnsealSecret_AllowsOwnedAlreadyExists(t *testing.T) {
+	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.UID = types.UID("test-cluster-uid")
+	secretName := resourceidentity.UnsealSecretName(cluster)
+
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            secretName,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{bootstrapOwnerRef(cluster)},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			unsealSecretKey: []byte("existing-key"),
+		},
+	}
+
+	ctx := context.Background()
+	logger := logr.Discard()
+	k8sClient := newTestClientWithObjects(t, existingSecret)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system")
+
+	if err := manager.ensureUnsealSecret(ctx, logger, cluster); err != nil {
+		t.Fatalf("ensureUnsealSecret() error = %v", err)
 	}
 }
 
@@ -204,12 +231,14 @@ func TestEnsureConfigMap_CreatesConfigMap(t *testing.T) {
 
 func TestEnsureConfigMap_UpdatesConfigMap(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.UID = types.UID("test-cluster-uid")
 	cmName := resourceidentity.ConfigMapName(cluster)
 
 	existingConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: cluster.Namespace,
+			Name:            cmName,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{bootstrapOwnerRef(cluster)},
 		},
 		Data: map[string]string{
 			configFileName: "old config content",
@@ -245,13 +274,15 @@ func TestEnsureConfigMap_UpdatesConfigMap(t *testing.T) {
 
 func TestEnsureConfigMap_IsIdempotent(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.UID = types.UID("test-cluster-uid")
 	cmName := resourceidentity.ConfigMapName(cluster)
 	configContent := "test config content"
 
 	existingConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: cluster.Namespace,
+			Name:            cmName,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{bootstrapOwnerRef(cluster)},
 		},
 		Data: map[string]string{
 			configFileName: configContent,
@@ -292,6 +323,7 @@ func TestEnsureConfigMap_IsIdempotent(t *testing.T) {
 
 func TestEnsureSelfInitConfigMap_Disabled(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.UID = types.UID("test-cluster-uid")
 	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
 		Enabled: false,
 	}
@@ -299,8 +331,9 @@ func TestEnsureSelfInitConfigMap_Disabled(t *testing.T) {
 
 	existingConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: cluster.Namespace,
+			Name:            cmName,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{bootstrapOwnerRef(cluster)},
 		},
 		Data: map[string]string{
 			configFileName: "old init config",
@@ -643,5 +676,16 @@ func TestDeleteSecrets_PartialMissing(t *testing.T) {
 	err := deleteSecrets(ctx, k8sClient, cluster)
 	if err != nil {
 		t.Fatalf("deleteSecrets() with missing secrets should not error, got: %v", err)
+	}
+}
+
+func bootstrapOwnerRef(cluster *openbaov1alpha1.OpenBaoCluster) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
 	}
 }

--- a/internal/service/bootstrap/helpers_test.go
+++ b/internal/service/bootstrap/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -56,6 +57,7 @@ func newMinimalCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",

--- a/internal/service/certs/manager_secrets.go
+++ b/internal/service/certs/manager_secrets.go
@@ -15,6 +15,8 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 // applySecret creates or patches a Secret using Server-Side Apply.
@@ -33,6 +35,9 @@ func (m *Manager) applySecret(ctx context.Context, secret *corev1.Secret) error 
 }
 
 func (m *Manager) ensureManagedSecretMetadata(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, secret *corev1.Secret) error {
+	if err := resourceownership.RequireOwnerProof("use operator-managed TLS Secret", secret, cluster); err != nil {
+		return err
+	}
 	before := secret.DeepCopy()
 
 	if secret.Labels == nil {
@@ -44,8 +49,13 @@ func (m *Manager) ensureManagedSecretMetadata(ctx context.Context, cluster *open
 	if err := controllerutil.SetControllerReference(cluster, secret, m.scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on Secret %s/%s: %w", secret.Namespace, secret.Name, err)
 	}
+	if err := resourceownership.SetOwnerUIDAnnotation(secret, cluster); err != nil {
+		return err
+	}
 
-	if reflect.DeepEqual(before.Labels, secret.Labels) && reflect.DeepEqual(before.OwnerReferences, secret.OwnerReferences) {
+	if reflect.DeepEqual(before.Labels, secret.Labels) &&
+		reflect.DeepEqual(before.Annotations, secret.Annotations) &&
+		reflect.DeepEqual(before.OwnerReferences, secret.OwnerReferences) {
 		return nil
 	}
 
@@ -73,11 +83,18 @@ func (m *Manager) getSecret(ctx context.Context, namespace, name, description st
 }
 
 func (m *Manager) applyOwnedSecret(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, secret *corev1.Secret, description string) error {
-	if err := controllerutil.SetControllerReference(cluster, secret, m.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference on %s %s/%s: %w", description, secret.Namespace, secret.Name, err)
+	resolvedCluster, err := resourceapply.ResolveOwnerIdentity(ctx, m.client, cluster)
+	if err != nil {
+		return err
+	}
+	if err := resourceapply.EnsureOwnedResourceManageable(ctx, m.client, resolvedCluster, secret); err != nil {
+		return fmt.Errorf("failed to verify %s %s/%s owner proof: %w", description, secret.Namespace, secret.Name, err)
+	}
+	if err := resourceapply.PrepareOwned(secret, resolvedCluster, m.scheme); err != nil {
+		return err
 	}
 	if err := m.applySecret(ctx, secret); err != nil {
 		return fmt.Errorf("failed to apply %s %s/%s: %w", description, secret.Namespace, secret.Name, err)
 	}
-	return nil
+	return resourceapply.EnsureOwnedResourceProofStamped(ctx, m.client, m.scheme, resolvedCluster, secret)
 }

--- a/internal/service/certs/manager_test.go
+++ b/internal/service/certs/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"strings"
 	"testing"
 	"time"
 
@@ -200,6 +201,7 @@ func TestReconcileCreatesCAAndServerSecrets(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dev-cluster",
 			Namespace: "security",
+			UID:       types.UID("dev-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.1.0",
@@ -281,6 +283,7 @@ func TestReconcileBackfillsManagedSecretLabels(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "backfill-cluster",
 			Namespace: "security",
+			UID:       types.UID("backfill-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -320,6 +323,7 @@ func TestReconcileBackfillsManagedSecretLabels(t *testing.T) {
 			Labels: map[string]string{
 				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
 			},
+			OwnerReferences: []metav1.OwnerReference{certOwnerRef(cluster)},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -334,6 +338,7 @@ func TestReconcileBackfillsManagedSecretLabels(t *testing.T) {
 			Labels: map[string]string{
 				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
 			},
+			OwnerReferences: []metav1.OwnerReference{certOwnerRef(cluster)},
 		},
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{
@@ -373,9 +378,97 @@ func TestReconcileBackfillsManagedSecretLabels(t *testing.T) {
 	}
 }
 
+func TestReconcileRejectsUnownedOperatorManagedCASecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add OpenBao scheme: %v", err)
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preseeded-cluster",
+			Namespace: "security",
+			UID:       types.UID("preseeded-cluster-uid"),
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version:  "2.4.4",
+			Image:    "openbao/openbao:2.4.4",
+			Replicas: 3,
+			TLS: openbaov1alpha1.TLSConfig{
+				Enabled:        true,
+				RotationPeriod: "720h",
+			},
+			Storage: openbaov1alpha1.StorageConfig{Size: "10Gi"},
+		},
+	}
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caSecretName(cluster),
+			Namespace: cluster.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			caCertKey: []byte("attacker-ca"),
+			caKeyKey:  []byte("attacker-key"),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, caSecret).Build()
+	manager := NewManagerWithReloader(client, scheme, nil)
+
+	if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err == nil {
+		t.Fatal("Reconcile() error = nil, want owner proof error")
+	}
+}
+
+func TestApplyOwnedSecretRejectsUnownedExistingSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add OpenBao scheme: %v", err)
+	}
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "race-cluster",
+			Namespace: "security",
+			UID:       types.UID("race-cluster-uid"),
+		},
+	}
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caSecretName(cluster),
+			Namespace: cluster.Namespace,
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	manager := NewManagerWithReloader(client, scheme, nil)
+
+	desired := buildCASecret(cluster, caSecretName(cluster), []byte("ca"), []byte("key"))
+	err := manager.applyOwnedSecret(context.Background(), cluster, desired, "CA Secret")
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("applyOwnedSecret() error = %v, want owner proof error", err)
+	}
+}
+
 type recordingReloadSignaler struct {
 	called   bool
 	lastHash string
+}
+
+func certOwnerRef(cluster *openbaov1alpha1.OpenBaoCluster) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}
 }
 
 func (r *recordingReloadSignaler) SignalReload(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, certHash string) error {
@@ -402,6 +495,7 @@ func TestReconcileTriggersReloadOnNewServerCert(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "reload-cluster",
 			Namespace: "security",
+			UID:       types.UID("reload-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.1.0",
@@ -448,6 +542,7 @@ func TestReconcileRotatesNearExpiryCertAndSignalsReload(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "rotate-cluster",
 			Namespace: "security",
+			UID:       types.UID("rotate-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -569,6 +664,7 @@ func TestReconcileReissuesServerCertOnSANMismatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "san-mismatch-cluster",
 			Namespace: "security",
+			UID:       types.UID("san-mismatch-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -614,6 +710,8 @@ func TestReconcileReissuesServerCertOnSANMismatch(t *testing.T) {
 
 	caSecret := buildCASecret(cluster, caSecretName(cluster), caCertPEM, caKeyPEM)
 	serverSecret := buildServerSecret(cluster, serverSecretName(cluster), staleServerCertPEM, staleServerKeyPEM, parsedCAPEM)
+	caSecret.OwnerReferences = []metav1.OwnerReference{certOwnerRef(cluster)}
+	serverSecret.OwnerReferences = []metav1.OwnerReference{certOwnerRef(cluster)}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(caSecret, serverSecret).Build()
 	reloader := &recordingReloadSignaler{}

--- a/internal/service/identity/helpers_test.go
+++ b/internal/service/identity/helpers_test.go
@@ -5,6 +5,7 @@ package identity
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
@@ -14,6 +15,7 @@ func newMinimalCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",

--- a/internal/service/init/manager_root_token.go
+++ b/internal/service/init/manager_root_token.go
@@ -16,6 +16,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 func (m *Manager) ensureRootTokenSecretPresent(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) error {
@@ -53,11 +54,34 @@ func (m *Manager) preflightRootTokenStorage(ctx context.Context, cluster *openba
 	secret := buildRootTokenSecret(cluster, "dry-run")
 	secretName := secret.Name
 
-	_, err := m.clientset.CoreV1().Secrets(cluster.Namespace).Create(ctx, secret, metav1.CreateOptions{
+	existing, err := m.clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err == nil {
+		if err := resourceownership.RequireOwnerProof("use root token Secret", existing, cluster); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err != nil && !apierrors.IsNotFound(err) {
+		if apierrors.IsForbidden(err) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) || apierrors.IsInternalError(err) {
+			return operatorerrors.WrapTransientKubernetesAPI(
+				fmt.Errorf("failed to read root token Secret %s/%s before initialization: %w", cluster.Namespace, secretName, err),
+			)
+		}
+		return fmt.Errorf("failed to read root token Secret %s/%s before initialization: %w", cluster.Namespace, secretName, err)
+	}
+
+	_, err = m.clientset.CoreV1().Secrets(cluster.Namespace).Create(ctx, secret, metav1.CreateOptions{
 		DryRun: []string{metav1.DryRunAll},
 	})
-	if err == nil || apierrors.IsAlreadyExists(err) {
+	if err == nil {
 		return nil
+	}
+	if apierrors.IsAlreadyExists(err) {
+		existing, getErr := m.clientset.CoreV1().Secrets(cluster.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("failed to read existing root token Secret %s/%s after dry-run collision: %w", cluster.Namespace, secretName, getErr)
+		}
+		return resourceownership.RequireOwnerProof("use root token Secret", existing, cluster)
 	}
 	if apierrors.IsForbidden(err) {
 		return operatorerrors.WrapTransientKubernetesAPI(
@@ -131,23 +155,62 @@ func (m *Manager) storeRootToken(ctx context.Context, _ logr.Logger, cluster *op
 		return nil
 	}
 
+	return m.updateExistingRootTokenSecret(ctx, cluster, desired, rootToken)
+}
+
+func (m *Manager) updateExistingRootTokenSecret(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, desired *corev1.Secret, rootToken string) error {
+	secretsClient := m.clientset.CoreV1().Secrets(cluster.Namespace)
+	secretName := desired.Name
+
 	existing, err := secretsClient.Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return nil
+			return operatorerrors.WrapTransientKubernetesAPI(
+				fmt.Errorf("failed to get root token Secret %s/%s after create collision: %w", cluster.Namespace, secretName, err),
+			)
 		}
 		return fmt.Errorf("failed to get root token Secret %s/%s: %w", cluster.Namespace, secretName, err)
 	}
+	if err := resourceownership.RequireOwnerProof("update root token Secret", existing, cluster); err != nil {
+		return err
+	}
 
+	if err := mergeRootTokenSecret(existing, desired, cluster, rootToken); err != nil {
+		return err
+	}
+
+	if _, updateErr := secretsClient.Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+		if apierrors.IsForbidden(updateErr) {
+			return operatorerrors.WrapTransientKubernetesAPI(
+				fmt.Errorf("failed to update root token Secret %s/%s: %w", cluster.Namespace, secretName, updateErr),
+			)
+		}
+		return fmt.Errorf("failed to update root token Secret %s/%s: %w", cluster.Namespace, secretName, updateErr)
+	}
+
+	return nil
+}
+
+func mergeRootTokenSecret(existing, desired *corev1.Secret, cluster *openbaov1alpha1.OpenBaoCluster, rootToken string) error {
 	secretLabels := desired.Labels
+	secretAnnotations := desired.Annotations
 	ownerRef := desired.OwnerReferences[0]
 	immutable := desired.Immutable != nil && *desired.Immutable
+	if existing.Immutable != nil && *existing.Immutable && string(existing.Data[rootTokenSecretKey]) != rootToken {
+		return fmt.Errorf("root token Secret %s/%s is immutable and does not contain the current root token", cluster.Namespace, desired.Name)
+	}
 
 	if existing.Labels == nil {
 		existing.Labels = make(map[string]string)
 	}
 	for k, v := range secretLabels {
 		existing.Labels[k] = v
+	}
+	if existing.Annotations == nil {
+		existing.Annotations = make(map[string]string)
+	}
+	for k, v := range secretAnnotations {
+		existing.Annotations[k] = v
 	}
 
 	hasOwnerRef := false
@@ -164,13 +227,10 @@ func (m *Manager) storeRootToken(ctx context.Context, _ logr.Logger, cluster *op
 	if existing.Immutable == nil || *existing.Immutable != immutable {
 		existing.Immutable = &immutable
 	}
-
-	if _, updateErr := secretsClient.Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
-		if apierrors.IsForbidden(updateErr) {
-			return nil
-		}
-		return fmt.Errorf("failed to update root token Secret %s/%s: %w", cluster.Namespace, secretName, updateErr)
+	if existing.Data == nil {
+		existing.Data = make(map[string][]byte)
 	}
+	existing.Data[rootTokenSecretKey] = []byte(rootToken)
 
 	return nil
 }
@@ -180,7 +240,7 @@ func buildRootTokenSecret(cluster *openbaov1alpha1.OpenBaoCluster, token string)
 	ownerRef := metav1.NewControllerRef(cluster, openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"))
 
 	immutable := true
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: cluster.Namespace,
@@ -198,4 +258,6 @@ func buildRootTokenSecret(cluster *openbaov1alpha1.OpenBaoCluster, token string)
 			rootTokenSecretKey: []byte(token),
 		},
 	}
+	_ = resourceownership.SetOwnerUIDAnnotation(secret, cluster)
+	return secret
 }

--- a/internal/service/init/manager_test.go
+++ b/internal/service/init/manager_test.go
@@ -306,6 +306,7 @@ func TestStoreRootTokenCreatesOrUpdatesSecret(t *testing.T) {
 		existingSecret             *corev1.Secret
 		rootToken                  string
 		wantTokenInSecret          string
+		wantErrContains            string
 		transientCreateFailures    int
 		wantCreateFailuresObserved int
 	}{
@@ -322,7 +323,7 @@ func TestStoreRootTokenCreatesOrUpdatesSecret(t *testing.T) {
 			wantCreateFailuresObserved: 2,
 		},
 		{
-			name: "does not overwrite existing Secret token",
+			name: "rejects unowned existing Secret",
 			existingSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster-root-token",
@@ -333,8 +334,24 @@ func TestStoreRootTokenCreatesOrUpdatesSecret(t *testing.T) {
 					rootTokenSecretKey: []byte("old-token"),
 				},
 			},
+			rootToken:       "s.newtoken",
+			wantErrContains: "requires OpenBaoCluster owner proof",
+		},
+		{
+			name: "updates owned mutable existing Secret token",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "cluster-root-token",
+					Namespace:       "default",
+					OwnerReferences: []metav1.OwnerReference{rootTokenOwnerRef("cluster", types.UID("test-uid-12345"))},
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					rootTokenSecretKey: []byte("old-token"),
+				},
+			},
 			rootToken:         "s.newtoken",
-			wantTokenInSecret: "old-token",
+			wantTokenInSecret: "s.newtoken",
 		},
 	}
 
@@ -373,7 +390,17 @@ func TestStoreRootTokenCreatesOrUpdatesSecret(t *testing.T) {
 				}
 			}
 
-			if err := manager.storeRootToken(context.Background(), logr.Discard(), cluster, tt.rootToken); err != nil {
+			err := manager.storeRootToken(context.Background(), logr.Discard(), cluster, tt.rootToken)
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("storeRootToken() error = nil, want %q", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("storeRootToken() error = %q, want %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
 				t.Fatalf("storeRootToken() error = %v", err)
 			}
 
@@ -407,6 +434,51 @@ func TestStoreRootTokenCreatesOrUpdatesSecret(t *testing.T) {
 				t.Errorf("expected OwnerReference Kind 'OpenBaoCluster', got %s", ownerRef.Kind)
 			}
 		})
+	}
+}
+
+func TestStoreRootTokenRejectsImmutableOwnedSecretWithDifferentToken(t *testing.T) {
+	immutable := true
+	clusterUID := types.UID("test-uid-12345")
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cluster-root-token",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{rootTokenOwnerRef("cluster", clusterUID)},
+		},
+		Immutable: &immutable,
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			rootTokenSecretKey: []byte("old-token"),
+		},
+	}
+	clientset := kubernetesfake.NewClientset(existingSecret)
+	manager := NewManager(&rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "openbao.org/v1alpha1",
+			Kind:       "OpenBaoCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default", UID: clusterUID},
+	}
+
+	err := manager.storeRootToken(context.Background(), logr.Discard(), cluster, "s.newtoken")
+	if err == nil {
+		t.Fatal("storeRootToken() error = nil, want immutable mismatch error")
+	}
+	if !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("storeRootToken() error = %q, want immutable mismatch", err.Error())
+	}
+}
+
+func rootTokenOwnerRef(name string, uid types.UID) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       name,
+		UID:        uid,
+		Controller: &controller,
 	}
 }
 

--- a/internal/service/networking/backend_tls_policy.go
+++ b/internal/service/networking/backend_tls_policy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 // ensureBackendTLSPolicy manages the Gateway API BackendTLSPolicy for the OpenBaoCluster.
@@ -39,6 +40,9 @@ func (m *Manager) ensureBackendTLSPolicy(ctx context.Context, logger logr.Logger
 		}
 
 		logger.V(1).Info("BackendTLSPolicy not needed with TLS passthrough; deleting", "backendtlspolicy", name)
+		if err := resourceownership.RequireOwnerProof("delete BackendTLSPolicy", backendTLSPolicy, cluster); err != nil {
+			return err
+		}
 		if err := m.client.Delete(ctx, backendTLSPolicy); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete BackendTLSPolicy %s/%s: %w", cluster.Namespace, name, err)
 		}
@@ -62,6 +66,7 @@ func (m *Manager) ensureBackendTLSPolicy(ctx context.Context, logger logr.Logger
 		apiVersion:        "gateway.networking.k8s.io/v1",
 		enabled:           backendTLSEnabled,
 		name:              name,
+		owner:             cluster,
 		logger:            logger,
 		logKey:            "backendtlspolicy",
 		deleteDisabledMsg: "BackendTLSPolicy no longer enabled; deleting",
@@ -164,6 +169,9 @@ func (m *Manager) ensureGatewayCAConfigMap(ctx context.Context, logger logr.Logg
 		}
 
 		logger.Info("Gateway disabled; deleting CA ConfigMap", "configmap", configMapName)
+		if err := resourceownership.RequireOwnerProof("delete Gateway CA ConfigMap", configMap, cluster); err != nil {
+			return err
+		}
 		if deleteErr := m.client.Delete(ctx, configMap); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 			return fmt.Errorf("failed to delete Gateway CA ConfigMap %s/%s: %w", cluster.Namespace, configMapName, deleteErr)
 		}

--- a/internal/service/networking/helpers_test.go
+++ b/internal/service/networking/helpers_test.go
@@ -3,6 +3,7 @@ package networking
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -20,7 +21,7 @@ var testScheme = func() *runtime.Scheme {
 //nolint:unparam // namespace is used by tests across the package
 func newMinimalCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 	return &openbaov1alpha1.OpenBaoCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:       "2.4.4",
 			Image:         "openbao/openbao:2.4.4",

--- a/internal/service/networking/http_route.go
+++ b/internal/service/networking/http_route.go
@@ -26,6 +26,7 @@ func (m *Manager) ensureHTTPRoute(ctx context.Context, logger logr.Logger, clust
 		apiVersion:        "gateway.networking.k8s.io/v1",
 		enabled:           enabled,
 		name:              name,
+		owner:             cluster,
 		logger:            logger,
 		logKey:            "httproute",
 		deleteDisabledMsg: "HTTPRoute no longer enabled; deleting",

--- a/internal/service/networking/ingress.go
+++ b/internal/service/networking/ingress.go
@@ -25,6 +25,7 @@ func (m *Manager) ensureIngress(ctx context.Context, logger logr.Logger, cluster
 		apiVersion:        "networking.k8s.io/v1",
 		enabled:           enabled,
 		name:              name,
+		owner:             cluster,
 		logger:            logger,
 		logKey:            "ingress",
 		deleteDisabledMsg: "Ingress no longer enabled; deleting",

--- a/internal/service/networking/metrics.go
+++ b/internal/service/networking/metrics.go
@@ -23,6 +23,7 @@ func (m *Manager) ensureWorkloadServiceMonitor(ctx context.Context, logger logr.
 		apiVersion:        "monitoring.coreos.com/v1",
 		enabled:           workloadServiceMonitorEnabled(cluster),
 		name:              name,
+		owner:             cluster,
 		logger:            logger,
 		logKey:            "servicemonitor",
 		deleteDisabledMsg: "workload ServiceMonitor no longer enabled; deleting",

--- a/internal/service/networking/optional_resource.go
+++ b/internal/service/networking/optional_resource.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 type optionalResourceOptions struct {
@@ -19,6 +20,7 @@ type optionalResourceOptions struct {
 
 	enabled bool
 	name    types.NamespacedName
+	owner   client.Object
 
 	logger logr.Logger
 
@@ -54,6 +56,11 @@ func reconcileOptionalResource(ctx context.Context, opts optionalResourceOptions
 				return nil
 			}
 			return fmt.Errorf("failed to get %s %s/%s: %w", opts.kind, opts.name.Namespace, opts.name.Name, err)
+		}
+		if opts.owner != nil {
+			if err := resourceownership.RequireOwnerProof("delete optional "+opts.kind, empty, opts.owner); err != nil {
+				return err
+			}
 		}
 
 		if msg != "" {

--- a/internal/service/networking/optional_resource_test.go
+++ b/internal/service/networking/optional_resource_test.go
@@ -3,6 +3,7 @@ package networking
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -13,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
 
 func newHTTPRouteNoKindMatchError() error {
@@ -124,6 +127,53 @@ func TestReconcileOptionalResource_Disabled_DeletesWhenPresent(t *testing.T) {
 	}
 	if getCalls != 1 || deleteCalls != 1 || applyCalls != 0 {
 		t.Fatalf("unexpected calls: get=%d delete=%d apply=%d", getCalls, deleteCalls, applyCalls)
+	}
+}
+
+func TestReconcileOptionalResource_DisabledRejectsUnownedExistingResource(t *testing.T) {
+	t.Parallel()
+
+	var deleteCalls int
+	owner := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default", UID: types.UID("cluster-uid")},
+	}
+
+	opts := optionalResourceOptions{
+		kind:              "ConfigMap",
+		apiVersion:        "v1",
+		enabled:           false,
+		name:              types.NamespacedName{Namespace: "default", Name: "cluster-config"},
+		owner:             owner,
+		logger:            logr.Discard(),
+		deleteDisabledMsg: "disabled; deleting",
+		newEmpty: func() client.Object {
+			return &corev1.ConfigMap{}
+		},
+		buildDesired: func() (client.Object, bool, error) {
+			t.Fatalf("buildDesired should not be called")
+			return nil, false, nil
+		},
+		get: func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+			obj.SetName("cluster-config")
+			obj.SetNamespace("default")
+			return nil
+		},
+		delete: func(_ context.Context, _ client.Object) error {
+			deleteCalls++
+			return nil
+		},
+		apply: func(_ context.Context, _ client.Object) error { return nil },
+	}
+
+	err := reconcileOptionalResource(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected owner proof error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("error = %q, want owner proof error", err.Error())
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("deleteCalls = %d, want 0", deleteCalls)
 	}
 }
 

--- a/internal/service/networking/services.go
+++ b/internal/service/networking/services.go
@@ -15,6 +15,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -66,14 +67,14 @@ func (m *Manager) ensureExternalService(ctx context.Context, _ logr.Logger, clus
 	// If service is not needed, check if it exists and delete it
 	if !needsService {
 		// Delete main external service
-		if err := m.deleteServiceIfExists(ctx, cluster.Namespace, svcName); err != nil {
+		if err := m.deleteServiceIfExists(ctx, cluster, svcName); err != nil {
 			return fmt.Errorf("failed to delete external Service %s/%s: %w", cluster.Namespace, svcName, err)
 		}
 		// Delete any blue/green-specific services that might exist from previous runs
-		if err := m.deleteServiceIfExists(ctx, cluster.Namespace, externalServiceNameBlue(cluster)); err != nil {
+		if err := m.deleteServiceIfExists(ctx, cluster, externalServiceNameBlue(cluster)); err != nil {
 			return fmt.Errorf("failed to delete blue external Service %s/%s: %w", cluster.Namespace, externalServiceNameBlue(cluster), err)
 		}
-		if err := m.deleteServiceIfExists(ctx, cluster.Namespace, externalServiceNameGreen(cluster)); err != nil {
+		if err := m.deleteServiceIfExists(ctx, cluster, externalServiceNameGreen(cluster)); err != nil {
 			return fmt.Errorf("failed to delete green external Service %s/%s: %w", cluster.Namespace, externalServiceNameGreen(cluster), err)
 		}
 		return nil
@@ -126,10 +127,10 @@ func (m *Manager) ensureExternalService(ctx context.Context, _ logr.Logger, clus
 
 	// Gateway-weighted traffic switching was removed. Clean up any stale Services
 	// from previous iterations that used revision-specific HTTPRoute backends.
-	if err := m.deleteServiceIfExists(ctx, cluster.Namespace, externalServiceNameBlue(cluster)); err != nil {
+	if err := m.deleteServiceIfExists(ctx, cluster, externalServiceNameBlue(cluster)); err != nil {
 		return fmt.Errorf("failed to delete stale blue external Service: %w", err)
 	}
-	if err := m.deleteServiceIfExists(ctx, cluster.Namespace, externalServiceNameGreen(cluster)); err != nil {
+	if err := m.deleteServiceIfExists(ctx, cluster, externalServiceNameGreen(cluster)); err != nil {
 		return fmt.Errorf("failed to delete stale green external Service: %w", err)
 	}
 
@@ -144,7 +145,7 @@ func (m *Manager) ensureReadReplicaService(ctx context.Context, _ logr.Logger, c
 		cluster.Spec.ReadReplicas.Service != nil &&
 		cluster.Spec.ReadReplicas.Service.Enabled
 	if !enabled {
-		if err := m.deleteServiceIfExists(ctx, cluster.Namespace, svcName); err != nil {
+		if err := m.deleteServiceIfExists(ctx, cluster, svcName); err != nil {
 			return fmt.Errorf("failed to delete read-replica Service %s/%s: %w", cluster.Namespace, svcName, err)
 		}
 		return nil
@@ -194,7 +195,7 @@ func (m *Manager) ensureReadReplicaService(ctx context.Context, _ logr.Logger, c
 func (m *Manager) ensureMetricsService(ctx context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	svcName := metricsServiceName(cluster)
 	if !workloadServiceMonitorEnabled(cluster) {
-		if err := m.deleteServiceIfExists(ctx, cluster.Namespace, svcName); err != nil {
+		if err := m.deleteServiceIfExists(ctx, cluster, svcName); err != nil {
 			return fmt.Errorf("failed to delete metrics Service %s/%s: %w", cluster.Namespace, svcName, err)
 		}
 		return nil
@@ -273,7 +274,7 @@ func (m *Manager) ensureACMEChallengeService(ctx context.Context, _ logr.Logger,
 	svcName := acmeServiceName(cluster)
 
 	if !enabled {
-		if err := m.deleteServiceIfExists(ctx, cluster.Namespace, svcName); err != nil {
+		if err := m.deleteServiceIfExists(ctx, cluster, svcName); err != nil {
 			return fmt.Errorf("failed to delete ACME challenge Service %s/%s: %w", cluster.Namespace, svcName, err)
 		}
 		return nil
@@ -322,21 +323,24 @@ func (m *Manager) ensureACMEChallengeService(ctx context.Context, _ logr.Logger,
 	return nil
 }
 
-// deleteServiceIfExists deletes the Service with the given namespace/name if it exists.
-func (m *Manager) deleteServiceIfExists(ctx context.Context, namespace, name string) error {
+// deleteServiceIfExists deletes an operator-owned Service with the given name if it exists.
+func (m *Manager) deleteServiceIfExists(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, name string) error {
 	if strings.TrimSpace(name) == "" {
 		return nil
 	}
 
 	service := &corev1.Service{}
 	err := m.client.Get(ctx, types.NamespacedName{
-		Namespace: namespace,
+		Namespace: cluster.Namespace,
 		Name:      name,
 	}, service)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
+		return err
+	}
+	if err := resourceownership.RequireOwnerProof("delete Service", service, cluster); err != nil {
 		return err
 	}
 

--- a/internal/service/networking/services_test.go
+++ b/internal/service/networking/services_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -20,19 +22,19 @@ func TestEnsureExternalService_UsesSharedClientSelector(t *testing.T) {
 	cluster.Spec.Service = &openbaov1alpha1.ServiceConfig{}
 	cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
 
-	client := fake.NewClientBuilder().
+	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(cluster).
 		WithReturnManagedFields().
 		Build()
-	manager := NewManager(client, testScheme, "operators", constants.PlatformKubernetes)
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
 
 	if err := manager.ensureExternalService(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("ensureExternalService() error = %v", err)
 	}
 
 	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      externalServiceName(cluster),
 	}, service); err != nil {
@@ -55,19 +57,19 @@ func TestEnsureExternalService_BlueGreenSelectorStillPinsActiveRevision(t *testi
 		BlueRevision: "blue123",
 	}
 
-	client := fake.NewClientBuilder().
+	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(cluster).
 		WithReturnManagedFields().
 		Build()
-	manager := NewManager(client, testScheme, "operators", constants.PlatformKubernetes)
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
 
 	if err := manager.ensureExternalService(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("ensureExternalService() error = %v", err)
 	}
 
 	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      externalServiceName(cluster),
 	}, service); err != nil {
@@ -94,19 +96,19 @@ func TestEnsureReadReplicaService_CreatesDedicatedSelector(t *testing.T) {
 		},
 	}
 
-	client := fake.NewClientBuilder().
+	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(cluster).
 		WithReturnManagedFields().
 		Build()
-	manager := NewManager(client, testScheme, "operators", constants.PlatformKubernetes)
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
 
 	if err := manager.ensureReadReplicaService(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("ensureReadReplicaService() error = %v", err)
 	}
 
 	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      resourceidentity.ReadReplicaServiceName(cluster),
 	}, service); err != nil {
@@ -127,19 +129,19 @@ func TestEnsureMetricsService_CreatesActiveMetricsSelector(t *testing.T) {
 		Metrics: &openbaov1alpha1.MetricsConfig{Enabled: true},
 	}
 
-	client := fake.NewClientBuilder().
+	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(cluster).
 		WithReturnManagedFields().
 		Build()
-	manager := NewManager(client, testScheme, "operators", constants.PlatformKubernetes)
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
 
 	if err := manager.ensureMetricsService(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("ensureMetricsService() error = %v", err)
 	}
 
 	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      metricsServiceName(cluster),
 	}, service); err != nil {
@@ -169,19 +171,19 @@ func TestEnsureMetricsService_AllNodesUsesHeadlessMetricsListener(t *testing.T) 
 		},
 	}
 
-	client := fake.NewClientBuilder().
+	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(cluster).
 		WithReturnManagedFields().
 		Build()
-	manager := NewManager(client, testScheme, "operators", constants.PlatformKubernetes)
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
 
 	if err := manager.ensureMetricsService(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("ensureMetricsService() error = %v", err)
 	}
 
 	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      metricsServiceName(cluster),
 	}, service); err != nil {
@@ -209,19 +211,19 @@ func TestEnsureHeadlessService_RemainsBroadAcrossPools(t *testing.T) {
 	cluster := newMinimalCluster("svc-headless", "default")
 	cluster.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 1}
 
-	client := fake.NewClientBuilder().
+	k8sClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(cluster).
 		WithReturnManagedFields().
 		Build()
-	manager := NewManager(client, testScheme, "operators", constants.PlatformKubernetes)
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
 
 	if err := manager.ensureHeadlessService(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("ensureHeadlessService() error = %v", err)
 	}
 
 	service := &corev1.Service{}
-	if err := client.Get(context.Background(), types.NamespacedName{
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      resourceidentity.HeadlessServiceName(cluster),
 	}, service); err != nil {
@@ -230,5 +232,64 @@ func TestEnsureHeadlessService_RemainsBroadAcrossPools(t *testing.T) {
 
 	if _, ok := service.Spec.Selector[constants.LabelOpenBaoWorkloadPool]; ok {
 		t.Fatalf("did not expect headless Service selector to pin a workload pool")
+	}
+}
+
+func TestDeleteServiceIfExistsRejectsUnownedService(t *testing.T) {
+	cluster := newMinimalCluster("svc-delete", "default")
+	cluster.UID = types.UID("svc-delete-uid")
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      externalServiceName(cluster),
+			Namespace: cluster.Namespace,
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cluster, service).
+		Build()
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
+
+	err := manager.deleteServiceIfExists(context.Background(), cluster, service.Name)
+	if err == nil {
+		t.Fatal("deleteServiceIfExists() error = nil, want owner proof error")
+	}
+
+	current := &corev1.Service{}
+	if getErr := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(service), current); getErr != nil {
+		t.Fatalf("expected unowned Service to remain: %v", getErr)
+	}
+}
+
+func TestDeleteServiceIfExistsDeletesOwnedService(t *testing.T) {
+	cluster := newMinimalCluster("svc-delete-owned", "default")
+	cluster.UID = types.UID("svc-delete-owned-uid")
+	controller := true
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      externalServiceName(cluster),
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: openbaov1alpha1.GroupVersion.String(),
+				Kind:       "OpenBaoCluster",
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+				Controller: &controller,
+			}},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cluster, service).
+		Build()
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
+
+	if err := manager.deleteServiceIfExists(context.Background(), cluster, service.Name); err != nil {
+		t.Fatalf("deleteServiceIfExists() error = %v", err)
+	}
+
+	current := &corev1.Service{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(service), current); err == nil {
+		t.Fatal("expected owned Service to be deleted")
 	}
 }

--- a/internal/service/networking/tls_route.go
+++ b/internal/service/networking/tls_route.go
@@ -26,6 +26,7 @@ func (m *Manager) ensureTLSRoute(ctx context.Context, logger logr.Logger, cluste
 		apiVersion:        "gateway.networking.k8s.io/v1",
 		enabled:           enabled,
 		name:              name,
+		owner:             cluster,
 		logger:            logger,
 		logKey:            "tlsroute",
 		deleteDisabledMsg: "TLSRoute no longer enabled; deleting",

--- a/internal/service/restore/ensure_test.go
+++ b/internal/service/restore/ensure_test.go
@@ -24,6 +24,7 @@ func TestEnsureRestoreServiceAccount_WithWorkloadIdentityAnnotations(t *testing.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 	}
 	target := openbaov1alpha1.BackupTarget{

--- a/internal/service/upgrade/bluegreen/manager_abort_test.go
+++ b/internal/service/upgrade/bluegreen/manager_abort_test.go
@@ -41,6 +41,7 @@ func newBlueGreenCluster() *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example",
 			Namespace: "default",
+			UID:       types.UID("example-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.5.0",

--- a/internal/service/upgrade/bluegreen/snapshot_job_test.go
+++ b/internal/service/upgrade/bluegreen/snapshot_job_test.go
@@ -14,6 +14,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,6 +62,7 @@ func TestBuildSnapshotJob_PodSecurityContext_Platform(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
+			UID:       types.UID("test-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Replicas: 3,
@@ -132,6 +134,7 @@ func TestEnsurePreUpgradeSnapshotJob_RequiresBackupAuthUnlessOIDC(t *testing.T) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile: openbaov1alpha1.ProfileDevelopment,
@@ -164,6 +167,7 @@ func TestEnsurePreUpgradeSnapshotJob_AllowsOIDCDefaultRole(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile: openbaov1alpha1.ProfileDevelopment,
@@ -205,6 +209,7 @@ func TestEnsurePreUpgradeSnapshotJob_VerifiesDefaultBackupExecutorImageForHarden
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile: openbaov1alpha1.ProfileHardened,
@@ -263,6 +268,7 @@ func TestHandlePhaseIdle_BlocksOnFailedSnapshot(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.5.0",

--- a/internal/service/upgrade/rolling/events_test.go
+++ b/internal/service/upgrade/rolling/events_test.go
@@ -15,6 +15,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -243,6 +244,7 @@ func TestHandlePreUpgradeSnapshot_EmitsSnapshotEvents(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
 				Namespace: "test-ns",
+				UID:       types.UID("test-cluster-uid"),
 			},
 			Spec: openbaov1alpha1.OpenBaoClusterSpec{
 				Profile:  openbaov1alpha1.ProfileDevelopment,
@@ -302,6 +304,7 @@ func TestHandlePreUpgradeSnapshot_EmitsSnapshotEvents(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-cluster",
 				Namespace:  "test-ns",
+				UID:        types.UID("test-cluster-uid"),
 				Generation: 1,
 			},
 			Spec: openbaov1alpha1.OpenBaoClusterSpec{

--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -534,6 +535,7 @@ func TestReconcile_PersistsResumeValidationFailureStatus(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.5.0",
@@ -1240,6 +1242,7 @@ func TestReconcile_ReleasesUpgradeLockOnValidationFailureBeforeStart(t *testing.
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
 					Namespace: "default",
+					UID:       types.UID("test-cluster-uid"),
 				},
 				Spec: openbaov1alpha1.OpenBaoClusterSpec{
 					Version:  tt.version,

--- a/internal/service/upgrade/rolling/snapshot_job_test.go
+++ b/internal/service/upgrade/rolling/snapshot_job_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,6 +51,7 @@ func newPreUpgradeSnapshotCluster() *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -211,6 +213,7 @@ func TestHandlePreUpgradeSnapshot_CreatesJob(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile:  openbaov1alpha1.ProfileDevelopment,
@@ -278,6 +281,7 @@ func TestHandlePreUpgradeSnapshot_VerifiesDefaultBackupExecutorImageForHardenedC
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile:  openbaov1alpha1.ProfileHardened,
@@ -340,6 +344,7 @@ func TestHandlePreUpgradeSnapshot_CreateAlreadyExists(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile:  openbaov1alpha1.ProfileDevelopment,
@@ -395,6 +400,7 @@ func TestHandlePreUpgradeSnapshot_CreatesJobWithOIDCDefaultRole(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile:  openbaov1alpha1.ProfileDevelopment,
@@ -464,6 +470,7 @@ func TestHandlePreUpgradeSnapshot_HardenedRequiresEgressRules(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile: openbaov1alpha1.ProfileHardened,
@@ -550,6 +557,7 @@ func TestHandlePreUpgradeSnapshot_JobFailed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -632,6 +640,7 @@ func TestHandlePreUpgradeSnapshot_JobFailedRetriesOnFirstFailure(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",
@@ -817,6 +826,7 @@ func TestPreUpgradeSnapshotBlocksUpgradeInitialization(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "test-ns",
+			UID:       types.UID("test-cluster-uid"),
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.4.4",

--- a/internal/service/upgrade/service_account.go
+++ b/internal/service/upgrade/service_account.go
@@ -11,6 +11,8 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 // EnsureUpgradeServiceAccount creates or updates the ServiceAccount for upgrade executor Jobs using
@@ -21,6 +23,13 @@ func EnsureUpgradeServiceAccount(ctx context.Context, c client.Client, cluster *
 	}
 	if fieldOwner == "" {
 		fieldOwner = constants.FieldOwnerOpenBaoOperator
+	}
+	resolvedCluster, err := resourceapply.ResolveOwnerIdentity(ctx, c, cluster)
+	if err != nil {
+		return err
+	}
+	if err := resourceownership.RequireOwnerUID(resolvedCluster); err != nil {
+		return err
 	}
 
 	saName := cluster.Name + constants.SuffixUpgradeServiceAccount
@@ -44,6 +53,13 @@ func EnsureUpgradeServiceAccount(ctx context.Context, c client.Client, cluster *
 		},
 	}
 
+	if err := resourceapply.EnsureOwnedResourceManageable(ctx, c, resolvedCluster, sa); err != nil {
+		return fmt.Errorf("failed to verify upgrade ServiceAccount %s/%s owner proof: %w", cluster.Namespace, saName, err)
+	}
+	if err := resourceownership.SetOwnerUIDAnnotation(sa, resolvedCluster); err != nil {
+		return err
+	}
+
 	applyConfig, err := kube.ToApplyConfiguration(sa, c)
 	if err != nil {
 		return fmt.Errorf("failed to convert ServiceAccount to ApplyConfiguration: %w", err)
@@ -58,5 +74,5 @@ func EnsureUpgradeServiceAccount(ctx context.Context, c client.Client, cluster *
 		return fmt.Errorf("failed to ensure upgrade ServiceAccount %s/%s: %w", cluster.Namespace, saName, err)
 	}
 
-	return nil
+	return resourceapply.EnsureRetainedResourceProofStamped(ctx, c, resolvedCluster, sa)
 }

--- a/internal/service/upgrade/service_account_test.go
+++ b/internal/service/upgrade/service_account_test.go
@@ -69,7 +69,7 @@ func TestEnsureUpgradeServiceAccountApplyFailure(t *testing.T) {
 		t.Fatalf("AddToScheme(core) error: %v", err)
 	}
 
-	cluster := newUpgradeTestCluster("demo", "default")
+	cluster := newUpgradeTestCluster()
 	expected := errors.New("apply failed")
 	injector := robustness.NewInjector(map[robustness.Operation]robustness.Rule{
 		robustness.OpApply: robustness.Always(expected),
@@ -103,7 +103,7 @@ func TestEnsureUpgradeServiceAccount_TransientApplyFailureThenSuccess(t *testing
 		t.Fatalf("AddToScheme(core) error: %v", err)
 	}
 
-	cluster := newUpgradeTestCluster("demo", "default")
+	cluster := newUpgradeTestCluster()
 	expected := errors.New("transient apply failed")
 	injector := robustness.NewInjector(map[robustness.Operation]robustness.Rule{
 		robustness.OpApply: robustness.Once(expected),
@@ -170,7 +170,7 @@ func TestEnsureUpgradeServiceAccountSuccess(t *testing.T) {
 				t.Fatalf("AddToScheme(core) error: %v", err)
 			}
 
-			cluster := newUpgradeTestCluster("demo", "default")
+			cluster := newUpgradeTestCluster()
 			var capturedOptions client.ApplyOptions
 
 			k8sClient := fake.NewClientBuilder().
@@ -211,6 +211,9 @@ func TestEnsureUpgradeServiceAccountSuccess(t *testing.T) {
 			if sa.Labels[constants.LabelOpenBaoServiceAccountRole] != constants.ServiceAccountRoleUpgrade {
 				t.Fatalf("label %q=%q, want %q", constants.LabelOpenBaoServiceAccountRole, sa.Labels[constants.LabelOpenBaoServiceAccountRole], constants.ServiceAccountRoleUpgrade)
 			}
+			if sa.Annotations[constants.AnnotationOpenBaoOwnerUID] != string(cluster.UID) {
+				t.Fatalf("annotation %q=%q, want %q", constants.AnnotationOpenBaoOwnerUID, sa.Annotations[constants.AnnotationOpenBaoOwnerUID], cluster.UID)
+			}
 
 			if capturedOptions.FieldManager != tt.wantFieldOwner {
 				t.Fatalf("FieldManager=%q, want %q", capturedOptions.FieldManager, tt.wantFieldOwner)
@@ -222,11 +225,43 @@ func TestEnsureUpgradeServiceAccountSuccess(t *testing.T) {
 	}
 }
 
-func newUpgradeTestCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
+func TestEnsureUpgradeServiceAccountRejectsUnownedExistingServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core) error: %v", err)
+	}
+
+	cluster := newUpgradeTestCluster()
+	existing := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + constants.SuffixUpgradeServiceAccount,
+			Namespace: cluster.Namespace,
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	err := EnsureUpgradeServiceAccount(context.Background(), k8sClient, cluster, "")
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("EnsureUpgradeServiceAccount() error = %v, want owner proof error", err)
+	}
+}
+
+func newUpgradeTestCluster() *openbaov1alpha1.OpenBaoCluster {
+	name := "demo"
+	namespace := "default"
 	return &openbaov1alpha1.OpenBaoCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
 		},
 	}
 }

--- a/internal/service/workload/helpers_test.go
+++ b/internal/service/workload/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -43,7 +44,7 @@ func newTestClient(t *testing.T) client.Client {
 //nolint:unparam // namespace varies across workload tests and integration reuse.
 func newMinimalCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 	return &openbaov1alpha1.OpenBaoCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:       "2.4.4",
 			Image:         "openbao/openbao:2.4.4",

--- a/internal/service/workload/manager.go
+++ b/internal/service/workload/manager.go
@@ -8,17 +8,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
-	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 )
 
 // Manager reconciles workload-owned resources for an OpenBaoCluster.
@@ -80,24 +80,7 @@ func (m *Manager) ScaleDownStatefulSetIfExists(ctx context.Context, logger logr.
 
 func (m *Manager) DeleteStatefulSetIfExists(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSpec) error {
 	name := statefulSetNameForSpec(cluster, spec)
-	if name == "" {
-		return nil
-	}
-
-	statefulSet := &appsv1.StatefulSet{}
-	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: name}, statefulSet); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to get StatefulSet %s/%s for deletion: %w", cluster.Namespace, name, err)
-	}
-
-	if err := m.client.Delete(ctx, statefulSet); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete StatefulSet %s/%s: %w", cluster.Namespace, name, err)
-	}
-
-	logger.Info("Deleted StatefulSet", "statefulset", name, "pool", spec.Pool)
-	return nil
+	return m.deleteOwnedObjectIfExists(ctx, logger, cluster, name, &appsv1.StatefulSet{}, "StatefulSet", "statefulset", spec.Pool)
 }
 
 func (m *Manager) ScaleStatefulSetIfExists(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSpec, replicas int32) error {
@@ -117,6 +100,9 @@ func (m *Manager) ScaleStatefulSetIfExists(ctx context.Context, logger logr.Logg
 	if statefulSet.Spec.Replicas != nil && *statefulSet.Spec.Replicas == replicas {
 		return nil
 	}
+	if err := resourceownership.RequireOwnerProof("scale workload StatefulSet", statefulSet, cluster); err != nil {
+		return err
+	}
 
 	updated := statefulSet.DeepCopy()
 	updated.Spec.Replicas = int32Ptr(replicas)
@@ -130,23 +116,29 @@ func (m *Manager) ScaleStatefulSetIfExists(ctx context.Context, logger logr.Logg
 
 func (m *Manager) DeleteConfigMapIfExists(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSpec) error {
 	cmName := configMapNameForSpec(cluster, spec)
-	if cmName == "" {
+	return m.deleteOwnedObjectIfExists(ctx, logger, cluster, cmName, &corev1.ConfigMap{}, "ConfigMap", "configmap", spec.Pool)
+}
+
+func (m *Manager) deleteOwnedObjectIfExists(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, name string, obj client.Object, kind, logKey, pool string) error {
+	if name == "" {
 		return nil
 	}
 
-	configMap := &corev1.ConfigMap{}
-	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cmName}, configMap); err != nil {
+	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: name}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get ConfigMap %s/%s for deletion: %w", cluster.Namespace, cmName, err)
+		return fmt.Errorf("failed to get %s %s/%s for deletion: %w", kind, cluster.Namespace, name, err)
+	}
+	if err := resourceownership.RequireOwnerProof("delete workload "+kind, obj, cluster); err != nil {
+		return err
 	}
 
-	if err := m.client.Delete(ctx, configMap); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete ConfigMap %s/%s: %w", cluster.Namespace, cmName, err)
+	if err := m.client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete %s %s/%s: %w", kind, cluster.Namespace, name, err)
 	}
 
-	logger.Info("Deleted ConfigMap", "configmap", cmName, "pool", spec.Pool)
+	logger.Info("Deleted "+kind, logKey, name, "pool", pool)
 	return nil
 }
 
@@ -155,17 +147,19 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 		return fmt.Errorf("config ConfigMap name is required")
 	}
 
-	configMap := corev1apply.ConfigMap(cmName, cluster.Namespace).
-		WithLabels(resourceidentity.Labels(cluster)).
-		WithData(map[string]string{configFileName: configContent})
-	configMap.Kind = ptrTo("ConfigMap")
-	configMap.APIVersion = ptrTo("v1")
-
-	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner(constants.FieldOwnerOpenBaoOperator)}
-	if err := m.client.Apply(ctx, configMap, applyOpts...); err != nil {
-		if operatorerrors.IsTransientKubernetesAPI(err) || apierrors.IsConflict(err) {
-			return operatorerrors.WrapTransientKubernetesAPI(fmt.Errorf("failed to ensure config ConfigMap %s/%s: %w", cluster.Namespace, cmName, err))
-		}
+	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: cluster.Namespace,
+			Labels:    resourceidentity.Labels(cluster),
+		},
+		Data: map[string]string{configFileName: configContent},
+	}
+	if err := resourceapply.ApplyOwned(ctx, m.client, m.scheme, cluster, configMap); err != nil {
 		return fmt.Errorf("failed to ensure config ConfigMap %s/%s: %w", cluster.Namespace, cmName, err)
 	}
 
@@ -175,7 +169,14 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	if sts, ok := obj.(*appsv1.StatefulSet); ok &&
 		(cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen) {
-		if err := resourceapply.PrepareOwned(obj, cluster, m.scheme); err != nil {
+		resolvedCluster, err := resourceapply.ResolveOwnerIdentity(ctx, m.client, cluster)
+		if err != nil {
+			return err
+		}
+		if err := resourceapply.EnsureOwnedResourceManageable(ctx, m.client, resolvedCluster, obj); err != nil {
+			return err
+		}
+		if err := resourceapply.PrepareOwned(obj, resolvedCluster, m.scheme); err != nil {
 			return err
 		}
 		u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sts)
@@ -194,10 +195,11 @@ func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster 
 			}
 		}
 		unstructuredObj.SetGroupVersionKind(gvk)
-		return resourceapply.ApplyConfiguration(ctx, m.client, obj, client.ApplyConfigurationFromUnstructured(unstructuredObj))
+		if err := resourceapply.ApplyConfiguration(ctx, m.client, obj, client.ApplyConfigurationFromUnstructured(unstructuredObj)); err != nil {
+			return err
+		}
+		return resourceapply.EnsureOwnedResourceProofStamped(ctx, m.client, m.scheme, resolvedCluster, obj)
 	}
 
 	return resourceapply.ApplyOwned(ctx, m.client, m.scheme, cluster, obj)
 }
-
-func ptrTo[T any](v T) *T { return &v }

--- a/internal/service/workload/manager_ownership_test.go
+++ b/internal/service/workload/manager_ownership_test.go
@@ -1,0 +1,145 @@
+package workload
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+)
+
+func TestDeleteStatefulSetIfExistsRejectsUnownedStatefulSet(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, nil, 0)
+	mgr := workloadOwnershipManager(cluster, statefulSet)
+
+	err := mgr.DeleteStatefulSetIfExists(context.Background(), logr.Discard(), cluster, StatefulSetSpec{Name: statefulSet.Name})
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("DeleteStatefulSetIfExists() error = %v, want owner proof error", err)
+	}
+
+	stored := &appsv1.StatefulSet{}
+	if getErr := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), stored); getErr != nil {
+		t.Fatalf("expected unowned StatefulSet to remain: %v", getErr)
+	}
+}
+
+func TestScaleStatefulSetIfExistsRejectsUnownedStatefulSet(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, nil, 3)
+	mgr := workloadOwnershipManager(cluster, statefulSet)
+
+	err := mgr.ScaleStatefulSetIfExists(context.Background(), logr.Discard(), cluster, StatefulSetSpec{Name: statefulSet.Name}, 0)
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("ScaleStatefulSetIfExists() error = %v, want owner proof error", err)
+	}
+
+	stored := &appsv1.StatefulSet{}
+	if getErr := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), stored); getErr != nil {
+		t.Fatalf("expected unowned StatefulSet to remain: %v", getErr)
+	}
+	if stored.Spec.Replicas == nil || *stored.Spec.Replicas != 3 {
+		t.Fatalf("stored StatefulSet replicas = %v, want 3", stored.Spec.Replicas)
+	}
+}
+
+func TestEnsureStatefulSetRejectsUnownedExistingStatefulSet(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, nil, 3)
+	tlsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceidentity.TLSServerSecretName(cluster),
+			Namespace: cluster.Namespace,
+		},
+	}
+	mgr := workloadOwnershipManager(cluster, tlsSecret, statefulSet)
+
+	err := mgr.EnsureStatefulSet(context.Background(), logr.Discard(), cluster, "listener \"tcp\" {}", StatefulSetSpec{Name: statefulSet.Name})
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("EnsureStatefulSet() error = %v, want owner proof error", err)
+	}
+
+	stored := &appsv1.StatefulSet{}
+	if getErr := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), stored); getErr != nil {
+		t.Fatalf("expected unowned StatefulSet to remain: %v", getErr)
+	}
+	if len(stored.OwnerReferences) != 0 {
+		t.Fatalf("expected unowned StatefulSet owner references to remain empty, got %#v", stored.OwnerReferences)
+	}
+}
+
+func TestStatefulSetMutationAllowsOwnedStatefulSet(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, workloadOwnershipRef(cluster), 3)
+	mgr := workloadOwnershipManager(cluster, statefulSet)
+
+	if err := mgr.ScaleStatefulSetIfExists(context.Background(), logr.Discard(), cluster, StatefulSetSpec{Name: statefulSet.Name}, 0); err != nil {
+		t.Fatalf("ScaleStatefulSetIfExists() error = %v", err)
+	}
+	stored := &appsv1.StatefulSet{}
+	if err := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), stored); err != nil {
+		t.Fatalf("get scaled StatefulSet: %v", err)
+	}
+	if stored.Spec.Replicas == nil || *stored.Spec.Replicas != 0 {
+		t.Fatalf("stored StatefulSet replicas = %v, want 0", stored.Spec.Replicas)
+	}
+
+	if err := mgr.DeleteStatefulSetIfExists(context.Background(), logr.Discard(), cluster, StatefulSetSpec{Name: statefulSet.Name}); err != nil {
+		t.Fatalf("DeleteStatefulSetIfExists() error = %v", err)
+	}
+	if err := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), &appsv1.StatefulSet{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected owned StatefulSet to be deleted, got error %v", err)
+	}
+}
+
+func workloadOwnershipCluster() *openbaov1alpha1.OpenBaoCluster {
+	cluster := newMinimalCluster("owned-workload", "default")
+	cluster.UID = types.UID("owned-workload-uid")
+	return cluster
+}
+
+func workloadOwnershipManager(cluster *openbaov1alpha1.OpenBaoCluster, objects ...client.Object) *Manager {
+	builder := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(cluster)
+	if len(objects) > 0 {
+		builder = builder.WithObjects(objects...)
+	}
+	c := builder.Build()
+	return NewManager(c, testScheme, "")
+}
+
+func workloadOwnershipStatefulSet(name, namespace string, ownerRef *metav1.OwnerReference, replicas int32) *appsv1.StatefulSet {
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: int32Ptr(replicas),
+		},
+	}
+	if ownerRef != nil {
+		statefulSet.OwnerReferences = []metav1.OwnerReference{*ownerRef}
+	}
+	return statefulSet
+}
+
+func workloadOwnershipRef(cluster *openbaov1alpha1.OpenBaoCluster) *metav1.OwnerReference {
+	controller := true
+	return &metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}
+}

--- a/internal/service/workload/statefulset_builder_spec.go
+++ b/internal/service/workload/statefulset_builder_spec.go
@@ -13,6 +13,8 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 func desiredStatefulSetReplicas(cluster *openbaov1alpha1.OpenBaoCluster, initialized bool, spec StatefulSetSpec) int32 {
@@ -168,6 +170,9 @@ func buildStatefulSetPVC(cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulS
 		className := *storageClassName
 		pvc.Spec.StorageClassName = &className
 	}
+	if err := resourceownership.SetOwnerUIDAnnotation(&pvc, cluster); err != nil {
+		return corev1.PersistentVolumeClaim{}, err
+	}
 
 	return pvc, nil
 }
@@ -183,6 +188,9 @@ func buildStatefulSetPodLabelsAndAnnotations(cluster *openbaov1alpha1.OpenBaoClu
 			return
 		}
 		for key, value := range metadata.Labels {
+			if isReservedOpenBaoPodLabel(key) {
+				continue
+			}
 			if _, exists := podLabels[key]; exists {
 				continue
 			}
@@ -218,6 +226,19 @@ func buildStatefulSetPodLabelsAndAnnotations(cluster *openbaov1alpha1.OpenBaoClu
 	}
 
 	return podLabels, annotations
+}
+
+func isReservedOpenBaoPodLabel(key string) bool {
+	switch key {
+	case portopenbao.LabelActive,
+		portopenbao.LabelInitialized,
+		portopenbao.LabelSealed,
+		portopenbao.LabelVersion,
+		"openbao-perf-standby":
+		return true
+	default:
+		return false
+	}
 }
 
 func effectiveRestartAt(cluster *openbaov1alpha1.OpenBaoCluster, spec StatefulSetSpec) string {

--- a/internal/service/workload/statefulset_builder_test.go
+++ b/internal/service/workload/statefulset_builder_test.go
@@ -292,6 +292,8 @@ func TestBuildStatefulSet_PodMetadata(t *testing.T) {
 		Labels: map[string]string{
 			"azure.workload.identity/use": "true",
 			constants.LabelOpenBaoCluster: "should-not-override",
+			"openbao-active":              "true",
+			"openbao-sealed":              "false",
 		},
 		Annotations: map[string]string{
 			"example.com/custom":          "enabled",
@@ -313,6 +315,12 @@ func TestBuildStatefulSet_PodMetadata(t *testing.T) {
 	}
 	if got := statefulSet.Spec.Template.Labels[constants.LabelOpenBaoCluster]; got != cluster.Name {
 		t.Fatalf("expected operator-managed pod label %q=%q, got %q", constants.LabelOpenBaoCluster, cluster.Name, got)
+	}
+	if _, ok := statefulSet.Spec.Template.Labels["openbao-active"]; ok {
+		t.Fatalf("did not expect CR podMetadata to set OpenBao service-registration label")
+	}
+	if _, ok := statefulSet.Spec.Template.Labels["openbao-sealed"]; ok {
+		t.Fatalf("did not expect CR podMetadata to set OpenBao service-registration label")
 	}
 
 	if got := statefulSet.Spec.Template.Annotations["example.com/custom"]; got != "enabled" {

--- a/test/integration/controller_reconcile_test.go
+++ b/test/integration/controller_reconcile_test.go
@@ -285,6 +285,13 @@ func TestOpenBaoClusterReconciler_IdempotentReconcile(t *testing.T) {
 		if err := reconcileClusterResources(ctx, discardLogger(), controllerClient, k8sScheme, cluster, spec); err != nil {
 			t.Fatalf("Reconcile iteration %d error: %v", i+1, err)
 		}
+		if i == 0 {
+			configMap := &corev1.ConfigMap{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName + constants.SuffixConfigMap, Namespace: namespace}, configMap); err != nil {
+				t.Fatalf("get ConfigMap after first reconcile: %v", err)
+			}
+			requireIntegrationOwnerProof(t, configMap, cluster)
+		}
 	}
 
 	// Verify resources still exist and are correct

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -23,6 +23,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	bootstrapmanager "github.com/dc-tec/openbao-operator/internal/service/bootstrap"
 	identitymanager "github.com/dc-tec/openbao-operator/internal/service/identity"
 	networkingmanager "github.com/dc-tec/openbao-operator/internal/service/networking"
@@ -193,6 +194,10 @@ func createMinimalCluster(t *testing.T, namespace, name string) *openbaov1alpha1
 		t.Fatalf("create OpenBaoCluster: %v", err)
 	}
 
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cluster); err != nil {
+		t.Fatalf("get created OpenBaoCluster: %v", err)
+	}
+
 	return cluster
 }
 
@@ -274,6 +279,12 @@ func reconcileClusterResources(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	spec workloadsvc.StatefulSetSpec,
 ) error {
+	liveCluster := &openbaov1alpha1.OpenBaoCluster{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, liveCluster); err != nil {
+		return fmt.Errorf("failed to get live OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	}
+	cluster = liveCluster
+
 	configContent, err := bootstrapmanager.NewManagerWithReader(
 		kubeClient,
 		kubeClient,
@@ -301,4 +312,32 @@ func reconcileClusterResources(
 	return workloadsvc.NewManager(kubeClient, scheme, "").
 		WithReader(kubeClient).
 		Reconcile(ctx, logger, cluster, configContent, spec)
+}
+
+func integrationOwnerRef(cluster *openbaov1alpha1.OpenBaoCluster) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}
+}
+
+func requireIntegrationOwnerProof(t *testing.T, obj client.Object, owner client.Object) {
+	t.Helper()
+
+	if resourceownership.HasOwnerProof(obj, owner) {
+		return
+	}
+	t.Fatalf(
+		"expected %T %s/%s to have owner proof for OpenBaoCluster UID %q, ownerRefs=%#v annotations=%#v",
+		obj,
+		obj.GetNamespace(),
+		obj.GetName(),
+		owner.GetUID(),
+		obj.GetOwnerReferences(),
+		obj.GetAnnotations(),
+	)
 }

--- a/test/integration/infra_network_test.go
+++ b/test/integration/infra_network_test.go
@@ -303,12 +303,16 @@ func TestInfraNetwork_BlueGreenExternalService_UsesRevisionSelectorAndCleansStal
 	if err := k8sClient.Create(ctx, cluster); err != nil {
 		t.Fatalf("create OpenBaoCluster: %v", err)
 	}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cluster.Name}, cluster); err != nil {
+		t.Fatalf("get OpenBaoCluster: %v", err)
+	}
 	createTLSSecret(t, namespace, cluster.Name)
 
 	staleBlue := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name + "-public-blue",
-			Namespace: namespace,
+			Name:            cluster.Name + "-public-blue",
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{integrationOwnerRef(cluster)},
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -321,8 +325,9 @@ func TestInfraNetwork_BlueGreenExternalService_UsesRevisionSelectorAndCleansStal
 	}
 	staleGreen := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name + "-public-green",
-			Namespace: namespace,
+			Name:            cluster.Name + "-public-green",
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{integrationOwnerRef(cluster)},
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -155,6 +155,7 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		t.Fatal("openbao-lock-managed-resource-mutations policy missing spec.matchConstraints.resourceRules")
 	}
 	var hasServiceMonitorRule bool
+	var hasPersistentVolumeClaimRule bool
 	for _, rule := range resourceRules {
 		ruleMap, ok := rule.(map[string]any)
 		if !ok {
@@ -164,11 +165,16 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		resources, _, _ := unstructured.NestedStringSlice(ruleMap, "resources")
 		if containsString(groups, "monitoring.coreos.com") && containsString(resources, "servicemonitors") {
 			hasServiceMonitorRule = true
-			break
+		}
+		if containsString(groups, "") && containsString(resources, "persistentvolumeclaims") {
+			hasPersistentVolumeClaimRule = true
 		}
 	}
 	if !hasServiceMonitorRule {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy does not protect monitoring.coreos.com ServiceMonitors")
+	}
+	if !hasPersistentVolumeClaimRule {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy does not protect PersistentVolumeClaims")
 	}
 
 	variables, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "variables")
@@ -184,6 +190,9 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	var maintenanceClusterNameExpression string
 	var isManagedExpression string
 	var isServiceMonitorRequestExpression string
+	var hasCurrentOwnerUIDAnnotationExpression string
+	var hasOldOwnerUIDAnnotationExpression string
+	var ownerUIDAnnotationAllowedExpression string
 	var currentServiceMonitorOwnedExpression string
 	var oldServiceMonitorOwnedExpression string
 	for _, variable := range variables {
@@ -204,6 +213,12 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			isManagedExpression = expression
 		case "is_service_monitor_request":
 			isServiceMonitorRequestExpression = expression
+		case "has_current_owner_uid_annotation":
+			hasCurrentOwnerUIDAnnotationExpression = expression
+		case "has_old_owner_uid_annotation":
+			hasOldOwnerUIDAnnotationExpression = expression
+		case "owner_uid_annotation_allowed":
+			ownerUIDAnnotationAllowedExpression = expression
 		case "current_service_monitor_is_operator_owned":
 			currentServiceMonitorOwnedExpression = expression
 		case "old_service_monitor_is_operator_owned":
@@ -232,6 +247,14 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			maintenanceClusterNameExpression,
 		)
 	}
+	if !strings.Contains(maintenanceClusterNameExpression, `request.operation == "CREATE"`) ||
+		!strings.Contains(maintenanceClusterNameExpression, `variables.maintenance_old_labels["openbao.org/cluster"]`) ||
+		!strings.Contains(maintenanceClusterNameExpression, `variables.maintenance_old_labels["app.kubernetes.io/instance"]`) {
+		t.Fatalf(
+			"maintenance_cluster_name expression must authorize updates/deletes from old object labels: %q",
+			maintenanceClusterNameExpression,
+		)
+	}
 	if !strings.Contains(maintenanceAuthorizedExpression, `authorizer.group("openbao.org")`) {
 		t.Fatalf("maintenance_authorized expression does not use the CEL authorizer: %q", maintenanceAuthorizedExpression)
 	}
@@ -244,6 +267,19 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	if !strings.Contains(isServiceMonitorRequestExpression, `request.kind.group == "monitoring.coreos.com"`) ||
 		!strings.Contains(isServiceMonitorRequestExpression, `request.kind.kind == "ServiceMonitor"`) {
 		t.Fatalf("is_service_monitor_request expression does not target ServiceMonitors: %q", isServiceMonitorRequestExpression)
+	}
+	if !strings.Contains(hasCurrentOwnerUIDAnnotationExpression, `"openbao.org/owner-uid"`) {
+		t.Fatalf("has_current_owner_uid_annotation expression does not check owner UID provenance: %q", hasCurrentOwnerUIDAnnotationExpression)
+	}
+	if !strings.Contains(hasOldOwnerUIDAnnotationExpression, `"openbao.org/owner-uid"`) {
+		t.Fatalf("has_old_owner_uid_annotation expression does not check owner UID provenance: %q", hasOldOwnerUIDAnnotationExpression)
+	}
+	if !strings.Contains(ownerUIDAnnotationAllowedExpression, "variables.is_operator_controller") ||
+		!strings.Contains(ownerUIDAnnotationAllowedExpression, "variables.is_operator_provisioner") ||
+		!strings.Contains(ownerUIDAnnotationAllowedExpression, "variables.is_kube_controller_manager") ||
+		!strings.Contains(ownerUIDAnnotationAllowedExpression, "variables.is_system_controller") ||
+		!strings.Contains(ownerUIDAnnotationAllowedExpression, "variables.is_kube_system_controller") {
+		t.Fatalf("owner_uid_annotation_allowed expression does not restrict owner UID provenance writers: %q", ownerUIDAnnotationAllowedExpression)
 	}
 	if !strings.Contains(currentServiceMonitorOwnedExpression, `object.metadata.name.endsWith("-metrics")`) ||
 		!strings.Contains(currentServiceMonitorOwnedExpression, `"app.kubernetes.io/managed-by"`) ||
@@ -265,6 +301,7 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		t.Fatalf("read policy validations: found=%v err=%v", found, err)
 	}
 	var foundServiceMonitorOwnershipGuard bool
+	var foundOwnerUIDAnnotationGuard bool
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
 		if !ok {
@@ -277,11 +314,19 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			strings.Contains(expression, "variables.current_service_monitor_is_operator_owned") &&
 			strings.Contains(expression, "variables.old_service_monitor_is_operator_owned") {
 			foundServiceMonitorOwnershipGuard = true
-			break
+		}
+		if strings.Contains(message, "openbao.org/owner-uid annotation is reserved") &&
+			strings.Contains(expression, "variables.owner_uid_annotation_allowed") &&
+			strings.Contains(expression, "variables.has_current_owner_uid_annotation") &&
+			strings.Contains(expression, "variables.has_old_owner_uid_annotation") {
+			foundOwnerUIDAnnotationGuard = true
 		}
 	}
 	if !foundServiceMonitorOwnershipGuard {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy missing ServiceMonitor ownership guard")
+	}
+	if !foundOwnerUIDAnnotationGuard {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy missing owner UID provenance annotation guard")
 	}
 }
 

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -156,6 +156,7 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	}
 	var hasServiceMonitorRule bool
 	var hasPersistentVolumeClaimRule bool
+	var hasServiceAccountRule bool
 	for _, rule := range resourceRules {
 		ruleMap, ok := rule.(map[string]any)
 		if !ok {
@@ -169,12 +170,18 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		if containsString(groups, "") && containsString(resources, "persistentvolumeclaims") {
 			hasPersistentVolumeClaimRule = true
 		}
+		if containsString(groups, "") && containsString(resources, "serviceaccounts") {
+			hasServiceAccountRule = true
+		}
 	}
 	if !hasServiceMonitorRule {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy does not protect monitoring.coreos.com ServiceMonitors")
 	}
 	if !hasPersistentVolumeClaimRule {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy does not protect PersistentVolumeClaims")
+	}
+	if !hasServiceAccountRule {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy does not protect ServiceAccounts")
 	}
 
 	variables, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "variables")

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -200,6 +200,12 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	var hasCurrentOwnerUIDAnnotationExpression string
 	var hasOldOwnerUIDAnnotationExpression string
 	var ownerUIDAnnotationAllowedExpression string
+	var isKubeSchedulerExpression string
+	var isStorageProvisionerServiceAccountExpression string
+	var isPersistentVolumeBinderExpression string
+	var isPVCProtectionControllerExpression string
+	var isStatefulSetControllerExpression string
+	var isStoragePVCBindingUpdateExpression string
 	var currentServiceMonitorOwnedExpression string
 	var oldServiceMonitorOwnedExpression string
 	for _, variable := range variables {
@@ -226,6 +232,18 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			hasOldOwnerUIDAnnotationExpression = expression
 		case "owner_uid_annotation_allowed":
 			ownerUIDAnnotationAllowedExpression = expression
+		case "is_kube_scheduler":
+			isKubeSchedulerExpression = expression
+		case "is_storage_provisioner_serviceaccount":
+			isStorageProvisionerServiceAccountExpression = expression
+		case "is_persistent_volume_binder":
+			isPersistentVolumeBinderExpression = expression
+		case "is_pvc_protection_controller":
+			isPVCProtectionControllerExpression = expression
+		case "is_statefulset_controller":
+			isStatefulSetControllerExpression = expression
+		case "is_storage_pvc_binding_update":
+			isStoragePVCBindingUpdateExpression = expression
 		case "current_service_monitor_is_operator_owned":
 			currentServiceMonitorOwnedExpression = expression
 		case "old_service_monitor_is_operator_owned":
@@ -288,6 +306,37 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		!strings.Contains(ownerUIDAnnotationAllowedExpression, "variables.is_kube_system_controller") {
 		t.Fatalf("owner_uid_annotation_allowed expression does not restrict owner UID provenance writers: %q", ownerUIDAnnotationAllowedExpression)
 	}
+	if !strings.Contains(isStatefulSetControllerExpression, "system:controller:statefulset-controller") ||
+		!strings.Contains(isStatefulSetControllerExpression, "system:serviceaccount:kube-system:statefulset-controller") {
+		t.Fatalf("is_statefulset_controller expression does not recognize StatefulSet controller identities: %q", isStatefulSetControllerExpression)
+	}
+	if !strings.Contains(isKubeSchedulerExpression, "system:kube-scheduler") ||
+		!strings.Contains(isKubeSchedulerExpression, "system:serviceaccount:kube-system:kube-scheduler") {
+		t.Fatalf("is_kube_scheduler expression does not recognize scheduler identities: %q", isKubeSchedulerExpression)
+	}
+	if !strings.Contains(isStorageProvisionerServiceAccountExpression, "system:serviceaccount:") ||
+		!strings.Contains(isStorageProvisionerServiceAccountExpression, "csi|provisioner") {
+		t.Fatalf("is_storage_provisioner_serviceaccount expression does not recognize CSI/provisioner identities: %q", isStorageProvisionerServiceAccountExpression)
+	}
+	if !strings.Contains(isPersistentVolumeBinderExpression, "system:serviceaccount:kube-system:persistent-volume-binder") {
+		t.Fatalf("is_persistent_volume_binder expression does not recognize the PV binder identity: %q", isPersistentVolumeBinderExpression)
+	}
+	if !strings.Contains(isPVCProtectionControllerExpression, "system:serviceaccount:kube-system:pvc-protection-controller") {
+		t.Fatalf("is_pvc_protection_controller expression does not recognize the PVC protection identity: %q", isPVCProtectionControllerExpression)
+	}
+	if !strings.Contains(isStoragePVCBindingUpdateExpression, "variables.is_kube_scheduler") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "variables.is_kube_controller_manager") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "variables.is_persistent_volume_binder") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "variables.is_pvc_protection_controller") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "variables.is_storage_provisioner_serviceaccount") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "object.metadata.labels == oldObject.metadata.labels") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, `k.startsWith("openbao.org/")`) ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "object.spec.resources == oldObject.spec.resources") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "object.spec.volumeName") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "external-provisioner.volume.kubernetes.io/finalizer") ||
+		!strings.Contains(isStoragePVCBindingUpdateExpression, "kubernetes.io/pvc-protection") {
+		t.Fatalf("is_storage_pvc_binding_update expression does not constrain storage binding updates: %q", isStoragePVCBindingUpdateExpression)
+	}
 	if !strings.Contains(currentServiceMonitorOwnedExpression, `object.metadata.name.endsWith("-metrics")`) ||
 		!strings.Contains(currentServiceMonitorOwnedExpression, `"app.kubernetes.io/managed-by"`) ||
 		!strings.Contains(currentServiceMonitorOwnedExpression, `"openbao.org/cluster"`) ||
@@ -309,6 +358,8 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	}
 	var foundServiceMonitorOwnershipGuard bool
 	var foundOwnerUIDAnnotationGuard bool
+	var foundStatefulSetPVCGuard bool
+	var foundStoragePVCBindingGuard bool
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
 		if !ok {
@@ -328,12 +379,28 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			strings.Contains(expression, "variables.has_old_owner_uid_annotation") {
 			foundOwnerUIDAnnotationGuard = true
 		}
+		if strings.Contains(message, "Direct modification of OpenBao-managed resources is prohibited") &&
+			strings.Contains(expression, "variables.is_statefulset_controller") &&
+			strings.Contains(expression, `"persistentvolumeclaims"`) &&
+			strings.Contains(expression, `request.operation == "CREATE"`) {
+			foundStatefulSetPVCGuard = true
+		}
+		if strings.Contains(message, "Direct modification of OpenBao-managed resources is prohibited") &&
+			strings.Contains(expression, "variables.is_storage_pvc_binding_update") {
+			foundStoragePVCBindingGuard = true
+		}
 	}
 	if !foundServiceMonitorOwnershipGuard {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy missing ServiceMonitor ownership guard")
 	}
 	if !foundOwnerUIDAnnotationGuard {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy missing owner UID provenance annotation guard")
+	}
+	if !foundStatefulSetPVCGuard {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy missing StatefulSet controller PVC create guard")
+	}
+	if !foundStoragePVCBindingGuard {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy missing storage PVC binding update guard")
 	}
 }
 

--- a/test/integration/vap_controller_serviceaccounts_test.go
+++ b/test/integration/vap_controller_serviceaccounts_test.go
@@ -11,6 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 )
 
 func ensureControllerServiceAccountRBAC(t *testing.T, namespace string) {
@@ -76,6 +78,9 @@ func TestVAP_ControllerServiceAccounts_AllowsManagedBackupServiceAccount(t *test
 				"openbao.org/component":            "backup",
 				"openbao.org/service-account-role": "backup",
 			},
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: "example-uid",
+			},
 		},
 	}
 
@@ -86,6 +91,9 @@ func TestVAP_ControllerServiceAccounts_AllowsManagedBackupServiceAccount(t *test
 	var latest corev1.ServiceAccount
 	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: sa.Name}, &latest); err != nil {
 		t.Fatalf("get created ServiceAccount: %v", err)
+	}
+	if got := latest.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != "example-uid" {
+		t.Fatalf("owner UID annotation = %q, want example-uid", got)
 	}
 }
 

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -403,7 +403,8 @@ func createManagedMaintenancePod(t *testing.T, c client.Client, namespace, clust
 			Name:      podName,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				"openbao.org/maintenance": testTrueString,
+				constants.AnnotationMaintenance:     testTrueString,
+				constants.AnnotationOpenBaoOwnerUID: string(cluster.UID),
 			},
 			Labels: map[string]string{
 				"app.kubernetes.io/name":       "openbao",

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -4,12 +4,14 @@
 package integration
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -349,6 +351,37 @@ func newOwnedServiceMonitorObject(cluster *openbaov1alpha1.OpenBaoCluster) *unst
 	return obj
 }
 
+func newManagedStatefulSetPVC(namespace, clusterName, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.LabelAppName:        constants.LabelValueAppNameOpenBao,
+				constants.LabelAppInstance:    clusterName,
+				constants.LabelAppManagedBy:   constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoCluster: clusterName,
+			},
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: "example-cluster-uid",
+			},
+			Finalizers: []string{"kubernetes.io/pvc-protection"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+}
+
 func createManagedMaintenancePod(t *testing.T, c client.Client, namespace, clusterName, podName string) {
 	t.Helper()
 
@@ -522,6 +555,111 @@ func TestVAP_LockManagedRBAC_DeniesForgedServiceAccountOwnerUID(t *testing.T) {
 	}
 
 	t.Fatalf("expected VAP to deny forged ServiceAccount owner UID provenance")
+}
+
+func TestVAP_LockManagedRBAC_AllowsStatefulSetControllerManagedPVC(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	editorClient := newPrivilegedImpersonatedClient(t, "managed-pvc-editor")
+
+	var deniedForgedPVC bool
+	for attempt := 0; attempt < 25; attempt++ {
+		forged := newManagedStatefulSetPVC(namespace, "example", fmt.Sprintf("data-example-forged-%d", attempt))
+		err := editorClient.Create(ctx, forged.DeepCopy())
+		if err == nil {
+			_ = k8sClient.Delete(ctx, forged)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		if !strings.Contains(err.Error(), "openbao.org/owner-uid annotation is reserved") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+		deniedForgedPVC = true
+		break
+	}
+	if !deniedForgedPVC {
+		t.Fatalf("expected VAP to deny forged managed PVC owner UID provenance")
+	}
+
+	statefulSetControllerClient := newPrivilegedImpersonatedClient(
+		t,
+		"system:serviceaccount:kube-system:statefulset-controller",
+	)
+	managedPVC := newManagedStatefulSetPVC(namespace, "example", "data-example-0")
+	if err := statefulSetControllerClient.Create(ctx, managedPVC); err != nil {
+		t.Fatalf("expected StatefulSet controller managed PVC create to succeed, got: %v", err)
+	}
+
+	if err := editorClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: managedPVC.Name}, managedPVC); err != nil {
+		t.Fatalf("get managed PVC before direct editor update: %v", err)
+	}
+	if managedPVC.Annotations == nil {
+		managedPVC.Annotations = map[string]string{}
+	}
+	managedPVC.Annotations["example.com/direct-edit"] = "true"
+	err := editorClient.Update(ctx, managedPVC)
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "Direct modification of OpenBao-managed resources is prohibited") {
+		t.Fatalf("unexpected direct PVC update error message: %v", err)
+	}
+
+	schedulerClient := newPrivilegedImpersonatedClient(t, "system:kube-scheduler")
+	if err := schedulerClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: managedPVC.Name}, managedPVC); err != nil {
+		t.Fatalf("get managed PVC before scheduler bind update: %v", err)
+	}
+	if managedPVC.Annotations == nil {
+		managedPVC.Annotations = map[string]string{}
+	}
+	managedPVC.Annotations["volume.kubernetes.io/selected-node"] = "worker-0"
+	if err := schedulerClient.Update(ctx, managedPVC); err != nil {
+		t.Fatalf("expected kube-scheduler managed PVC selected-node update to succeed, got: %v", err)
+	}
+
+	storageProvisionerClient := newPrivilegedImpersonatedClient(
+		t,
+		"system:serviceaccount:storage-system:example-csi-provisioner",
+	)
+	if err := storageProvisionerClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: managedPVC.Name}, managedPVC); err != nil {
+		t.Fatalf("get managed PVC before storage provisioner update: %v", err)
+	}
+	if managedPVC.Annotations == nil {
+		managedPVC.Annotations = map[string]string{}
+	}
+	managedPVC.Annotations["volume.kubernetes.io/storage-provisioner"] = "example.csi.test"
+	managedPVC.Finalizers = append(
+		managedPVC.Finalizers,
+		"external-provisioner.volume.kubernetes.io/finalizer",
+	)
+	if err := storageProvisionerClient.Update(ctx, managedPVC); err != nil {
+		t.Fatalf("expected CSI provisioner managed PVC metadata update to succeed, got: %v", err)
+	}
+
+	persistentVolumeBinderClient := newPrivilegedImpersonatedClient(
+		t,
+		"system:serviceaccount:kube-system:persistent-volume-binder",
+	)
+	if err := persistentVolumeBinderClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: managedPVC.Name}, managedPVC); err != nil {
+		t.Fatalf("get managed PVC before persistent volume binder update: %v", err)
+	}
+	managedPVC.Spec.VolumeName = "pv-example"
+	if err := persistentVolumeBinderClient.Update(ctx, managedPVC); err != nil {
+		t.Fatalf("expected persistent-volume-binder managed PVC bind update to succeed, got: %v", err)
+	}
+
+	pvcProtectionClient := newPrivilegedImpersonatedClient(
+		t,
+		"system:serviceaccount:kube-system:pvc-protection-controller",
+	)
+	if err := pvcProtectionClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: managedPVC.Name}, managedPVC); err != nil {
+		t.Fatalf("get managed PVC before PVC protection finalizer update: %v", err)
+	}
+	managedPVC.Finalizers = []string{"external-provisioner.volume.kubernetes.io/finalizer"}
+	if err := pvcProtectionClient.Update(ctx, managedPVC); err != nil {
+		t.Fatalf("expected pvc-protection-controller managed PVC finalizer update to succeed, got: %v", err)
+	}
 }
 
 func TestVAP_LockManagedRBAC_DeniesDirectMutationOfControllerManagedRole(t *testing.T) {

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -179,6 +179,57 @@ func grantPodUpdateAccess(t *testing.T, namespace, username string) {
 	}
 }
 
+func grantServiceAccountWriteAccess(t *testing.T, namespace, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-serviceaccount-write",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"serviceaccounts"},
+				Verbs:     []string{"create", "get", "update"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create serviceaccount write role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-serviceaccount-write-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create serviceaccount write binding: %v", err)
+	}
+}
+
 func grantClusterMaintenanceAccess(t *testing.T, namespace, clusterName, username string) {
 	t.Helper()
 
@@ -422,6 +473,55 @@ func TestVAP_LockManagedRBAC_RestrictsOperatorServiceMonitorOwnership(t *testing
 	if err := controllerClient.Delete(ctx, ownedMonitor); err != nil {
 		t.Fatalf("expected owned ServiceMonitor delete to succeed, got: %v", err)
 	}
+}
+
+func TestVAP_LockManagedRBAC_DeniesForgedServiceAccountOwnerUID(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	editorUsername := "serviceaccount-provenance-editor"
+	grantServiceAccountWriteAccess(t, namespace, editorUsername)
+	cluster := createClusterForServiceMonitorGuard(t, namespace, "forged-sa")
+
+	forged := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + constants.SuffixUpgradeServiceAccount,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.LabelAppName:                   constants.LabelValueAppNameOpenBao,
+				constants.LabelAppInstance:               cluster.Name,
+				constants.LabelAppManagedBy:              constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoCluster:            cluster.Name,
+				constants.LabelOpenBaoComponent:          constants.ServiceAccountRoleUpgrade,
+				constants.LabelOpenBaoServiceAccountRole: constants.ServiceAccountRoleUpgrade,
+			},
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: string(cluster.UID),
+			},
+		},
+	}
+
+	editorClient := newImpersonatedClient(t, editorUsername)
+	for attempt := 0; attempt < 25; attempt++ {
+		err := editorClient.Create(ctx, forged.DeepCopy())
+		if err == nil {
+			_ = k8sClient.Delete(ctx, forged)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		if !strings.Contains(err.Error(), "openbao.org/owner-uid annotation is reserved") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+		return
+	}
+
+	t.Fatalf("expected VAP to deny forged ServiceAccount owner UID provenance")
 }
 
 func TestVAP_LockManagedRBAC_DeniesDirectMutationOfControllerManagedRole(t *testing.T) {

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -128,6 +128,57 @@ func grantPodDeleteAccess(t *testing.T, namespace, username string) {
 	}
 }
 
+func grantPodUpdateAccess(t *testing.T, namespace, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-pod-update",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "update"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create pod update role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-pod-update-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create pod update binding: %v", err)
+	}
+}
+
 func grantClusterMaintenanceAccess(t *testing.T, namespace, clusterName, username string) {
 	t.Helper()
 
@@ -491,6 +542,44 @@ func TestVAP_LockManagedRBAC_AllowsMaintenanceMutationWithClusterMaintenanceVerb
 	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, &deleted); err == nil {
 		t.Fatalf("expected Pod %s/%s to be deleted", namespace, podName)
 	}
+}
+
+func TestVAP_LockManagedRBAC_DeniesMaintenanceRelabelToAuthorizedCluster(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	victimClusterName := "victim"
+	attackerClusterName := "attacker"
+	podName := "victim-maintenance-pod"
+	editorUsername := "maintenance-relabel-editor"
+	controllerClient := newPrivilegedImpersonatedClient(t, controllerUsername)
+	createManagedMaintenancePod(t, controllerClient, namespace, victimClusterName, podName)
+	grantPodUpdateAccess(t, namespace, editorUsername)
+	grantClusterMaintenanceAccess(t, namespace, attackerClusterName, editorUsername)
+
+	editorClient := newImpersonatedClient(t, editorUsername)
+	pod := &corev1.Pod{}
+	if err := editorClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: podName}, pod); err != nil {
+		t.Fatalf("get managed maintenance pod: %v", err)
+	}
+	pod.Labels["openbao.org/cluster"] = attackerClusterName
+	pod.Labels["app.kubernetes.io/instance"] = attackerClusterName
+
+	for attempt := 0; attempt < 25; attempt++ {
+		err := editorClient.Update(ctx, pod)
+		if err == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		if !strings.Contains(err.Error(), "Direct modification of OpenBao-managed resources is prohibited") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+		return
+	}
+
+	t.Fatalf("expected VAP to deny maintenance relabel against a different cluster")
 }
 
 func TestVAP_LockManagedRBAC_DeniesDirectMutationOfProvisionerManagedRoleBinding(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR tightens ownership/provenance handling for deterministic OpenBao Operator child resources.

The operator now requires proof before mutating or deleting existing generated resources instead of adopting by name or mutable labels alone. Proof is either an `OpenBaoCluster` controller owner reference or the operator-written `openbao.org/owner-uid` provenance annotation for retained resources. The admission policy now reserves that annotation across protected managed resource kinds, including generated ServiceAccounts, so non-controller users cannot forge provenance and make a pre-created object adoptable.

The change also updates PVC cleanup/storage resize behavior, workload ConfigMap/StatefulSet handling, root token/unseal/TLS Secret handling, networking cleanup, retained PVCs, upgrade ServiceAccounts, and user-facing docs for the safer ownership model.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This is a security tightening with migration edge cases.

Existing operator-created resources should continue to reconcile normally. Existing hand-created resources that only match generated names or OpenBao labels may no longer be adopted, mutated, or deleted unless they carry valid owner proof. `DeletePVCs` and `DeleteAll` now leave label-matched PVCs without owner proof behind for manual review. The `openbao.org/owner-uid` annotation is reserved for operator/Kubernetes controller provenance and must not be set by users or GitOps automation.

Release notes should call out that stale generated resources, especially retained PVCs or old `*-upgrade-serviceaccount` objects, may need review before upgrade workflows.

## Verification

- `GOFLAGS=-mod=vendor go test ./internal/... -count=1`
- `GOFLAGS=-mod=vendor go test ./internal/platform/resourceapply ./internal/service/bootstrap ./internal/service/networking -tags=integration -count=1`
- `GOFLAGS=-mod=vendor go test ./test/integration -tags=integration -count=1`
- `GOFLAGS=-mod=vendor go test ./test/integration -tags=integration -run 'TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels|TestVAP_LockManagedRBAC_DeniesForgedServiceAccountOwnerUID|TestVAP_ControllerServiceAccounts_AllowsManagedBackupServiceAccount' -count=1 -v`
- `go test -tags=integration ./test/integration -run 'TestVAP_LockManagedRBAC_AllowsStatefulSetControllerManagedPVC|TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels'`
- `E2E_LABEL_FILTER='case:operator-manager-metrics-endpoint || (lifecycle && critical && tenant)' E2E_FAIL_ON_EMPTY=true E2E_NO_COLOR=true E2E_PARALLEL_NODES=1 E2E_TIMEOUT=25m make test-e2e`
- `make test-ci`
- `make lint-ci`
- `make verify-generated`
- `make verify-e2e-manifest`
- `make verify-helm`
- `make helm-test`
- `make docs-build`

## Reviewer Notes

Key review areas:

- `internal/platform/resourceownership` and `internal/platform/resourceapply` proof enforcement boundaries.
- Existing-resource preflight behavior for deterministic resources that previously could be adopted by name/labels.
- Admission policy coverage for `openbao.org/owner-uid`, especially ServiceAccounts.
- Retained resource behavior for PVCs and upgrade ServiceAccounts.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
