### PR TITLE
ci(release): avoid post-publish release asset upload

### DIFF
--- a/.github/workflows/post-release-verification.yml
+++ b/.github/workflows/post-release-verification.yml
@@ -137,10 +137,22 @@ jobs:
           mkdir -p dist
           bash hack/ci/verify-post-release.sh
 
-      - name: Publish release evidence and comment on release PR
+      - name: Mint GitHub App token for release PR comment
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.OPENBAO_OPERATOR_RELEASE_PR_CLIENT_ID }}
+          private-key: ${{ secrets.OPENBAO_OPERATOR_RELEASE_PR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Comment on release PR
         id: publish
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.context.outputs.tag }}
           REPO: ${{ github.repository }}
           RELEASE_RUN_ID: ${{ steps.context.outputs.release_run_id }}
@@ -160,7 +172,8 @@ jobs:
               "- Release workflow run: \(.release_run.id // "n/a")",
               "- Chart digest: \(.chart.digest)",
               "- Required assets: \(.release.assets | length)",
-              "- Evidence asset: ${{ steps.publish.outputs.evidence_asset_url }}",
+              "- Evidence artifact: ${{ steps.publish.outputs.evidence_artifact_name }}",
+              "- Evidence sha256: ${{ steps.publish.outputs.evidence_sha256 }}",
               "- Release PR: ${{ steps.publish.outputs.release_pr_url || 'not resolved' }}",
               "- Verification: passed"
             ' dist/post-release-verification.json
@@ -172,4 +185,4 @@ jobs:
           name: post-release-verification-${{ steps.context.outputs.tag }}
           path: dist/post-release-verification.json
           if-no-files-found: error
-          retention-days: 90
+          retention-days: 30

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -179,7 +179,7 @@ For patch releases, make the source that release-please sees match the release n
 
 <Callout type="note" title="Post-release verification evidence">
 
-The `Release` workflow removes the release-please `autorelease: pending` label from the merged release PR after the GitHub Release is published. The follow-up workflow uploads `post-release-verification.json` to the GitHub Release as durable evidence and also keeps a 90-day Actions artifact copy named `post-release-verification-<version>`. That JSON evidence captures the release URL, release workflow run, release PR, chart digest, published asset list, provenance index, and the post-release invariant checks that passed. When the merged release PR can be resolved, the workflow also writes or updates a release PR comment linking to the release, workflow runs, chart digest, and evidence asset.
+The `Release` workflow removes the release-please `autorelease: pending` label from the merged release PR after the GitHub Release is published. Published GitHub Releases are immutable in this repository, so the follow-up workflow does not try to attach new release assets. Instead, it keeps a 30-day Actions artifact named `post-release-verification-<version>` and writes or updates a release PR comment with the release links, workflow runs, chart digest, and evidence sha256. The JSON evidence captures the release URL, release workflow run, release PR, chart digest, published asset list, provenance index, and the post-release invariant checks that passed.
 
 </Callout>
 

