### PR TITLE
ci: satisfy dependency security policy scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: monday
       time: "03:00"
       timezone: Europe/Amsterdam
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     groups:
@@ -21,6 +23,8 @@ updates:
       day: tuesday
       time: "03:00"
       timezone: Europe/Amsterdam
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     groups:
@@ -36,6 +40,8 @@ updates:
       day: wednesday
       time: "03:00"
       timezone: Europe/Amsterdam
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     groups:
@@ -50,6 +56,8 @@ updates:
       day: thursday
       time: "03:00"
       timezone: Europe/Amsterdam
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     groups:
@@ -64,6 +72,8 @@ updates:
       day: friday
       time: "03:00"
       timezone: Europe/Amsterdam
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1229,7 +1229,6 @@ jobs:
       backup_executor_image: ${{ needs.prepare-edge-candidate.outputs.backup_executor_image }}
       upgrade_executor_image: ${{ needs.prepare-edge-candidate.outputs.upgrade_executor_image }}
       byte_artifact_name: edge-byte-verified-assets
-    secrets: inherit
 
   assemble-edge-candidate-bundle:
     name: Assemble Edge Candidate Bundle

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -603,7 +603,6 @@ jobs:
       backup_executor_image: ${{ needs.prepare-nightly-candidate.outputs.backup_executor_image }}
       upgrade_executor_image: ${{ needs.prepare-nightly-candidate.outputs.upgrade_executor_image }}
       byte_artifact_name: nightly-byte-verified-assets
-    secrets: inherit
 
   assemble-nightly-candidate-bundle:
     name: Assemble Nightly Candidate Bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,6 @@ jobs:
       source_date_epoch: ${{ needs.prepare.outputs.source_date_epoch }}
       cache-scope: ${{ needs.prepare.outputs.build_tag }}
       sign_images: true
-    secrets: inherit
 
   rebuild:
     name: Independent Rebuild Images
@@ -132,7 +131,6 @@ jobs:
       ref: ${{ github.ref }}
       source_date_epoch: ${{ needs.prepare.outputs.source_date_epoch }}
       cache-scope: ${{ needs.prepare.outputs.repro_build_tag }}
-    secrets: inherit
 
   security-govulncheck:
     name: Security Gate (vulncheck + Semgrep)

--- a/.github/workflows/reusable-channel-hardening.yml
+++ b/.github/workflows/reusable-channel-hardening.yml
@@ -94,7 +94,6 @@ jobs:
       ref: ${{ inputs.ref }}
       source_date_epoch: ${{ inputs.source_date_epoch }}
       cache-scope: ${{ inputs.build_tag }}
-    secrets: inherit
 
   rebuild:
     name: Independent Rebuild Images
@@ -109,7 +108,6 @@ jobs:
       ref: ${{ inputs.ref }}
       source_date_epoch: ${{ inputs.source_date_epoch }}
       cache-scope: ${{ inputs.repro_build_tag }}
-    secrets: inherit
 
   verify-provenance:
     name: Verify Image Provenance


### PR DESCRIPTION
## Summary

- Add a 7-day Dependabot cooldown to each configured package ecosystem.
- Remove broad `secrets: inherit` from local reusable workflow calls where the called workflows only require the automatically provided `secrets.GITHUB_TOKEN`.
- Clear the Semgrep policy findings that currently surface when dependency PRs trigger the filesystem security lane.

## Related Issues

None. Follow-up: rebase the open dependency PRs after this lands, especially #526 and #524.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, upgrade, or runtime behavior changes. The workflow risk is limited to local reusable workflow secret propagation: the called workflows continue to use the GitHub-provided `GITHUB_TOKEN` instead of inheriting all caller secrets. This reduces secret exposure while preserving the existing token permissions declared on the calling jobs.

## Verification

- `make semgrep-ci`
- `bin/actionlint .github/workflows/*.yml`
- `ruby -e 'require "yaml"; [".github/dependabot.yml", ".github/workflows/ci.yml", ".github/workflows/nightly.yml", ".github/workflows/release.yml", ".github/workflows/reusable-channel-hardening.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
- pre-push hook: `make lint-ci` (including 61 AST/lint policy tests)

Full `make ci-core` was not run locally because this change is limited to Dependabot configuration and GitHub workflow policy; the targeted security, workflow lint, YAML, and publish-hook checks cover the changed surface.

## Reviewer Notes

The dependency PR template check failures on Dependabot PRs are expected and left unchanged. After this PR lands on `main`, Dependabot should rebase or recreate the affected dependency PRs so the security lane runs with the updated policy baseline.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.