### PR TITLE
ci(release): publish post-release verification evidence

### DIFF
--- a/.github/workflows/post-release-verification.yml
+++ b/.github/workflows/post-release-verification.yml
@@ -1,0 +1,175 @@
+name: Post-Release Verification
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "SemVer release/prerelease tag to verify (e.g. 0.4.0, 0.4.0-rc.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-release-verification-${{ github.event.workflow_run.id || github.event.inputs.tag || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify Published Release
+    runs-on: ubuntu-24.04
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' &&
+         github.event.workflow_run.event == 'push' &&
+         !github.event.workflow_run.repository.fork)
+      }}
+    permissions:
+      contents: write
+      actions: read
+      issues: write
+      packages: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Resolve release context
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            tag="${WORKFLOW_RUN_HEAD_BRANCH}"
+            if ! [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
+              echo "Release workflow head branch is not a SemVer tag: ${tag}" >&2
+              exit 1
+            fi
+            {
+              echo "release_run_id=${WORKFLOW_RUN_ID}"
+              echo "tag_head_sha=${WORKFLOW_RUN_HEAD_SHA}"
+              echo "tag=${tag}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! [[ "${INPUT_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
+            echo "SemVer tag required (X.Y.Z or X.Y.Z-rc.N). Got: ${INPUT_TAG}" >&2
+            exit 1
+          fi
+
+          ref_json="$(gh api "repos/${REPO}/git/ref/tags/${INPUT_TAG}")"
+          tag_object_type="$(REF_JSON="${ref_json}" python3 -c 'import json, os; print(json.loads(os.environ["REF_JSON"])["object"]["type"])')"
+          tag_object_sha="$(REF_JSON="${ref_json}" python3 -c 'import json, os; print(json.loads(os.environ["REF_JSON"])["object"]["sha"])')"
+          if [[ "${tag_object_type}" == "tag" ]]; then
+            head_sha="$(gh api "repos/${REPO}/git/tags/${tag_object_sha}" --jq '.object.sha')"
+          else
+            head_sha="${tag_object_sha}"
+          fi
+
+          runs_json="$(gh api "repos/${REPO}/actions/workflows/release.yml/runs?event=push&status=completed&head_sha=${head_sha}&per_page=100")"
+          release_run_id="$(
+            RUNS_JSON="${runs_json}" INPUT_TAG="${INPUT_TAG}" python3 - <<'PY'
+          import json
+          import os
+
+          data = json.loads(os.environ["RUNS_JSON"])
+          input_tag = os.environ["INPUT_TAG"]
+          for run in data.get("workflow_runs", []):
+              if run.get("conclusion") == "success" and run.get("head_branch") == input_tag:
+                  print(run["id"])
+                  break
+          PY
+          )"
+
+          if [[ -z "${release_run_id}" ]]; then
+            echo "No successful Release workflow run found for tag ${INPUT_TAG}" >&2
+            exit 1
+          fi
+
+          {
+            echo "release_run_id=${release_run_id}"
+            echo "tag_head_sha=${head_sha}"
+            echo "tag=${INPUT_TAG}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          version: v0.31.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.4
+
+      - name: Run post-release verification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.context.outputs.tag }}
+          REPO: ${{ github.repository }}
+          RELEASE_RUN_ID: ${{ steps.context.outputs.release_run_id }}
+          EVIDENCE_OUT: dist/post-release-verification.json
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          bash hack/ci/verify-post-release.sh
+
+      - name: Publish release evidence and comment on release PR
+        id: publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.context.outputs.tag }}
+          REPO: ${{ github.repository }}
+          RELEASE_RUN_ID: ${{ steps.context.outputs.release_run_id }}
+          TAG_HEAD_SHA: ${{ steps.context.outputs.tag_head_sha }}
+          EVIDENCE_PATH: dist/post-release-verification.json
+        run: bash hack/ci/publish-post-release-evidence.sh
+
+      - name: Append verification summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Post-Release Verification"
+            echo
+            jq -r '
+              "- Release: \(.version)",
+              "- GitHub Release: \(.release.url)",
+              "- Release workflow run: \(.release_run.id // "n/a")",
+              "- Chart digest: \(.chart.digest)",
+              "- Required assets: \(.release.assets | length)",
+              "- Evidence asset: ${{ steps.publish.outputs.evidence_asset_url }}",
+              "- Release PR: ${{ steps.publish.outputs.release_pr_url || 'not resolved' }}",
+              "- Verification: passed"
+            ' dist/post-release-verification.json
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload verification evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: post-release-verification-${{ steps.context.outputs.tag }}
+          path: dist/post-release-verification.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -718,6 +718,8 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      issues: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1003,6 +1005,14 @@ jobs:
           else
             gh release edit "${version}" --title "${version}" --draft=false --latest
           fi