--- a/hack/ci/publish-post-release-evidence.sh
+++ b/hack/ci/publish-post-release-evidence.sh
@@ -19,9 +19,8 @@ require_cmd() {
 upsert_release_pr_comment() {
   local pr_number="$1"
   local pr_url="$2"
-  local evidence_url="$3"
-  local evidence_sha="$4"
-  local body_file="$5"
+  local evidence_sha="$3"
+  local body_file="$4"
   local marker
   local comments_json
   local comment_id
@@ -37,7 +36,7 @@ ${marker}
 - Release workflow run: ${RELEASE_RUN_URL}
 - Verification workflow run: ${VERIFICATION_RUN_URL}
 - Chart digest: \`${CHART_DIGEST}\`
-- Evidence asset: ${evidence_url}
+- Evidence artifact: ${VERIFICATION_RUN_URL} (artifact: \`${EVIDENCE_ARTIFACT_NAME}\`)
 - Evidence sha256: \`${evidence_sha}\`
 
 The published release assets, checksum signature, Helm chart signature, provenance index, and release-please cleanup checks have been verified.
@@ -54,10 +53,12 @@ EOF
   jq -n --rawfile body "${body_file}" '{body: $body}' > "${payload_file}"
 
   if [[ -n "${comment_id}" ]]; then
-    gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" --input "${payload_file}" >/dev/null
+    gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" --input "${payload_file}" >/dev/null ||
+      fail "failed to update post-release verification comment on ${pr_url}"
     echo "Updated post-release verification comment on ${pr_url}"
   else
-    gh api -X POST "repos/${REPO}/issues/${pr_number}/comments" --input "${payload_file}" >/dev/null
+    gh api -X POST "repos/${REPO}/issues/${pr_number}/comments" --input "${payload_file}" >/dev/null ||
+      fail "failed to create post-release verification comment on ${pr_url}"
     echo "Created post-release verification comment on ${pr_url}"
   fi
 }
@@ -109,43 +110,21 @@ done
 : "${REPO:?REPO is required}"
 : "${EVIDENCE_PATH:?EVIDENCE_PATH is required}"
 
-if [[ ! -s "${EVIDENCE_PATH}" ]]; then
-  fail "evidence file does not exist or is empty: ${EVIDENCE_PATH}"
-fi
-
-ASSET_NAME="${ASSET_NAME:-post-release-verification.json}"
 TAG_HEAD_SHA="${TAG_HEAD_SHA:-}"
 RELEASE_RUN_ID="${RELEASE_RUN_ID:-}"
 VERIFICATION_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-${REPO}}/actions/runs/${GITHUB_RUN_ID:-}"
 RELEASE_RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${RELEASE_RUN_ID}"
+EVIDENCE_ARTIFACT_NAME="${EVIDENCE_ARTIFACT_NAME:-post-release-verification-${VERSION}}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR}"' EXIT
 
-release_json="$(gh release view "${VERSION}" --repo "${REPO}" --json assets,url)"
-RELEASE_URL="$(jq -r '.url' <<<"${release_json}")"
-asset_url="$(jq -r --arg name "${ASSET_NAME}" '.assets[]? | select(.name == $name) | .url' <<<"${release_json}" | head -n1)"
-evidence_sha="$(sha256sum "${EVIDENCE_PATH}" | awk '{print $1}')"
-
-if [[ -z "${asset_url}" ]]; then
-  upload_path="${TMPDIR}/${ASSET_NAME}"
-  cp "${EVIDENCE_PATH}" "${upload_path}"
-  gh release upload "${VERSION}" "${upload_path}" --repo "${REPO}"
-  release_json="$(gh release view "${VERSION}" --repo "${REPO}" --json assets,url)"
-  asset_url="$(jq -r --arg name "${ASSET_NAME}" '.assets[]? | select(.name == $name) | .url' <<<"${release_json}" | head -n1)"
-  if [[ -z "${asset_url}" ]]; then
-    fail "release evidence asset upload succeeded but ${ASSET_NAME} was not found on ${VERSION}"
-  fi
-  echo "Uploaded release evidence asset: ${asset_url}"
-else
-  existing_dir="${TMPDIR}/existing"
-  mkdir -p "${existing_dir}"
-  gh release download "${VERSION}" --repo "${REPO}" --pattern "${ASSET_NAME}" --dir "${existing_dir}"
-  existing_sha="$(sha256sum "${existing_dir}/${ASSET_NAME}" | awk '{print $1}')"
-  if [[ "${existing_sha}" != "${evidence_sha}" ]]; then
-    fail "existing ${ASSET_NAME} differs from local evidence (release=${existing_sha}, local=${evidence_sha})"
-  fi
-  echo "Release evidence asset already exists: ${asset_url}"
+if [[ ! -s "${EVIDENCE_PATH}" ]]; then
+  fail "evidence file does not exist or is empty: ${EVIDENCE_PATH}"
 fi
+
+release_json="$(gh release view "${VERSION}" --repo "${REPO}" --json url)"
+RELEASE_URL="$(jq -r '.url' <<<"${release_json}")"
+evidence_sha="$(sha256sum "${EVIDENCE_PATH}" | awk '{print $1}')"
 
 CHART_DIGEST="$(jq -r '.chart.digest' "${EVIDENCE_PATH}")"
 if [[ -z "${CHART_DIGEST}" || "${CHART_DIGEST}" == "null" ]]; then
@@ -155,15 +134,13 @@ fi
 RELEASE_PR_NUMBER=""
 RELEASE_PR_URL=""
 if resolve_release_pr; then
-  if ! upsert_release_pr_comment "${RELEASE_PR_NUMBER}" "${RELEASE_PR_URL}" "${asset_url}" "${evidence_sha}" "${TMPDIR}/release-pr-comment.md"; then
-    warn "failed to write post-release verification comment on release PR ${RELEASE_PR_URL}"
-  fi
+  upsert_release_pr_comment "${RELEASE_PR_NUMBER}" "${RELEASE_PR_URL}" "${evidence_sha}" "${TMPDIR}/release-pr-comment.md"
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
-    echo "evidence_asset_url=${asset_url}"
-    echo "evidence_asset_sha256=${evidence_sha}"
+    echo "evidence_artifact_name=${EVIDENCE_ARTIFACT_NAME}"
+    echo "evidence_sha256=${evidence_sha}"
     echo "release_pr_url=${RELEASE_PR_URL}"
   } >> "${GITHUB_OUTPUT}"
 fi


### PR DESCRIPTION
## Summary

Follow-up to the post-release verification workflow after the first manual `0.4.0` verification run exposed two operational constraints:

- published GitHub Releases are immutable in this repository, so the post-release workflow must not try to upload new release assets
- the default `GITHUB_TOKEN` cannot write the release PR breadcrumb comment, so the workflow now uses the existing release-PR GitHub App token with pull request write permission

The workflow now records evidence through the Actions artifact and the release PR comment, and the docs describe the immutable-release behavior explicitly.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Release automation only. No API, CRD, Helm chart, RBAC, or controller runtime behavior changes.

This keeps post-release verification strict for actual verification failures. It only removes the invalid post-publish release asset upload path and uses the release-PR app token for the comment step.

## Verification

- `bash -n hack/ci/publish-post-release-evidence.sh hack/ci/verify-post-release.sh hack/ci/clear-release-please-pending-label.sh`
- `shellcheck hack/ci/publish-post-release-evidence.sh hack/ci/verify-post-release.sh hack/ci/clear-release-please-pending-label.sh`
- `actionlint .github/workflows/post-release-verification.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/post-release-verification.yml`
- `git diff --check`
- `make lint-ci`
- `npm --prefix website run build`
- Branch workflow dispatch for `0.4.0`: https://github.com/dc-tec/openbao-operator/actions/runs/28712399867

The branch workflow verified the release, uploaded the `post-release-verification-0.4.0` artifact, and created the release PR comment on #506.

## Reviewer Notes

After this merges, rerun `Post-Release Verification` for `0.4.0` from `main` so the durable breadcrumb comment points at the merged workflow run instead of the branch validation run.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
