### PR TITLE
fix(self-init): make bootstrap config one-shot

### DIFF
--- a/internal/controller/openbaocluster/initialization_integration_test.go
+++ b/internal/controller/openbaocluster/initialization_integration_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,6 +18,8 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	security "github.com/dc-tec/openbao-operator/internal/adapter/security"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 )
 
 var _ = Describe("OpenBaoCluster Initialization", func() {
@@ -182,6 +185,60 @@ var _ = Describe("OpenBaoCluster Initialization", func() {
 			}, updated)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updated.Status.Initialized).To(BeTrue())
+		})
+
+		It("renders an inert self-init ConfigMap after self-initialization completes", func() {
+			cluster := createMinimalCluster("test-self-init-inert")
+			cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+				Requests: []openbaov1alpha1.SelfInitRequest{
+					{
+						Name:      "bootstrap_policy",
+						Operation: openbaov1alpha1.SelfInitOperationUpdate,
+						Path:      "sys/policies/acl/bootstrap",
+						Policy: &openbaov1alpha1.SelfInitPolicy{
+							Policy: `path "secret/*" { capabilities = ["read"] }`,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cluster.Name,
+					Namespace: cluster.Namespace,
+				},
+			}
+
+			reconciler := newReconciler()
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := &corev1.ConfigMap{}
+			configMapKey := types.NamespacedName{
+				Name:      resourceidentity.ConfigInitMapName(cluster),
+				Namespace: cluster.Namespace,
+			}
+			Expect(k8sClient.Get(ctx, configMapKey, configMap)).To(Succeed())
+			Expect(configMap.Data[constants.OpenBaoConfigFileName]).To(ContainSubstring("initialize"))
+			Expect(configMap.Data[constants.OpenBaoConfigFileName]).To(ContainSubstring("bootstrap_policy"))
+
+			latest := &openbaov1alpha1.OpenBaoCluster{}
+			Expect(k8sClient.Get(ctx, req.NamespacedName, latest)).To(Succeed())
+			original := latest.DeepCopy()
+			latest.Status.Initialized = true
+			latest.Status.SelfInitialized = true
+			Expect(k8sClient.Status().Patch(ctx, latest, client.MergeFrom(original))).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, configMapKey, configMap)).To(Succeed())
+			content := configMap.Data[constants.OpenBaoConfigFileName]
+			Expect(content).To(Equal(constants.CompletedSelfInitConfig))
+			Expect(content).NotTo(ContainSubstring("initialize"))
+			Expect(content).NotTo(ContainSubstring("bootstrap_policy"))
 		})
 	})
 })

--- a/internal/platform/constants/filesystem.go
+++ b/internal/platform/constants/filesystem.go
@@ -8,6 +8,12 @@ const (
 	PathPlugins = "/openbao/plugins"
 )
 
+// Common configuration file names and sentinel contents.
+const (
+	OpenBaoConfigFileName   = "config.hcl"
+	CompletedSelfInitConfig = "# OpenBao self-initialization completed; bootstrap stanzas are intentionally omitted.\n"
+)
+
 // Common volume names used by OpenBao pods.
 const (
 	VolumeTLS     = "tls"

--- a/internal/service/bootstrap/config.go
+++ b/internal/service/bootstrap/config.go
@@ -18,10 +18,13 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/auth"
 	configbuilder "github.com/dc-tec/openbao-operator/internal/adapter/config"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 )
+
+const completedSelfInitConfig = constants.CompletedSelfInitConfig
 
 // usesStaticSeal returns true if the cluster is configured to use the static seal
 // (either by default when unseal config is nil, or explicitly when type is "static").