+
+      - name: Clear release-please pending label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          REPO: ${{ github.repository }}
+          TAG_HEAD_SHA: ${{ github.sha }}
+        run: bash hack/ci/clear-release-please-pending-label.sh
 
   deploy-docs:
     name: Deploy Docs Site

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -174,8 +174,14 @@ For patch releases, make the source that release-please sees match the release n
   title="Run post-release verification"
   code={`VERSION=X.Y.Z REPO=dc-tec/openbao-operator hack/ci/verify-post-release.sh`}
 >
-  Requires `gh`, `jq`, `git`, Docker Buildx, and `cosign`. Checks the remote tag, published GitHub Release assets, checksum signature, OCI Helm chart publication and signature, and leftover release-please PRs or branches.
+  The `Post-Release Verification` workflow runs this automatically after a successful `Release` workflow and can also be started manually for a tag. Local runs require `gh`, `jq`, `git`, Docker Buildx, and `cosign`. The verifier checks the remote tag, published GitHub Release assets, checksum signature, OCI Helm chart publication and signature, release-please pending-label cleanup, and leftover release-please PRs or branches.
 </CommandBlock>
+
+<Callout type="note" title="Post-release verification evidence">
+
+The `Release` workflow removes the release-please `autorelease: pending` label from the merged release PR after the GitHub Release is published. The follow-up workflow uploads `post-release-verification.json` to the GitHub Release as durable evidence and also keeps a 90-day Actions artifact copy named `post-release-verification-<version>`. That JSON evidence captures the release URL, release workflow run, release PR, chart digest, published asset list, provenance index, and the post-release invariant checks that passed. When the merged release PR can be resolved, the workflow also writes or updates a release PR comment linking to the release, workflow runs, chart digest, and evidence asset.
+
+</Callout>
 
 <CommandBlock
   language="bash"

