### PR TITLE
fix(config): omit plugin directory without plugins

### DIFF
--- a/internal/adapter/config/builder.go
+++ b/internal/adapter/config/builder.go
@@ -151,12 +151,17 @@ func RenderHCL(cluster *openbaov1alpha1.OpenBaoCluster, infra InfrastructureDeta
 	apiAddr := fmt.Sprintf("https://${HOSTNAME}.%s.%s.svc:%d", infra.HeadlessServiceName, infra.Namespace, infra.APIPort)
 	clusterAddr := fmt.Sprintf("https://${HOSTNAME}.%s.%s.svc:%d", infra.HeadlessServiceName, infra.Namespace, infra.ClusterPort)
 
+	var pluginDirectory *string
+	if len(cluster.Spec.Plugins) > 0 {
+		pluginDirectory = stringPtr(constants.PathPlugins)
+	}
+
 	gohcl.EncodeIntoBody(hclCoreAttributes{
 		UI:              uiEnabled,
 		ClusterName:     cluster.Name,
 		APIAddr:         apiAddr,
 		ClusterAddr:     clusterAddr,
-		PluginDirectory: constants.PathPlugins,
+		PluginDirectory: pluginDirectory,
 	}, body)
 
 	listenerBlocks, err := buildListenerBlocks(cluster)

--- a/internal/adapter/config/gohcl_types.go
+++ b/internal/adapter/config/gohcl_types.go
@@ -8,11 +8,11 @@ import (
 )
 
 type hclCoreAttributes struct {
-	UI              bool   `hcl:"ui"`
-	ClusterName     string `hcl:"cluster_name"`
-	APIAddr         string `hcl:"api_addr"`
-	ClusterAddr     string `hcl:"cluster_addr"`
-	PluginDirectory string `hcl:"plugin_directory"`
+	UI              bool    `hcl:"ui"`
+	ClusterName     string  `hcl:"cluster_name"`
+	APIAddr         string  `hcl:"api_addr"`
+	ClusterAddr     string  `hcl:"cluster_addr"`
+	PluginDirectory *string `hcl:"plugin_directory"`
 }
 
 type hclListenerTCP struct {

--- a/internal/adapter/config/testdata/render_hcl_acme_mode.hcl
+++ b/internal/adapter/config/testdata/render_hcl_acme_mode.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "acme-cluster"
-api_addr         = "https://$${HOSTNAME}.acme-cluster.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.acme-cluster.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "acme-cluster"
+api_addr     = "https://$${HOSTNAME}.acme-cluster.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.acme-cluster.default.svc:8201"
 listener "tcp" {
   address                         = "[::]:8200"
   cluster_address                 = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_acme_mode_default_domain.hcl
+++ b/internal/adapter/config/testdata/render_hcl_acme_mode_default_domain.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "acme-cluster"
-api_addr         = "https://$${HOSTNAME}.acme-cluster.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.acme-cluster.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "acme-cluster"
+api_addr     = "https://$${HOSTNAME}.acme-cluster.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.acme-cluster.default.svc:8201"
 listener "tcp" {
   address                         = "[::]:8200"
   cluster_address                 = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_acme_mode_no_email.hcl
+++ b/internal/adapter/config/testdata/render_hcl_acme_mode_no_email.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "acme-cluster"
-api_addr         = "https://$${HOSTNAME}.acme-cluster.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.acme-cluster.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "acme-cluster"
+api_addr     = "https://$${HOSTNAME}.acme-cluster.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.acme-cluster.default.svc:8201"
 listener "tcp" {
   address                         = "[::]:8200"
   cluster_address                 = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_all_config_options.hcl
+++ b/internal/adapter/config/testdata/render_hcl_all_config_options.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "full-config"
-api_addr         = "https://$${HOSTNAME}.full-config.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.full-config.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "full-config"
+api_addr     = "https://$${HOSTNAME}.full-config.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.full-config.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_auto_join.hcl
+++ b/internal/adapter/config/testdata/render_hcl_auto_join.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "test-cluster"
-api_addr         = "https://$${HOSTNAME}.test-cluster.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.test-cluster.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "test-cluster"
+api_addr     = "https://$${HOSTNAME}.test-cluster.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.test-cluster.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_awskms_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_awskms_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "awskms-seal"
-api_addr         = "https://$${HOSTNAME}.awskms-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.awskms-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "awskms-seal"
+api_addr     = "https://$${HOSTNAME}.awskms-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.awskms-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_azure_keyvault_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_azure_keyvault_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "azure-seal"
-api_addr         = "https://$${HOSTNAME}.azure-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.azure-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "azure-seal"
+api_addr     = "https://$${HOSTNAME}.azure-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.azure-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_core_stanzas.hcl
+++ b/internal/adapter/config/testdata/render_hcl_core_stanzas.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "config-hcl"
-api_addr         = "https://$${HOSTNAME}.config-hcl.security.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.config-hcl.security.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "config-hcl"
+api_addr     = "https://$${HOSTNAME}.config-hcl.security.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.config-hcl.security.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_gcp_cloudkms_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_gcp_cloudkms_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "gcp-seal"
-api_addr         = "https://$${HOSTNAME}.gcp-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.gcp-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "gcp-seal"
+api_addr     = "https://$${HOSTNAME}.gcp-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.gcp-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_kmip_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_kmip_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "kmip-seal"
-api_addr         = "https://$${HOSTNAME}.kmip-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.kmip-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "kmip-seal"
+api_addr     = "https://$${HOSTNAME}.kmip-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.kmip-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_ocikms_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_ocikms_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "oci-seal"
-api_addr         = "https://$${HOSTNAME}.oci-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.oci-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "oci-seal"
+api_addr     = "https://$${HOSTNAME}.oci-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.oci-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_pkcs11_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_pkcs11_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "pkcs11-seal"
-api_addr         = "https://$${HOSTNAME}.pkcs11-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.pkcs11-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "pkcs11-seal"
+api_addr     = "https://$${HOSTNAME}.pkcs11-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.pkcs11-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_static_seal_custom.hcl
+++ b/internal/adapter/config/testdata/render_hcl_static_seal_custom.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "static-seal-custom"
-api_addr         = "https://$${HOSTNAME}.static-seal-custom.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.static-seal-custom.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "static-seal-custom"
+api_addr     = "https://$${HOSTNAME}.static-seal-custom.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.static-seal-custom.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_static_seal_default.hcl
+++ b/internal/adapter/config/testdata/render_hcl_static_seal_default.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "static-seal"
-api_addr         = "https://$${HOSTNAME}.static-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.static-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "static-seal"
+api_addr     = "https://$${HOSTNAME}.static-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.static-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_structured_config.hcl
+++ b/internal/adapter/config/testdata/render_hcl_structured_config.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "structured-config"
-api_addr         = "https://$${HOSTNAME}.structured-config.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.structured-config.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "structured-config"
+api_addr     = "https://$${HOSTNAME}.structured-config.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.structured-config.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"

--- a/internal/adapter/config/testdata/render_hcl_transit_seal.hcl
+++ b/internal/adapter/config/testdata/render_hcl_transit_seal.hcl
@@ -1,8 +1,7 @@
-ui               = true
-cluster_name     = "transit-seal"
-api_addr         = "https://$${HOSTNAME}.transit-seal.default.svc:8200"
-cluster_addr     = "https://$${HOSTNAME}.transit-seal.default.svc:8201"
-plugin_directory = "/openbao/plugins"
+ui           = true
+cluster_name = "transit-seal"
+api_addr     = "https://$${HOSTNAME}.transit-seal.default.svc:8200"
+cluster_addr = "https://$${HOSTNAME}.transit-seal.default.svc:8201"
 listener "tcp" {
   address              = "[::]:8200"
   cluster_address      = "[::]:8201"


### PR DESCRIPTION
## Summary

OpenBao 2.6.0-beta fails startup when the rendered config points `plugin_directory` at `/openbao/plugins` and that directory does not exist. The Operator was rendering that setting for every cluster, including clusters without any declarative plugins.

This change renders `plugin_directory = "/openbao/plugins"` only when `spec.plugins` is configured. Plugin-enabled clusters keep the existing HCL output; pluginless clusters no longer require the runtime image to contain an unused plugin directory.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. This only changes generated OpenBao HCL for clusters without `spec.plugins`; plugin-enabled clusters still render `plugin_directory` and OCI plugin auto-download behavior is unchanged.

Docs were checked. The existing plugin docs describe `plugin_directory` in the context of configured plugins and OCI auto-download, so no documentation update is needed for the pluginless-cluster fix.

## Verification

- `go test ./internal/adapter/config`
- `go test ./internal/service/workload -run 'TestStatefulSet_OCIPlugin|TestBuildStatefulSet|TestStatefulSet' -count=1`
- `make test-e2e E2E_LABEL_FILTER='lifecycle && smoke' E2E_OPENBAO_VERSION=2.6.0-beta20260622 E2E_OPENBAO_IMAGE=openbao/openbao:2.6.0-beta20260622 E2E_TIMEOUT=1h`
- `make ci-core`
- `git diff --check`
- pre-push hook: `make lint-ci`

## Reviewer Notes

This is intended to land before broader OpenBao 2.6.0 KMS plugin verification work. Proper KMS-plugin-path verification should be handled separately with a plugin-backed fixture.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
