### PR TITLE
test(e2e): use qualified blue-green versions for drift

### DIFF
--- a/test/e2e/Upgrade_Target_Drift_test.go
+++ b/test/e2e/Upgrade_Target_Drift_test.go
@@ -46,8 +46,8 @@ var _ = Describe("Upgrade Strategies: Blue/Green Drift", Label("upgrade", "blueg
 		tenantNamespace = tenantFW.Namespace
 		admin = tenantFW.Client
 
-		initialVersion = envOrDefault("E2E_UPGRADE_FROM_VERSION", defaultUpgradeFromVersion)
-		targetVersion = envOrDefault("E2E_UPGRADE_TO_VERSION", defaultUpgradeToVersion)
+		initialVersion = blueGreenUpgradeFromVersion()
+		targetVersion = blueGreenUpgradeToVersion()
 		initialImage = fmt.Sprintf("openbao/openbao:%s", initialVersion)
 		targetImage = fmt.Sprintf("openbao/openbao:%s", targetVersion)
 		driftImage = fmt.Sprintf("ghcr.io/openbao/openbao:%s", targetVersion)


### PR DESCRIPTION
## Summary

Use the qualified Blue/Green upgrade version pair in the target-drift E2E case. The generic defaults now exercise OpenBao 2.5.5 to 2.6.0, which the operator intentionally rejects for Blue/Green upgrades.

## Related Issues

Follow-up to the failed 0.4.1 release E2E gate.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No runtime or API impact. This only corrects the versions selected by one Blue/Green E2E case.

## Verification

- `go test -tags=e2e ./test/e2e -run '^TestE2E$' -count=0`
- Exact target-drift E2E on kind 1.34.3: 1 passed, 0 failed
- Pre-commit affected-path lint
- Pre-push `make lint-ci`

## Reviewer Notes

The failed release run showed `BlueGreenVersionIncompatible` because this case was the remaining Blue/Green spec using the generic 2.5.5 to 2.6.0 defaults.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