--- a/hack/ci/clear-release-please-pending-label.sh
+++ b/hack/ci/clear-release-please-pending-label.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "${cmd}" >/dev/null 2>&1 || fail "required command not found: ${cmd}"
+}
+
+for cmd in gh jq; do
+  require_cmd "${cmd}"
+done
+
+: "${VERSION:?VERSION is required}"
+: "${REPO:?REPO is required}"
+
+TAG_HEAD_SHA="${TAG_HEAD_SHA:-}"
+
+pr_candidates="$(
+  gh pr list \
+    --repo "${REPO}" \
+    --state merged \
+    --search "${VERSION} in:title" \
+    --limit 50 \
+    --json number,title,url,mergeCommit,labels
+)"
+
+release_pr_json="$(
+  jq \
+    --arg version "${VERSION}" \
+    --arg tag_head_sha "${TAG_HEAD_SHA}" \
+    '[.[] | select((.title | startswith("chore(")) and (.title | endswith("): release " + $version)))]
+     | if ($tag_head_sha | length) > 0 then
+         (map(select((.mergeCommit.oid // "") == $tag_head_sha)) as $exact
+           | if ($exact | length) == 1 then $exact else . end)
+       else
+         .
+       end' \
+    <<<"${pr_candidates}"
+)"
+
+match_count="$(jq 'length' <<<"${release_pr_json}")"
+if [[ "${match_count}" != "1" ]]; then
+  echo "expected exactly one merged release PR for ${VERSION}, found ${match_count}" >&2
+  jq -r '.[] | "- #\(.number) \(.title) (\(.url))"' <<<"${pr_candidates}" >&2 || true
+  exit 1
+fi
+
+release_pr_number="$(jq -r '.[0].number' <<<"${release_pr_json}")"
+release_pr_url="$(jq -r '.[0].url' <<<"${release_pr_json}")"
+labels="$(jq -r '.[0].labels[]?.name' <<<"${release_pr_json}")"
+removed=0
+pending_labels=(
+  "autorelease: pending"
+  "autorelease:pending"
+)
+
+for label in "${pending_labels[@]}"; do
+  if grep -Fxq "${label}" <<<"${labels}"; then
+    encoded_label="$(jq -rn --arg label "${label}" '$label | @uri')"
+    gh api -X DELETE "repos/${REPO}/issues/${release_pr_number}/labels/${encoded_label}" >/dev/null
+    echo "Removed '${label}' from release PR ${release_pr_url}"
+    removed=1
+  fi
+done
+
+if [[ "${removed}" == "0" ]]; then
+  echo "No release-please pending label found on ${release_pr_url}"
+fi

--- a/hack/ci/publish-post-release-evidence.sh
+++ b/hack/ci/publish-post-release-evidence.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "::warning::$*"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "${cmd}" >/dev/null 2>&1 || fail "required command not found: ${cmd}"
+}
+
+upsert_release_pr_comment() {
+  local pr_number="$1"
+  local pr_url="$2"
+  local evidence_url="$3"
+  local evidence_sha="$4"
+  local body_file="$5"
+  local marker
+  local comments_json
+  local comment_id
+  local payload_file
+
+  marker="<!-- openbao-operator:post-release-verification:${VERSION} -->"
+  cat > "${body_file}" <<EOF
+${marker}
+## Post-release verification passed
+
+- Release: \`${VERSION}\`
+- GitHub Release: ${RELEASE_URL}
+- Release workflow run: ${RELEASE_RUN_URL}
+- Verification workflow run: ${VERIFICATION_RUN_URL}
+- Chart digest: \`${CHART_DIGEST}\`
+- Evidence asset: ${evidence_url}
+- Evidence sha256: \`${evidence_sha}\`
+
+The published release assets, checksum signature, Helm chart signature, provenance index, and release-please cleanup checks have been verified.
+EOF
+
+  comments_json="$(gh api "repos/${REPO}/issues/${pr_number}/comments?per_page=100" --paginate --slurp)"
+  comment_id="$(
+    jq -r --arg marker "${marker}" \
+      '[.[][] | select((.body // "") | contains($marker))][0].id // empty' \
+      <<<"${comments_json}"
+  )"
+
+  payload_file="${TMPDIR}/release-pr-comment.json"
+  jq -n --rawfile body "${body_file}" '{body: $body}' > "${payload_file}"
+
+  if [[ -n "${comment_id}" ]]; then
+    gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" --input "${payload_file}" >/dev/null
+    echo "Updated post-release verification comment on ${pr_url}"
+  else
+    gh api -X POST "repos/${REPO}/issues/${pr_number}/comments" --input "${payload_file}" >/dev/null
+    echo "Created post-release verification comment on ${pr_url}"
+  fi
+}
+
+resolve_release_pr() {
+  local pr_candidates
+  local release_pr_json
+  local match_count
+
+  pr_candidates="$(
+    gh pr list \
+      --repo "${REPO}" \
+      --state merged \
+      --search "${VERSION} in:title" \
+      --limit 50 \
+      --json number,title,url,mergeCommit
+  )"
+
+  release_pr_json="$(
+    jq \
+      --arg version "${VERSION}" \
+      --arg tag_head_sha "${TAG_HEAD_SHA}" \
+      '[.[] | select((.title | startswith("chore(")) and (.title | endswith("): release " + $version)))]
+       | if ($tag_head_sha | length) > 0 then
+           (map(select((.mergeCommit.oid // "") == $tag_head_sha)) as $exact
+             | if ($exact | length) == 1 then $exact else . end)
+         else
+           .
+         end' \
+      <<<"${pr_candidates}"
+  )"
+  match_count="$(jq 'length' <<<"${release_pr_json}")"
+
+  if [[ "${match_count}" != "1" ]]; then
+    warn "expected exactly one merged release PR for ${VERSION}, found ${match_count}; skipping PR comment"
+    jq -r '.[] | "- #\(.number) \(.title) (\(.url))"' <<<"${pr_candidates}" >&2 || true
+    return 1
+  fi
+
+  RELEASE_PR_NUMBER="$(jq -r '.[0].number' <<<"${release_pr_json}")"
+  RELEASE_PR_URL="$(jq -r '.[0].url' <<<"${release_pr_json}")"
+}
+
+for cmd in gh jq sha256sum; do
+  require_cmd "${cmd}"
+done
+
+: "${VERSION:?VERSION is required}"
+: "${REPO:?REPO is required}"
+: "${EVIDENCE_PATH:?EVIDENCE_PATH is required}"
+
+if [[ ! -s "${EVIDENCE_PATH}" ]]; then
+  fail "evidence file does not exist or is empty: ${EVIDENCE_PATH}"
+fi
+
+ASSET_NAME="${ASSET_NAME:-post-release-verification.json}"
+TAG_HEAD_SHA="${TAG_HEAD_SHA:-}"
+RELEASE_RUN_ID="${RELEASE_RUN_ID:-}"
+VERIFICATION_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-${REPO}}/actions/runs/${GITHUB_RUN_ID:-}"
+RELEASE_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${RELEASE_RUN_ID}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+release_json="$(gh release view "${VERSION}" --repo "${REPO}" --json assets,url)"
+RELEASE_URL="$(jq -r '.url' <<<"${release_json}")"
+asset_url="$(jq -r --arg name "${ASSET_NAME}" '.assets[]? | select(.name == $name) | .url' <<<"${release_json}" | head -n1)"
+evidence_sha="$(sha256sum "${EVIDENCE_PATH}" | awk '{print $1}')"
+
+if [[ -z "${asset_url}" ]]; then
+  upload_path="${TMPDIR}/${ASSET_NAME}"
+  cp "${EVIDENCE_PATH}" "${upload_path}"
+  gh release upload "${VERSION}" "${upload_path}" --repo "${REPO}"
+  release_json="$(gh release view "${VERSION}" --repo "${REPO}" --json assets,url)"
+  asset_url="$(jq -r --arg name "${ASSET_NAME}" '.assets[]? | select(.name == $name) | .url' <<<"${release_json}" | head -n1)"
+  if [[ -z "${asset_url}" ]]; then
+    fail "release evidence asset upload succeeded but ${ASSET_NAME} was not found on ${VERSION}"
+  fi
+  echo "Uploaded release evidence asset: ${asset_url}"
+else
+  existing_dir="${TMPDIR}/existing"
+  mkdir -p "${existing_dir}"
+  gh release download "${VERSION}" --repo "${REPO}" --pattern "${ASSET_NAME}" --dir "${existing_dir}"
+  existing_sha="$(sha256sum "${existing_dir}/${ASSET_NAME}" | awk '{print $1}')"
+  if [[ "${existing_sha}" != "${evidence_sha}" ]]; then
+    fail "existing ${ASSET_NAME} differs from local evidence (release=${existing_sha}, local=${evidence_sha})"
+  fi
+  echo "Release evidence asset already exists: ${asset_url}"
+fi
+
+CHART_DIGEST="$(jq -r '.chart.digest' "${EVIDENCE_PATH}")"
+if [[ -z "${CHART_DIGEST}" || "${CHART_DIGEST}" == "null" ]]; then
+  fail "chart digest missing from evidence file"
+fi
+
+RELEASE_PR_NUMBER=""
+RELEASE_PR_URL=""
+if resolve_release_pr; then
+  if ! upsert_release_pr_comment "${RELEASE_PR_NUMBER}" "${RELEASE_PR_URL}" "${asset_url}" "${evidence_sha}" "${TMPDIR}/release-pr-comment.md"; then
+    warn "failed to write post-release verification comment on release PR ${RELEASE_PR_URL}"
+  fi
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "evidence_asset_url=${asset_url}"
+    echo "evidence_asset_sha256=${evidence_sha}"
+    echo "release_pr_url=${RELEASE_PR_URL}"
+  } >> "${GITHUB_OUTPUT}"
+fi

--- a/hack/ci/verify-post-release.sh
+++ b/hack/ci/verify-post-release.sh
@@ -14,6 +14,7 @@ Environment:
   REPO          GitHub repository. Default: dc-tec/openbao-operator.
   GIT_REMOTE    Git remote used for branch/tag checks. Default: https://github.com/${REPO}.git.
   ALLOW_DRAFT   Set to 1 to allow a draft GitHub Release. Default: 0.
+  EVIDENCE_OUT  Optional path where a JSON verification evidence file is written.
 USAGE
 }
 
@@ -36,6 +37,11 @@ REPO="${REPO:-dc-tec/openbao-operator}"
 OWNER="${REPO%%/*}"
 GIT_REMOTE="${GIT_REMOTE:-https://github.com/${REPO}.git}"
 ALLOW_DRAFT="${ALLOW_DRAFT:-0}"
+EVIDENCE_OUT="${EVIDENCE_OUT:-}"
+VERIFIED_AT="${VERIFIED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+RELEASE_RUN_ID="${RELEASE_RUN_ID:-}"
+VERIFICATION_RUN_ID="${GITHUB_RUN_ID:-}"
+VERIFICATION_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-${REPO}}/actions/runs/${GITHUB_RUN_ID:-}"
 
 if [[ "${VERSION}" == "-h" || "${VERSION}" == "--help" ]]; then
   usage
@@ -70,8 +76,15 @@ required_assets=(
 )
 
 info "checking remote tag ${VERSION}"
-git ls-remote --exit-code --tags "${GIT_REMOTE}" "refs/tags/${VERSION}" >/dev/null ||
+tag_refs="$(git ls-remote --tags "${GIT_REMOTE}" "refs/tags/${VERSION}" "refs/tags/${VERSION}^{}")" ||
   fail "release tag ${VERSION} was not found on ${GIT_REMOTE}"
+tag_head_sha="$(awk '$2 ~ /\^\{\}$/ {print $1; exit}' <<<"${tag_refs}")"
+if [[ -z "${tag_head_sha}" ]]; then
+  tag_head_sha="$(awk -v ref="refs/tags/${VERSION}" '$2 == ref {print $1; exit}' <<<"${tag_refs}")"
+fi
+if [[ -z "${tag_head_sha}" ]]; then
+  fail "could not resolve release tag ${VERSION} target commit from ${GIT_REMOTE}"
+fi
 
 info "checking GitHub Release ${VERSION}"
 release_json="$(
@@ -167,6 +180,117 @@ stale_branches="$(git ls-remote --heads "${GIT_REMOTE}" 'release-please--branche
 if [[ -n "${stale_branches}" ]]; then
   echo "${stale_branches}" >&2
   fail "stale release-please branches remain"
+fi
+
+info "checking release-please pending label cleanup"
+release_pr_candidates="$(
+  gh pr list \
+    --repo "${REPO}" \
+    --state merged \
+    --search "${VERSION} in:title" \
+    --limit 50 \
+    --json number,title,url,mergeCommit,labels
+)"
+release_pr_json="$(
+  jq \
+    --arg version "${VERSION}" \
+    --arg tag_head_sha "${tag_head_sha}" \
+    '[.[] | select((.title | startswith("chore(")) and (.title | endswith("): release " + $version)))]
+     | if ($tag_head_sha | length) > 0 then
+         (map(select((.mergeCommit.oid // "") == $tag_head_sha)) as $exact
+           | if ($exact | length) == 1 then $exact else . end)
+       else
+         .
+       end' \
+    <<<"${release_pr_candidates}"
+)"
+release_pr_match_count="$(jq 'length' <<<"${release_pr_json}")"
+if [[ "${release_pr_match_count}" != "1" ]]; then
+  echo "expected exactly one merged release PR for ${VERSION}, found ${release_pr_match_count}" >&2
+  jq -r '.[] | "- #\(.number) \(.title) (\(.url))"' <<<"${release_pr_candidates}" >&2 || true
+  exit 1
+fi
+
+release_pr_number="$(jq -r '.[0].number' <<<"${release_pr_json}")"
+release_pr_url="$(jq -r '.[0].url' <<<"${release_pr_json}")"
+pending_release_labels="$(
+  jq -r '.[]?.labels[]?.name | select(. == "autorelease: pending" or . == "autorelease:pending")' \
+    <<<"${release_pr_json}"
+)"
+if [[ -n "${pending_release_labels}" ]]; then
+  echo "${pending_release_labels}" >&2
+  fail "release PR ${release_pr_url} still has release-please pending label"
+fi
+
+if [[ -n "${EVIDENCE_OUT}" ]]; then
+  info "writing post-release verification evidence: ${EVIDENCE_OUT}"
+  mkdir -p "$(dirname "${EVIDENCE_OUT}")"
+  assets_file="${tmpdir}/release-assets.txt"
+  printf '%s\n' "${asset_names[@]}" > "${assets_file}"
+  jq -n \
+    --arg schema_version "1" \
+    --arg repo "${REPO}" \
+    --arg version "${VERSION}" \
+    --arg verified_at "${VERIFIED_AT}" \
+    --arg release_run_id "${RELEASE_RUN_ID}" \
+    --arg verification_run_id "${VERIFICATION_RUN_ID}" \
+    --arg verification_run_url "${VERIFICATION_RUN_URL}" \
+    --arg release_url "${release_url}" \
+    --arg release_pr_number "${release_pr_number}" \
+    --arg release_pr_url "${release_pr_url}" \
+    --arg identity "${identity}" \
+    --arg chart_ref "${chart_ref}" \
+    --arg chart_digest "${chart_digest}" \
+    --slurpfile release <(printf '%s\n' "${release_json}") \
+    --slurpfile provenance "${tmpdir}/provenance-index.json" \
+    --rawfile assets "${assets_file}" \
+    'def optional_string($value):
+      if ($value | length) > 0 then $value else null end;
+
+    {
+      schema_version: $schema_version,
+      repository: $repo,
+      version: $version,
+      verified_at: $verified_at,
+      release_run: {
+        id: optional_string($release_run_id)
+      },
+      verification_run: {
+        id: optional_string($verification_run_id),
+        url: (if ($verification_run_id | length) > 0 then $verification_run_url else null end)
+      },
+      release: {
+        url: $release_url,
+        tag: $release[0].tagName,
+        draft: $release[0].isDraft,
+        prerelease: $release[0].isPrerelease,
+        assets: ($assets | split("\n") | map(select(length > 0)))
+      },
+      release_pr: {
+        number: ($release_pr_number | tonumber),
+        url: $release_pr_url
+      },
+      identity_constraints: {
+        certificate_identity: $identity,
+        certificate_oidc_issuer: "https://token.actions.githubusercontent.com"
+      },
+      chart: {
+        ref: $chart_ref,
+        digest: $chart_digest
+      },
+      published_provenance: $provenance[0],
+      checks: {
+        remote_tag_present: true,
+        github_release_published: true,
+        required_assets_present: true,
+        checksums_signature_verified: true,
+        helm_chart_published: true,
+        helm_chart_signature_verified: true,
+        no_open_release_please_prs: true,
+        no_stale_release_please_branches: true,
+        release_please_pending_label_cleared: true
+      }
+    }' > "${EVIDENCE_OUT}"
 fi
 
 info "post-release verification passed for ${VERSION}"

--- a/releases/0.4.0.mdx
+++ b/releases/0.4.0.mdx
@@ -1,0 +1,163 @@
+---
+title: 0.4.0
+description: Release notes for OpenBao Operator 0.4.0.
+slug: /0.4.0
+---
+
+<StatusPill>0.4.0</StatusPill>
+
+Published 2026-07-04.
+
+<CardGrid>
+  <LinkCard title="Matching docs" to="/docs">
+    Open the docs experience aligned to this release line.
+  </LinkCard>
+  <LinkCard title="GitHub release" to="https://github.com/dc-tec/openbao-operator/releases/tag/0.4.0">
+    View release assets, tag metadata, and the GitHub release entry.
+  </LinkCard>
+</CardGrid>
+
+0.4.0 is the next stable pre-GA release line for OpenBao Operator. This
+release focuses on security-boundary hardening, explicit delegation for
+high-impact controls, and safer self-initialization for auto-unseal clusters.
+It also refreshes the OpenBao validation baseline and expands property and
+model-based test coverage for lifecycle-critical paths.
+
+### Highlights
+
+* Tightened the authorization boundary around sensitive `OpenBaoCluster` and
+  `OpenBaoRestore` controls. Network publication, custom helper images, image
+  trust roots, cloud identity references, restore delegation, and other
+  high-impact fields now require explicit Kubernetes-side authority instead of
+  being implicitly accepted from ordinary cluster update rights.
+* Hardened the production contract for unsafe controls. Hardened clusters now
+  reject more ambiguous or unsafe shapes consistently, including raw or broad
+  network policy escape hatches, implicit object-storage identity in hardened
+  backup and restore paths, unsafe TLS and observability settings, and
+  dangerous runtime overrides.
+* Added managed-resource provenance guardrails. Operator-managed resources are
+  annotated with ownership metadata, and admission policies lock protected
+  resources so direct mutation does not silently bypass the owning
+  `OpenBaoCluster` contract.
+* Added initial recovery-key bootstrap for self-initializing auto-unseal
+  clusters through `spec.recoveryKeys.initial`. The operator can now render the
+  first recovery-key request with declared OpenPGP recipients, share count, and
+  threshold during initial self-init.
+* Made self-init bootstrap configuration one-shot. Bootstrap configuration is
+  cleaned up after initialization succeeds, reducing the chance that stale
+  first-boot material remains part of steady state.
+* Moved the default OpenBao validation baseline to `2.5.5`, with current
+  release validation covering Kubernetes `v1.34` and `v1.35` and config
+  compatibility coverage for OpenBao `2.4.4` and `2.5.5`.
+* Refreshed Go, base image, GitHub Actions, website, and transitive dependency
+  baselines, including the dependency security-policy alignment needed by CI
+  and Nightly security scans.
+* Added property and model-based tests for ownership/provenance, backup job
+  environment rendering, operation locks, upgrade request state, rolling
+  upgrade state, and restore lifecycle behavior.
+
+### Breaking and Migration Notes
+
+* Apply the `0.4.0` CRDs before upgrading the controller or Helm chart. This
+  release adds and tightens `openbao.org/v1alpha1` fields, validation rules,
+  admission policies, and delegated RBAC roles.
+* Review RBAC for every identity that creates or updates `OpenBaoCluster` and
+  `OpenBaoRestore` resources. Users, GitOps controllers, and platform
+  automation may now need explicit delegated roles for network publication,
+  helper images, image trust roots, cloud identity references, restore
+  delegation, custom executables, or other dangerous controls.
+* Review existing Hardened clusters before applying admission enforcement.
+  Specs that previously updated successfully may now be rejected if they rely
+  on unsafe controls, broad network rules, provider-default backup or restore
+  identity, TLS verification bypasses, backend HTTP, raw ingress rules, or
+  dangerous runtime flags.
+* Review direct mutations of operator-managed Kubernetes resources. Resources
+  owned by an `OpenBaoCluster` are now expected to carry operator provenance,
+  and protected managed resources should be changed through the owning custom
+  resource rather than patched directly.
+* For self-init clusters, configure a real human access path in
+  `spec.selfInit.requests` before first reconcile. `spec.selfInit.oidc.enabled`
+  only bootstraps operator lifecycle authentication; it does not create user
+  login access after the root token is auto-revoked.
+* Use `spec.recoveryKeys.initial` only for first-time self-initialization on
+  non-static unseal clusters. The recipient count must match the share count,
+  the threshold must be valid, and OpenPGP key custody and proof ceremonies
+  remain user-owned processes.
+
+### Operational Notes
+
+* Treat 0.4.0 as a security-hardening release when planning rollout. Stage the
+  CRD and admission-policy update, then validate representative cluster specs
+  before upgrading production controllers.
+* In multi-tenant environments, audit the difference between ordinary cluster
+  authors and platform administrators. The new delegated roles are intended to
+  let tenants manage day-to-day cluster intent without automatically gaining
+  authority over publication, restore, image, or identity trust boundaries.
+* If you use GitOps, make sure the controller identity has the same delegated
+  permissions as the human or platform role it represents. Otherwise GitOps may
+  fail on apply even when the manifest is otherwise valid.
+* If you rely on backup, restore, or upgrade jobs, verify the JWT role path and
+  object-storage identity path in staging. Hardened clusters favor explicit job
+  identity through `credentialsSecretRef`, workload identity metadata, or
+  provider-specific role configuration instead of ambient credentials.
+* Self-init recovery-key bootstrap does not replace recovery-key custody. Plan
+  recipient verification, share distribution, and recovery proof outside the
+  operator workflow.
+* Users already running `0.3.x` have the 0.3 hardening around inline auth,
+  metrics, audit file storage, Gateway/Ingress readiness, PKCS#11 runtime
+  wiring, backup and restore validation, and storage endpoint guards; those
+  remain included in `0.4.0`.
+
+### Upgrade from 0.3.x
+
+Before upgrading an existing `0.3.x` installation:
+
+1. Review every existing `OpenBaoCluster` and `OpenBaoRestore` against the new
+   delegated authorization and Hardened validation rules.
+2. Grant only the required delegated RBAC roles to the identities that need
+   network publication, restore, helper image, trust root, cloud identity, or
+   custom executable authority.
+3. For Hardened clusters, replace broad or implicit configuration with
+   explicit ingress peers, port-scoped egress rules, non-static unseal, trusted
+   TLS, and explicit backup/restore identity.
+4. For self-init clusters, confirm `spec.selfInit.requests` creates a user
+   login path before root token revocation, and add `spec.recoveryKeys.initial`
+   only before the first initialization event.
+5. Apply the `0.4.0` CRDs first:
+
+   ```sh
+   kubectl apply -f https://github.com/dc-tec/openbao-operator/releases/download/0.4.0/crds.yaml
+   ```
+
+6. Upgrade the Helm release:
+
+   ```sh
+   helm upgrade openbao-operator oci://ghcr.io/dc-tec/charts/openbao-operator \
+     --version 0.4.0 \
+     --namespace openbao-operator-system \
+     --reuse-values
+   ```
+
+7. Verify admission-policy health, delegated RBAC coverage, operator rollout,
+   managed cluster conditions, backup/restore events, and recent controller
+   logs before continuing with production workload changes.
+
+### Compatibility
+
+OpenBao Operator requires Kubernetes `v1.33+`. The current release validation
+baseline is Kubernetes `v1.34`-`v1.35` and OpenBao `2.5.5`, with config
+compatibility coverage for OpenBao `2.4.4` and `2.5.5`.
+
+### Features
+
+* **security:** require authority for network publication ([#507](https://github.com/dc-tec/openbao-operator/issues/507)) ([f873094](https://github.com/dc-tec/openbao-operator/commit/f873094f2add4c3bd4d261a14105c6b5853b49c9))
+* **self-init:** add initial recovery key bootstrap ([#516](https://github.com/dc-tec/openbao-operator/issues/516)) ([a04cb23](https://github.com/dc-tec/openbao-operator/commit/a04cb232aeaf7d7a6a53b8afbd6af81da1c0e442))
+
+
+### Bug Fixes
+
+* **security:** delegate dangerous CR controls ([#499](https://github.com/dc-tec/openbao-operator/issues/499)) ([14e1dad](https://github.com/dc-tec/openbao-operator/commit/14e1dadffe0c85e38db60bf76614580629d8b55c))
+* **security:** enforce CR reference authorization ([#500](https://github.com/dc-tec/openbao-operator/issues/500)) ([875b999](https://github.com/dc-tec/openbao-operator/commit/875b9997632f16181c233f5f94aba7765840c161))
+* **security:** enforce hardened contract for unsafe controls ([#502](https://github.com/dc-tec/openbao-operator/issues/502)) ([6b8f2ad](https://github.com/dc-tec/openbao-operator/commit/6b8f2ad81e797902246948d667f5a11be1a73063))
+* **security:** require provenance for managed resources ([#505](https://github.com/dc-tec/openbao-operator/issues/505)) ([fd39a1e](https://github.com/dc-tec/openbao-operator/commit/fd39a1e8c7ccfcb60240776dc1864c6dd810f9e3))
+* **self-init:** make bootstrap config one-shot ([#514](https://github.com/dc-tec/openbao-operator/issues/514)) ([cc5876c](https://github.com/dc-tec/openbao-operator/commit/cc5876cb64d00e64158f88fe6a71435376ca3572))

--- a/releases/index.mdx
+++ b/releases/index.mdx
@@ -6,15 +6,15 @@ slug: /
 
 # Release Notes
 
-<StatusPill>0.3.0</StatusPill>
+<StatusPill>0.4.0</StatusPill>
 
 Release pages combine hand-written notes from [release-notes/](https://github.com/dc-tec/openbao-operator/tree/main/release-notes) with generated entries from [CHANGELOG.md](https://github.com/dc-tec/openbao-operator/blob/main/CHANGELOG.md).
 
 ## Latest highlighted release
 
 <CardGrid>
-  <LinkCard title="0.3.0" to="/releases/0.3.0">
-    Published 2026-06-01. Open the full notes, compare changes, and jump into the matching docs version.
+  <LinkCard title="0.4.0" to="/releases/0.4.0">
+    Published 2026-07-04. Open the full notes, compare changes, and jump into the matching docs version.
   </LinkCard>
   <LinkCard title="GitHub Releases" to="https://github.com/dc-tec/openbao-operator/releases">
     Browse published release assets, tags, and signed artifacts in GitHub.
@@ -23,6 +23,7 @@ Release pages combine hand-written notes from [release-notes/](https://github.co
 
 ## Archive
 
+- [0.4.0](/releases/0.4.0) — 2026-07-04
 - [0.3.0](/releases/0.3.0) — 2026-06-01
 - [0.2.0](/releases/0.2.0) — 2026-05-01
 - [0.1.1](/releases/0.1.1) — 2026-03-31


### PR DESCRIPTION
## Summary

Adds post-release operational evidence and cleanup around the release flow.

This PR publishes the generated 0.4.0 release page, adds an automatic `Post-Release Verification` workflow, records durable `post-release-verification.json` evidence on the GitHub Release, and writes/updates a breadcrumb comment on the merged release PR.

It also fixes the release-please lifecycle gap: after a successful `Release` publish, the workflow now removes the `autorelease: pending` label from the merged release PR so release-please can open the next release PR.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

Operational release-flow change only. No API, CRD, Helm chart, RBAC, or controller runtime behavior changes.

The `Release` workflow gains `issues: write` and `pull-requests: read` permissions for the publish job so it can resolve the merged release PR and remove release-please's pending label after the GitHub Release has been published. The post-release verification workflow also uses scoped write access to upload the evidence asset and maintain the release PR comment.

## Verification

- `bash -n hack/ci/verify-post-release.sh hack/ci/publish-post-release-evidence.sh hack/ci/clear-release-please-pending-label.sh`
- `shellcheck hack/ci/verify-post-release.sh hack/ci/publish-post-release-evidence.sh hack/ci/clear-release-please-pending-label.sh`
- `actionlint .github/workflows/release.yml .github/workflows/post-release-verification.yml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "yaml ok #{path}" }' .github/workflows/release.yml .github/workflows/post-release-verification.yml`
- `git diff --check`
- `make lint-ci`
- `npm --prefix website run build`
- `VERSION=0.4.0 REPO=dc-tec/openbao-operator TAG_HEAD_SHA=a2766ccf977b5b3136296451cebc51f19182435b bash hack/ci/clear-release-please-pending-label.sh`

## Reviewer Notes

I also removed the stale `autorelease: pending` label from the already-published 0.4.0 release PR (#506) using the new helper, then reran the helper to confirm the no-op path exits cleanly.

After this merges, manually dispatch `Post-Release Verification` for `0.4.0` once to attach the durable evidence asset and release PR comment for the release that already completed before this workflow existed on `main`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