@@ -145,6 +148,11 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 // only the first pod needs to execute initialization requests.
 func (m *Manager) ensureSelfInitConfigMap(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	cmName := resourceidentity.ConfigInitMapName(cluster)
+
+	if cluster.Status.SelfInitialized {
+		logger.Info("Self-init already completed; reconciling inert self-init ConfigMap", "configmap", cmName)
+		return m.ensureConfigMapWithName(ctx, cluster, cmName, completedSelfInitConfig)
+	}
 
 	// If self-init is not enabled, delete the ConfigMap if it exists
 	if cluster.Spec.SelfInit == nil || !cluster.Spec.SelfInit.Enabled {

--- a/internal/service/bootstrap/config_test.go
+++ b/internal/service/bootstrap/config_test.go
@@ -362,6 +362,53 @@ func TestEnsureSelfInitConfigMap_Disabled(t *testing.T) {
 	}
 }
 
+func TestEnsureSelfInitConfigMap_SelfInitializedDisabledKeepsInertConfig(t *testing.T) {
+	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.UID = types.UID("test-cluster-uid")
+	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
+		Enabled: false,
+	}
+	cluster.Status.SelfInitialized = true
+	cmName := resourceidentity.ConfigInitMapName(cluster)
+
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            cmName,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{bootstrapOwnerRef(cluster)},
+		},
+		Data: map[string]string{
+			configFileName: `initialize "old-bootstrap" {}`,
+		},
+	}
+
+	ctx := context.Background()
+	logger := logr.Discard()
+	k8sClient := newTestClientWithObjects(t, existingConfigMap)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system")
+
+	err := manager.ensureSelfInitConfigMap(ctx, logger, cluster)
+	if err != nil {
+		t.Fatalf("ensureSelfInitConfigMap() error = %v", err)
+	}
+
+	configMap := &corev1.ConfigMap{}
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cmName,
+	}, configMap)
+	if err != nil {
+		t.Fatalf("expected ConfigMap to remain: %v", err)
+	}
+	content := configMap.Data[configFileName]
+	if content != completedSelfInitConfig {
+		t.Fatalf("ConfigMap content = %q, want inert completed config %q", content, completedSelfInitConfig)
+	}
+	if strings.Contains(content, "initialize") {
+		t.Fatalf("completed self-init ConfigMap still contains initialize stanza:\n%s", content)
+	}
+}
+
 func TestEnsureSelfInitConfigMap_NotConfigured(t *testing.T) {
 	cluster := newMinimalCluster("test-cluster", "default")
 	cluster.Spec.SelfInit = nil
@@ -526,6 +573,62 @@ func TestEnsureSelfInitConfigMap_DevelopmentProfileWithBackupJWTAuthBootstraps(t
 	for _, snippet := range expectedSnippets {
 		if !strings.Contains(content, snippet) {
 			t.Errorf("expected ConfigMap content to contain %q, got:\n%s", snippet, content)
+		}
+	}
+}
+
+func TestEnsureSelfInitConfigMap_SelfInitializedRendersInertConfig(t *testing.T) {
+	cluster := newMinimalCluster("test-cluster", "default")
+	cluster.Spec.SelfInit = &openbaov1alpha1.SelfInitConfig{
+		Enabled: true,
+		OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+			Enabled: true,
+		},
+		Requests: []openbaov1alpha1.SelfInitRequest{
+			{
+				Name:      "create-admin-policy",
+				Operation: openbaov1alpha1.SelfInitOperationUpdate,
+				Path:      "sys/policies/acl/admin",
+				Policy: &openbaov1alpha1.SelfInitPolicy{
+					Policy: `path "*" { capabilities = ["create"] }`,
+				},
+			},
+		},
+	}
+	cluster.Status.SelfInitialized = true
+
+	ctx := context.Background()
+	logger := logr.Discard()
+	k8sClient := newTestClient(t)
+	manager := NewManager(k8sClient, testScheme, "openbao-operator-system")
+
+	err := manager.ensureSelfInitConfigMap(ctx, logger, cluster)
+	if err != nil {
+		t.Fatalf("ensureSelfInitConfigMap() error = %v", err)
+	}
+
+	cmName := resourceidentity.ConfigInitMapName(cluster)
+	configMap := &corev1.ConfigMap{}
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cmName,
+	}, configMap)
+	if err != nil {
+		t.Fatalf("expected ConfigMap to exist: %v", err)
+	}
+
+	content := configMap.Data[configFileName]
+	if content != completedSelfInitConfig {
+		t.Fatalf("ConfigMap content = %q, want inert completed config %q", content, completedSelfInitConfig)
+	}
+	for _, forbidden := range []string{
+		`initialize "operator-bootstrap"`,
+		`initialize "create-admin-policy"`,
+		`request "create-operator-role"`,
+		`sys/policies/acl/admin`,
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("completed self-init ConfigMap still contains executable bootstrap snippet %q:\n%s", forbidden, content)
 		}
 	}
 }

