### PR TITLE
ci(coverage): enforce internal coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,9 +478,8 @@ jobs:
       - name: Setup repo tools
         uses: ./.github/actions/setup-repo-tools
 
-      - name: Run integration tests
-        run: |
-          make test-integration
+      - name: Run unit and integration tests with coverage gate
+        run: make test-ci
 
   fuzz:
     name: Fuzz Smoke

--- a/hack/tools/coverage_check/main.go
+++ b/hack/tools/coverage_check/main.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var coverageLinePattern = regexp.MustCompile(
+	`^(.+):([0-9]+)\.([0-9]+),([0-9]+)\.([0-9]+) ([0-9]+) ([0-9]+)$`,
+)
+
+type coverageStats struct {
+	Covered int64
+	Total   int64
+}
+
+func (s coverageStats) percent() float64 {
+	if s.Total == 0 {
+		return 0
+	}
+	return float64(s.Covered) * 100 / float64(s.Total)
+}
+
+type coverageBlock struct {
+	Layer   string
+	Covered bool
+	Total   int64
+}
+
+type coverageReport struct {
+	Internal coverageStats
+	Layers   map[string]coverageStats
+}
+
+func main() {
+	profilePath := flag.String("profile", "cover.out", "Path to a Go coverage profile")
+	minimum := flag.Float64("minimum", -1, "Minimum required internal package coverage percentage")
+	flag.Parse()
+
+	if math.IsNaN(*minimum) || math.IsInf(*minimum, 0) || *minimum < 0 || *minimum > 100 {
+		fail(fmt.Errorf("minimum must be between 0 and 100"))
+	}
+
+	profile, err := os.Open(*profilePath)
+	if err != nil {
+		fail(fmt.Errorf("open profile %s: %w", *profilePath, err))
+	}
+	defer func() { _ = profile.Close() }()
+
+	report, err := parseCoverageProfile(profile)
+	if err != nil {
+		fail(fmt.Errorf("parse profile %s: %w", *profilePath, err))
+	}
+
+	if err := printCoverageReport(os.Stdout, report, *minimum); err != nil {
+		fail(fmt.Errorf("write report: %w", err))
+	}
+	if err := verifyMinimum(report, *minimum); err != nil {
+		fail(err)
+	}
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "coverage_check: %v\n", err)
+	os.Exit(1)
+}
+
+func parseCoverageProfile(r io.Reader) (coverageReport, error) {
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return coverageReport{}, fmt.Errorf("read mode: %w", err)
+		}
+		return coverageReport{}, fmt.Errorf("profile is empty")
+	}
+
+	mode := strings.TrimPrefix(scanner.Text(), "mode: ")
+	if mode != "set" && mode != "count" && mode != "atomic" {
+		return coverageReport{}, fmt.Errorf("unsupported mode line %q", scanner.Text())
+	}
+
+	blocks := make(map[string]coverageBlock)
+	lineNumber := 1
+	for scanner.Scan() {
+		lineNumber++
+		matches := coverageLinePattern.FindStringSubmatch(scanner.Text())
+		if matches == nil {
+			return coverageReport{}, fmt.Errorf("line %d has invalid coverage syntax", lineNumber)
+		}
+
+		layer, ok := internalLayer(matches[1])
+		if !ok {
+			continue
+		}
+
+		total, err := strconv.ParseInt(matches[6], 10, 64)
+		if err != nil {
+			return coverageReport{}, fmt.Errorf("line %d statement count: %w", lineNumber, err)
+		}
+		count, err := strconv.ParseInt(matches[7], 10, 64)
+		if err != nil {
+			return coverageReport{}, fmt.Errorf("line %d execution count: %w", lineNumber, err)
+		}
+
+		key := strings.Join(matches[1:6], ":")
+		if existing, found := blocks[key]; found {
+			if existing.Total != total {
+				return coverageReport{}, fmt.Errorf(
+					"line %d changes statement count for duplicate block from %d to %d",
+					lineNumber,
+					existing.Total,
+					total,
+				)
+			}
+			existing.Covered = existing.Covered || count > 0
+			blocks[key] = existing
+			continue
+		}
+
+		blocks[key] = coverageBlock{
+			Layer:   layer,
+			Covered: count > 0,
+			Total:   total,
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return coverageReport{}, fmt.Errorf("read profile: %w", err)
+	}
+	if len(blocks) == 0 {
+		return coverageReport{}, fmt.Errorf("profile contains no internal package statements")
+	}
+
+	report := coverageReport{Layers: make(map[string]coverageStats)}
+	for _, block := range blocks {
+		report.Internal.Total += block.Total
+		layerStats := report.Layers[block.Layer]
+		layerStats.Total += block.Total
+		if block.Covered {
+			report.Internal.Covered += block.Total
+			layerStats.Covered += block.Total
+		}
+		report.Layers[block.Layer] = layerStats
+	}
+
+	return report, nil
+}
+
+func internalLayer(fileName string) (string, bool) {
+	normalized := strings.ReplaceAll(fileName, "\\", "/")
+	const modulePrefix = "github.com/dc-tec/openbao-operator/internal/"
+
+	var relative string
+	if strings.HasPrefix(normalized, modulePrefix) {
+		relative = strings.TrimPrefix(normalized, modulePrefix)
+	} else if strings.HasPrefix(normalized, "internal/") {
+		relative = strings.TrimPrefix(normalized, "internal/")
+	} else {
+		return "", false
+	}
+
+	layer, _, found := strings.Cut(relative, "/")
+	if layer == "" {
+		return "", false
+	}
+	if !found {
+		return "root", true
+	}
+	return layer, true
+}
+
+func verifyMinimum(report coverageReport, minimum float64) error {
+	actual := report.Internal.percent()
+	if actual < minimum {
+		return fmt.Errorf("internal coverage %.2f%% is below required minimum %.2f%%", actual, minimum)
+	}
+	return nil
+}
+
+func printCoverageReport(w io.Writer, report coverageReport, minimum float64) error {
+	if _, err := fmt.Fprintf(
+		w,
+		"internal coverage: %.2f%% (%d/%d statements)\n",
+		report.Internal.percent(),
+		report.Internal.Covered,
+		report.Internal.Total,
+	); err != nil {
+		return err
+	}
+
+	layers := make([]string, 0, len(report.Layers))
+	for layer := range report.Layers {
+		layers = append(layers, layer)
+	}
+	sort.Strings(layers)
+	for _, layer := range layers {
+		stats := report.Layers[layer]
+		if _, err := fmt.Fprintf(
+			w,
+			"  %-12s %.2f%% (%d/%d)\n",
+			layer,
+			stats.percent(),
+			stats.Covered,
+			stats.Total,
+		); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(w, "required minimum: %.2f%%\n", minimum); err != nil {
+		return err
+	}
+	if verifyMinimum(report, minimum) == nil {
+		_, err := fmt.Fprintln(w, "coverage gate: pass")
+		return err
+	}
+	_, err := fmt.Fprintln(w, "coverage gate: fail")
+	return err
+}

--- a/hack/tools/coverage_check/main_test.go
+++ b/hack/tools/coverage_check/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseCoverageProfileScopesToInternalPackages(t *testing.T) {
+	profile := `mode: set
+github.com/dc-tec/openbao-operator/internal/app/app.go:1.1,2.1 4 1
+github.com/dc-tec/openbao-operator/internal/service/service.go:3.1,4.1 6 0
+github.com/dc-tec/openbao-operator/hack/tools/tool.go:1.1,2.1 100 1
+github.com/dc-tec/openbao-operator/cmd/controller/main.go:1.1,2.1 100 1
+github.com/dc-tec/openbao-operator/test/e2e/suite.go:1.1,2.1 100 1
+github.com/dc-tec/openbao-operator/api/v1alpha1/types.go:1.1,2.1 100 1
+`
+
+	report, err := parseCoverageProfile(strings.NewReader(profile))
+	if err != nil {
+		t.Fatalf("parseCoverageProfile() error = %v", err)
+	}
+	if report.Internal != (coverageStats{Covered: 4, Total: 10}) {
+		t.Fatalf("internal stats = %#v, want covered=4 total=10", report.Internal)
+	}
+	if len(report.Layers) != 2 {
+		t.Fatalf("layer count = %d, want 2", len(report.Layers))
+	}
+	if report.Layers["app"] != (coverageStats{Covered: 4, Total: 4}) {
+		t.Fatalf("app stats = %#v, want covered=4 total=4", report.Layers["app"])
+	}
+	if report.Layers["service"] != (coverageStats{Covered: 0, Total: 6}) {
+		t.Fatalf("service stats = %#v, want covered=0 total=6", report.Layers["service"])
+	}
+}
+
+func TestParseCoverageProfileMergesDuplicateBlocks(t *testing.T) {
+	profile := `mode: count
+github.com/dc-tec/openbao-operator/internal/app/app.go:1.1,2.1 4 0
+github.com/dc-tec/openbao-operator/internal/app/app.go:1.1,2.1 4 3
+`
+
+	report, err := parseCoverageProfile(strings.NewReader(profile))
+	if err != nil {
+		t.Fatalf("parseCoverageProfile() error = %v", err)
+	}
+	if report.Internal != (coverageStats{Covered: 4, Total: 4}) {
+		t.Fatalf("internal stats = %#v, want covered=4 total=4", report.Internal)
+	}
+}
+
+func TestParseCoverageProfileRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		want    string
+	}{
+		{name: "empty", profile: "", want: "profile is empty"},
+		{name: "mode", profile: "mode: invalid\n", want: "unsupported mode"},
+		{name: "line", profile: "mode: set\nnot-a-profile-line\n", want: "invalid coverage syntax"},
+		{
+			name:    "no internal statements",
+			profile: "mode: set\ngithub.com/dc-tec/openbao-operator/hack/tool.go:1.1,2.1 1 1\n",
+			want:    "no internal package statements",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseCoverageProfile(strings.NewReader(tt.profile))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("parseCoverageProfile() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestInternalLayer(t *testing.T) {
+	tests := []struct {
+		fileName string
+		want     string
+		ok       bool
+	}{
+		{fileName: "github.com/dc-tec/openbao-operator/internal/service/manager.go", want: "service", ok: true},
+		{fileName: "internal/platform/status.go", want: "platform", ok: true},
+		{fileName: "internal/version.go", want: "root", ok: true},
+		{fileName: "github.com/dc-tec/openbao-operator/hack/internal/tool.go", want: "", ok: false},
+		{fileName: "github.com/example/project/cmd/main.go", want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fileName, func(t *testing.T) {
+			got, ok := internalLayer(tt.fileName)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("internalLayer(%q) = (%q, %t), want (%q, %t)", tt.fileName, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestVerifyMinimum(t *testing.T) {
+	report := coverageReport{Internal: coverageStats{Covered: 6832, Total: 10000}}
+	if err := verifyMinimum(report, 68.0); err != nil {
+		t.Fatalf("verifyMinimum() unexpected error = %v", err)
+	}
+	if err := verifyMinimum(report, 68.5); err == nil {
+		t.Fatal("verifyMinimum() error = nil, want threshold failure")
+	}
+}
+
+func TestPrintCoverageReport(t *testing.T) {
+	report := coverageReport{
+		Internal: coverageStats{Covered: 7, Total: 10},
+		Layers: map[string]coverageStats{
+			"service": {Covered: 3, Total: 6},
+			"app":     {Covered: 4, Total: 4},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := printCoverageReport(&out, report, 68.0); err != nil {
+		t.Fatalf("printCoverageReport() error = %v", err)
+	}
+	want := `internal coverage: 70.00% (7/10 statements)
+  app          100.00% (4/4)
+  service      50.00% (3/6)
+required minimum: 68.00%
+coverage gate: pass
+`
+	if out.String() != want {
+		t.Fatalf("printCoverageReport() =\n%s\nwant:\n%s", out.String(), want)
+	}
+}

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -87,9 +87,25 @@ test-sum: manifests generate fmt vet gotestsum ## Run unit tests with gotestsum 
 	@mkdir -p "$(TEST_ARTIFACT_DIR)"
 	GOFLAGS="$(GOFLAGS_VENDOR)" "$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" --junitfile "$(TEST_ARTIFACT_DIR)/unit.xml" -- -coverprofile "$(TEST_ARTIFACT_DIR)/unit.cover.out" $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e)
 
+COVERAGE_PROFILE ?= cover.out
+COVERAGE_MIN_INTERNAL ?= 68.0
+
+.PHONY: verify-coverage
+verify-coverage: ## Verify production code under internal/ meets the coverage regression floor.
+	GOFLAGS="$(GOFLAGS_VENDOR)" go run ./hack/tools/coverage_check \
+		--profile "$(COVERAGE_PROFILE)" \
+		--minimum "$(COVERAGE_MIN_INTERNAL)"
+
 .PHONY: test-ci
-test-ci: manifests generate vet setup-envtest ## Run unit + integration tests in CI mode (does not modify tracked files).
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" GOFLAGS="$(GOFLAGS_VENDOR)" go test $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e) -tags=integration -coverprofile cover.out
+test-ci: manifests generate vet setup-envtest gotestsum ## Run unit + integration tests and enforce the coverage floor.
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
+		GOFLAGS="$(GOFLAGS_VENDOR)" \
+		"$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" -- \
+		-tags=integration \
+		-count=1 \
+		-coverprofile "$(COVERAGE_PROFILE)" \
+		$$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e)
+	$(MAKE) verify-coverage COVERAGE_PROFILE="$(COVERAGE_PROFILE)" COVERAGE_MIN_INTERNAL="$(COVERAGE_MIN_INTERNAL)"
 
 .PHONY: test-integration
 test-integration: manifests generate vet setup-envtest ## Run envtest-based integration tests (envtest; requires -tags=integration).


### PR DESCRIPTION
## Summary

- add a repository-local checker for Go coverage profiles
- enforce a 68.0% regression floor for module-level `internal/**` code
- keep `api/`, `cmd/`, `hack/`, `test/`, and E2E code outside the enforced metric
- run the same gotestsum-backed coverage gate locally and in the Envtest integration job

The current baseline is 68.33% (11,228/16,432 statements).

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or runtime behavior changes. The CI integration job will now fail when internal coverage drops below 68.0%.

## Verification

- `make doctor`
- `make test-ci`
- `make lint`
- `bin/actionlint .github/workflows/*.yml`
- `make ci-core`
- explicit failure-path check with `COVERAGE_MIN_INTERNAL=100`

## Reviewer Notes

Please focus on the enforced package scope and whether 68.0% is the right initial regression floor. The test suite still runs non-E2E packages; the checker controls which code contributes to the metric.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.