--- a/internal/service/bootstrap/manager.go
+++ b/internal/service/bootstrap/manager.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	configurationservice "github.com/dc-tec/openbao-operator/internal/service/configuration"
@@ -17,7 +18,7 @@ import (
 const (
 	unsealSecretKey   = "key"
 	unsealKeyBytes    = 32
-	configFileName    = "config.hcl"
+	configFileName    = constants.OpenBaoConfigFileName
 	unsealTypeTransit = "transit"
 )
 

--- a/internal/service/init/manager_reconcile.go
+++ b/internal/service/init/manager_reconcile.go
@@ -14,7 +14,12 @@ import (
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+const (
+	selfInitConfigMapUpdateReason = "reconcile completed self-init ConfigMap"
 )
 
 // Reconcile checks if the OpenBao cluster is initialized and initializes it if needed.
@@ -52,7 +57,7 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 	}
 
 	if selfInitEnabled {
-		return m.reconcileSelfInit(ctx, logger, cluster, pod), nil
+		return m.reconcileSelfInit(ctx, logger, cluster, pod)
 	}
 
 	return m.reconcileOperatorInit(ctx, logger, cluster, pod, selfInitEnabled)
@@ -90,15 +95,15 @@ func (m *Manager) reconcileSelfInit(
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	pod *corev1.Pod,
-) recon.Result {
+) (recon.Result, error) {
 	emitNormalEvent(m.recorder, cluster, ReasonInitStarted, "Self-initialization in progress for cluster %s", cluster.Name)
 
-	if handled, result := m.reconcileSelfInitFromServiceLabels(ctx, logger, cluster, pod); handled {
-		return result
+	if handled, result, err := m.reconcileSelfInitFromServiceLabels(ctx, logger, cluster, pod); handled || err != nil {
+		return result, err
 	}
 
-	if handled, result := m.reconcileSelfInitFromPodReadiness(ctx, logger, cluster, pod); handled {
-		return result
+	if handled, result, err := m.reconcileSelfInitFromPodReadiness(ctx, logger, cluster, pod); handled || err != nil {
+		return result, err
 	}
 
 	return m.reconcileSelfInitFromHealth(ctx, logger, cluster, pod)
@@ -109,7 +114,7 @@ func (m *Manager) reconcileSelfInitFromServiceLabels(
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	pod *corev1.Pod,
-) (bool, recon.Result) {
+) (bool, recon.Result, error) {
 	initializedLabel, hasInitializedLabel, err := portopenbao.ParseBoolLabel(pod.Labels, portopenbao.LabelInitialized)
 	if err != nil {
 		logger.V(1).Info("Invalid OpenBao initialized label value", "pod", pod.Name, "error", err)
@@ -121,12 +126,14 @@ func (m *Manager) reconcileSelfInitFromServiceLabels(
 	}
 
 	if !hasInitializedLabel || !hasSealedLabel || !initializedLabel || sealedLabel {
-		return false, recon.Result{}
+		return false, recon.Result{}, nil
 	}
 
 	logger.Info("OpenBao service registration labels indicate initialized and unsealed; marking cluster as initialized", "pod", pod.Name)
-	m.markSelfInitComplete(ctx, logger, cluster)
-	return true, recon.Result{RequeueAfter: constants.RequeueShort}
+	if err := m.markSelfInitComplete(ctx, logger, cluster); err != nil {
+		return true, recon.Result{}, err
+	}
+	return true, recon.Result{RequeueAfter: constants.RequeueShort}, nil
 }
 
 func (m *Manager) reconcileSelfInitFromPodReadiness(
@@ -134,14 +141,16 @@ func (m *Manager) reconcileSelfInitFromPodReadiness(
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	pod *corev1.Pod,
-) (bool, recon.Result) {
+) (bool, recon.Result, error) {
 	if isPodReady(pod) {
 		logger.Info("OpenBao pod is Ready; marking cluster as initialized", "pod", pod.Name)
-		m.markSelfInitComplete(ctx, logger, cluster)
-		return true, recon.Result{RequeueAfter: constants.RequeueShort}
+		if err := m.markSelfInitComplete(ctx, logger, cluster); err != nil {
+			return true, recon.Result{}, err
+		}
+		return true, recon.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 
-	return false, recon.Result{}
+	return false, recon.Result{}, nil
 }
 
 func (m *Manager) reconcileSelfInitFromHealth(
@@ -149,11 +158,11 @@ func (m *Manager) reconcileSelfInitFromHealth(
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	pod *corev1.Pod,
-) recon.Result {
+) (recon.Result, error) {
 	client, err := m.newOpenBaoClient(ctx, cluster)
 	if err != nil {
 		logger.Info("Self-initialization health observation is not ready yet; will retry", "pod", pod.Name, "error", err)
-		return recon.Result{RequeueAfter: constants.RequeueShort}
+		return recon.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 
 	healthCtx, cancel := context.WithTimeout(ctx, selfInitHealthTimeout)
@@ -162,23 +171,29 @@ func (m *Manager) reconcileSelfInitFromHealth(
 	health, err := client.Health(healthCtx)
 	if err != nil {
 		logger.Info("Self-initialization health observation failed; will retry", "pod", pod.Name, "error", err)
-		return recon.Result{RequeueAfter: constants.RequeueShort}
+		return recon.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 	if health != nil && health.Initialized && !health.Sealed {
 		logger.Info("OpenBao health endpoint reports initialized and unsealed; marking cluster as initialized", "pod", pod.Name)
-		m.markSelfInitComplete(ctx, logger, cluster)
-		return recon.Result{RequeueAfter: constants.RequeueShort}
+		if err := m.markSelfInitComplete(ctx, logger, cluster); err != nil {
+			return recon.Result{}, err
+		}
+		return recon.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 	if health != nil {
 		logger.Info("Self-initialization is enabled; waiting for OpenBao health to report initialized and unsealed", "pod", pod.Name, "initialized", health.Initialized, "sealed", health.Sealed)
-		return recon.Result{RequeueAfter: constants.RequeueShort}
+		return recon.Result{RequeueAfter: constants.RequeueShort}, nil
 	}
 
 	logger.Info("Self-initialization is enabled; waiting for OpenBao health observation", "pod", pod.Name)
-	return recon.Result{RequeueAfter: constants.RequeueShort}
+	return recon.Result{RequeueAfter: constants.RequeueShort}, nil
 }
 
-func (m *Manager) markSelfInitComplete(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) {
+func (m *Manager) markSelfInitComplete(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if err := m.reconcileCompletedSelfInitConfigMap(ctx, logger, cluster); err != nil {
+		return err
+	}
+
 	cluster.Status.Initialized = true
 	cluster.Status.SelfInitialized = true
 
@@ -190,6 +205,43 @@ func (m *Manager) markSelfInitComplete(ctx context.Context, logger logr.Logger, 
 		}
 	}
 	emitNormalEvent(m.recorder, cluster, ReasonInitCompleted, "Self-initialization completed for cluster %s", cluster.Name)
+	return nil
+}
+
+func (m *Manager) reconcileCompletedSelfInitConfigMap(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if m.clientset == nil {
+		return fmt.Errorf("kubernetes clientset is required to %s", selfInitConfigMapUpdateReason)
+	}
+
+	configMaps := m.clientset.CoreV1().ConfigMaps(cluster.Namespace)
+	cmName := resourceidentity.ConfigInitMapName(cluster)
+	configMap, err := configMaps.Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("Self-init ConfigMap not found during completion; bootstrap reconcile will create inert ConfigMap", "configmap", cmName)
+			return nil
+		}
+		return operatorerrors.WrapTransientKubernetesAPI(
+			fmt.Errorf("failed to get self-init ConfigMap %s/%s while completing self-init: %w", cluster.Namespace, cmName, err),
+		)
+	}
+
+	if configMap.Data != nil && configMap.Data[constants.OpenBaoConfigFileName] == constants.CompletedSelfInitConfig && len(configMap.Data) == 1 {
+		return nil
+	}
+
+	updated := configMap.DeepCopy()
+	updated.Data = map[string]string{
+		constants.OpenBaoConfigFileName: constants.CompletedSelfInitConfig,
+	}
+	if _, err := configMaps.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return operatorerrors.WrapTransientKubernetesAPI(
+			fmt.Errorf("failed to update self-init ConfigMap %s/%s while completing self-init: %w", cluster.Namespace, cmName, err),
+		)
+	}
+
+	logger.Info("Reconciled inert self-init ConfigMap after self-initialization completed", "configmap", cmName)
+	return nil
 }
 
 func (m *Manager) reconcileOperatorInit(

--- a/internal/service/init/manager_test.go
+++ b/internal/service/init/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
@@ -185,6 +186,150 @@ func TestReconcileSelfInitReady_EmitsInitEvents(t *testing.T) {
 
 	expectEventContains(t, recorder, "Normal", ReasonInitStarted)
 	expectEventContains(t, recorder, "Normal", ReasonInitCompleted)
+}
+
+func TestReconcileSelfInitReady_InertizesConfigMapBeforeStatus(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	started := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.LabelAppInstance:  "cluster",
+				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: constants.ContainerBao,
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: metav1.Now(),
+					},
+				},
+				Started: &started,
+			}},
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceidentity.ConfigInitMapName(cluster),
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			constants.OpenBaoConfigFileName: `initialize "bootstrap" {}`,
+		},
+	}
+
+	clientset := kubernetesfake.NewClientset(pod, configMap)
+	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
+	manager := NewManager(&rest.Config{}, clientset, clientMgr)
+
+	if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if !cluster.Status.Initialized || !cluster.Status.SelfInitialized {
+		t.Fatalf("status initialized=%t selfInitialized=%t, want both true", cluster.Status.Initialized, cluster.Status.SelfInitialized)
+	}
+
+	got, err := clientset.CoreV1().ConfigMaps(cluster.Namespace).Get(context.Background(), configMap.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get ConfigMap: %v", err)
+	}
+	if got.Data[constants.OpenBaoConfigFileName] != constants.CompletedSelfInitConfig {
+		t.Fatalf("ConfigMap content = %q, want %q", got.Data[constants.OpenBaoConfigFileName], constants.CompletedSelfInitConfig)
+	}
+	if strings.Contains(got.Data[constants.OpenBaoConfigFileName], "initialize") {
+		t.Fatalf("completed self-init ConfigMap still contains initialize stanza:\n%s", got.Data[constants.OpenBaoConfigFileName])
+	}
+}
+
+func TestReconcileSelfInitReady_DoesNotMarkCompleteWhenConfigMapUpdateFails(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	started := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.LabelAppInstance:  "cluster",
+				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: constants.ContainerBao,
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: metav1.Now(),
+					},
+				},
+				Started: &started,
+			}},
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceidentity.ConfigInitMapName(cluster),
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			constants.OpenBaoConfigFileName: `initialize "bootstrap" {}`,
+		},
+	}
+
+	clientset := kubernetesfake.NewClientset(pod, configMap)
+	clientset.PrependReactor("update", "configmaps", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewTooManyRequests("too many requests", 0)
+	})
+	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
+	manager := NewManager(&rest.Config{}, clientset, clientMgr)
+
+	_, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want ConfigMap update error")
+	}
+	if !operatorerrors.IsTransient(err) {
+		t.Fatalf("Reconcile() error = %v, want transient", err)
+	}
+	if cluster.Status.Initialized || cluster.Status.SelfInitialized {
+		t.Fatalf("status initialized=%t selfInitialized=%t, want both false", cluster.Status.Initialized, cluster.Status.SelfInitialized)
+	}
 }
 
 func TestReconcileOperatorInitFailure_EmitsInitFailedEvent(t *testing.T) {


### PR DESCRIPTION
## Summary

Make self-init bootstrap configuration one-shot after self-initialization completes. Completed self-init clusters now keep the pod-0 ConfigMap mount stable, but reconcile the mounted `config.hcl` to inert content so CRD-rendered `initialize` stanzas are not available if pod-0 is recreated after its PVC is deleted.

The init completion path also updates the self-init ConfigMap before marking `status.initialized` and `status.selfInitialized`, reducing the window where active bootstrap content could remain mounted after OpenBao reports self-init success.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No CRD schema, RBAC, Helm, or generated artifact changes. Operationally, self-init ConfigMaps remain present for completed self-init clusters, but their contents are replaced with an inert sentinel `config.hcl`. New self-init clusters still receive active bootstrap configuration until self-initialization completes.

## Verification

- `go test -tags=integration ./internal/controller/openbaocluster -run TestControllers -ginkgo.focus "renders an inert self-init ConfigMap after self-initialization completes"`
- `go test -tags=integration ./internal/controller/openbaocluster`
- `go test ./internal/service/init`
- `go test -tags=integration ./internal/service/bootstrap`
- pre-commit hook: whitespace check, gofmt, golangci-lint on affected Go paths
- pre-push hook: `make lint-ci`

## Reviewer Notes

Focused regression coverage was added at both the self-init service boundary and the controller/envtest path. Full `make ci-core` was not run locally; the focused tests and repository hooks cover the changed paths.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
