### PR TITLE
fix(upgrade): allow idle strategy switching on 0.4.x

### DIFF
--- a/api/v1alpha1/openbaocluster_types.go
+++ b/api/v1alpha1/openbaocluster_types.go
@@ -2048,7 +2048,6 @@ type PluginConfig struct {
 // +kubebuilder:validation:XValidation:rule="self.tls.mode != 'OperatorManaged' || size(self.tls.rotationPeriod) > 0",message="spec.tls.rotationPeriod is required when spec.tls.mode is OperatorManaged"
 // +kubebuilder:validation:XValidation:rule="self.tls.mode == 'ACME' || !has(self.tls.acme) || !has(self.tls.acme.sharedCache)",message="spec.tls.acme.sharedCache is only supported when spec.tls.mode is ACME"
 // +kubebuilder:validation:XValidation:rule="self.tls.mode != 'ACME' || ((self.replicas <= 1) && (!has(self.upgrade) || self.upgrade.strategy != 'BlueGreen')) || (has(self.tls.acme) && has(self.tls.acme.sharedCache))",message="HA ACME clusters require spec.tls.acme.sharedCache when more than one Pod can serve the same hostname"
-// +kubebuilder:validation:XValidation:rule="((!has(self.upgrade) || !has(self.upgrade.strategy) || size(self.upgrade.strategy) == 0) ? 'RollingUpdate' : self.upgrade.strategy) == ((!has(oldSelf.upgrade) || !has(oldSelf.upgrade.strategy) || size(oldSelf.upgrade.strategy) == 0) ? 'RollingUpdate' : oldSelf.upgrade.strategy)",message="spec.upgrade.strategy is immutable after creation; switching between RollingUpdate and BlueGreen is not supported."
 // +kubebuilder:validation:XValidation:rule="!has(self.unseal) || self.unseal.type != 'ocikms' || !has(self.unseal.credentialsSecretRef) || (has(self.unseal.ocikms) && has(self.unseal.ocikms.authTypeAPIKey) && self.unseal.ocikms.authTypeAPIKey == true)",message="spec.unseal.credentialsSecretRef for ocikms requires spec.unseal.ocikms.authTypeAPIKey=true"
 // +kubebuilder:validation:XValidation:rule="!has(self.recoveryKeys) || !has(self.recoveryKeys.initial) || (has(self.selfInit) && self.selfInit.enabled)",message="spec.recoveryKeys.initial requires spec.selfInit.enabled=true"
 // +kubebuilder:validation:XValidation:rule="!has(self.recoveryKeys) || !has(self.recoveryKeys.initial) || (has(self.unseal) && self.unseal.type != 'static')",message="spec.recoveryKeys.initial requires a non-static spec.unseal.type"
@@ -2326,6 +2325,11 @@ type BlueGreenStatus struct {
 	Phase BlueGreenPhase `json:"phase,omitempty"`
 	// BlueRevision is the hash/name of the currently active cluster.
 	BlueRevision string `json:"blueRevision,omitempty"`
+	// BlueControllerRevision is the Kubernetes StatefulSet controller revision
+	// of Blue. It identifies an unrevisioned rolling workload after switching to
+	// BlueGreen without requiring the existing Pods to be restarted or relabeled.
+	// +optional
+	BlueControllerRevision string `json:"blueControllerRevision,omitempty"`
 	// BlueImage is the container image used by the Blue cluster.
 	// This ensures the Blue cluster is not actively upgraded when spec.image changes.
 	BlueImage string `json:"blueImage,omitempty"`
@@ -2481,6 +2485,12 @@ type OpenBaoClusterStatus struct {
 	// CurrentVersion is the OpenBao version currently running on the cluster.
 	// +optional
 	CurrentVersion string `json:"currentVersion,omitempty"`
+	// AcceptedUpgradeStrategy is the upgrade strategy the operator has accepted
+	// after applying idle-state transition guards. While a requested strategy
+	// change is blocked, controllers continue using this strategy so an existing
+	// operation can finish safely.
+	// +optional
+	AcceptedUpgradeStrategy UpdateStrategyType `json:"acceptedUpgradeStrategy,omitempty"`
 	// Initialized indicates whether the OpenBao cluster has been initialized.
 	// This is set to true after the first pod is initialized using bao operator init
 	// or after self-initialization completes.

--- a/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
+++ b/charts/openbao-operator/crds/openbao.org_openbaoclusters.yaml
@@ -4940,12 +4940,6 @@ spec:
               rule: self.tls.mode != 'ACME' || ((self.replicas <= 1) && (!has(self.upgrade)
                 || self.upgrade.strategy != 'BlueGreen')) || (has(self.tls.acme) &&
                 has(self.tls.acme.sharedCache))
-            - message: spec.upgrade.strategy is immutable after creation; switching
-                between RollingUpdate and BlueGreen is not supported.
-              rule: '((!has(self.upgrade) || !has(self.upgrade.strategy) || size(self.upgrade.strategy)
-                == 0) ? ''RollingUpdate'' : self.upgrade.strategy) == ((!has(oldSelf.upgrade)
-                || !has(oldSelf.upgrade.strategy) || size(oldSelf.upgrade.strategy)
-                == 0) ? ''RollingUpdate'' : oldSelf.upgrade.strategy)'
             - message: spec.unseal.credentialsSecretRef for ocikms requires spec.unseal.ocikms.authTypeAPIKey=true
               rule: '!has(self.unseal) || self.unseal.type != ''ocikms'' || !has(self.unseal.credentialsSecretRef)
                 || (has(self.unseal.ocikms) && has(self.unseal.ocikms.authTypeAPIKey)
@@ -4959,6 +4953,16 @@ spec:
           status:
             description: Status defines the observed state of OpenBaoCluster.
             properties:
+              acceptedUpgradeStrategy:
+                description: |-
+                  AcceptedUpgradeStrategy is the upgrade strategy the operator has accepted
+                  after applying idle-state transition guards. While a requested strategy
+                  change is blocked, controllers continue using this strategy so an existing
+                  operation can finish safely.
+                enum:
+                - RollingUpdate
+                - BlueGreen
+                type: string
               activeLeader:
                 description: ActiveLeader is the current Raft leader pod name, for
                   example "prod-cluster-0".
@@ -5052,6 +5056,12 @@ spec:
                 description: BlueGreen tracks the state of blue/green upgrades (if
                   enabled).
                 properties:
+                  blueControllerRevision:
+                    description: |-
+                      BlueControllerRevision is the Kubernetes StatefulSet controller revision
+                      of Blue. It identifies an unrevisioned rolling workload after switching to
+                      BlueGreen without requiring the existing Pods to be restarted or relabeled.
+                    type: string
                   blueImage:
                     description: |-
                       BlueImage is the container image used by the Blue cluster.

--- a/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
+++ b/charts/openbao-operator/templates/admission/validate-openbaocluster.yaml
@@ -39,6 +39,68 @@ spec:
     - name: previous_upgrade_strategy
       expression: >-
         oldObject != null && has(oldObject.spec.upgrade) && has(oldObject.spec.upgrade.strategy) && oldObject.spec.upgrade.strategy != "" ? oldObject.spec.upgrade.strategy : "RollingUpdate"
+    - name: upgrade_strategy_changed
+      expression: >-
+        oldObject != null && variables.requested_upgrade_strategy != variables.previous_upgrade_strategy
+    - name: upgrade_strategy_status_idle
+      expression: >-
+        oldObject != null &&
+        has(oldObject.status) &&
+        has(oldObject.status.initialized) && oldObject.status.initialized == true &&
+        has(oldObject.status.phase) && oldObject.status.phase == "Running" &&
+        has(oldObject.status.currentVersion) && oldObject.status.currentVersion == oldObject.spec.version &&
+        has(oldObject.status.readyReplicas) && oldObject.status.readyReplicas == oldObject.spec.replicas &&
+        has(oldObject.status.acceptedUpgradeStrategy) && oldObject.status.acceptedUpgradeStrategy == variables.previous_upgrade_strategy &&
+        (!has(oldObject.status.upgrade)) &&
+        (!has(oldObject.status.operationLock) || oldObject.status.operationLock == null) &&
+        (!has(oldObject.status.breakGlass) || !has(oldObject.status.breakGlass.active) || oldObject.status.breakGlass.active == false) &&
+        (!has(oldObject.status.workload) || !has(oldObject.status.workload.lastError)) &&
+        has(oldObject.status.conditions) &&
+        oldObject.status.conditions.exists(c, c.type == "Available" && c.status == "True") &&
+        !oldObject.status.conditions.exists(c, c.type == "Degraded" && c.status == "True") &&
+        (!has(oldObject.status.blueGreen) ||
+          ((!has(oldObject.status.blueGreen.phase) || oldObject.status.blueGreen.phase == "Idle") &&
+           (!has(oldObject.status.blueGreen.greenRevision) || oldObject.status.blueGreen.greenRevision == "") &&
+           (!has(oldObject.status.blueGreen.startTime)) &&
+           (!has(oldObject.status.blueGreen.rollbackStartTime)) &&
+           (!has(oldObject.status.blueGreen.manualPromotionRequired) || oldObject.status.blueGreen.manualPromotionRequired == false) &&
+           (!has(oldObject.status.blueGreen.jobFailureCount) || oldObject.status.blueGreen.jobFailureCount == 0) &&
+           (!has(oldObject.status.blueGreen.lastJobFailure) || oldObject.status.blueGreen.lastJobFailure == ""))) &&
+        (!has(oldObject.spec.readReplicas) || oldObject.spec.readReplicas.replicas == 0 ||
+          (has(oldObject.status.readReplicas) && has(oldObject.status.readReplicas.readyReplicas) && oldObject.status.readReplicas.readyReplicas == oldObject.spec.readReplicas.replicas))
+    - name: upgrade_requests_handled
+      expression: >-
+        oldObject == null || !has(object.spec.upgrade) || !has(object.spec.upgrade.requests) ||
+        (((!has(object.spec.upgrade.requests.retry) || object.spec.upgrade.requests.retry == "") ||
+          (has(oldObject.status.upgradeRequests) && has(oldObject.status.upgradeRequests.lastHandledRetry) && object.spec.upgrade.requests.retry == oldObject.status.upgradeRequests.lastHandledRetry)) &&
+         ((!has(object.spec.upgrade.requests.promote) || object.spec.upgrade.requests.promote == "") ||
+          (has(oldObject.status.upgradeRequests) && has(oldObject.status.upgradeRequests.lastHandledPromote) && object.spec.upgrade.requests.promote == oldObject.status.upgradeRequests.lastHandledPromote)) &&
+         ((!has(object.spec.upgrade.requests.rollback) || object.spec.upgrade.requests.rollback == "") ||
+          (has(oldObject.status.upgradeRequests) && has(oldObject.status.upgradeRequests.lastHandledRollback) && object.spec.upgrade.requests.rollback == oldObject.status.upgradeRequests.lastHandledRollback)))
+    - name: requested_image
+      expression: >-
+        has(object.spec.image) ? object.spec.image : ""
+    - name: previous_image
+      expression: >-
+        oldObject != null && has(oldObject.spec.image) ? oldObject.spec.image : ""
+    - name: requested_runtime_restart
+      expression: >-
+        has(object.spec.runtime) && has(object.spec.runtime.restartAt) ? object.spec.runtime.restartAt : ""
+    - name: previous_runtime_restart
+      expression: >-
+        oldObject != null && has(oldObject.spec.runtime) && has(oldObject.spec.runtime.restartAt) ? oldObject.spec.runtime.restartAt : ""
+    - name: requested_maintenance_restart
+      expression: >-
+        has(object.spec.maintenance) && has(object.spec.maintenance.restartAt) ? object.spec.maintenance.restartAt : ""
+    - name: previous_maintenance_restart
+      expression: >-
+        oldObject != null && has(oldObject.spec.maintenance) && has(oldObject.spec.maintenance.restartAt) ? oldObject.spec.maintenance.restartAt : ""
+    - name: requested_read_replicas
+      expression: >-
+        has(object.spec.readReplicas) ? object.spec.readReplicas.replicas : 0
+    - name: previous_read_replicas
+      expression: >-
+        oldObject != null && has(oldObject.spec.readReplicas) ? oldObject.spec.readReplicas.replicas : 0
     - name: has_pre_upgrade_snapshot
       expression: has(object.spec.upgrade) && has(object.spec.upgrade.preUpgradeSnapshot) && object.spec.upgrade.preUpgradeSnapshot == true
     - name: has_bluegreen_pre_upgrade_snapshot
@@ -595,9 +657,29 @@ spec:
           object.spec.backup.schedule.matches("^\\S+\\s+\\S+\\s+\\S+\\s+\\S+\\s+\\S+$"))
       message: spec.backup requires schedule, OpenBao auth (jwtAuthRole or tokenSecretRef, or self-init OIDC bootstrap enabled when jwtAuthRole is empty/unset for auto-creation of "openbao-operator-backup" role), and a 5-field cron expression. Hardened profile requires explicit storage credentials via target.credentialsSecretRef, target.workloadIdentity, or target.roleArn for S3 targets.
     - expression: >-
-        oldObject == null ||
-        variables.requested_upgrade_strategy == variables.previous_upgrade_strategy
-      message: "spec.upgrade.strategy is immutable after creation; switching between RollingUpdate and BlueGreen is not supported."
+        !variables.upgrade_strategy_changed ||
+        (object.spec.version == oldObject.spec.version &&
+          variables.requested_image == variables.previous_image &&
+          object.spec.replicas == oldObject.spec.replicas &&
+          variables.requested_read_replicas == variables.previous_read_replicas &&
+          object.spec.storage == oldObject.spec.storage &&
+          variables.requested_runtime_restart == variables.previous_runtime_restart &&
+          variables.requested_maintenance_restart == variables.previous_maintenance_restart)
+      message: "Change only spec.upgrade.strategy first; wait for the operator to accept it before changing version, image, replicas, storage, or restart controls."
+    - expression: >-
+        !variables.upgrade_strategy_changed ||
+        variables.upgrade_strategy_status_idle
+      message: "spec.upgrade.strategy can change only while the cluster is initialized, healthy, fully ready, at spec.version, and no upgrade, backup/restore lock, restart/resize, BlueGreen phase, failure, pending Green workload, or safe-mode recovery is active."
+    - expression: >-
+        !variables.upgrade_strategy_changed ||
+        variables.upgrade_requests_handled
+      message: "Finish or clear pending spec.upgrade.requests before changing spec.upgrade.strategy."
+    - expression: >-
+        !variables.upgrade_strategy_changed ||
+        variables.requested_upgrade_strategy != "BlueGreen" ||
+        ((has(object.spec.upgrade.jwtAuthRole) && object.spec.upgrade.jwtAuthRole.trim() != "") ||
+          (has(object.spec.selfInit) && object.spec.selfInit.enabled == true && has(object.spec.selfInit.oidc) && object.spec.selfInit.oidc.enabled == true))
+      message: "Switching to BlueGreen requires spec.upgrade.jwtAuthRole or the default upgrade role created by enabled spec.selfInit.oidc bootstrap."
     - expression: >-
         !has(object.spec.profile) ||
         object.spec.profile != "Hardened" ||

--- a/config/crd/bases/openbao.org_openbaoclusters.yaml
+++ b/config/crd/bases/openbao.org_openbaoclusters.yaml
@@ -4939,12 +4939,6 @@ spec:
               rule: self.tls.mode != 'ACME' || ((self.replicas <= 1) && (!has(self.upgrade)
                 || self.upgrade.strategy != 'BlueGreen')) || (has(self.tls.acme) &&
                 has(self.tls.acme.sharedCache))
-            - message: spec.upgrade.strategy is immutable after creation; switching
-                between RollingUpdate and BlueGreen is not supported.
-              rule: '((!has(self.upgrade) || !has(self.upgrade.strategy) || size(self.upgrade.strategy)
-                == 0) ? ''RollingUpdate'' : self.upgrade.strategy) == ((!has(oldSelf.upgrade)
-                || !has(oldSelf.upgrade.strategy) || size(oldSelf.upgrade.strategy)
-                == 0) ? ''RollingUpdate'' : oldSelf.upgrade.strategy)'
             - message: spec.unseal.credentialsSecretRef for ocikms requires spec.unseal.ocikms.authTypeAPIKey=true
               rule: '!has(self.unseal) || self.unseal.type != ''ocikms'' || !has(self.unseal.credentialsSecretRef)
                 || (has(self.unseal.ocikms) && has(self.unseal.ocikms.authTypeAPIKey)
@@ -4958,6 +4952,16 @@ spec:
           status:
             description: Status defines the observed state of OpenBaoCluster.
             properties:
+              acceptedUpgradeStrategy:
+                description: |-
+                  AcceptedUpgradeStrategy is the upgrade strategy the operator has accepted
+                  after applying idle-state transition guards. While a requested strategy
+                  change is blocked, controllers continue using this strategy so an existing
+                  operation can finish safely.
+                enum:
+                - RollingUpdate
+                - BlueGreen
+                type: string
               activeLeader:
                 description: ActiveLeader is the current Raft leader pod name, for
                   example "prod-cluster-0".
@@ -5051,6 +5055,12 @@ spec:
                 description: BlueGreen tracks the state of blue/green upgrades (if
                   enabled).
                 properties:
+                  blueControllerRevision:
+                    description: |-
+                      BlueControllerRevision is the Kubernetes StatefulSet controller revision
+                      of Blue. It identifies an unrevisioned rolling workload after switching to
+                      BlueGreen without requiring the existing Pods to be restarted or relabeled.
+                    type: string
                   blueImage:
                     description: |-
                       BlueImage is the container image used by the Blue cluster.

--- a/config/policy/openbao-validate-openbaocluster.yaml
+++ b/config/policy/openbao-validate-openbaocluster.yaml
@@ -36,6 +36,68 @@ spec:
     - name: previous_upgrade_strategy
       expression: >-
         oldObject != null && has(oldObject.spec.upgrade) && has(oldObject.spec.upgrade.strategy) && oldObject.spec.upgrade.strategy != "" ? oldObject.spec.upgrade.strategy : "RollingUpdate"
+    - name: upgrade_strategy_changed
+      expression: >-
+        oldObject != null && variables.requested_upgrade_strategy != variables.previous_upgrade_strategy
+    - name: upgrade_strategy_status_idle
+      expression: >-
+        oldObject != null &&
+        has(oldObject.status) &&
+        has(oldObject.status.initialized) && oldObject.status.initialized == true &&
+        has(oldObject.status.phase) && oldObject.status.phase == "Running" &&
+        has(oldObject.status.currentVersion) && oldObject.status.currentVersion == oldObject.spec.version &&
+        has(oldObject.status.readyReplicas) && oldObject.status.readyReplicas == oldObject.spec.replicas &&
+        has(oldObject.status.acceptedUpgradeStrategy) && oldObject.status.acceptedUpgradeStrategy == variables.previous_upgrade_strategy &&
+        (!has(oldObject.status.upgrade)) &&
+        (!has(oldObject.status.operationLock) || oldObject.status.operationLock == null) &&
+        (!has(oldObject.status.breakGlass) || !has(oldObject.status.breakGlass.active) || oldObject.status.breakGlass.active == false) &&
+        (!has(oldObject.status.workload) || !has(oldObject.status.workload.lastError)) &&
+        has(oldObject.status.conditions) &&
+        oldObject.status.conditions.exists(c, c.type == "Available" && c.status == "True") &&
+        !oldObject.status.conditions.exists(c, c.type == "Degraded" && c.status == "True") &&
+        (!has(oldObject.status.blueGreen) ||
+          ((!has(oldObject.status.blueGreen.phase) || oldObject.status.blueGreen.phase == "Idle") &&
+           (!has(oldObject.status.blueGreen.greenRevision) || oldObject.status.blueGreen.greenRevision == "") &&
+           (!has(oldObject.status.blueGreen.startTime)) &&
+           (!has(oldObject.status.blueGreen.rollbackStartTime)) &&
+           (!has(oldObject.status.blueGreen.manualPromotionRequired) || oldObject.status.blueGreen.manualPromotionRequired == false) &&
+           (!has(oldObject.status.blueGreen.jobFailureCount) || oldObject.status.blueGreen.jobFailureCount == 0) &&
+           (!has(oldObject.status.blueGreen.lastJobFailure) || oldObject.status.blueGreen.lastJobFailure == ""))) &&
+        (!has(oldObject.spec.readReplicas) || oldObject.spec.readReplicas.replicas == 0 ||
+          (has(oldObject.status.readReplicas) && has(oldObject.status.readReplicas.readyReplicas) && oldObject.status.readReplicas.readyReplicas == oldObject.spec.readReplicas.replicas))
+    - name: upgrade_requests_handled
+      expression: >-
+        oldObject == null || !has(object.spec.upgrade) || !has(object.spec.upgrade.requests) ||
+        (((!has(object.spec.upgrade.requests.retry) || object.spec.upgrade.requests.retry == "") ||
+          (has(oldObject.status.upgradeRequests) && has(oldObject.status.upgradeRequests.lastHandledRetry) && object.spec.upgrade.requests.retry == oldObject.status.upgradeRequests.lastHandledRetry)) &&
+         ((!has(object.spec.upgrade.requests.promote) || object.spec.upgrade.requests.promote == "") ||
+          (has(oldObject.status.upgradeRequests) && has(oldObject.status.upgradeRequests.lastHandledPromote) && object.spec.upgrade.requests.promote == oldObject.status.upgradeRequests.lastHandledPromote)) &&
+         ((!has(object.spec.upgrade.requests.rollback) || object.spec.upgrade.requests.rollback == "") ||
+          (has(oldObject.status.upgradeRequests) && has(oldObject.status.upgradeRequests.lastHandledRollback) && object.spec.upgrade.requests.rollback == oldObject.status.upgradeRequests.lastHandledRollback)))
+    - name: requested_image
+      expression: >-
+        has(object.spec.image) ? object.spec.image : ""
+    - name: previous_image
+      expression: >-
+        oldObject != null && has(oldObject.spec.image) ? oldObject.spec.image : ""
+    - name: requested_runtime_restart
+      expression: >-
+        has(object.spec.runtime) && has(object.spec.runtime.restartAt) ? object.spec.runtime.restartAt : ""
+    - name: previous_runtime_restart
+      expression: >-
+        oldObject != null && has(oldObject.spec.runtime) && has(oldObject.spec.runtime.restartAt) ? oldObject.spec.runtime.restartAt : ""
+    - name: requested_maintenance_restart
+      expression: >-
+        has(object.spec.maintenance) && has(object.spec.maintenance.restartAt) ? object.spec.maintenance.restartAt : ""
+    - name: previous_maintenance_restart
+      expression: >-
+        oldObject != null && has(oldObject.spec.maintenance) && has(oldObject.spec.maintenance.restartAt) ? oldObject.spec.maintenance.restartAt : ""
+    - name: requested_read_replicas
+      expression: >-
+        has(object.spec.readReplicas) ? object.spec.readReplicas.replicas : 0
+    - name: previous_read_replicas
+      expression: >-
+        oldObject != null && has(oldObject.spec.readReplicas) ? oldObject.spec.readReplicas.replicas : 0
     - name: has_pre_upgrade_snapshot
       expression: has(object.spec.upgrade) && has(object.spec.upgrade.preUpgradeSnapshot) && object.spec.upgrade.preUpgradeSnapshot == true
     - name: has_bluegreen_pre_upgrade_snapshot
@@ -592,9 +654,29 @@ spec:
           object.spec.backup.schedule.matches("^\\S+\\s+\\S+\\s+\\S+\\s+\\S+\\s+\\S+$"))
       message: spec.backup requires schedule, OpenBao auth (jwtAuthRole or tokenSecretRef, or self-init OIDC bootstrap enabled when jwtAuthRole is empty/unset for auto-creation of "openbao-operator-backup" role), and a 5-field cron expression. Hardened profile requires explicit storage credentials via target.credentialsSecretRef, target.workloadIdentity, or target.roleArn for S3 targets.
     - expression: >-
-        oldObject == null ||
-        variables.requested_upgrade_strategy == variables.previous_upgrade_strategy
-      message: "spec.upgrade.strategy is immutable after creation; switching between RollingUpdate and BlueGreen is not supported."
+        !variables.upgrade_strategy_changed ||
+        (object.spec.version == oldObject.spec.version &&
+          variables.requested_image == variables.previous_image &&
+          object.spec.replicas == oldObject.spec.replicas &&
+          variables.requested_read_replicas == variables.previous_read_replicas &&
+          object.spec.storage == oldObject.spec.storage &&
+          variables.requested_runtime_restart == variables.previous_runtime_restart &&
+          variables.requested_maintenance_restart == variables.previous_maintenance_restart)
+      message: "Change only spec.upgrade.strategy first; wait for the operator to accept it before changing version, image, replicas, storage, or restart controls."
+    - expression: >-
+        !variables.upgrade_strategy_changed ||
+        variables.upgrade_strategy_status_idle
+      message: "spec.upgrade.strategy can change only while the cluster is initialized, healthy, fully ready, at spec.version, and no upgrade, backup/restore lock, restart/resize, BlueGreen phase, failure, pending Green workload, or safe-mode recovery is active."
+    - expression: >-
+        !variables.upgrade_strategy_changed ||
+        variables.upgrade_requests_handled
+      message: "Finish or clear pending spec.upgrade.requests before changing spec.upgrade.strategy."
+    - expression: >-
+        !variables.upgrade_strategy_changed ||
+        variables.requested_upgrade_strategy != "BlueGreen" ||
+        ((has(object.spec.upgrade.jwtAuthRole) && object.spec.upgrade.jwtAuthRole.trim() != "") ||
+          (has(object.spec.selfInit) && object.spec.selfInit.enabled == true && has(object.spec.selfInit.oidc) && object.spec.selfInit.oidc.enabled == true))
+      message: "Switching to BlueGreen requires spec.upgrade.jwtAuthRole or the default upgrade role created by enabled spec.selfInit.oidc bootstrap."
     - expression: >-
         !has(object.spec.profile) ||
         object.spec.profile != "Hardened" ||

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -438,6 +438,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `phase` _[BlueGreenPhase](#bluegreenphase)_ | Phase is the current phase of the blue/green upgrade. |  | Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RestoringReadReplicas RollingBack RollbackCleanup] <br /> |
 | `blueRevision` _string_ | BlueRevision is the hash/name of the currently active cluster. |  |  |
+| `blueControllerRevision` _string_ | BlueControllerRevision is the Kubernetes StatefulSet controller revision<br />of Blue. It identifies an unrevisioned rolling workload after switching to<br />BlueGreen without requiring the existing Pods to be restarted or relabeled. |  | Optional: \{\} <br /> |
 | `blueImage` _string_ | BlueImage is the container image used by the Blue cluster.<br />This ensures the Blue cluster is not actively upgraded when spec.image changes. |  |  |
 | `greenRevision` _string_ | GreenRevision is the hash/name of the next cluster (if upgrade in progress). |  |  |
 | `manualPromotionRequired` _boolean_ | ManualPromotionRequired snapshots whether the current in-flight blue/green<br />upgrade requires an explicit spec.upgrade.requests.promote request before<br />promotion can proceed. It is derived from spec.upgrade.blueGreen.autoPromote<br />when the upgrade starts. |  | Optional: \{\} <br /> |
@@ -1093,6 +1094,7 @@ _Appears in:_
 | `readyReplicas` _integer_ | ReadyReplicas is the number of replicas that are currently Ready. |  | Optional: \{\} <br /> |
 | `readReplicas` _[ReadReplicaStatus](#readreplicastatus)_ | ReadReplicas captures observed state for the read-replica pool. |  | Optional: \{\} <br /> |
 | `currentVersion` _string_ | CurrentVersion is the OpenBao version currently running on the cluster. |  | Optional: \{\} <br /> |
+| `acceptedUpgradeStrategy` _[UpdateStrategyType](#updatestrategytype)_ | AcceptedUpgradeStrategy is the upgrade strategy the operator has accepted<br />after applying idle-state transition guards. While a requested strategy<br />change is blocked, controllers continue using this strategy so an existing<br />operation can finish safely. |  | Enum: [RollingUpdate BlueGreen] <br />Optional: \{\} <br /> |
 | `initialized` _boolean_ | Initialized indicates whether the OpenBao cluster has been initialized.<br />This is set to true after the first pod is initialized using bao operator init<br />or after self-initialization completes. |  | Optional: \{\} <br /> |
 | `selfInitialized` _boolean_ | SelfInitialized indicates whether the cluster was initialized using<br />OpenBao's self-initialization feature. When true, no root token Secret<br />exists for this cluster (the root token was auto-revoked). |  | Optional: \{\} <br /> |
 | `lastBackupTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | LastBackupTime is the timestamp of the last successful backup, if configured.<br />Deprecated: Use Backup.LastBackupTime instead. |  | Optional: \{\} <br /> |
@@ -2069,6 +2071,7 @@ _Validation:_
 - Enum: [RollingUpdate BlueGreen]
 
 _Appears in:_
+- [OpenBaoClusterStatus](#openbaoclusterstatus)
 - [UpgradeConfig](#upgradeconfig)
 
 | Field | Description |

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -118,7 +118,7 @@ Always validate new Kubernetes or OpenBao versions in a staging environment befo
 
 <Callout type="warning" title="OpenBao 2.6.0 BlueGreen upgrade limitation">
 
-OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. A 2.6.0 Green peer cannot report Raft Autopilot health to a pre-2.6 Blue leader, so the operator blocks pre-2.6 to 2.6-or-newer `BlueGreen` transitions before creating Green resources until a compatible target is explicitly qualified. Fresh 2.6.0 clusters and rolling upgrades remain validated. Existing `BlueGreen` clusters must wait for a qualified upstream fix or restore a backup into a new target-version cluster.
+OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. A 2.6.0 Green peer cannot report Raft Autopilot health to a pre-2.6 Blue leader, so the operator blocks pre-2.6 to 2.6-or-newer `BlueGreen` transitions before creating Green resources until a compatible target is explicitly qualified. Fresh 2.6.0 clusters and rolling upgrades remain validated. Existing `BlueGreen` clusters can return to a healthy, idle state, change only `spec.upgrade.strategy` to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request 2.6.x.
 
 </Callout>
 

--- a/docs/reference/known-limitations.md
+++ b/docs/reference/known-limitations.md
@@ -41,11 +41,7 @@ journey: reference
       cells: ['Audit file storage archival', '`spec.auditFileStorage` provides a PVC-backed collector handoff and replay buffer; it does not provide rotation, pruning, tamper-proof retention, or a collector.', 'Mount the audit PVC read-only into a collector and ship records to external retention-controlled storage.'],
     },
     {
-      cells: ['Upgrade strategy switching', 'Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a supported in-place transition today.', 'Choose the strategy before the next rollout and keep it stable. Safe idle-only switching is tracked in [#548](https://github.com/dc-tec/openbao-operator/issues/548).'],
-      emphasis: 'caution',
-    },
-    {
-      cells: ['OpenBao 2.6.0 BlueGreen upgrade', 'OpenBao 2.6.0 cannot exchange Raft Autopilot health with pre-2.6 peers because its internal request-forwarding gRPC service name changed. The operator blocks pre-2.6 to 2.6-or-newer BlueGreen transitions before deploying Green until a compatible target is explicitly qualified.', 'Use a rolling upgrade on clusters already configured for RollingUpdate. Existing BlueGreen clusters must wait for a qualified upstream fix or restore a backup into a new target-version cluster.'],
+      cells: ['OpenBao 2.6.0 BlueGreen upgrade', 'OpenBao 2.6.0 cannot exchange Raft Autopilot health with pre-2.6 peers because its internal request-forwarding gRPC service name changed. The operator blocks pre-2.6 to 2.6-or-newer BlueGreen transitions before deploying Green until a compatible target is explicitly qualified.', 'Return the cluster to a healthy, idle BlueGreen state, change only `spec.upgrade.strategy` to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request 2.6.x. Fresh 2.6.x clusters and rolling upgrades remain supported.'],
       emphasis: 'caution',
     },
   ]}

--- a/docs/user-guide/openbaocluster/operations/upgrades.md
+++ b/docs/user-guide/openbaocluster/operations/upgrades.md
@@ -38,9 +38,11 @@ journey: operate
   ]}
 />
 
-<Callout type="warning" title="Do not switch strategies on an existing cluster">
+<Callout type="note" title="Switch strategies only while the cluster is idle">
 
-Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a supported in-place transition today. Choose the strategy before the next rollout and keep it stable for that cluster.
+The operator supports `RollingUpdate` to `BlueGreen` and `BlueGreen` to `RollingUpdate` without renaming or replacing the active StatefulSet. Admission allows the change only after initialization, while every voter is Ready, `status.currentVersion` equals `spec.version`, and no upgrade, backup, restore, resize, restart, Green workload, pending request, failure, or safe-mode recovery is active.
+
+Change only `spec.upgrade.strategy`, then wait until `status.acceptedUpgradeStrategy` reports the new value. Change `spec.version` or other workload settings only after that acknowledgment. A strategy change that does not meet these conditions is rejected with recovery guidance.
 
 </Callout>
 
@@ -48,7 +50,7 @@ Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a s
 
 OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. During a pre-2.6 to 2.6.0 `BlueGreen` upgrade, Green peers cannot report Raft Autopilot health to the Blue leader and therefore cannot be promoted safely. The operator rejects pre-2.6 to 2.6-or-newer transitions before creating Green resources until a compatible target is explicitly qualified.
 
-Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If the existing cluster is already configured for `BlueGreen`, wait for an operator release that qualifies an upstream compatibility fix or restore a backup into a new target-version cluster. Safe idle-only strategy switching is tracked in [#548](https://github.com/dc-tec/openbao-operator/issues/548); do not bypass the current immutability check.
+Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If a pre-2.6 cluster is configured for `BlueGreen`, first let the cluster return to a healthy `Idle` state, switch only the strategy to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request the 2.6.0 version change.
 
 </Callout>
 
@@ -85,6 +87,35 @@ Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If the exist
   - with an explicit `spec.upgrade.jwtAuthRole`
 - If you want pre-upgrade snapshots, configure `spec.backup` first and make sure the backup auth path is already working.
 - In the `Hardened` profile, explicitly allow egress to object storage or other external dependencies the upgrade path needs.
+
+## Change the strategy of an existing cluster
+
+Use this sequence in either direction. It deliberately separates the control-plane strategy transition from the next workload change.
+
+1. Finish or recover every active upgrade, backup, restore, resize, restart, promotion, rollback, or safe-mode workflow.
+2. Verify `status.phase=Running`, `status.currentVersion=spec.version`, all voter and configured read replicas are Ready, `Available=True`, and BlueGreen is absent or `Idle` with no Green revision.
+3. Ensure the BlueGreen executor prerequisites are configured before switching to `BlueGreen`: an explicit `spec.upgrade.jwtAuthRole` or the default role created by enabled `selfInit.oidc`, plus a resolvable upgrade executor image. The referenced role must already grant the BlueGreen raft join, configuration, remove-peer, promote, and demote capabilities. Self-init policies are created during initial bootstrap and are not rewritten by a later strategy change, so update the role policy first when a rolling-origin cluster was initialized with rolling-only permissions.
+4. Patch only `spec.upgrade.strategy`.
+5. Wait for `status.acceptedUpgradeStrategy` to equal the requested strategy.
+6. Patch `spec.version`, `spec.image`, replicas, storage, or restart controls in a later request.
+
+<CommandBlock
+  language="bash"
+  label="switch"
+  title="Switch an idle cluster from blue-green to rolling"
+  code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
+  "spec": {
+    "upgrade": {
+      "strategy": "RollingUpdate"
+    }
+  }
+}'
+
+kubectl get openbaocluster <name> -n <namespace> \
+  -o jsonpath='{.status.acceptedUpgradeStrategy}{"\\n"}'`}
+/>
+
+The active StatefulSet and its PVCs remain the stable workload after either transition. A later rolling rollout continues against a revisioned StatefulSet when switching from BlueGreen; a later blue-green rollout treats the original unrevisioned StatefulSet as Blue when switching from RollingUpdate.
 
 <Callout type="note" title="Upgrade auth is separate from backup auth">
 

--- a/docs/user-guide/openbaocluster/operations/upgrades.md
+++ b/docs/user-guide/openbaocluster/operations/upgrades.md
@@ -102,11 +102,27 @@ Use this sequence in either direction. It deliberately separates the control-pla
 <CommandBlock
   language="bash"
   label="switch"
-  title="Switch an idle cluster from blue-green to rolling"
+  title="Switch an idle cluster from BlueGreen to RollingUpdate"
   code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
   "spec": {
     "upgrade": {
       "strategy": "RollingUpdate"
+    }
+  }
+}'
+
+kubectl get openbaocluster <name> -n <namespace> \
+  -o jsonpath='{.status.acceptedUpgradeStrategy}{"\\n"}'`}
+/>
+
+<CommandBlock
+  language="bash"
+  label="switch"
+  title="Switch an idle cluster from RollingUpdate to BlueGreen"
+  code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
+  "spec": {
+    "upgrade": {
+      "strategy": "BlueGreen"
     }
   }
 }'

--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	backupmanager "github.com/dc-tec/openbao-operator/internal/service/backup"
+	upgrademanager "github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/bluegreen"
 	rollingupgrade "github.com/dc-tec/openbao-operator/internal/service/upgrade/rolling"
 	workloadmanager "github.com/dc-tec/openbao-operator/internal/service/workload"
@@ -145,6 +146,10 @@ func ensureAdminOpsStatus(cluster *openbaov1alpha1.OpenBaoCluster) {
 func buildReconcilers(deps Dependencies) []subReconciler {
 	workloadMgr := workloadmanager.NewManager(deps.Client, deps.Scheme, deps.Platform).WithReader(deps.APIReader)
 	backupRuntime := backupmanager.NewUpgradeStrategyRuntime(deps.Client, deps.Scheme)
+	strategyReader := deps.APIReader
+	if strategyReader == nil {
+		strategyReader = deps.Client
+	}
 	adminOpsMutator := func(
 		ctx context.Context,
 		cluster *openbaov1alpha1.OpenBaoCluster,
@@ -158,6 +163,7 @@ func buildReconcilers(deps Dependencies) []subReconciler {
 	}
 
 	return []subReconciler{
+		upgrademanager.NewStrategyTransitionManager(strategyReader),
 		bluegreen.NewManager(
 			deps.Client,
 			deps.Scheme,

--- a/internal/app/openbaocluster/adminops/reconcile_test.go
+++ b/internal/app/openbaocluster/adminops/reconcile_test.go
@@ -19,6 +19,7 @@ import (
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	backupmanager "github.com/dc-tec/openbao-operator/internal/service/backup"
+	upgrademanager "github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/bluegreen"
 	rollingupgrade "github.com/dc-tec/openbao-operator/internal/service/upgrade/rolling"
 )
@@ -328,25 +329,29 @@ func TestBuildReconcilers_InjectsRecorderIntoManagers(t *testing.T) {
 		Recorder:  recorder,
 	})
 
-	if len(reconcilers) != 3 {
-		t.Fatalf("len(reconcilers) = %d, want 3", len(reconcilers))
+	if len(reconcilers) != 4 {
+		t.Fatalf("len(reconcilers) = %d, want 4", len(reconcilers))
 	}
 
-	blueGreenMgr, ok := reconcilers[0].(*bluegreen.Manager)
+	if _, ok := reconcilers[0].(*upgrademanager.StrategyTransitionManager); !ok {
+		t.Fatalf("reconcilers[0] = %T, want *upgrade.StrategyTransitionManager", reconcilers[0])
+	}
+
+	blueGreenMgr, ok := reconcilers[1].(*bluegreen.Manager)
 	if !ok {
-		t.Fatalf("reconcilers[0] = %T, want *bluegreen.Manager", reconcilers[0])
+		t.Fatalf("reconcilers[1] = %T, want *bluegreen.Manager", reconcilers[1])
 	}
 	assertRecorderInjected(t, blueGreenMgr)
 
-	rollingMgr, ok := reconcilers[1].(*rollingupgrade.Manager)
+	rollingMgr, ok := reconcilers[2].(*rollingupgrade.Manager)
 	if !ok {
-		t.Fatalf("reconcilers[1] = %T, want *rollingupgrade.Manager", reconcilers[1])
+		t.Fatalf("reconcilers[2] = %T, want *rollingupgrade.Manager", reconcilers[2])
 	}
 	assertRecorderInjected(t, rollingMgr)
 
-	backupMgr, ok := reconcilers[2].(*backupmanager.Manager)
+	backupMgr, ok := reconcilers[3].(*backupmanager.Manager)
 	if !ok {
-		t.Fatalf("reconcilers[2] = %T, want *backup.Manager", reconcilers[2])
+		t.Fatalf("reconcilers[3] = %T, want *backup.Manager", reconcilers[3])
 	}
 	assertRecorderInjected(t, backupMgr)
 }

--- a/internal/app/openbaocluster/adminopsstatus/mutate.go
+++ b/internal/app/openbaocluster/adminopsstatus/mutate.go
@@ -51,6 +51,7 @@ func MutateWithReader(
 	}
 
 	cluster.ResourceVersion = updated.ResourceVersion
+	cluster.Status.AcceptedUpgradeStrategy = updated.Status.AcceptedUpgradeStrategy
 	cluster.Status.Upgrade = updated.Status.Upgrade
 	cluster.Status.UpgradeRequests = updated.Status.UpgradeRequests
 	cluster.Status.Backup = updated.Status.Backup

--- a/internal/app/openbaocluster/infra_images.go
+++ b/internal/app/openbaocluster/infra_images.go
@@ -230,7 +230,7 @@ func (r *infraReconciler) resolveTargetMainImage(ctx context.Context, logger log
 		targetImage = defaultOpenBaoImage(cluster.Spec.Version)
 	}
 
-	if cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen {
+	if !workloadsvc.IsBlueGreenStrategy(cluster) {
 		return targetImage
 	}
 

--- a/internal/app/openbaocluster/infra_read_replica_operation.go
+++ b/internal/app/openbaocluster/infra_read_replica_operation.go
@@ -2,6 +2,7 @@ package openbaocluster
 
 import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	upgradesvc "github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
 )
 
@@ -42,8 +43,7 @@ func shouldStageSteadyReadReplicasDown(cluster *openbaov1alpha1.OpenBaoCluster) 
 	case openbaov1alpha1.ClusterOperationRestore:
 		return true
 	case openbaov1alpha1.ClusterOperationUpgrade:
-		return cluster.Spec.Upgrade != nil &&
-			cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen &&
+		return upgradesvc.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen &&
 			(phase == "" || phase == openbaov1alpha1.PhaseIdle)
 	default:
 		return false

--- a/internal/app/openbaocluster/infra_statefulset.go
+++ b/internal/app/openbaocluster/infra_statefulset.go
@@ -8,6 +8,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
 )
 
@@ -27,7 +28,7 @@ func (r *infraReconciler) computeStatefulSetSpec(
 		SkipReconciliation: false,
 	}
 
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
+	if workloadsvc.IsBlueGreenStrategy(cluster) {
 		spec.Revision = workloadsvc.BlueGreenStableRevision(cluster)
 		if spec.Revision == "" {
 			spec.Name = cluster.Name
@@ -44,8 +45,8 @@ func (r *infraReconciler) computeStatefulSetSpec(
 			return spec
 		}
 	} else {
-		spec.Revision = ""
-		spec.Name = cluster.Name
+		spec.Revision = upgrade.StableVoterRevision(cluster)
+		spec.Name = upgrade.StableVoterStatefulSetName(cluster)
 	}
 
 	return spec

--- a/internal/app/openbaocluster/patch.go
+++ b/internal/app/openbaocluster/patch.go
@@ -134,7 +134,8 @@ func PatchAdminOpsOwnedFieldsWithReader(
 	// Backup-only diffs are persisted by the backup manager. When we do patch
 	// adminops status for other reasons, we still apply the full current adminops
 	// plane so shared SSA ownership does not clear backup or peer fields by omission.
-	if reflect.DeepEqual(original.Status.BlueGreen, cluster.Status.BlueGreen) &&
+	if original.Status.AcceptedUpgradeStrategy == cluster.Status.AcceptedUpgradeStrategy &&
+		reflect.DeepEqual(original.Status.BlueGreen, cluster.Status.BlueGreen) &&
 		reflect.DeepEqual(original.Status.UpgradeRequests, cluster.Status.UpgradeRequests) &&
 		reflect.DeepEqual(original.Status.BreakGlass, cluster.Status.BreakGlass) &&
 		reflect.DeepEqual(original.Status.AdminOps, cluster.Status.AdminOps) {
@@ -148,6 +149,7 @@ func PatchAdminOpsOwnedFieldsWithReader(
 
 	cluster.Status.AdminOps = adminOps
 	err := adminopsstatus.MutateWithReader(ctx, reader, c, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+		obj.Status.AcceptedUpgradeStrategy = cluster.Status.AcceptedUpgradeStrategy
 		obj.Status.BlueGreen = cluster.Status.BlueGreen
 		obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
 		obj.Status.BreakGlass = cluster.Status.BreakGlass

--- a/internal/app/openbaocluster/statusops/observe.go
+++ b/internal/app/openbaocluster/statusops/observe.go
@@ -218,9 +218,10 @@ func gatherStatefulSetState(
 		Name:      cluster.Name,
 	}
 
-	// Compute active revision for blue/green deployments.
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
-		state.ActiveRevision = workloadsvc.BlueGreenActiveRevision(cluster)
+	// Preserve the active revision across strategy changes so status follows the
+	// existing workload rather than assuming the requested strategy renamed it.
+	state.ActiveRevision = workloadsvc.BlueGreenActiveRevision(cluster)
+	if state.ActiveRevision != "" {
 		statefulSetName.Name = fmt.Sprintf("%s-%s", cluster.Name, state.ActiveRevision)
 	}
 
@@ -299,8 +300,15 @@ func gatherPodState(
 	podSelector := resourceidentity.VoterPodSelectorLabels(cluster)
 	podSelector[labelsCfg.AppNameKey] = labelsCfg.AppNameValue
 	podSelector[labelsCfg.AppManagedByKey] = labelsCfg.AppManagedByValue
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen && state.ActiveRevision != "" {
+	if state.ActiveRevision != "" {
 		podSelector[labelsCfg.OpenBaoRevisionKey] = state.ActiveRevision
+	} else if upgrade.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen && cluster.Status.BlueGreen != nil {
+		// A RollingUpdate-to-BlueGreen transition keeps the original StatefulSet
+		// as Blue. Isolate those pods from Green using their controller revision
+		// because the original workload has no OpenBao revision label.
+		if controllerRevision := strings.TrimSpace(cluster.Status.BlueGreen.BlueControllerRevision); controllerRevision != "" {
+			podSelector[appsv1.ControllerRevisionHashLabelKey] = controllerRevision
+		}
 	}
 
 	var pods corev1.PodList
@@ -314,7 +322,7 @@ func gatherPodState(
 	state.Pods = pods.Items
 
 	pod0Name := fmt.Sprintf("%s-0", cluster.Name)
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen && state.ActiveRevision != "" {
+	if state.ActiveRevision != "" {
 		pod0Name = fmt.Sprintf("%s-%s-0", cluster.Name, state.ActiveRevision)
 	}
 

--- a/internal/app/openbaocluster/statusops/observe_test.go
+++ b/internal/app/openbaocluster/statusops/observe_test.go
@@ -175,6 +175,61 @@ func TestGatherState_ObservesReadServingAndMembership(t *testing.T) {
 	require.EqualValues(t, 1, state.ReadReplicaHealthyReplicas)
 }
 
+func TestGatherPodState_IsolatesUnrevisionedBlueByControllerRevision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			AcceptedUpgradeStrategy: openbaov1alpha1.UpdateStrategyBlueGreen,
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueControllerRevision: "blue-controller-revision",
+				GreenRevision:          "green-revision",
+				Phase:                  openbaov1alpha1.PhaseDemotingBlue,
+			},
+		},
+	}
+	labelsForPod := func(controllerRevision, revision string) map[string]string {
+		podLabels := map[string]string{
+			constants.LabelAppName:                constants.LabelValueAppNameOpenBao,
+			constants.LabelAppInstance:            cluster.Name,
+			constants.LabelAppManagedBy:           constants.LabelValueAppManagedByOpenBaoOperator,
+			constants.LabelOpenBaoCluster:         cluster.Name,
+			constants.LabelOpenBaoWorkloadPool:    constants.LabelValueOpenBaoWorkloadPoolVoter,
+			appsv1.ControllerRevisionHashLabelKey: controllerRevision,
+		}
+		if revision != "" {
+			podLabels[constants.LabelOpenBaoRevision] = revision
+		}
+		return podLabels
+	}
+	bluePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "example-0", Namespace: cluster.Namespace,
+		Labels: labelsForPod("blue-controller-revision", ""),
+	}}
+	greenPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "example-green-revision-0", Namespace: cluster.Namespace,
+		Labels: labelsForPod("green-controller-revision", "green-revision"),
+	}}
+	reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, bluePod, greenPod).Build()
+	state := &StatusState{}
+
+	err := gatherPodState(context.Background(), reader, cluster, state, LabelConfig{
+		AppNameKey:         constants.LabelAppName,
+		AppNameValue:       constants.LabelValueAppNameOpenBao,
+		AppManagedByKey:    constants.LabelAppManagedBy,
+		AppManagedByValue:  constants.LabelValueAppManagedByOpenBaoOperator,
+		OpenBaoRevisionKey: constants.LabelOpenBaoRevision,
+	})
+	require.NoError(t, err)
+	require.Len(t, state.Pods, 1)
+	require.Equal(t, bluePod.Name, state.Pods[0].Name)
+	require.NotNil(t, state.Pod0)
+	require.Equal(t, bluePod.Name, state.Pod0.Name)
+}
+
 type fakePodObserver struct {
 	health  map[string]*portopenbao.HealthStatus
 	podName string

--- a/internal/app/openbaocluster/statusops/versioning.go
+++ b/internal/app/openbaocluster/statusops/versioning.go
@@ -75,8 +75,7 @@ func MaybeAdvanceCurrentVersionForBlueGreen(logger logr.Logger, cluster *openbao
 		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle ||
 		cluster.Status.CurrentVersion == "" ||
 		cluster.Status.CurrentVersion == cluster.Spec.Version ||
-		cluster.Spec.Upgrade == nil ||
-		cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen {
+		upgrade.EffectiveStrategy(cluster) != openbaov1alpha1.UpdateStrategyBlueGreen {
 		return
 	}
 

--- a/internal/app/openbaocluster/storage_resize_restart.go
+++ b/internal/app/openbaocluster/storage_resize_restart.go
@@ -15,6 +15,7 @@ import (
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	upgradesvc "github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	workloadsvc "github.com/dc-tec/openbao-operator/internal/service/workload"
 )
 
@@ -51,7 +52,7 @@ func nextPodNeedingFSResizeRestart(
 	}
 
 	var wantRev string
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
+	if upgradesvc.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen {
 		wantRev = workloadsvc.BlueGreenActiveRevision(cluster)
 	}
 

--- a/internal/controller/openbaocluster/setup.go
+++ b/internal/controller/openbaocluster/setup.go
@@ -52,8 +52,9 @@ func (r *OpenBaoClusterReconciler) setupSingleTenantMode(mgr ctrl.Manager) error
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
-			ReconcileOnBlueGreenStatus: true,
-			ReconcileOnOperationLock:   true,
+			ReconcileOnAcceptedUpgradeStrategy: true,
+			ReconcileOnBlueGreenStatus:         true,
+			ReconcileOnOperationLock:           true,
 		})).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 2,
@@ -126,8 +127,9 @@ func (r *OpenBaoClusterReconciler) setupMultiTenantMode(mgr ctrl.Manager) error 
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&openbaov1alpha1.OpenBaoCluster{}).
 		WithEventFilter(operatorpredicates.OpenBaoClusterPredicateWithOptions(operatorpredicates.OpenBaoClusterPredicateOptions{
-			ReconcileOnBlueGreenStatus: true,
-			ReconcileOnOperationLock:   true,
+			ReconcileOnAcceptedUpgradeStrategy: true,
+			ReconcileOnBlueGreenStatus:         true,
+			ReconcileOnOperationLock:           true,
 		})).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 2,

--- a/internal/platform/predicates/predicates.go
+++ b/internal/platform/predicates/predicates.go
@@ -26,6 +26,9 @@ import (
 
 // OpenBaoClusterPredicateOptions controls which OpenBaoCluster changes should trigger reconciliation.
 type OpenBaoClusterPredicateOptions struct {
+	// ReconcileOnAcceptedUpgradeStrategy enables reconciliation when the
+	// operator-accepted upgrade strategy changes.
+	ReconcileOnAcceptedUpgradeStrategy bool
 	// ReconcileOnUpgradeStatus enables reconciliation when status.upgrade changes.
 	ReconcileOnUpgradeStatus bool
 	// ReconcileOnBackupStatus enables reconciliation when status.backup changes.
@@ -76,6 +79,10 @@ func shouldReconcileOpenBaoClusterUpdate(
 	opts OpenBaoClusterPredicateOptions,
 	oldCluster, newCluster *openbaov1alpha1.OpenBaoCluster,
 ) bool {
+	if opts.ReconcileOnAcceptedUpgradeStrategy &&
+		oldCluster.Status.AcceptedUpgradeStrategy != newCluster.Status.AcceptedUpgradeStrategy {
+		return true
+	}
 	if opts.ReconcileOnUpgradeStatus && !equality.Semantic.DeepEqual(oldCluster.Status.Upgrade, newCluster.Status.Upgrade) {
 		return true
 	}

--- a/internal/platform/statusapply/openbaocluster.go
+++ b/internal/platform/statusapply/openbaocluster.go
@@ -41,12 +41,13 @@ func ApplyOpenBaoClusterAdminOpsStatus(
 			Namespace: cluster.Namespace,
 		},
 		Status: openbaov1alpha1.OpenBaoClusterStatus{
-			Upgrade:         cluster.Status.Upgrade,
-			UpgradeRequests: cluster.Status.UpgradeRequests,
-			Backup:          cluster.Status.Backup,
-			BlueGreen:       cluster.Status.BlueGreen,
-			BreakGlass:      cluster.Status.BreakGlass,
-			AdminOps:        cluster.Status.AdminOps,
+			AcceptedUpgradeStrategy: cluster.Status.AcceptedUpgradeStrategy,
+			Upgrade:                 cluster.Status.Upgrade,
+			UpgradeRequests:         cluster.Status.UpgradeRequests,
+			Backup:                  cluster.Status.Backup,
+			BlueGreen:               cluster.Status.BlueGreen,
+			BreakGlass:              cluster.Status.BreakGlass,
+			AdminOps:                cluster.Status.AdminOps,
 		},
 	}, c)
 	if err != nil {

--- a/internal/port/workload/strategy.go
+++ b/internal/port/workload/strategy.go
@@ -1,0 +1,49 @@
+package workload
+
+import (
+	"fmt"
+	"strings"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+// DesiredStrategy returns the strategy requested by the cluster spec.
+func DesiredStrategy(cluster *openbaov1alpha1.OpenBaoCluster) openbaov1alpha1.UpdateStrategyType {
+	if cluster == nil || cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy == "" {
+		return openbaov1alpha1.UpdateStrategyRollingUpdate
+	}
+	return cluster.Spec.Upgrade.Strategy
+}
+
+// EffectiveStrategy returns the last strategy accepted by the operator.
+func EffectiveStrategy(cluster *openbaov1alpha1.OpenBaoCluster) openbaov1alpha1.UpdateStrategyType {
+	if cluster != nil && cluster.Status.AcceptedUpgradeStrategy != "" {
+		return cluster.Status.AcceptedUpgradeStrategy
+	}
+	return DesiredStrategy(cluster)
+}
+
+// StableVoterRevision returns the durable revision of the active voter StatefulSet.
+func StableVoterRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	if cluster == nil || cluster.Status.BlueGreen == nil {
+		return ""
+	}
+	return strings.TrimSpace(cluster.Status.BlueGreen.BlueRevision)
+}
+
+// StableVoterStatefulSetName returns the active voter StatefulSet name.
+func StableVoterStatefulSetName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	if cluster == nil {
+		return ""
+	}
+	revision := StableVoterRevision(cluster)
+	if revision == "" {
+		return cluster.Name
+	}
+	return fmt.Sprintf("%s-%s", cluster.Name, revision)
+}
+
+// StableVoterPodName returns a pod name in the active voter StatefulSet.
+func StableVoterPodName(cluster *openbaov1alpha1.OpenBaoCluster, ordinal int32) string {
+	return fmt.Sprintf("%s-%d", StableVoterStatefulSetName(cluster), ordinal)
+}

--- a/internal/service/identity/manager.go
+++ b/internal/service/identity/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
 // Manager reconciles ServiceAccount and RBAC resources for an OpenBaoCluster.
@@ -154,20 +155,27 @@ func openBaoPodResourceNames(cluster *openbaov1alpha1.OpenBaoCluster) []string {
 	}
 
 	prefixReplicaCounts := map[string]int32{
-		cluster.Name: voterReplicas,
+		portworkload.StableVoterStatefulSetName(cluster): voterReplicas,
 	}
 
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
+	if portworkload.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen {
+		// Keep the original name authorized for initial BlueGreen bootstrap and
+		// RollingUpdate-to-BlueGreen transitions with an unrevisioned Blue.
+		prefixReplicaCounts[cluster.Name] = voterReplicas
 		resolvedImage := cluster.Spec.Image
 		if resolvedImage == "" {
 			resolvedImage = constants.GetOpenBaoImage(cluster.Spec.Version)
 		}
 
-		blueRevision := revision.OpenBaoClusterRevision(cluster.Spec.Version, resolvedImage, cluster.Spec.Replicas)
-		if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.BlueRevision != "" {
+		blueRevision := ""
+		if cluster.Status.BlueGreen == nil {
+			blueRevision = revision.OpenBaoClusterRevision(cluster.Spec.Version, resolvedImage, cluster.Spec.Replicas)
+		} else {
 			blueRevision = cluster.Status.BlueGreen.BlueRevision
 		}
-		prefixReplicaCounts[fmt.Sprintf("%s-%s", cluster.Name, blueRevision)] = voterReplicas
+		if blueRevision != "" {
+			prefixReplicaCounts[fmt.Sprintf("%s-%s", cluster.Name, blueRevision)] = voterReplicas
+		}
 
 		if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.GreenRevision != "" {
 			prefixReplicaCounts[fmt.Sprintf("%s-%s", cluster.Name, cluster.Status.BlueGreen.GreenRevision)] = voterReplicas

--- a/internal/service/networking/service_revision.go
+++ b/internal/service/networking/service_revision.go
@@ -3,32 +3,37 @@ package networking
 import (
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/revision"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
-func activeServiceRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
+func applyActiveServiceSelector(cluster *openbaov1alpha1.OpenBaoCluster, selector map[string]string) {
 	if !isBlueGreenStrategy(cluster) {
-		return ""
+		return
 	}
 
-	stableRevision := stableServiceRevision(cluster)
-	if stableRevision == "" {
-		return ""
-	}
-	if cluster.Status.BlueGreen == nil {
-		return stableRevision
-	}
-
-	if cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseCleanup {
+	if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseCleanup {
 		greenRevision := strings.TrimSpace(cluster.Status.BlueGreen.GreenRevision)
 		if greenRevision != "" {
-			return greenRevision
+			selector[constants.LabelOpenBaoRevision] = greenRevision
+			return
 		}
 	}
 
-	return stableRevision
+	if stableRevision := stableServiceRevision(cluster); stableRevision != "" {
+		selector[constants.LabelOpenBaoRevision] = stableRevision
+		return
+	}
+
+	if cluster.Status.BlueGreen != nil {
+		if controllerRevision := strings.TrimSpace(cluster.Status.BlueGreen.BlueControllerRevision); controllerRevision != "" {
+			selector[appsv1.ControllerRevisionHashLabelKey] = controllerRevision
+		}
+	}
 }
 
 func stableServiceRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
@@ -37,10 +42,7 @@ func stableServiceRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
 	}
 
 	if cluster.Status.BlueGreen != nil {
-		blueRevision := strings.TrimSpace(cluster.Status.BlueGreen.BlueRevision)
-		if blueRevision != "" {
-			return blueRevision
-		}
+		return strings.TrimSpace(cluster.Status.BlueGreen.BlueRevision)
 	}
 
 	return revision.OpenBaoClusterRevision(
@@ -51,9 +53,7 @@ func stableServiceRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
 }
 
 func isBlueGreenStrategy(cluster *openbaov1alpha1.OpenBaoCluster) bool {
-	return cluster != nil &&
-		cluster.Spec.Upgrade != nil &&
-		cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen
+	return portworkload.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen
 }
 
 func resolvedSpecImage(cluster *openbaov1alpha1.OpenBaoCluster) string {

--- a/internal/service/networking/services.go
+++ b/internal/service/networking/services.go
@@ -93,9 +93,7 @@ func (m *Manager) ensureExternalService(ctx context.Context, _ logr.Logger, clus
 	}
 
 	selectorLabels := resourceidentity.PodSelectorLabels(cluster)
-	if activeRevision := activeServiceRevision(cluster); activeRevision != "" {
-		selectorLabels[constants.LabelOpenBaoRevision] = activeRevision
-	}
+	applyActiveServiceSelector(cluster, selectorLabels)
 
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -281,9 +279,7 @@ func (m *Manager) ensureACMEChallengeService(ctx context.Context, _ logr.Logger,
 	}
 
 	selectorLabels := resourceidentity.PodSelectorLabels(cluster)
-	if activeRevision := activeServiceRevision(cluster); activeRevision != "" {
-		selectorLabels[constants.LabelOpenBaoRevision] = activeRevision
-	}
+	applyActiveServiceSelector(cluster, selectorLabels)
 
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/service/networking/services_test.go
+++ b/internal/service/networking/services_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -81,6 +82,87 @@ func TestEnsureExternalService_BlueGreenSelectorStillPinsActiveRevision(t *testi
 	}
 	if _, ok := service.Spec.Selector[constants.LabelOpenBaoWorkloadPool]; ok {
 		t.Fatalf("did not expect external Service selector to pin a workload pool during blue/green")
+	}
+}
+
+func TestEnsureExternalService_BlueGreenSelectorPinsUnrevisionedBlueControllerRevision(t *testing.T) {
+	cluster := newMinimalCluster("svc-bluegreen-unrevisioned", "default")
+	cluster.Spec.Service = &openbaov1alpha1.ServiceConfig{}
+	cluster.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{
+		Strategy: openbaov1alpha1.UpdateStrategyBlueGreen,
+	}
+	cluster.Status.AcceptedUpgradeStrategy = openbaov1alpha1.UpdateStrategyBlueGreen
+	cluster.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{
+		Phase:                  openbaov1alpha1.PhaseIdle,
+		BlueControllerRevision: "svc-bluegreen-unrevisioned-6d89f76c4b",
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cluster).
+		WithReturnManagedFields().
+		Build()
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
+
+	if err := manager.ensureExternalService(context.Background(), logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensureExternalService() error = %v", err)
+	}
+
+	service := &corev1.Service{}
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      externalServiceName(cluster),
+	}, service); err != nil {
+		t.Fatalf("failed to get external Service: %v", err)
+	}
+
+	if got := service.Spec.Selector[appsv1.ControllerRevisionHashLabelKey]; got != cluster.Status.BlueGreen.BlueControllerRevision {
+		t.Fatalf("selector controller revision = %q, want %q", got, cluster.Status.BlueGreen.BlueControllerRevision)
+	}
+	if _, ok := service.Spec.Selector[constants.LabelOpenBaoRevision]; ok {
+		t.Fatalf("did not expect revision selector for unrevisioned Blue: %#v", service.Spec.Selector)
+	}
+}
+
+func TestEnsureExternalService_SwitchToRollingRemovesBlueGreenSelector(t *testing.T) {
+	cluster := newMinimalCluster("svc-switch-rolling", "default")
+	cluster.Spec.Service = &openbaov1alpha1.ServiceConfig{}
+	cluster.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{Strategy: openbaov1alpha1.UpdateStrategyBlueGreen}
+	cluster.Status.AcceptedUpgradeStrategy = openbaov1alpha1.UpdateStrategyBlueGreen
+	cluster.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{
+		Phase:        openbaov1alpha1.PhaseIdle,
+		BlueRevision: "blue123",
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cluster).
+		WithReturnManagedFields().
+		Build()
+	manager := NewManager(k8sClient, testScheme, "operators", constants.PlatformKubernetes)
+	ctx := context.Background()
+
+	if err := manager.ensureExternalService(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensureExternalService() BlueGreen error = %v", err)
+	}
+	cluster.Spec.Upgrade.Strategy = openbaov1alpha1.UpdateStrategyRollingUpdate
+	cluster.Status.AcceptedUpgradeStrategy = openbaov1alpha1.UpdateStrategyRollingUpdate
+	if err := manager.ensureExternalService(ctx, logr.Discard(), cluster); err != nil {
+		t.Fatalf("ensureExternalService() RollingUpdate error = %v", err)
+	}
+
+	service := &corev1.Service{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      externalServiceName(cluster),
+	}, service); err != nil {
+		t.Fatalf("failed to get external Service: %v", err)
+	}
+	if _, ok := service.Spec.Selector[constants.LabelOpenBaoRevision]; ok {
+		t.Fatalf("did not expect rolling Service to retain the BlueGreen revision selector: %#v", service.Spec.Selector)
+	}
+	if _, ok := service.Spec.Selector[appsv1.ControllerRevisionHashLabelKey]; ok {
+		t.Fatalf("did not expect rolling Service to retain the Blue controller selector: %#v", service.Spec.Selector)
 	}
 }
 

--- a/internal/service/upgrade/bluegreen/cutover_cleanup.go
+++ b/internal/service/upgrade/bluegreen/cutover_cleanup.go
@@ -115,7 +115,7 @@ func (m *Manager) ensureBlueStatefulSetDeleted(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 ) (phaseOutcome, bool, error) {
 	blueRevision := cluster.Status.BlueGreen.BlueRevision
-	blueStatefulSetName := fmt.Sprintf("%s-%s", cluster.Name, blueRevision)
+	blueStatefulSetName := upgrade.StableVoterStatefulSetName(cluster)
 	blueStatefulSet := &appsv1.StatefulSet{}
 	if err := m.client.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,

--- a/internal/service/upgrade/bluegreen/deploying_green.go
+++ b/internal/service/upgrade/bluegreen/deploying_green.go
@@ -43,6 +43,9 @@ func (m *Manager) ensureBlueClusterReadyForGreen(
 
 func bluePodsHaveExpectedRevision(logger logr.Logger, bluePods []corev1.Pod, blueRevision string) bool {
 	for _, pod := range bluePods {
+		if blueRevision == "" && pod.Labels[constants.LabelOpenBaoRevision] == "" {
+			continue
+		}
 		rev, present := pod.Labels[constants.LabelOpenBaoRevision]
 		if present && rev == blueRevision {
 			continue

--- a/internal/service/upgrade/bluegreen/manager.go
+++ b/internal/service/upgrade/bluegreen/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
 )
 
@@ -107,10 +108,7 @@ func requeueAfter(duration time.Duration) recon.Result {
 // For Green resources (StatefulSet and snapshot Jobs), we verify and pin digests here to ensure the
 // target images are validated when ImageVerification is enabled.
 func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
-	updateStrategy := "RollingUpdate"
-	if cluster.Spec.Upgrade != nil {
-		updateStrategy = string(cluster.Spec.Upgrade.Strategy)
-	}
+	updateStrategy := string(upgrade.EffectiveStrategy(cluster))
 	logger.Info("Manager reconciling",
 		"updateStrategy", updateStrategy,
 		"currentVersion", cluster.Status.CurrentVersion,

--- a/internal/service/upgrade/bluegreen/manager_phase_startup.go
+++ b/internal/service/upgrade/bluegreen/manager_phase_startup.go
@@ -3,11 +3,15 @@ package bluegreen
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	configurationservice "github.com/dc-tec/openbao-operator/internal/service/configuration"
 )
 
@@ -45,9 +49,7 @@ func (m *Manager) createGreenStatefulSet(ctx context.Context, logger logr.Logger
 		return phaseOutcome{}, fmt.Errorf("workload runtime is not configured")
 	}
 
-	configContent, err := configurationservice.Render(cluster, configurationservice.RenderOptions{
-		TargetRevisionForJoin: blueRevision,
-	})
+	configContent, err := configurationservice.Render(cluster, greenRenderOptions(cluster, blueRevision))
 	if err != nil {
 		return phaseOutcome{}, fmt.Errorf("failed to render config for Green cluster: %w", err)
 	}
@@ -63,6 +65,29 @@ func (m *Manager) createGreenStatefulSet(ctx context.Context, logger logr.Logger
 
 	logger.Info("Created Green StatefulSet", "greenRevision", greenRevision)
 	return requeueAfterOutcome(constants.RequeueShort), nil
+}
+
+func greenRenderOptions(cluster *openbaov1alpha1.OpenBaoCluster, blueRevision string) configurationservice.RenderOptions {
+	return configurationservice.RenderOptions{
+		TargetRevisionForJoin:  blueRevision,
+		RetryJoinLabelSelector: blueRetryJoinLabelSelector(cluster, blueRevision),
+		RetryJoinAsNonVoter:    true,
+	}
+}
+
+func blueRetryJoinLabelSelector(cluster *openbaov1alpha1.OpenBaoCluster, blueRevision string) string {
+	if strings.TrimSpace(blueRevision) != "" || cluster == nil || cluster.Status.BlueGreen == nil {
+		return ""
+	}
+
+	controllerRevision := strings.TrimSpace(cluster.Status.BlueGreen.BlueControllerRevision)
+	if controllerRevision == "" {
+		return ""
+	}
+
+	selector := resourceidentity.VoterPodSelectorLabels(cluster)
+	selector[appsv1.ControllerRevisionHashLabelKey] = controllerRevision
+	return labels.Set(selector).String()
 }
 
 func (m *Manager) prepareGreenStatefulSetImages(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (string, string, error) {

--- a/internal/service/upgrade/bluegreen/pods.go
+++ b/internal/service/upgrade/bluegreen/pods.go
@@ -3,6 +3,7 @@ package bluegreen
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,11 +41,16 @@ func countActivePods(pods []corev1.Pod) int {
 // This is a unified helper used for both Blue and Green pod lookup.
 func (m *Manager) getPodsByRevision(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, rev string) ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
-	labelSelector := labels.SelectorFromSet(map[string]string{
-		constants.LabelAppInstance:     cluster.Name,
-		constants.LabelAppName:         constants.LabelValueAppNameOpenBao,
-		constants.LabelOpenBaoRevision: rev,
-	})
+	selectorLabels := map[string]string{
+		constants.LabelAppInstance: cluster.Name,
+		constants.LabelAppName:     constants.LabelValueAppNameOpenBao,
+	}
+	if rev != "" {
+		selectorLabels[constants.LabelOpenBaoRevision] = rev
+	} else if cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.BlueControllerRevision != "" {
+		selectorLabels[appsv1.ControllerRevisionHashLabelKey] = cluster.Status.BlueGreen.BlueControllerRevision
+	}
+	labelSelector := labels.SelectorFromSet(selectorLabels)
 
 	if err := m.client.List(ctx, podList,
 		client.InNamespace(cluster.Namespace),
@@ -53,7 +59,21 @@ func (m *Manager) getPodsByRevision(ctx context.Context, cluster *openbaov1alpha
 		return nil, fmt.Errorf("failed to list pods for revision %s: %w", rev, err)
 	}
 
-	return podList.Items, nil
+	if rev != "" || (cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.BlueControllerRevision != "") {
+		return podList.Items, nil
+	}
+
+	// Compatibility fallback for status written before BlueControllerRevision
+	// existed: only Pods from the original unrevisioned StatefulSet are Blue.
+	pods := make([]corev1.Pod, 0, len(podList.Items))
+	prefix := cluster.Name + "-"
+	for i := range podList.Items {
+		pod := podList.Items[i]
+		if strings.HasPrefix(pod.Name, prefix) && pod.Labels[constants.LabelOpenBaoRevision] == "" {
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
 }
 
 // cleanupGreenStatefulSet removes any lingering Green StatefulSet.

--- a/internal/service/upgrade/bluegreen/read_replica_restore.go
+++ b/internal/service/upgrade/bluegreen/read_replica_restore.go
@@ -27,6 +27,7 @@ func beginSteadyReadReplicaRestore(
 
 	if greenRevision := cluster.Status.BlueGreen.GreenRevision; greenRevision != "" {
 		cluster.Status.BlueGreen.BlueRevision = greenRevision
+		cluster.Status.BlueGreen.BlueControllerRevision = ""
 	}
 	if cluster.Spec.Image != "" {
 		cluster.Status.BlueGreen.BlueImage = cluster.Spec.Image

--- a/internal/service/upgrade/bluegreen/strategy_switch_test.go
+++ b/internal/service/upgrade/bluegreen/strategy_switch_test.go
@@ -1,0 +1,84 @@
+package bluegreen
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+)
+
+func TestBlueRetryJoinLabelSelector_UnrevisionedBlueUsesControllerRevision(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao", Namespace: "tenant"},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueControllerRevision: "bao-6d89f76c4b",
+			},
+		},
+	}
+
+	selector := blueRetryJoinLabelSelector(cluster, "")
+	for _, expected := range []string{
+		appsv1.ControllerRevisionHashLabelKey + "=bao-6d89f76c4b",
+		constants.LabelOpenBaoCluster + "=bao",
+		constants.LabelOpenBaoWorkloadPool + "=" + constants.LabelValueOpenBaoWorkloadPoolVoter,
+	} {
+		if !strings.Contains(selector, expected) {
+			t.Fatalf("selector %q does not contain %q", selector, expected)
+		}
+	}
+
+	if got := blueRetryJoinLabelSelector(cluster, "blue123"); got != "" {
+		t.Fatalf("revisioned Blue selector override = %q, want empty", got)
+	}
+
+	options := greenRenderOptions(cluster, "")
+	if !options.RetryJoinAsNonVoter {
+		t.Fatal("unrevisioned Green render options RetryJoinAsNonVoter=false, want true")
+	}
+	if options.RetryJoinLabelSelector != selector {
+		t.Fatalf("Green render selector = %q, want %q", options.RetryJoinLabelSelector, selector)
+	}
+}
+
+func TestGetPodsByRevision_UnrevisionedBlueUsesControllerRevision(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao", Namespace: "tenant"},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{
+				BlueControllerRevision: "bao-6d89f76c4b",
+			},
+		},
+	}
+	blueLabels := resourceidentity.VoterPodSelectorLabels(cluster)
+	blueLabels[appsv1.ControllerRevisionHashLabelKey] = "bao-6d89f76c4b"
+	greenLabels := resourceidentity.VoterPodSelectorLabels(cluster)
+	greenLabels[appsv1.ControllerRevisionHashLabelKey] = "bao-green-75f84d9b"
+	greenLabels[constants.LabelOpenBaoRevision] = "green123"
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	manager := &Manager{client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bao-0", Namespace: cluster.Namespace, Labels: blueLabels}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bao-green123-0", Namespace: cluster.Namespace, Labels: greenLabels}},
+	).Build()}
+
+	pods, err := manager.getPodsByRevision(context.Background(), cluster, "")
+	if err != nil {
+		t.Fatalf("getPodsByRevision() error = %v", err)
+	}
+	if len(pods) != 1 || pods[0].Name != "bao-0" {
+		t.Fatalf("unrevisioned Blue pods = %#v, want only bao-0", pods)
+	}
+}

--- a/internal/service/upgrade/bluegreen/workflow_preflight.go
+++ b/internal/service/upgrade/bluegreen/workflow_preflight.go
@@ -14,13 +14,10 @@ import (
 )
 
 func (m *Manager) shouldReconcileBlueGreen(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) bool {
-	if cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen {
-		updateStrategy := "nil"
-		if cluster.Spec.Upgrade != nil {
-			updateStrategy = string(cluster.Spec.Upgrade.Strategy)
-		}
+	if upgrade.EffectiveStrategy(cluster) != openbaov1alpha1.UpdateStrategyBlueGreen {
 		logger.V(1).Info("UpdateStrategy is not BlueGreen; skipping blue/green upgrade reconciliation",
-			"updateStrategy", updateStrategy)
+			"requestedStrategy", upgrade.DesiredStrategy(cluster),
+			"acceptedStrategy", cluster.Status.AcceptedUpgradeStrategy)
 		return false
 	}
 	return true

--- a/internal/service/upgrade/config_test.go
+++ b/internal/service/upgrade/config_test.go
@@ -32,7 +32,7 @@ func TestExecutorConfig_Validate_BlueGreenRepairConsensus(t *testing.T) {
 			},
 		},
 		{
-			name: "requires blue revision",
+			name: "accepts unrevisioned blue workload",
 			cfg: ExecutorConfig{
 				ClusterNamespace: "default",
 				ClusterName:      "example",
@@ -45,8 +45,6 @@ func TestExecutorConfig_Validate_BlueGreenRepairConsensus(t *testing.T) {
 				SyncThreshold:    100,
 				Timeout:          10 * time.Second,
 			},
-			wantErr:    true,
-			errContain: "blue revision is required",
 		},
 		{
 			name: "requires green revision",

--- a/internal/service/upgrade/core/bluegreen_state.go
+++ b/internal/service/upgrade/core/bluegreen_state.go
@@ -66,6 +66,7 @@ func FinalizeBlueGreenTerminalState(cluster *openbaov1alpha1.OpenBaoCluster, pro
 
 	if promoteGreenToBlue {
 		cluster.Status.BlueGreen.BlueRevision = cluster.Status.BlueGreen.GreenRevision
+		cluster.Status.BlueGreen.BlueControllerRevision = ""
 		if cluster.Spec.Image != "" {
 			cluster.Status.BlueGreen.BlueImage = cluster.Spec.Image
 		}

--- a/internal/service/upgrade/executor_helpers_test.go
+++ b/internal/service/upgrade/executor_helpers_test.go
@@ -184,6 +184,18 @@ func TestNewLeaderSearchPolicy(t *testing.T) {
 	}
 }
 
+func TestNewLeaderSearchPolicyForRevisions(t *testing.T) {
+	t.Parallel()
+
+	policy := raftops.NewLeaderSearchPolicyForRevisions("green", "", "Green", "Blue")
+	if !policy.AllowFallback {
+		t.Fatal("NewLeaderSearchPolicyForRevisions() AllowFallback=false, want true for unrevisioned fallback")
+	}
+	if policy.FallbackRevision != "" {
+		t.Fatalf("NewLeaderSearchPolicyForRevisions() FallbackRevision=%q, want unrevisioned fallback", policy.FallbackRevision)
+	}
+}
+
 func TestNormalizeRetryPolicy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/upgrade/executor_orchestration_test.go
+++ b/internal/service/upgrade/executor_orchestration_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
 	"github.com/go-logr/logr"
 )
@@ -874,15 +873,6 @@ func TestRunBlueGreenRepairConsensusValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "missing blue revision",
-			cfg: func() *ExecutorConfig {
-				cfg := baseExecutorTestConfig()
-				cfg.BlueRevision = ""
-				return cfg
-			}(),
-			wantErr: "blue revision is required for consensus repair",
-		},
-		{
 			name: "missing green revision",
 			cfg: func() *ExecutorConfig {
 				cfg := baseExecutorTestConfig()
@@ -907,23 +897,26 @@ func TestRunBlueGreenRepairConsensusValidation(t *testing.T) {
 	}
 }
 
-func TestRunBlueGreenRemovePeersValidation(t *testing.T) {
+func TestRunBlueGreenRemovePeersAcceptsUnrevisionedTarget(t *testing.T) {
 	t.Parallel()
 
 	err := raftops.RunBlueGreenRemovePeers(
-		context.Background(),
+		canceledContext(),
 		logr.Discard(),
 		baseExecutorTestConfig(),
 		"",
 		"green",
-		"blue",
+		"",
 		"Blue",
 	)
 	if err == nil {
-		t.Fatalf("RunBlueGreenRemovePeers() error=nil, want validation error")
+		t.Fatal("RunBlueGreenRemovePeers() error=nil, want leader lookup error")
 	}
-	if !strings.Contains(err.Error(), "revision to remove is required") {
-		t.Fatalf("RunBlueGreenRemovePeers() error=%q, want revision validation error", err.Error())
+	if strings.Contains(err.Error(), "revision to remove is required") {
+		t.Fatalf("RunBlueGreenRemovePeers() rejected an unrevisioned target: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to find leader") {
+		t.Fatalf("RunBlueGreenRemovePeers() error=%q, want leader lookup error", err.Error())
 	}
 }
 
@@ -944,95 +937,6 @@ func TestFindLeaderAndFindLeaderOnceValidation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "config is required") {
 		t.Fatalf("raftops.FindLeader() error=%q, want contains %q", err.Error(), "config is required")
-	}
-}
-
-func TestRaftLeaderInfo(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		config     *portopenbao.RaftConfigurationResponse
-		bluePrefix string
-		wantID     string
-		wantBlue   bool
-	}{
-		{
-			name:       "nil config",
-			config:     nil,
-			bluePrefix: "openbao-blue-",
-			wantID:     "",
-			wantBlue:   false,
-		},
-		{
-			name: "no leader in config",
-			config: &portopenbao.RaftConfigurationResponse{
-				Config: portopenbao.RaftConfiguration{
-					Servers: []portopenbao.RaftServer{
-						{NodeID: "openbao-blue-0", Leader: false},
-					},
-				},
-			},
-			bluePrefix: "openbao-blue-",
-			wantID:     "",
-			wantBlue:   false,
-		},
-		{
-			name: "leader is blue by node id",
-			config: &portopenbao.RaftConfigurationResponse{
-				Config: portopenbao.RaftConfiguration{
-					Servers: []portopenbao.RaftServer{
-						{NodeID: "openbao-blue-1", Leader: true},
-					},
-				},
-			},
-			bluePrefix: "openbao-blue-",
-			wantID:     "openbao-blue-1",
-			wantBlue:   true,
-		},
-		{
-			name: "leader is blue by address",
-			config: &portopenbao.RaftConfigurationResponse{
-				Config: portopenbao.RaftConfiguration{
-					Servers: []portopenbao.RaftServer{
-						{
-							NodeID:  "node-1",
-							Address: "https://openbao-blue-2.openbao.default.svc:8201",
-							Leader:  true,
-						},
-					},
-				},
-			},
-			bluePrefix: "openbao-blue-",
-			wantID:     "node-1",
-			wantBlue:   true,
-		},
-		{
-			name: "leader is not blue",
-			config: &portopenbao.RaftConfigurationResponse{
-				Config: portopenbao.RaftConfiguration{
-					Servers: []portopenbao.RaftServer{
-						{NodeID: "openbao-green-0", Leader: true},
-					},
-				},
-			},
-			bluePrefix: "openbao-blue-",
-			wantID:     "openbao-green-0",
-			wantBlue:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			gotID, gotBlue := raftops.RaftLeaderInfo(tt.config, tt.bluePrefix)
-			if gotID != tt.wantID {
-				t.Fatalf("raftops.RaftLeaderInfo() id=%q, want %q", gotID, tt.wantID)
-			}
-			if gotBlue != tt.wantBlue {
-				t.Fatalf("raftops.RaftLeaderInfo() isBlue=%v, want %v", gotBlue, tt.wantBlue)
-			}
-		})
 	}
 }
 

--- a/internal/service/upgrade/raftops/actions.go
+++ b/internal/service/upgrade/raftops/actions.go
@@ -233,9 +233,6 @@ func RunBlueGreenWaitGreenSynced(ctx context.Context, logger logr.Logger, cfg *E
 // RunBlueGreenRepairConsensus enforces Blue voters and Green non-voters during
 // rollback repair.
 func RunBlueGreenRepairConsensus(ctx context.Context, logger logr.Logger, cfg *ExecutorConfig) error {
-	if cfg.BlueRevision == "" {
-		return fmt.Errorf("blue revision is required for consensus repair")
-	}
 	if cfg.GreenRevision == "" {
 		return fmt.Errorf("green revision is required for consensus repair")
 	}
@@ -433,11 +430,7 @@ func RunBlueGreenRemovePeers(
 	fallbackLeaderRevision string,
 	peerColor string,
 ) error {
-	if strings.TrimSpace(revisionToRemove) == "" {
-		return fmt.Errorf("revision to remove is required")
-	}
-
-	leaderURL, err := FindPreferredLeaderWithFallback(
+	leaderURL, err := FindPreferredLeaderForRevisions(
 		ctx,
 		logger,
 		cfg,

--- a/internal/service/upgrade/raftops/config.go
+++ b/internal/service/upgrade/raftops/config.go
@@ -87,9 +87,6 @@ func (c *ExecutorConfig) Validate() error {
 		ExecutorActionBlueGreenRemoveBluePeers,
 		ExecutorActionBlueGreenRemoveGreenPeers,
 		ExecutorActionBlueGreenRepairConsensus:
-		if strings.TrimSpace(c.BlueRevision) == "" {
-			return fmt.Errorf("blue revision is required for blue/green actions")
-		}
 		if strings.TrimSpace(c.GreenRevision) == "" {
 			return fmt.Errorf("green revision is required for blue/green actions")
 		}

--- a/internal/service/upgrade/raftops/leader_search.go
+++ b/internal/service/upgrade/raftops/leader_search.go
@@ -182,6 +182,22 @@ func FindPreferredLeaderWithFallback(
 	return FindLeaderWithPolicy(ctx, logger, cfg, policy)
 }
 
+// FindPreferredLeaderForRevisions searches two concrete workload revisions.
+// Unlike an optional fallback, an empty revision identifies an unrevisioned
+// StatefulSet and is searched when it differs from the preferred revision.
+func FindPreferredLeaderForRevisions(
+	ctx context.Context,
+	logger logr.Logger,
+	cfg *ExecutorConfig,
+	preferredRevision string,
+	fallbackRevision string,
+	preferredLabel string,
+	fallbackLabel string,
+) (string, error) {
+	policy := NewLeaderSearchPolicyForRevisions(preferredRevision, fallbackRevision, preferredLabel, fallbackLabel)
+	return FindLeaderWithPolicy(ctx, logger, cfg, policy)
+}
+
 // FindAnyLeader tries the first revision and then the second revision.
 func FindAnyLeader(
 	ctx context.Context,
@@ -190,7 +206,7 @@ func FindAnyLeader(
 	firstRevision string,
 	secondRevision string,
 ) (string, error) {
-	return FindPreferredLeaderWithFallback(ctx, logger, cfg, firstRevision, secondRevision, "first", "second")
+	return FindPreferredLeaderForRevisions(ctx, logger, cfg, firstRevision, secondRevision, "first", "second")
 }
 
 // FindLeaderWithPolicy resolves a leader using the provided search policy.

--- a/internal/service/upgrade/raftops/leader_transfer.go
+++ b/internal/service/upgrade/raftops/leader_transfer.go
@@ -57,7 +57,7 @@ const (
 
 // FindInitialLeader prefers a Green leader and falls back to Blue.
 func FindInitialLeader(ctx context.Context, logger logr.Logger, cfg *ExecutorConfig) (string, error) {
-	leaderURL, err := FindPreferredLeaderWithFallback(
+	leaderURL, err := FindPreferredLeaderForRevisions(
 		ctx,
 		logger,
 		cfg,
@@ -134,7 +134,7 @@ func EnsureGreenLeaderBySteppingDownBlueWithFuncs(
 					return nil, NewExecutorReasonedError(ReasonLeaderTransferStateFailed, fmt.Sprintf("leader transfer state %s failed", state), err)
 				}
 				config = currentConfig
-				leaderID, leaderIsBlue = RaftLeaderInfo(config, bluePrefix)
+				leaderID, leaderIsBlue = RaftLeaderInfoForRevision(config, cfg)
 				if leaderID == "" {
 					return nil, NewExecutorReasonedError(ReasonLeaderTransferStateFailed, fmt.Sprintf("leader transfer state %s failed", state), errors.New("raft leader not found in configuration"))
 				}
@@ -205,10 +205,11 @@ func clientForLeaderURL(ctx context.Context, cfg *ExecutorConfig, factory *openb
 	return client, nil
 }
 
-// RaftLeaderInfo returns the leader ID from the raft configuration and whether
-// it belongs to the Blue revision.
-func RaftLeaderInfo(config *portopenbao.RaftConfigurationResponse, bluePrefix string) (string, bool) {
-	if config == nil {
+// RaftLeaderInfoForRevision returns the leader and whether it belongs to the
+// configured Blue workload. Exact expected pod names are required because the
+// original unrevisioned StatefulSet prefix also prefixes revisioned Green Pods.
+func RaftLeaderInfoForRevision(config *portopenbao.RaftConfigurationResponse, cfg *ExecutorConfig) (string, bool) {
+	if config == nil || cfg == nil {
 		return "", false
 	}
 
@@ -216,8 +217,13 @@ func RaftLeaderInfo(config *portopenbao.RaftConfigurationResponse, bluePrefix st
 		if !server.Leader {
 			continue
 		}
-		leaderID := server.NodeID
-		return leaderID, IsBlueRaftServer(server.NodeID, server.Address, bluePrefix)
+		return server.NodeID, RaftServerMatchesRevision(
+			server.NodeID,
+			server.Address,
+			cfg.ClusterName,
+			cfg.BlueRevision,
+			cfg.ClusterReplicas,
+		)
 	}
 
 	return "", false
@@ -247,7 +253,14 @@ func DemoteBlueVotersExceptLeader(
 		if !server.Voter || server.NodeID == leaderID {
 			continue
 		}
-		if !IsBlueRaftServer(server.NodeID, server.Address, bluePrefix) {
+		isBlue := RaftServerMatchesRevision(server.NodeID, server.Address, cfg.ClusterName, cfg.BlueRevision, cfg.ClusterReplicas)
+		// Retain the prefix-based contract for older direct callers that did not
+		// populate BlueRevision. Production passes "<cluster>--" for an
+		// unrevisioned Blue workload and therefore uses exact expected pod names.
+		if cfg.BlueRevision == "" && bluePrefix != "" && bluePrefix != cfg.ClusterName+"--" {
+			isBlue = IsBlueRaftServer(server.NodeID, server.Address, bluePrefix)
+		}
+		if !isBlue {
 			continue
 		}
 
@@ -441,7 +454,7 @@ func DemoteAllBluePods(ctx context.Context, logger logr.Logger, cfg *ExecutorCon
 	}
 
 	for _, i := range ReplicaOrdinals(cfg.ClusterReplicas) {
-		bluePodName := fmt.Sprintf("%s-%s-%d", cfg.ClusterName, cfg.BlueRevision, i)
+		bluePodName := RevisionPodName(cfg.ClusterName, cfg.BlueRevision, i)
 		logger.V(1).Info("Demoting Blue pod to non-voter", "pod_name", bluePodName)
 		if err := client.DemoteRaftPeer(ctx, bluePodName); err != nil {
 			if IsBenignDemoteError(err) {

--- a/internal/service/upgrade/raftops/leader_transfer_test.go
+++ b/internal/service/upgrade/raftops/leader_transfer_test.go
@@ -96,6 +96,44 @@ func TestDemoteBlueVotersExceptLeader(t *testing.T) {
 	})
 }
 
+func TestUnrevisionedBlueIdentityDoesNotMatchRevisionedGreen(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ExecutorConfig{
+		ClusterName:     "vault",
+		ClusterReplicas: 3,
+	}
+	config := &portopenbao.RaftConfigurationResponse{
+		Config: portopenbao.RaftConfiguration{
+			Servers: []portopenbao.RaftServer{
+				{NodeID: "vault-0", Address: "vault-0.vault.default.svc", Voter: true},
+				{NodeID: "vault-green-0", Address: "vault-green-0.vault.default.svc", Leader: true, Voter: true},
+			},
+		},
+	}
+
+	leaderID, leaderIsBlue := RaftLeaderInfoForRevision(config, cfg)
+	if leaderID != "vault-green-0" || leaderIsBlue {
+		t.Fatalf("RaftLeaderInfoForRevision() = (%q, %v), want (vault-green-0, false)", leaderID, leaderIsBlue)
+	}
+
+	demoter := &demoterStub{}
+	if err := DemoteBlueVotersExceptLeader(
+		context.Background(),
+		logr.Discard(),
+		cfg,
+		demoter,
+		config,
+		"vault-green-0",
+		"vault--",
+	); err != nil {
+		t.Fatalf("DemoteBlueVotersExceptLeader() error = %v", err)
+	}
+	if len(demoter.calls) != 1 || demoter.calls[0] != "vault-0" {
+		t.Fatalf("DemoteRaftPeer calls = %v, want [vault-0]", demoter.calls)
+	}
+}
+
 func TestWaitForLeaderElectionWithFinderAndPolicy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/upgrade/raftops/policy.go
+++ b/internal/service/upgrade/raftops/policy.go
@@ -176,6 +176,20 @@ func NewLeaderSearchPolicy(
 	}
 }
 
+// NewLeaderSearchPolicyForRevisions constructs a leader search policy for two
+// concrete workload revisions. An empty revision identifies an unrevisioned
+// StatefulSet and is therefore still a valid fallback when the revisions differ.
+func NewLeaderSearchPolicyForRevisions(
+	primaryRevision string,
+	fallbackRevision string,
+	primaryLabel string,
+	fallbackLabel string,
+) LeaderSearchPolicy {
+	policy := NewLeaderSearchPolicy(primaryRevision, fallbackRevision, primaryLabel, fallbackLabel)
+	policy.AllowFallback = fallbackRevision != primaryRevision
+	return policy
+}
+
 // MaxLeaderSearchAttempts returns the number of revision scans a policy allows.
 func MaxLeaderSearchAttempts(policy LeaderSearchPolicy) int {
 	if policy.AllowFallback {

--- a/internal/service/upgrade/rolling/helpers.go
+++ b/internal/service/upgrade/rolling/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 // getClusterPods returns all pods belonging to the cluster.
@@ -35,7 +36,7 @@ func (m *Manager) getClusterPods(ctx context.Context, cluster *openbaov1alpha1.O
 	// StatefulSet pods have a name pattern: <cluster-name>-<ordinal>
 	// Backup job pods have labels like "openbao.org/component": backup
 	filteredPods := make([]corev1.Pod, 0, len(podList.Items))
-	statefulSetPrefix := cluster.Name + "-"
+	statefulSetPrefix := upgrade.StableVoterStatefulSetName(cluster) + "-"
 	for _, pod := range podList.Items {
 		// Skip backup job pods (they have the backup component label)
 		if pod.Labels[constants.LabelOpenBaoComponent] == constants.ComponentBackup {

--- a/internal/service/upgrade/rolling/lifecycle.go
+++ b/internal/service/upgrade/rolling/lifecycle.go
@@ -10,6 +10,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
 )
 
@@ -51,7 +52,7 @@ func (m *Manager) waitForFinalizationConverged(ctx context.Context, logger logr.
 	sts := &appsv1.StatefulSet{}
 	stsKey := types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      cluster.Name,
+		Name:      upgrade.StableVoterStatefulSetName(cluster),
 	}
 	if err := m.client.Get(ctx, stsKey, sts); err != nil {
 		return false, fmt.Errorf("failed to get StatefulSet while checking upgrade convergence: %w", err)

--- a/internal/service/upgrade/rolling/manager.go
+++ b/internal/service/upgrade/rolling/manager.go
@@ -104,10 +104,7 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 	)
 
 	metrics := upgrade.NewMetrics(cluster.Namespace, cluster.Name)
-	strategy := string(openbaov1alpha1.UpdateStrategyRollingUpdate)
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy != "" {
-		strategy = string(cluster.Spec.Upgrade.Strategy)
-	}
+	strategy := string(upgrade.EffectiveStrategy(cluster))
 
 	if result, done := m.shouldSkipUpgradeReconcile(logger, cluster); done {
 		return result, nil

--- a/internal/service/upgrade/rolling/manager_workflow.go
+++ b/internal/service/upgrade/rolling/manager_workflow.go
@@ -20,7 +20,7 @@ func (m *Manager) shouldSkipUpgradeReconcile(logger logr.Logger, cluster *openba
 		return recon.Result{RequeueAfter: constants.RequeueStandard}, true
 	}
 
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
+	if upgrade.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen {
 		logger.V(1).Info("Skipping rolling upgrade reconciliation; BlueGreen strategy active")
 		return recon.Result{}, true
 	}

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -105,7 +105,7 @@ func (m *Manager) cleanupStepDownJobForRetry(ctx context.Context, logger logr.Lo
 	}
 
 	targetOrdinal := cluster.Status.Upgrade.CurrentPartition - 1
-	targetPod := fmt.Sprintf("%s-%d", cluster.Name, targetOrdinal)
+	targetPod := upgrade.StableVoterPodName(cluster, targetOrdinal)
 	jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, targetPod, "", "")
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
 
@@ -134,11 +134,12 @@ func (m *Manager) resetRolloutPodsForRetry(ctx context.Context, logger logr.Logg
 	}
 
 	sts := &appsv1.StatefulSet{}
-	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, sts); err != nil {
+	statefulSetName := upgrade.StableVoterStatefulSetName(cluster)
+	if err := m.client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: statefulSetName}, sts); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get StatefulSet %s/%s for retry pod reset: %w", cluster.Namespace, cluster.Name, err)
+		return fmt.Errorf("failed to get StatefulSet %s/%s for retry pod reset: %w", cluster.Namespace, statefulSetName, err)
 	}
 
 	desiredImage := strings.TrimSpace(baoContainerImage(sts.Spec.Template.Spec.Containers))
@@ -170,7 +171,7 @@ func (m *Manager) resetRolloutPodForRetry(
 	sts *appsv1.StatefulSet,
 	ordinal int32,
 ) error {
-	targetPod := fmt.Sprintf("%s-%d", cluster.Name, ordinal)
+	targetPod := upgrade.StableVoterPodName(cluster, ordinal)
 	podKey := types.NamespacedName{Namespace: cluster.Namespace, Name: targetPod}
 
 	pod := &corev1.Pod{}

--- a/internal/service/upgrade/rolling/rollout.go
+++ b/internal/service/upgrade/rolling/rollout.go
@@ -113,7 +113,7 @@ func nextRolloutTargetPod(cluster *openbaov1alpha1.OpenBaoCluster) (rolloutTarge
 		CurrentPartition: currentPartition,
 		NextPartition:    currentPartition - 1,
 		Ordinal:          targetOrdinal,
-		Name:             fmt.Sprintf("%s-%d", cluster.Name, targetOrdinal),
+		Name:             upgrade.StableVoterPodName(cluster, targetOrdinal),
 	}, false, nil
 }
 

--- a/internal/service/upgrade/rolling/rollout_wait.go
+++ b/internal/service/upgrade/rolling/rollout_wait.go
@@ -14,6 +14,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
 )
 
@@ -23,7 +24,7 @@ func (m *Manager) setStatefulSetPartition(ctx context.Context, cluster *openbaov
 	sts := &appsv1.StatefulSet{}
 	stsName := types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      cluster.Name,
+		Name:      upgrade.StableVoterStatefulSetName(cluster),
 	}
 
 	if err := m.client.Get(ctx, stsName, sts); err != nil {
@@ -53,7 +54,7 @@ func (m *Manager) waitForPodRevisionUpdated(ctx context.Context, logger logr.Log
 	sts := &appsv1.StatefulSet{}
 	stsKey := types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      cluster.Name,
+		Name:      upgrade.StableVoterStatefulSetName(cluster),
 	}
 	if err := m.client.Get(ctx, stsKey, sts); err != nil {
 		return false, fmt.Errorf("failed to get StatefulSet while checking pod revision: %w", err)

--- a/internal/service/upgrade/rolling/validate_health.go
+++ b/internal/service/upgrade/rolling/validate_health.go
@@ -111,7 +111,7 @@ func (m *Manager) getUpgradeStatefulSet(ctx context.Context, cluster *openbaov1a
 	sts := &appsv1.StatefulSet{}
 	stsName := types.NamespacedName{
 		Namespace: cluster.Namespace,
-		Name:      cluster.Name,
+		Name:      upgrade.StableVoterStatefulSetName(cluster),
 	}
 	if err := m.client.Get(ctx, stsName, sts); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -126,7 +126,7 @@ func currentResumeTargetPodName(cluster *openbaov1alpha1.OpenBaoCluster) string 
 	if cluster == nil || cluster.Status.Upgrade == nil || cluster.Status.Upgrade.CurrentPartition <= 0 {
 		return ""
 	}
-	return fmt.Sprintf("%s-%d", cluster.Name, cluster.Status.Upgrade.CurrentPartition-1)
+	return upgrade.StableVoterPodName(cluster, cluster.Status.Upgrade.CurrentPartition-1)
 }
 
 func requiredQuorum(replicas int32) int {
@@ -217,7 +217,7 @@ func (m *Manager) verifyNonTargetPodsReadyAndHealthy(
 	}
 
 	for ordinal := int32(0); ordinal < cluster.Spec.Replicas; ordinal++ {
-		podName := fmt.Sprintf("%s-%d", cluster.Name, ordinal)
+		podName := upgrade.StableVoterPodName(cluster, ordinal)
 		if podName == targetPodName {
 			continue
 		}

--- a/internal/service/upgrade/strategy.go
+++ b/internal/service/upgrade/strategy.go
@@ -1,0 +1,36 @@
+package upgrade
+
+import (
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
+)
+
+// DesiredStrategy returns the strategy requested by the cluster spec.
+func DesiredStrategy(cluster *openbaov1alpha1.OpenBaoCluster) openbaov1alpha1.UpdateStrategyType {
+	return portworkload.DesiredStrategy(cluster)
+}
+
+// EffectiveStrategy returns the last strategy accepted by the operator. This
+// keeps controllers on the previous strategy while a requested transition is
+// still blocked by an active operation or an unmet safety prerequisite.
+func EffectiveStrategy(cluster *openbaov1alpha1.OpenBaoCluster) openbaov1alpha1.UpdateStrategyType {
+	return portworkload.EffectiveStrategy(cluster)
+}
+
+// StableVoterRevision returns the durable revision of the active voter
+// StatefulSet. An empty revision identifies the original unrevisioned
+// StatefulSet used by rolling clusters.
+func StableVoterRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return portworkload.StableVoterRevision(cluster)
+}
+
+// StableVoterStatefulSetName returns the active voter StatefulSet name without
+// changing it merely because a different future upgrade strategy was selected.
+func StableVoterStatefulSetName(cluster *openbaov1alpha1.OpenBaoCluster) string {
+	return portworkload.StableVoterStatefulSetName(cluster)
+}
+
+// StableVoterPodName returns a pod name in the active voter StatefulSet.
+func StableVoterPodName(cluster *openbaov1alpha1.OpenBaoCluster, ordinal int32) string {
+	return portworkload.StableVoterPodName(cluster, ordinal)
+}

--- a/internal/service/upgrade/strategy_test.go
+++ b/internal/service/upgrade/strategy_test.go
@@ -1,0 +1,77 @@
+package upgrade
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestEffectiveStrategy(t *testing.T) {
+	tests := []struct {
+		name      string
+		cluster   *openbaov1alpha1.OpenBaoCluster
+		desired   openbaov1alpha1.UpdateStrategyType
+		effective openbaov1alpha1.UpdateStrategyType
+	}{
+		{
+			name:      "nil cluster defaults to rolling",
+			desired:   openbaov1alpha1.UpdateStrategyRollingUpdate,
+			effective: openbaov1alpha1.UpdateStrategyRollingUpdate,
+		},
+		{
+			name: "spec strategy is effective before status initialization",
+			cluster: &openbaov1alpha1.OpenBaoCluster{Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Upgrade: &openbaov1alpha1.UpgradeConfig{Strategy: openbaov1alpha1.UpdateStrategyBlueGreen},
+			}},
+			desired:   openbaov1alpha1.UpdateStrategyBlueGreen,
+			effective: openbaov1alpha1.UpdateStrategyBlueGreen,
+		},
+		{
+			name: "accepted strategy remains effective while transition is pending",
+			cluster: &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Upgrade: &openbaov1alpha1.UpgradeConfig{Strategy: openbaov1alpha1.UpdateStrategyBlueGreen},
+				},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					AcceptedUpgradeStrategy: openbaov1alpha1.UpdateStrategyRollingUpdate,
+				},
+			},
+			desired:   openbaov1alpha1.UpdateStrategyBlueGreen,
+			effective: openbaov1alpha1.UpdateStrategyRollingUpdate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DesiredStrategy(tt.cluster); got != tt.desired {
+				t.Fatalf("DesiredStrategy() = %q, want %q", got, tt.desired)
+			}
+			if got := EffectiveStrategy(tt.cluster); got != tt.effective {
+				t.Fatalf("EffectiveStrategy() = %q, want %q", got, tt.effective)
+			}
+		})
+	}
+}
+
+func TestStableVoterWorkloadIdentity(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao"},
+	}
+
+	if got := StableVoterStatefulSetName(cluster); got != "bao" {
+		t.Fatalf("StableVoterStatefulSetName() = %q, want bao", got)
+	}
+	if got := StableVoterPodName(cluster, 2); got != "bao-2" {
+		t.Fatalf("StableVoterPodName() = %q, want bao-2", got)
+	}
+
+	cluster.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{BlueRevision: "blue123"}
+	if got := StableVoterStatefulSetName(cluster); got != "bao-blue123" {
+		t.Fatalf("StableVoterStatefulSetName() = %q, want bao-blue123", got)
+	}
+	if got := StableVoterPodName(cluster, 1); got != "bao-blue123-1" {
+		t.Fatalf("StableVoterPodName() = %q, want bao-blue123-1", got)
+	}
+}

--- a/internal/service/upgrade/strategy_transition.go
+++ b/internal/service/upgrade/strategy_transition.go
@@ -1,0 +1,433 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade/core"
+)
+
+const ReasonUpgradeStrategyTransitionBlocked = "UpgradeStrategyTransitionBlocked"
+
+// StrategyTransitionManager accepts upgrade strategy changes only after the
+// current workload and every long-running operation have reached steady state.
+type StrategyTransitionManager struct {
+	reader client.Reader
+}
+
+// NewStrategyTransitionManager creates the strategy transition safety manager.
+func NewStrategyTransitionManager(reader client.Reader) *StrategyTransitionManager {
+	return &StrategyTransitionManager{reader: reader}
+}
+
+// Reconcile initializes strategy tracking and accepts safe idle transitions.
+func (m *StrategyTransitionManager) Reconcile(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (recon.Result, error) {
+	if cluster == nil || m.reader == nil {
+		return recon.Result{}, nil
+	}
+
+	desired := DesiredStrategy(cluster)
+	if cluster.Status.AcceptedUpgradeStrategy == "" {
+		inferred, err := m.inferCurrentStrategy(ctx, cluster)
+		if err != nil {
+			return recon.Result{}, operatorerrors.WithReason(
+				ReasonUpgradeStrategyTransitionBlocked,
+				operatorerrors.WrapTransientKubernetesAPI(err),
+			)
+		}
+		cluster.Status.AcceptedUpgradeStrategy = inferred
+		logger.Info("Initialized accepted upgrade strategy", "acceptedStrategy", inferred)
+	}
+
+	accepted := cluster.Status.AcceptedUpgradeStrategy
+	if desired == accepted {
+		return recon.Result{}, nil
+	}
+
+	// Keep the previously accepted manager running until any active operation
+	// completes. EffectiveStrategy ensures the requested strategy cannot take
+	// over mid-operation.
+	if hasActiveClusterOperation(cluster) {
+		logger.Info(
+			"Deferring requested upgrade strategy change until the active operation completes",
+			"acceptedStrategy", accepted,
+			"requestedStrategy", desired,
+		)
+		return recon.Result{}, nil
+	}
+
+	if err := validateIdleStrategyTransitionStatus(cluster, desired); err != nil {
+		return recon.Result{}, blockedStrategyTransition(err)
+	}
+	activeStatefulSet, err := m.validateSteadyWorkload(ctx, cluster)
+	if err != nil {
+		return recon.Result{}, blockedStrategyTransition(err)
+	}
+	if desired == openbaov1alpha1.UpdateStrategyBlueGreen {
+		if err := validateBlueGreenTransitionPrerequisites(cluster); err != nil {
+			return recon.Result{}, blockedStrategyTransition(err)
+		}
+	}
+
+	normalizeStrategyTransitionStatus(cluster, desired, activeStatefulSet)
+	cluster.Status.AcceptedUpgradeStrategy = desired
+	logger.Info(
+		"Accepted idle upgrade strategy change",
+		"previousStrategy", accepted,
+		"acceptedStrategy", desired,
+		"statefulSet", activeStatefulSet.Name,
+	)
+
+	return recon.Result{RequeueAfter: constants.RequeueShort}, nil
+}
+
+func blockedStrategyTransition(err error) error {
+	return operatorerrors.WithReason(
+		ReasonUpgradeStrategyTransitionBlocked,
+		operatorerrors.WrapTransientClusterState(err),
+	)
+}
+
+func (m *StrategyTransitionManager) inferCurrentStrategy(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (openbaov1alpha1.UpdateStrategyType, error) {
+	if cluster.Status.BlueGreen != nil {
+		return openbaov1alpha1.UpdateStrategyBlueGreen, nil
+	}
+
+	statefulSets, err := m.voterStatefulSets(ctx, cluster)
+	if err != nil {
+		return "", err
+	}
+	if len(statefulSets) == 0 {
+		return DesiredStrategy(cluster), nil
+	}
+
+	foundRolling := false
+	foundBlueGreen := false
+	for i := range statefulSets {
+		if statefulSets[i].Name == cluster.Name {
+			foundRolling = true
+		} else {
+			foundBlueGreen = true
+		}
+	}
+	if foundRolling && foundBlueGreen {
+		return "", fmt.Errorf("cannot infer current upgrade strategy while both rolling and revisioned voter StatefulSets exist")
+	}
+	if foundBlueGreen {
+		return openbaov1alpha1.UpdateStrategyBlueGreen, nil
+	}
+	return openbaov1alpha1.UpdateStrategyRollingUpdate, nil
+}
+
+func hasActiveClusterOperation(cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if cluster == nil {
+		return false
+	}
+	if cluster.Status.OperationLock != nil || cluster.Status.Upgrade != nil {
+		return true
+	}
+	if cluster.Status.BlueGreen != nil &&
+		cluster.Status.BlueGreen.Phase != "" &&
+		cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseIdle {
+		return true
+	}
+	return cluster.Status.BreakGlass != nil && cluster.Status.BreakGlass.Active
+}
+
+func validateIdleStrategyTransitionStatus(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	desired openbaov1alpha1.UpdateStrategyType,
+) error {
+	if !cluster.Status.Initialized {
+		return fmt.Errorf("finish cluster initialization before changing spec.upgrade.strategy")
+	}
+	if cluster.Status.Phase != openbaov1alpha1.ClusterPhaseRunning {
+		return fmt.Errorf("wait for status.phase=Running before changing spec.upgrade.strategy; current phase is %q", cluster.Status.Phase)
+	}
+	if strings.TrimSpace(cluster.Status.CurrentVersion) != strings.TrimSpace(cluster.Spec.Version) {
+		return fmt.Errorf(
+			"finish or recover the current version transition before changing spec.upgrade.strategy: status.currentVersion=%q spec.version=%q",
+			cluster.Status.CurrentVersion,
+			cluster.Spec.Version,
+		)
+	}
+	if cluster.Status.ReadyReplicas != cluster.Spec.Replicas {
+		return fmt.Errorf(
+			"wait for all voter replicas to become ready before changing spec.upgrade.strategy: ready=%d desired=%d",
+			cluster.Status.ReadyReplicas,
+			cluster.Spec.Replicas,
+		)
+	}
+	if available := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionAvailable)); available == nil || available.Status != metav1.ConditionTrue {
+		return fmt.Errorf("wait for the Available condition to become True before changing spec.upgrade.strategy")
+	}
+	if degraded := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionDegraded)); degraded != nil && degraded.Status == metav1.ConditionTrue && degraded.Reason != ReasonUpgradeStrategyTransitionBlocked {
+		return fmt.Errorf("resolve the Degraded condition before changing spec.upgrade.strategy")
+	}
+	if cluster.Status.Workload != nil && cluster.Status.Workload.LastError != nil {
+		return fmt.Errorf("resolve the workload controller error before changing spec.upgrade.strategy")
+	}
+	if cluster.Status.Upgrade != nil {
+		return fmt.Errorf("finish or recover the rolling upgrade before changing spec.upgrade.strategy")
+	}
+	if cluster.Status.OperationLock != nil {
+		return fmt.Errorf(
+			"wait for the %s operation lock held by %q to clear before changing spec.upgrade.strategy",
+			cluster.Status.OperationLock.Operation,
+			cluster.Status.OperationLock.Holder,
+		)
+	}
+	if cluster.Status.BreakGlass != nil && cluster.Status.BreakGlass.Active {
+		return fmt.Errorf("recover the cluster from safe mode before changing spec.upgrade.strategy")
+	}
+	if err := validateIdleBlueGreenStatus(cluster.Status.BlueGreen); err != nil {
+		return err
+	}
+	if RetryRequestPending(cluster) || PromoteRequestPending(cluster) || RollbackRequestPending(cluster) {
+		return fmt.Errorf("finish or clear pending spec.upgrade.requests before changing spec.upgrade.strategy")
+	}
+	if cluster.Spec.ReadReplicas != nil && cluster.Spec.ReadReplicas.Replicas > 0 {
+		if cluster.Status.ReadReplicas == nil {
+			return fmt.Errorf("wait for read replica status before changing spec.upgrade.strategy")
+		}
+		if cluster.Status.ReadReplicas.ReadyReplicas != cluster.Spec.ReadReplicas.Replicas {
+			return fmt.Errorf(
+				"wait for read replicas to become ready before changing spec.upgrade.strategy: ready=%d desired=%d",
+				cluster.Status.ReadReplicas.ReadyReplicas,
+				cluster.Spec.ReadReplicas.Replicas,
+			)
+		}
+	}
+	if desired != openbaov1alpha1.UpdateStrategyRollingUpdate && desired != openbaov1alpha1.UpdateStrategyBlueGreen {
+		return fmt.Errorf("unsupported requested upgrade strategy %q", desired)
+	}
+	return nil
+}
+
+func validateIdleBlueGreenStatus(status *openbaov1alpha1.BlueGreenStatus) error {
+	if status == nil {
+		return nil
+	}
+	if status.Phase != "" && status.Phase != openbaov1alpha1.PhaseIdle {
+		return fmt.Errorf("finish or recover the blue/green phase %q before changing spec.upgrade.strategy", status.Phase)
+	}
+	if strings.TrimSpace(status.GreenRevision) != "" {
+		return fmt.Errorf("remove the Green revision before changing spec.upgrade.strategy")
+	}
+	if status.StartTime != nil || status.RollbackStartTime != nil || status.ManualPromotionRequired {
+		return fmt.Errorf("finish the blue/green promotion or rollback before changing spec.upgrade.strategy")
+	}
+	if status.JobFailureCount != 0 || strings.TrimSpace(status.LastJobFailure) != "" {
+		return fmt.Errorf("recover the blue/green job failure state before changing spec.upgrade.strategy")
+	}
+	return nil
+}
+
+func validateBlueGreenTransitionPrerequisites(cluster *openbaov1alpha1.OpenBaoCluster) error {
+	if cluster.Spec.Upgrade == nil {
+		return fmt.Errorf("spec.upgrade is required when switching to BlueGreen")
+	}
+	if strings.TrimSpace(resolveUpgradeJWTAuthRole(cluster)) == "" {
+		return fmt.Errorf(
+			"switching to BlueGreen requires spec.upgrade.jwtAuthRole or the default role from spec.selfInit.oidc bootstrap",
+		)
+	}
+	if _, err := resolveUpgradeExecutorImage(cluster, ""); err != nil {
+		return fmt.Errorf("resolve BlueGreen upgrade executor image: %w", err)
+	}
+	return nil
+}
+
+func (m *StrategyTransitionManager) validateSteadyWorkload(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (*appsv1.StatefulSet, error) {
+	statefulSets, err := m.voterStatefulSets(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	activeName := StableVoterStatefulSetName(cluster)
+	var active *appsv1.StatefulSet
+	for i := range statefulSets {
+		if statefulSets[i].Name == activeName {
+			active = &statefulSets[i]
+			continue
+		}
+		return nil, fmt.Errorf(
+			"remove non-active voter StatefulSet %s before changing spec.upgrade.strategy",
+			statefulSets[i].Name,
+		)
+	}
+	if active == nil {
+		return nil, fmt.Errorf("active voter StatefulSet %s/%s was not found", cluster.Namespace, activeName)
+	}
+	if err := validateStatefulSetSteady(cluster, active); err != nil {
+		return nil, err
+	}
+	if err := m.validateVoterPodsSteady(ctx, cluster, activeName, active.Status.CurrentRevision); err != nil {
+		return nil, err
+	}
+	if err := m.validateNoPVCResizePending(ctx, cluster); err != nil {
+		return nil, err
+	}
+	return active, nil
+}
+
+func (m *StrategyTransitionManager) voterStatefulSets(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) ([]appsv1.StatefulSet, error) {
+	list := &appsv1.StatefulSetList{}
+	if err := m.reader.List(ctx, list, client.InNamespace(cluster.Namespace), client.MatchingLabels(resourceidentity.Labels(cluster))); err != nil {
+		return nil, fmt.Errorf("list managed StatefulSets: %w", err)
+	}
+
+	readName := resourceidentity.ReadReplicaStatefulSetName(cluster)
+	statefulSets := make([]appsv1.StatefulSet, 0, len(list.Items))
+	for i := range list.Items {
+		if list.Items[i].Name == readName {
+			continue
+		}
+		statefulSets = append(statefulSets, list.Items[i])
+	}
+	return statefulSets, nil
+}
+
+func validateStatefulSetSteady(cluster *openbaov1alpha1.OpenBaoCluster, sts *appsv1.StatefulSet) error {
+	desired := cluster.Spec.Replicas
+	if sts.Status.ObservedGeneration < sts.Generation ||
+		sts.Spec.Replicas == nil || *sts.Spec.Replicas != desired ||
+		sts.Status.Replicas != desired ||
+		sts.Status.CurrentReplicas != desired ||
+		sts.Status.ReadyReplicas != desired {
+		return fmt.Errorf("wait for voter StatefulSet %s to finish scaling or restarting before changing spec.upgrade.strategy", sts.Name)
+	}
+	if strings.TrimSpace(sts.Status.CurrentRevision) == "" {
+		return fmt.Errorf("wait for voter StatefulSet %s to report its current revision before changing spec.upgrade.strategy", sts.Name)
+	}
+	if sts.Spec.UpdateStrategy.Type != appsv1.OnDeleteStatefulSetStrategyType &&
+		(sts.Status.UpdatedReplicas != desired || sts.Status.CurrentRevision != sts.Status.UpdateRevision) {
+		return fmt.Errorf("wait for voter StatefulSet %s revisions to converge before changing spec.upgrade.strategy", sts.Name)
+	}
+	if sts.Spec.UpdateStrategy.RollingUpdate != nil &&
+		sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil &&
+		*sts.Spec.UpdateStrategy.RollingUpdate.Partition != 0 {
+		return fmt.Errorf("wait for voter StatefulSet %s rolling partition to reach zero before changing spec.upgrade.strategy", sts.Name)
+	}
+	return nil
+}
+
+func (m *StrategyTransitionManager) validateVoterPodsSteady(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	activeStatefulSetName string,
+	currentControllerRevision string,
+) error {
+	pods := &corev1.PodList{}
+	if err := m.reader.List(
+		ctx,
+		pods,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels(resourceidentity.VoterPodSelectorLabels(cluster)),
+	); err != nil {
+		return fmt.Errorf("list voter pods: %w", err)
+	}
+	if len(pods.Items) != int(cluster.Spec.Replicas) {
+		return fmt.Errorf(
+			"wait for exactly %d active voter pods before changing spec.upgrade.strategy; found %d",
+			cluster.Spec.Replicas,
+			len(pods.Items),
+		)
+	}
+	expectedPodNames := make(map[string]struct{}, cluster.Spec.Replicas)
+	for ordinal := int32(0); ordinal < cluster.Spec.Replicas; ordinal++ {
+		expectedPodNames[fmt.Sprintf("%s-%d", activeStatefulSetName, ordinal)] = struct{}{}
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if _, expected := expectedPodNames[pod.Name]; !expected {
+			return fmt.Errorf("remove non-active voter pod %s before changing spec.upgrade.strategy", pod.Name)
+		}
+		if pod.DeletionTimestamp != nil || !podReady(pod) {
+			return fmt.Errorf("wait for voter pod %s to become Ready before changing spec.upgrade.strategy", pod.Name)
+		}
+		if revision := strings.TrimSpace(pod.Labels[appsv1.ControllerRevisionHashLabelKey]); revision != strings.TrimSpace(currentControllerRevision) {
+			return fmt.Errorf("wait for voter pod %s to converge on current controller revision %q before changing spec.upgrade.strategy", pod.Name, currentControllerRevision)
+		}
+	}
+	return nil
+}
+
+func (m *StrategyTransitionManager) validateNoPVCResizePending(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) error {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := m.reader.List(ctx, pvcs, client.InNamespace(cluster.Namespace), client.MatchingLabels(resourceidentity.Labels(cluster))); err != nil {
+		return fmt.Errorf("list managed PVCs: %w", err)
+	}
+	for i := range pvcs.Items {
+		for _, condition := range pvcs.Items[i].Status.Conditions {
+			if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending && condition.Status == corev1.ConditionTrue {
+				return fmt.Errorf("finish the filesystem resize for PVC %s before changing spec.upgrade.strategy", pvcs.Items[i].Name)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeStrategyTransitionStatus(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	desired openbaov1alpha1.UpdateStrategyType,
+	activeStatefulSet *appsv1.StatefulSet,
+) {
+	cluster.Status.Upgrade = nil
+	if desired == openbaov1alpha1.UpdateStrategyBlueGreen {
+		if cluster.Status.BlueGreen == nil {
+			cluster.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{}
+		}
+		cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseIdle
+		cluster.Status.BlueGreen.BlueRevision = strings.TrimSpace(activeStatefulSet.Spec.Template.Labels[constants.LabelOpenBaoRevision])
+		cluster.Status.BlueGreen.BlueControllerRevision = strings.TrimSpace(activeStatefulSet.Status.CurrentRevision)
+		cluster.Status.BlueGreen.BlueImage = strings.TrimSpace(containerImage(activeStatefulSet.Spec.Template.Spec.Containers, constants.ContainerBao))
+	}
+	core.ResetBlueGreenTransientState(cluster.Status.BlueGreen)
+}
+
+func podReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func containerImage(containers []corev1.Container, name string) string {
+	for i := range containers {
+		if containers[i].Name == name {
+			return containers[i].Image
+		}
+	}
+	return ""
+}

--- a/internal/service/upgrade/strategy_transition_test.go
+++ b/internal/service/upgrade/strategy_transition_test.go
@@ -1,0 +1,397 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+)
+
+func TestStrategyTransitionManager_AcceptsIdleTransitionsWithoutRenamingStableWorkload(t *testing.T) {
+	tests := []struct {
+		name               string
+		accepted           openbaov1alpha1.UpdateStrategyType
+		desired            openbaov1alpha1.UpdateStrategyType
+		blueRevision       string
+		statefulSetName    string
+		controllerRevision string
+	}{
+		{
+			name:               "rolling to bluegreen preserves unrevisioned workload",
+			accepted:           openbaov1alpha1.UpdateStrategyRollingUpdate,
+			desired:            openbaov1alpha1.UpdateStrategyBlueGreen,
+			statefulSetName:    "bao",
+			controllerRevision: "bao-6d89f76c4b",
+		},
+		{
+			name:               "bluegreen to rolling preserves revisioned workload",
+			accepted:           openbaov1alpha1.UpdateStrategyBlueGreen,
+			desired:            openbaov1alpha1.UpdateStrategyRollingUpdate,
+			blueRevision:       "blue123",
+			statefulSetName:    "bao-blue123",
+			controllerRevision: "bao-blue123-7f6b8c9d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := healthyStrategyTransitionCluster(tt.accepted, tt.desired, tt.blueRevision)
+			sts := steadyStrategyStatefulSet(cluster, tt.statefulSetName, tt.blueRevision, tt.controllerRevision)
+			if tt.accepted == openbaov1alpha1.UpdateStrategyBlueGreen {
+				// A stable OnDelete workload can legitimately retain healthy pods on
+				// currentRevision while its post-promotion template advances.
+				sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType}
+				sts.Status.UpdatedReplicas = 0
+				sts.Status.UpdateRevision = tt.controllerRevision + "-desired"
+			}
+			objects := []client.Object{sts}
+			for ordinal := int32(0); ordinal < cluster.Spec.Replicas; ordinal++ {
+				objects = append(objects, readyStrategyPod(cluster, tt.statefulSetName, tt.blueRevision, tt.controllerRevision, ordinal))
+			}
+
+			scheme := runtime.NewScheme()
+			if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add OpenBao scheme: %v", err)
+			}
+			if err := appsv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add apps scheme: %v", err)
+			}
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add core scheme: %v", err)
+			}
+
+			manager := NewStrategyTransitionManager(fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build())
+			result, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
+			if err != nil {
+				t.Fatalf("Reconcile() error = %v", err)
+			}
+			if result.RequeueAfter <= 0 {
+				t.Fatalf("Reconcile() requeue = %s, want positive", result.RequeueAfter)
+			}
+			if cluster.Status.AcceptedUpgradeStrategy != tt.desired {
+				t.Fatalf("accepted strategy = %q, want %q", cluster.Status.AcceptedUpgradeStrategy, tt.desired)
+			}
+			if got := StableVoterStatefulSetName(cluster); got != tt.statefulSetName {
+				t.Fatalf("stable StatefulSet = %q, want %q", got, tt.statefulSetName)
+			}
+			if tt.desired == openbaov1alpha1.UpdateStrategyRollingUpdate && cluster.Status.BlueGreen.PreUpgradeSnapshotJobName != "preserved-history" {
+				t.Fatalf("durable BlueGreen history was not preserved: %#v", cluster.Status.BlueGreen)
+			}
+
+			if tt.desired == openbaov1alpha1.UpdateStrategyBlueGreen {
+				if cluster.Status.BlueGreen == nil {
+					t.Fatal("BlueGreen status was not initialized")
+				}
+				if cluster.Status.BlueGreen.BlueRevision != "" {
+					t.Fatalf("Blue revision = %q, want unrevisioned", cluster.Status.BlueGreen.BlueRevision)
+				}
+				if cluster.Status.BlueGreen.BlueControllerRevision != tt.controllerRevision {
+					t.Fatalf("Blue controller revision = %q, want %q", cluster.Status.BlueGreen.BlueControllerRevision, tt.controllerRevision)
+				}
+			}
+		})
+	}
+}
+
+func TestStrategyTransitionManager_DefersWhileOperationActive(t *testing.T) {
+	cluster := healthyStrategyTransitionCluster(
+		openbaov1alpha1.UpdateStrategyRollingUpdate,
+		openbaov1alpha1.UpdateStrategyBlueGreen,
+		"",
+	)
+	cluster.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+		Operation: openbaov1alpha1.ClusterOperationBackup,
+		Holder:    "backup-manager",
+	}
+
+	manager := NewStrategyTransitionManager(fake.NewClientBuilder().Build())
+	result, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("Reconcile() requeue = %s, want zero so active manager can continue", result.RequeueAfter)
+	}
+	if cluster.Status.AcceptedUpgradeStrategy != openbaov1alpha1.UpdateStrategyRollingUpdate {
+		t.Fatalf("accepted strategy changed during active operation: %q", cluster.Status.AcceptedUpgradeStrategy)
+	}
+}
+
+func TestValidateIdleStrategyTransitionStatus_Blockers(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*openbaov1alpha1.OpenBaoCluster)
+		wantErr string
+	}{
+		{name: "initializing", mutate: func(c *openbaov1alpha1.OpenBaoCluster) { c.Status.Initialized = false }, wantErr: "finish cluster initialization"},
+		{name: "not running", mutate: func(c *openbaov1alpha1.OpenBaoCluster) { c.Status.Phase = openbaov1alpha1.ClusterPhaseUpgrading }, wantErr: "status.phase=Running"},
+		{name: "version transition", mutate: func(c *openbaov1alpha1.OpenBaoCluster) { c.Status.CurrentVersion = "2.5.5" }, wantErr: "finish or recover the current version transition"},
+		{name: "voters not ready", mutate: func(c *openbaov1alpha1.OpenBaoCluster) { c.Status.ReadyReplicas = 2 }, wantErr: "all voter replicas"},
+		{name: "unavailable", mutate: func(c *openbaov1alpha1.OpenBaoCluster) { c.Status.Conditions = nil }, wantErr: "Available condition"},
+		{name: "degraded", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.Conditions = append(c.Status.Conditions, metav1.Condition{Type: string(openbaov1alpha1.ConditionDegraded), Status: metav1.ConditionTrue})
+		}, wantErr: "Degraded condition"},
+		{name: "workload error", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.Workload = &openbaov1alpha1.WorkloadControllerStatus{LastError: &openbaov1alpha1.ControllerErrorStatus{Reason: "ApplyFailed"}}
+		}, wantErr: "workload controller error"},
+		{name: "rolling failure", mutate: func(c *openbaov1alpha1.OpenBaoCluster) { c.Status.Upgrade = &openbaov1alpha1.UpgradeProgress{} }, wantErr: "rolling upgrade"},
+		{name: "operation lock", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{Operation: openbaov1alpha1.ClusterOperationRestore}
+		}, wantErr: "operation lock"},
+		{name: "safe mode", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.BreakGlass = &openbaov1alpha1.BreakGlassStatus{Active: true}
+		}, wantErr: "safe mode"},
+		{name: "bluegreen active", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseSyncing}
+		}, wantErr: "blue/green phase"},
+		{name: "green remains", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseIdle, GreenRevision: "green"}
+		}, wantErr: "remove the Green revision"},
+		{name: "job failure", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseIdle, JobFailureCount: 1}
+		}, wantErr: "job failure state"},
+		{name: "pending request", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Spec.Upgrade.Requests = &openbaov1alpha1.UpgradeRequestConfig{Retry: "retry-1"}
+		}, wantErr: "pending spec.upgrade.requests"},
+		{name: "read replica status missing", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 1}
+		}, wantErr: "read replica status"},
+		{name: "read replicas not ready", mutate: func(c *openbaov1alpha1.OpenBaoCluster) {
+			c.Spec.ReadReplicas = &openbaov1alpha1.ReadReplicaConfig{Replicas: 2}
+			c.Status.ReadReplicas = &openbaov1alpha1.ReadReplicaStatus{ReadyReplicas: 1}
+		}, wantErr: "read replicas to become ready"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := healthyStrategyTransitionCluster(
+				openbaov1alpha1.UpdateStrategyRollingUpdate,
+				openbaov1alpha1.UpdateStrategyBlueGreen,
+				"",
+			)
+			tt.mutate(cluster)
+			err := validateIdleStrategyTransitionStatus(cluster, openbaov1alpha1.UpdateStrategyBlueGreen)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateIdleStrategyTransitionStatus() error = %v, want contains %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateIdleStrategyTransitionStatus_RetriesOwnBlockedCondition(t *testing.T) {
+	cluster := healthyStrategyTransitionCluster(
+		openbaov1alpha1.UpdateStrategyBlueGreen,
+		openbaov1alpha1.UpdateStrategyRollingUpdate,
+		"blue123",
+	)
+	cluster.Status.Conditions = append(cluster.Status.Conditions, metav1.Condition{
+		Type:   string(openbaov1alpha1.ConditionDegraded),
+		Status: metav1.ConditionTrue,
+		Reason: ReasonUpgradeStrategyTransitionBlocked,
+	})
+
+	if err := validateIdleStrategyTransitionStatus(cluster, openbaov1alpha1.UpdateStrategyRollingUpdate); err != nil {
+		t.Fatalf("validateIdleStrategyTransitionStatus() error = %v, want self-reported transition block to be retried", err)
+	}
+}
+
+func TestNormalizeStrategyTransitionStatus_RefreshesHistoricalBlueBaseline(t *testing.T) {
+	cluster := healthyStrategyTransitionCluster(
+		openbaov1alpha1.UpdateStrategyRollingUpdate,
+		openbaov1alpha1.UpdateStrategyBlueGreen,
+		"",
+	)
+	cluster.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{
+		BlueRevision:              "stale-revision",
+		BlueControllerRevision:    "stale-controller-revision",
+		BlueImage:                 "openbao/openbao:stale",
+		PreUpgradeSnapshotJobName: "preserved-history",
+	}
+	sts := steadyStrategyStatefulSet(cluster, cluster.Name, "", "bao-current-controller-revision")
+
+	normalizeStrategyTransitionStatus(cluster, openbaov1alpha1.UpdateStrategyBlueGreen, sts)
+
+	if cluster.Status.BlueGreen.BlueRevision != "" {
+		t.Fatalf("BlueRevision = %q, want unrevisioned rolling baseline", cluster.Status.BlueGreen.BlueRevision)
+	}
+	if cluster.Status.BlueGreen.BlueControllerRevision != "bao-current-controller-revision" {
+		t.Fatalf("BlueControllerRevision = %q, want current controller revision", cluster.Status.BlueGreen.BlueControllerRevision)
+	}
+	if cluster.Status.BlueGreen.BlueImage != cluster.Spec.Image {
+		t.Fatalf("BlueImage = %q, want %q", cluster.Status.BlueGreen.BlueImage, cluster.Spec.Image)
+	}
+	if cluster.Status.BlueGreen.PreUpgradeSnapshotJobName != "preserved-history" {
+		t.Fatalf("durable history was not preserved: %#v", cluster.Status.BlueGreen)
+	}
+}
+
+func TestStrategyTransitionManager_BlocksNonSteadyWorkload(t *testing.T) {
+	cluster := healthyStrategyTransitionCluster(
+		openbaov1alpha1.UpdateStrategyRollingUpdate,
+		openbaov1alpha1.UpdateStrategyBlueGreen,
+		"",
+	)
+	sts := steadyStrategyStatefulSet(cluster, cluster.Name, "", "bao-abc")
+	sts.Status.ReadyReplicas = 2
+
+	scheme := runtime.NewScheme()
+	_ = openbaov1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	manager := NewStrategyTransitionManager(fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts).Build())
+
+	_, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want blocked transition")
+	}
+	if reason, ok := operatorerrors.Reason(err); !ok || reason != ReasonUpgradeStrategyTransitionBlocked {
+		t.Fatalf("Reconcile() reason = %q, %v; want %q", reason, ok, ReasonUpgradeStrategyTransitionBlocked)
+	}
+	if cluster.Status.AcceptedUpgradeStrategy != openbaov1alpha1.UpdateStrategyRollingUpdate {
+		t.Fatalf("accepted strategy changed for non-steady workload: %q", cluster.Status.AcceptedUpgradeStrategy)
+	}
+}
+
+func TestStrategyTransitionManager_BlocksOrphanedRevisionPod(t *testing.T) {
+	cluster := healthyStrategyTransitionCluster(
+		openbaov1alpha1.UpdateStrategyRollingUpdate,
+		openbaov1alpha1.UpdateStrategyBlueGreen,
+		"",
+	)
+	sts := steadyStrategyStatefulSet(cluster, cluster.Name, "", "bao-abc")
+	objects := []client.Object{sts}
+	for ordinal := int32(0); ordinal < cluster.Spec.Replicas-1; ordinal++ {
+		objects = append(objects, readyStrategyPod(cluster, cluster.Name, "", "bao-abc", ordinal))
+	}
+	objects = append(objects, readyStrategyPod(cluster, "bao-orphan-revision", "orphan-revision", "bao-orphan", 0))
+
+	scheme := runtime.NewScheme()
+	_ = openbaov1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	manager := NewStrategyTransitionManager(fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build())
+
+	_, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
+	if err == nil || !strings.Contains(err.Error(), "remove non-active voter pod bao-orphan-revision-0") {
+		t.Fatalf("Reconcile() error = %v, want orphaned revision pod blocker", err)
+	}
+	if cluster.Status.AcceptedUpgradeStrategy != openbaov1alpha1.UpdateStrategyRollingUpdate {
+		t.Fatalf("accepted strategy changed with orphaned revision pod: %q", cluster.Status.AcceptedUpgradeStrategy)
+	}
+}
+
+func healthyStrategyTransitionCluster(
+	accepted openbaov1alpha1.UpdateStrategyType,
+	desired openbaov1alpha1.UpdateStrategyType,
+	blueRevision string,
+) *openbaov1alpha1.OpenBaoCluster {
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "bao", Namespace: "tenant"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Version:  "2.6.0",
+			Image:    "quay.io/openbao/openbao:2.6.0",
+			Replicas: 3,
+			Upgrade: &openbaov1alpha1.UpgradeConfig{
+				Strategy:    desired,
+				JWTAuthRole: "upgrade-role",
+				Image:       "ghcr.io/dc-tec/openbao-upgrade:test",
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Initialized:             true,
+			Phase:                   openbaov1alpha1.ClusterPhaseRunning,
+			CurrentVersion:          "2.6.0",
+			ReadyReplicas:           3,
+			AcceptedUpgradeStrategy: accepted,
+			Conditions: []metav1.Condition{
+				{Type: string(openbaov1alpha1.ConditionAvailable), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	if accepted == openbaov1alpha1.UpdateStrategyBlueGreen {
+		cluster.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{
+			Phase:                     openbaov1alpha1.PhaseIdle,
+			BlueRevision:              blueRevision,
+			BlueImage:                 cluster.Spec.Image,
+			PreUpgradeSnapshotJobName: "preserved-history",
+		}
+	}
+	return cluster
+}
+
+func steadyStrategyStatefulSet(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	name string,
+	revision string,
+	controllerRevision string,
+) *appsv1.StatefulSet {
+	labels := resourceidentity.Labels(cluster)
+	labels[constants.LabelOpenBaoWorkloadPool] = constants.LabelValueOpenBaoWorkloadPoolVoter
+	templateLabels := resourceidentity.VoterPodSelectorLabels(cluster)
+	if revision != "" {
+		templateLabels[constants.LabelOpenBaoRevision] = revision
+	}
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cluster.Namespace, Labels: labels, Generation: 1},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To(cluster.Spec.Replicas),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: templateLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: constants.ContainerBao, Image: cluster.Spec.Image}}},
+			},
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					Partition: ptr.To(int32(0)),
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           cluster.Spec.Replicas,
+			CurrentReplicas:    cluster.Spec.Replicas,
+			ReadyReplicas:      cluster.Spec.Replicas,
+			UpdatedReplicas:    cluster.Spec.Replicas,
+			CurrentRevision:    controllerRevision,
+			UpdateRevision:     controllerRevision,
+		},
+	}
+}
+
+func readyStrategyPod(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	statefulSetName string,
+	revision string,
+	controllerRevision string,
+	ordinal int32,
+) *corev1.Pod {
+	labels := resourceidentity.VoterPodSelectorLabels(cluster)
+	labels[appsv1.ControllerRevisionHashLabelKey] = controllerRevision
+	if revision != "" {
+		labels[constants.LabelOpenBaoRevision] = revision
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", statefulSetName, ordinal),
+			Namespace: cluster.Namespace,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}

--- a/internal/service/workload/bluegreen_state.go
+++ b/internal/service/workload/bluegreen_state.go
@@ -10,27 +10,25 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/revision"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
 // IsBlueGreenStrategy returns true when the cluster is configured for blue/green upgrades.
 func IsBlueGreenStrategy(cluster *openbaov1alpha1.OpenBaoCluster) bool {
-	return cluster != nil &&
-		cluster.Spec.Upgrade != nil &&
-		cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen
+	return portworkload.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen
 }
 
 // BlueGreenStableRevision returns the currently-active stable revision ("Blue").
 // If status does not yet contain BlueRevision, a deterministic spec-derived revision is returned.
 func BlueGreenStableRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
-	if !IsBlueGreenStrategy(cluster) {
-		return ""
+	if cluster.Status.BlueGreen != nil {
+		// A non-nil status with an empty revision intentionally identifies the
+		// original unrevisioned StatefulSet after RollingUpdate -> BlueGreen.
+		return strings.TrimSpace(cluster.Status.BlueGreen.BlueRevision)
 	}
 
-	if cluster.Status.BlueGreen != nil {
-		blueRevision := strings.TrimSpace(cluster.Status.BlueGreen.BlueRevision)
-		if blueRevision != "" {
-			return blueRevision
-		}
+	if !IsBlueGreenStrategy(cluster) {
+		return ""
 	}
 
 	return revision.OpenBaoClusterRevision(
@@ -44,14 +42,7 @@ func BlueGreenStableRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
 // Traffic remains on Blue by default and switches to Green only in Cleanup phase.
 func BlueGreenActiveRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
 	blueRevision := BlueGreenStableRevision(cluster)
-	if blueRevision == "" {
-		return ""
-	}
-	if cluster.Status.BlueGreen == nil {
-		return blueRevision
-	}
-
-	if cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseCleanup {
+	if cluster != nil && cluster.Status.BlueGreen != nil && cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseCleanup {
 		greenRevision := strings.TrimSpace(cluster.Status.BlueGreen.GreenRevision)
 		if greenRevision != "" {
 			return greenRevision

--- a/internal/service/workload/bluegreen_state_test.go
+++ b/internal/service/workload/bluegreen_state_test.go
@@ -43,6 +43,12 @@ func TestBlueGreenActiveRevision_SwitchesInCleanup(t *testing.T) {
 	if got := BlueGreenActiveRevision(cluster); got != "blue-rev" {
 		t.Fatalf("expected blue revision before cleanup phase, got %q", got)
 	}
+
+	cluster.Status.BlueGreen.BlueRevision = ""
+	cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseCleanup
+	if got := BlueGreenActiveRevision(cluster); got != "green-rev" {
+		t.Fatalf("expected green revision in cleanup after unrevisioned Blue, got %q", got)
+	}
 }
 
 func TestEnsureBlueGreenStatus_PrefersCurrentVersionImageDuringUpgrade(t *testing.T) {

--- a/internal/service/workload/compute.go
+++ b/internal/service/workload/compute.go
@@ -16,7 +16,9 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
 // ErrStatefulSetPrerequisitesMissing indicates that required prerequisites (ConfigMap or TLS Secret)
@@ -173,16 +175,19 @@ func (m *Manager) EnsureStatefulSet(ctx context.Context, logger logr.Logger, clu
 		// the controllers reconcile concurrently, the workload controller must ensure the partition
 		// is locked before it applies an upgrade template, otherwise Kubernetes may roll all pods
 		// immediately and bypass the orchestrated upgrade flow.
-		rollingStrategy := cluster.Spec.Upgrade == nil ||
-			cluster.Spec.Upgrade.Strategy == "" ||
-			cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyRollingUpdate
+		rollingStrategy := portworkload.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyRollingUpdate
 		pendingVersionUpgrade := rollingStrategy &&
 			spec.Pool == constants.LabelValueOpenBaoWorkloadPoolVoter &&
 			initialized &&
-			spec.Revision == "" &&
 			cluster.Status.Upgrade == nil &&
 			cluster.Status.CurrentVersion != "" &&
 			cluster.Status.CurrentVersion != cluster.Spec.Version
+
+		if spec.Pool == constants.LabelValueOpenBaoWorkloadPoolVoter && !pendingVersionUpgrade {
+			if err := m.reconcileIdleStatefulSetUpdateStrategy(ctx, logger, cluster, existingSTS, rollingStrategy); err != nil {
+				return err
+			}
+		}
 
 		if pendingVersionUpgrade {
 			var existingPartition *int32
@@ -232,6 +237,67 @@ func (m *Manager) EnsureStatefulSet(ctx context.Context, logger logr.Logger, clu
 
 	if err := m.reconcileMaintenanceAnnotationsForPods(ctx, logger, cluster, spec); err != nil {
 		return fmt.Errorf("failed to reconcile maintenance annotations for OpenBaoCluster %s/%s pods: %w", cluster.Namespace, cluster.Name, err)
+	}
+
+	return nil
+}
+
+func (m *Manager) reconcileIdleStatefulSetUpdateStrategy(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	existingSTS *appsv1.StatefulSet,
+	rollingStrategy bool,
+) error {
+	if existingSTS == nil {
+		return nil
+	}
+
+	patched := existingSTS.DeepCopy()
+	if rollingStrategy {
+		if existingSTS.Spec.UpdateStrategy.Type != appsv1.OnDeleteStatefulSetStrategyType {
+			return nil
+		}
+
+		partition := int32(0)
+		if existingSTS.Status.CurrentRevision != "" &&
+			existingSTS.Status.UpdateRevision != "" &&
+			existingSTS.Status.CurrentRevision != existingSTS.Status.UpdateRevision {
+			// Preserve healthy OnDelete pods when the stable Blue workload has a
+			// newer post-promotion template. The next rolling version upgrade owns
+			// the partition and will advance these pods under normal orchestration.
+			partition = cluster.Spec.Replicas
+		}
+		patched.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+				Partition: &partition,
+			},
+		}
+		logger.Info("Restoring RollingUpdate StatefulSet strategy after idle strategy transition",
+			"statefulset", existingSTS.Name,
+			"partition", partition)
+	} else {
+		if existingSTS.Spec.UpdateStrategy.Type == appsv1.OnDeleteStatefulSetStrategyType &&
+			existingSTS.Spec.UpdateStrategy.RollingUpdate == nil {
+			return nil
+		}
+
+		// A typed SSA object cannot clear the API-defaulted rollingUpdate payload
+		// while changing the discriminator to OnDelete. Patch the union atomically
+		// first so Kubernetes never validates a mixed OnDelete/RollingUpdate value.
+		patched.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.OnDeleteStatefulSetStrategyType,
+		}
+		logger.Info("Setting OnDelete StatefulSet strategy after idle strategy transition",
+			"statefulset", existingSTS.Name)
+	}
+
+	if err := resourceownership.RequireOwnerProof("change workload StatefulSet update strategy", existingSTS, cluster); err != nil {
+		return err
+	}
+	if err := m.client.Patch(ctx, patched, client.MergeFrom(existingSTS)); err != nil {
+		return fmt.Errorf("failed to change update strategy on StatefulSet %s/%s: %w", cluster.Namespace, existingSTS.Name, err)
 	}
 
 	return nil

--- a/internal/service/workload/compute_strategy_test.go
+++ b/internal/service/workload/compute_strategy_test.go
@@ -1,0 +1,85 @@
+package workload
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestReconcileIdleStatefulSetUpdateStrategySwitchesToOnDeleteAtomically(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	partition := int32(0)
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, workloadOwnershipRef(cluster), 3)
+	statefulSet.UID = types.UID("stable-statefulset-uid")
+	statefulSet.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+			Partition: &partition,
+		},
+	}
+	mgr := workloadOwnershipManager(cluster, statefulSet)
+
+	if err := mgr.reconcileIdleStatefulSetUpdateStrategy(context.Background(), logr.Discard(), cluster, statefulSet, false); err != nil {
+		t.Fatalf("reconcileIdleStatefulSetUpdateStrategy() error = %v", err)
+	}
+
+	stored := &appsv1.StatefulSet{}
+	if err := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), stored); err != nil {
+		t.Fatalf("get transitioned StatefulSet: %v", err)
+	}
+	if stored.UID != statefulSet.UID {
+		t.Fatalf("StatefulSet UID = %q, want stable UID %q", stored.UID, statefulSet.UID)
+	}
+	if stored.Spec.UpdateStrategy.Type != appsv1.OnDeleteStatefulSetStrategyType {
+		t.Fatalf("update strategy type = %q, want %q", stored.Spec.UpdateStrategy.Type, appsv1.OnDeleteStatefulSetStrategyType)
+	}
+	if stored.Spec.UpdateStrategy.RollingUpdate != nil {
+		t.Fatalf("rollingUpdate = %#v, want nil for OnDelete", stored.Spec.UpdateStrategy.RollingUpdate)
+	}
+}
+
+func TestReconcileIdleStatefulSetUpdateStrategySwitchesToRollingUpdate(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, workloadOwnershipRef(cluster), 3)
+	statefulSet.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.OnDeleteStatefulSetStrategyType,
+	}
+	statefulSet.Status.CurrentRevision = "current-blue-revision"
+	statefulSet.Status.UpdateRevision = "post-promotion-template-revision"
+	mgr := workloadOwnershipManager(cluster, statefulSet)
+
+	if err := mgr.reconcileIdleStatefulSetUpdateStrategy(context.Background(), logr.Discard(), cluster, statefulSet, true); err != nil {
+		t.Fatalf("reconcileIdleStatefulSetUpdateStrategy() error = %v", err)
+	}
+
+	stored := &appsv1.StatefulSet{}
+	if err := mgr.client.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), stored); err != nil {
+		t.Fatalf("get transitioned StatefulSet: %v", err)
+	}
+	if stored.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		t.Fatalf("update strategy type = %q, want %q", stored.Spec.UpdateStrategy.Type, appsv1.RollingUpdateStatefulSetStrategyType)
+	}
+	if stored.Spec.UpdateStrategy.RollingUpdate == nil || stored.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+		t.Fatalf("rollingUpdate partition = %#v, want %d", stored.Spec.UpdateStrategy.RollingUpdate, cluster.Spec.Replicas)
+	}
+	if partition := *stored.Spec.UpdateStrategy.RollingUpdate.Partition; partition != cluster.Spec.Replicas {
+		t.Fatalf("rollingUpdate partition = %d, want %d", partition, cluster.Spec.Replicas)
+	}
+}
+
+func TestReconcileIdleStatefulSetUpdateStrategyRejectsUnownedStatefulSet(t *testing.T) {
+	cluster := workloadOwnershipCluster()
+	statefulSet := workloadOwnershipStatefulSet(cluster.Name, cluster.Namespace, nil, 3)
+	statefulSet.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+	mgr := workloadOwnershipManager(cluster, statefulSet)
+
+	err := mgr.reconcileIdleStatefulSetUpdateStrategy(context.Background(), logr.Discard(), cluster, statefulSet, false)
+	if err == nil || !strings.Contains(err.Error(), "requires OpenBaoCluster owner proof") {
+		t.Fatalf("reconcileIdleStatefulSetUpdateStrategy() error = %v, want owner proof error", err)
+	}
+}

--- a/internal/service/workload/manager.go
+++ b/internal/service/workload/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
 // Manager reconciles workload-owned resources for an OpenBaoCluster.
@@ -168,7 +169,7 @@ func (m *Manager) ensureConfigMapWithName(ctx context.Context, cluster *openbaov
 
 func (m *Manager) applyResource(ctx context.Context, obj client.Object, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	if sts, ok := obj.(*appsv1.StatefulSet); ok &&
-		(cluster.Spec.Upgrade == nil || cluster.Spec.Upgrade.Strategy != openbaov1alpha1.UpdateStrategyBlueGreen) {
+		portworkload.EffectiveStrategy(cluster) != openbaov1alpha1.UpdateStrategyBlueGreen {
 		resolvedCluster, err := resourceapply.ResolveOwnerIdentity(ctx, m.client, cluster)
 		if err != nil {
 			return err

--- a/internal/service/workload/statefulset_builder_spec.go
+++ b/internal/service/workload/statefulset_builder_spec.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
 func desiredStatefulSetReplicas(cluster *openbaov1alpha1.OpenBaoCluster, initialized bool, spec StatefulSetSpec) int32 {
@@ -109,7 +110,7 @@ func buildStatefulSetUpdateStrategy(cluster *openbaov1alpha1.OpenBaoCluster, spe
 	// Important: The rolling upgrade manager controls the RollingUpdate.Partition field to
 	// orchestrate upgrades. The workload manager strips updateStrategy from StatefulSet
 	// SSA patches for non-BlueGreen clusters to avoid clearing/overriding that partition value.
-	if cluster.Spec.Upgrade != nil && cluster.Spec.Upgrade.Strategy == openbaov1alpha1.UpdateStrategyBlueGreen {
+	if portworkload.EffectiveStrategy(cluster) == openbaov1alpha1.UpdateStrategyBlueGreen {
 		return appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.OnDeleteStatefulSetStrategyType,
 		}

--- a/release-notes/0.4.2.md
+++ b/release-notes/0.4.2.md
@@ -1,0 +1,67 @@
+OpenBao Operator 0.4.2 allows an existing `OpenBaoCluster` to change its
+upgrade strategy while the cluster is healthy and idle. This gives clusters
+configured for `BlueGreen` a supported path to use the validated rolling
+upgrade to OpenBao 2.6.x without snapshotting and recreating the cluster.
+
+If you do not use `BlueGreen` and do not plan to switch to it, there is no need
+to update from OpenBao Operator 0.4.1 to 0.4.2. Version 0.4.1 already supports
+the validated rolling upgrade to OpenBao 2.6.x. Upgrade to 0.4.2 when an
+existing cluster needs to change its upgrade strategy.
+
+### Idle Upgrade Strategy Switching
+
+Initialized clusters can now change `spec.upgrade.strategy` in either
+direction:
+
+- `BlueGreen` to `RollingUpdate`
+- `RollingUpdate` to `BlueGreen`
+
+The operator accepts a strategy change only after every voter and configured
+read replica is Ready, `status.currentVersion` equals `spec.version`, and no
+upgrade, rollback, backup, restore, resize, restart, Green workload, pending
+request, failure, operation lock, or safe-mode recovery is active. Unsafe
+changes are rejected with recovery guidance.
+
+Patch only `spec.upgrade.strategy`, then wait for
+`status.acceptedUpgradeStrategy` to report the requested strategy before
+changing `spec.version`, `spec.image`, replicas, storage, or restart controls.
+The active StatefulSet and its PVCs remain the stable workload during the
+strategy transition.
+
+Switching to `BlueGreen` requires a resolvable upgrade executor image and a JWT
+role with the BlueGreen upgrade capabilities. Self-init policies created for a
+rolling-origin cluster are not rewritten by a later strategy change, so update
+that role policy before requesting `BlueGreen` when necessary.
+
+### OpenBao 2.6.x Upgrade Guidance
+
+The mixed-version OpenBao incompatibility remains: a pre-2.6 Blue leader cannot
+safely promote a 2.6-or-newer Green revision. OpenBao Operator continues to
+block that BlueGreen transition before deploying Green.
+
+For an existing pre-2.6 cluster configured for `BlueGreen`:
+
+1. Upgrade the OpenBao Operator CRDs and controller to 0.4.2.
+2. Let the cluster return to a healthy BlueGreen `Idle` state.
+3. Change only `spec.upgrade.strategy` to `RollingUpdate`.
+4. Wait for `status.acceptedUpgradeStrategy=RollingUpdate`.
+5. Request the OpenBao 2.6.x version change separately.
+
+Do not combine the strategy and OpenBao version changes in one request.
+Clusters that already use `RollingUpdate` can remain on OpenBao Operator 0.4.1
+for the validated OpenBao 2.6.x rolling upgrade.
+
+### CRD Upgrade Required
+
+This patch adds `status.acceptedUpgradeStrategy` and
+`status.upgrade.blueGreen.blueControllerRevision` to the `OpenBaoCluster` CRD.
+Apply the 0.4.2 CRDs before upgrading the controller. Helm does not upgrade
+installed CRDs automatically:
+
+```sh
+kubectl apply -f https://github.com/dc-tec/openbao-operator/releases/download/0.4.2/crds.yaml
+```
+
+The existing 0.4.0 versioned documentation remains the release-line snapshot
+and has been refreshed with the strategy-switch procedure, OpenBao 2.6.x
+guidance, and the new status fields.

--- a/test/e2e/Upgrade_Strategy_Switch_test.go
+++ b/test/e2e/Upgrade_Strategy_Switch_test.go
@@ -1,0 +1,242 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/test/e2e/framework"
+	e2ehelpers "github.com/dc-tec/openbao-operator/test/e2e/helpers"
+)
+
+const strategySwitchUpgradeRole = "strategy-switch-upgrade"
+
+const strategySwitchUpgradePolicy = `path "sys/health" { capabilities = ["read"] }
+path "sys/step-down" { capabilities = ["sudo", "update"] }
+path "sys/storage/raft/snapshot" { capabilities = ["read"] }
+path "sys/storage/raft/autopilot/state" { capabilities = ["read"] }
+path "sys/storage/raft/join" { capabilities = ["update"] }
+path "sys/storage/raft/configuration" { capabilities = ["read", "update"] }
+path "sys/storage/raft/remove-peer" { capabilities = ["update"] }
+path "sys/storage/raft/promote" { capabilities = ["update"] }
+path "sys/storage/raft/demote" { capabilities = ["update"] }`
+
+var _ = Describe("Upgrade Strategy Switching", Label("upgrade", "rolling", "bluegreen", "slow"), Ordered, func() {
+	ctx := context.Background()
+
+	var (
+		tenantNamespace string
+		tenantFW        *framework.Framework
+		cluster         *openbaov1alpha1.OpenBaoCluster
+		admin           client.Client
+	)
+
+	BeforeAll(func() {
+		var err error
+		tenantFW, err = framework.NewSetup(ctx, "tenant-strategy-switch", operatorNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		tenantNamespace = tenantFW.Namespace
+		admin = tenantFW.Client
+
+		selfInitRequests := append([]openbaov1alpha1.SelfInitRequest{}, e2ehelpers.CreateE2ERequests(tenantNamespace)...)
+		selfInitRequests = append(selfInitRequests, e2ehelpers.CreateJWTPolicyRoleRequests(
+			tenantNamespace,
+			"strategy-switch-cluster-upgrade-serviceaccount",
+			strategySwitchUpgradeRole,
+			strategySwitchUpgradeRole,
+			strategySwitchUpgradePolicy,
+		)...)
+
+		cluster = &openbaov1alpha1.OpenBaoCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "strategy-switch-cluster",
+				Namespace: tenantNamespace,
+			},
+			Spec: openbaov1alpha1.OpenBaoClusterSpec{
+				Profile:  openbaov1alpha1.ProfileDevelopment,
+				Version:  defaultBlueGreenUpgradeFromVersion,
+				Image:    fmt.Sprintf("openbao/openbao:%s", defaultBlueGreenUpgradeFromVersion),
+				Replicas: 3,
+				InitContainer: &openbaov1alpha1.InitContainerConfig{
+					Enabled: true,
+					Image:   configInitImage,
+				},
+				SelfInit: &openbaov1alpha1.SelfInitConfig{
+					Enabled: true,
+					OIDC: &openbaov1alpha1.SelfInitOIDCConfig{
+						Enabled: true,
+					},
+					Requests: selfInitRequests,
+				},
+				TLS: openbaov1alpha1.TLSConfig{
+					Enabled:        true,
+					Mode:           openbaov1alpha1.TLSModeOperatorManaged,
+					RotationPeriod: "720h",
+				},
+				Storage: openbaov1alpha1.StorageConfig{Size: "1Gi"},
+				Network: &openbaov1alpha1.NetworkConfig{APIServerCIDR: apiServerCIDR},
+				Upgrade: &openbaov1alpha1.UpgradeConfig{
+					Strategy:    openbaov1alpha1.UpdateStrategyRollingUpdate,
+					Image:       upgradeExecutorImage,
+					JWTAuthRole: strategySwitchUpgradeRole,
+					BlueGreen: &openbaov1alpha1.BlueGreenConfig{
+						AutoPromote: true,
+						Verification: &openbaov1alpha1.VerificationConfig{
+							MinSyncDuration: "15s",
+						},
+					},
+				},
+				DeletionPolicy: openbaov1alpha1.DeletionPolicyDeleteAll,
+			},
+		}
+		Expect(admin.Create(ctx, cluster)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: tenantNamespace}, updated)).To(Succeed())
+			g.Expect(updated.Status.Initialized).To(BeTrue())
+			g.Expect(updated.Status.CurrentVersion).To(Equal(defaultBlueGreenUpgradeFromVersion))
+			g.Expect(updated.Status.AcceptedUpgradeStrategy).To(Equal(openbaov1alpha1.UpdateStrategyRollingUpdate))
+			available := meta.FindStatusCondition(updated.Status.Conditions, string(openbaov1alpha1.ConditionAvailable))
+			g.Expect(available).NotTo(BeNil())
+			g.Expect(available.Status).To(Equal(metav1.ConditionTrue))
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		if tenantFW != nil {
+			_ = tenantFW.Cleanup(ctx)
+		}
+	})
+
+	It("switches both directions at idle and preserves the active workload", Label(
+		"case:idle-upgrade-strategy-switch",
+		"covers:upgrade-strategy-switch",
+		"covers:stable-workload-identity",
+	), func() {
+		key := types.NamespacedName{Name: cluster.Name, Namespace: tenantNamespace}
+
+		By("recording the initial rolling StatefulSet identity")
+		initialSTS := &appsv1.StatefulSet{}
+		Expect(admin.Get(ctx, key, initialSTS)).To(Succeed())
+		initialUID := initialSTS.UID
+
+		By("switching only the idle strategy from RollingUpdate to BlueGreen")
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			original := updated.DeepCopy()
+			updated.Spec.Upgrade.Strategy = openbaov1alpha1.UpdateStrategyBlueGreen
+			g.Expect(admin.Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
+		}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			g.Expect(updated.Status.AcceptedUpgradeStrategy).To(Equal(openbaov1alpha1.UpdateStrategyBlueGreen))
+			g.Expect(updated.Status.BlueGreen).NotTo(BeNil())
+			g.Expect(updated.Status.BlueGreen.Phase).To(Equal(openbaov1alpha1.PhaseIdle))
+			g.Expect(updated.Status.BlueGreen.BlueRevision).To(BeEmpty())
+			g.Expect(updated.Status.BlueGreen.BlueControllerRevision).NotTo(BeEmpty())
+
+			stable := &appsv1.StatefulSet{}
+			g.Expect(admin.Get(ctx, key, stable)).To(Succeed())
+			g.Expect(stable.UID).To(Equal(initialUID))
+			g.Expect(stable.Spec.UpdateStrategy.Type).To(Equal(appsv1.OnDeleteStatefulSetStrategyType))
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		By("performing a blue-green upgrade from 2.4.4 to 2.5.5")
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			original := updated.DeepCopy()
+			updated.Spec.Version = defaultBlueGreenUpgradeToVersion
+			updated.Spec.Image = fmt.Sprintf("openbao/openbao:%s", defaultBlueGreenUpgradeToVersion)
+			g.Expect(admin.Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
+		}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		var promotedStatefulSetName string
+		var promotedStatefulSetUID types.UID
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			g.Expect(updated.Status.CurrentVersion).To(Equal(defaultBlueGreenUpgradeToVersion))
+			g.Expect(updated.Status.BlueGreen).NotTo(BeNil())
+			g.Expect(updated.Status.BlueGreen.Phase).To(Equal(openbaov1alpha1.PhaseIdle))
+			g.Expect(updated.Status.BlueGreen.BlueRevision).NotTo(BeEmpty())
+
+			promotedStatefulSetName = fmt.Sprintf("%s-%s", cluster.Name, updated.Status.BlueGreen.BlueRevision)
+			stable := &appsv1.StatefulSet{}
+			g.Expect(admin.Get(ctx, types.NamespacedName{Name: promotedStatefulSetName, Namespace: tenantNamespace}, stable)).To(Succeed())
+			g.Expect(stable.Status.ReadyReplicas).To(Equal(cluster.Spec.Replicas))
+			promotedStatefulSetUID = stable.UID
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		By("switching only the idle strategy from BlueGreen to RollingUpdate")
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			original := updated.DeepCopy()
+			updated.Spec.Upgrade.Strategy = openbaov1alpha1.UpdateStrategyRollingUpdate
+			g.Expect(admin.Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
+		}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			g.Expect(updated.Status.AcceptedUpgradeStrategy).To(Equal(openbaov1alpha1.UpdateStrategyRollingUpdate))
+
+			stable := &appsv1.StatefulSet{}
+			g.Expect(admin.Get(ctx, types.NamespacedName{Name: promotedStatefulSetName, Namespace: tenantNamespace}, stable)).To(Succeed())
+			g.Expect(stable.UID).To(Equal(promotedStatefulSetUID))
+			g.Expect(stable.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateStatefulSetStrategyType))
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		By("performing a rolling upgrade from 2.5.5 to 2.6.0 against the same StatefulSet")
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			original := updated.DeepCopy()
+			updated.Spec.Version = defaultUpgradeToVersion
+			updated.Spec.Image = fmt.Sprintf("openbao/openbao:%s", defaultUpgradeToVersion)
+			g.Expect(admin.Patch(ctx, updated, client.MergeFrom(original))).To(Succeed())
+		}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			updated := &openbaov1alpha1.OpenBaoCluster{}
+			g.Expect(admin.Get(ctx, key, updated)).To(Succeed())
+			g.Expect(updated.Status.CurrentVersion).To(Equal(defaultUpgradeToVersion))
+			g.Expect(updated.Status.Upgrade).To(BeNil())
+
+			stable := &appsv1.StatefulSet{}
+			g.Expect(admin.Get(ctx, types.NamespacedName{Name: promotedStatefulSetName, Namespace: tenantNamespace}, stable)).To(Succeed())
+			g.Expect(stable.UID).To(Equal(promotedStatefulSetUID))
+
+			pods := &corev1.PodList{}
+			g.Expect(admin.List(ctx, pods,
+				client.InNamespace(tenantNamespace),
+				client.MatchingLabels{
+					constants.LabelOpenBaoCluster:      cluster.Name,
+					constants.LabelOpenBaoWorkloadPool: constants.LabelValueOpenBaoWorkloadPoolVoter,
+				},
+			)).To(Succeed())
+			g.Expect(pods.Items).To(HaveLen(int(cluster.Spec.Replicas)))
+			for _, pod := range pods.Items {
+				e2ehelpers.ExpectOpenBaoPodVersion(g, pod, defaultUpgradeToVersion)
+			}
+		}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+	})
+})

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -11,10 +11,10 @@ Notes:
 
 ## Summary
 
-- Files: `19`
-- Specs: `82`
-- Explicit case IDs: `33`
-- Coverage tags: `44`
+- Files: `20`
+- Specs: `83`
+- Explicit case IDs: `34`
+- Coverage tags: `46`
 
 ## Suites
 
@@ -36,6 +36,7 @@ Notes:
 | [Tenant Isolation](suites/Tenant_Isolation_test.md) | 6 | 0 | 0 | `security`, `tenant`, `tenancy`, `critical`, `single-tenant` | `test/e2e/Tenant_Isolation_test.go` |
 | [Upgrade Strategies: Operation Lock Contention](suites/Upgrade_Operation_Lock_test.md) | 1 | 1 | 0 | `upgrade`, `backup`, `operation-lock`, `slow`, `e2e-anchor` | `test/e2e/Upgrade_Operation_Lock_test.go` |
 | [Upgrade Strategies](suites/Upgrade_Strategies_test.md) | 12 | 6 | 0 | `upgrade`, `upgrades`, `cluster`, `slow`, `bluegreen`, `verification`, `e2e-anchor`, `failure`, `gateway`, `requires-gateway-api`, `tls-passthrough`, `rollback`, `rolling`, `recovery`, `snapshot`, `read-replicas`, `read-replicas-rolling`, `chaos` | `test/e2e/Upgrade_Strategies_test.go` |
+| [Upgrade Strategy Switching](suites/Upgrade_Strategy_Switch_test.md) | 1 | 1 | 0 | `upgrade`, `rolling`, `bluegreen`, `slow` | `test/e2e/Upgrade_Strategy_Switch_test.go` |
 | [Upgrade Strategies: Blue/Green Drift](suites/Upgrade_Target_Drift_test.md) | 1 | 1 | 0 | `upgrade`, `bluegreen`, `slow` | `test/e2e/Upgrade_Target_Drift_test.go` |
 | [Security: Anti-Tamper Policy](suites/anti_tamper_policy_test.md) | 2 | 2 | 0 | `security`, `tamper`, `cluster`, `slow` | `test/e2e/anti_tamper_policy_test.go` |
 | [DR: Storage Providers Backup & Restore](suites/backup_restore_test.md) | 7 | 5 | 0 | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `provider-smoke`, `failure-injection`, `read-replicas`, `read-replicas-restore` | `test/e2e/backup_restore_test.go` |
@@ -79,6 +80,7 @@ Notes:
 | `rolling-upgrade` | 1 |
 | `scale-reconcile` | 1 |
 | `secret-regeneration` | 1 |
+| `stable-workload-identity` | 1 |
 | `stale-green-cleanup` | 1 |
 | `statefulset-protection` | 1 |
 | `target-revision-drift` | 1 |
@@ -88,3 +90,4 @@ Notes:
 | `tls-san` | 1 |
 | `tls-secret-cleanup` | 1 |
 | `tls-verification` | 1 |
+| `upgrade-strategy-switch` | 1 |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -2588,6 +2588,48 @@
     "suiteTitle": ""
   },
   {
+    "id": "idle-upgrade-strategy-switch",
+    "generatedId": "upgrade-strategy-switch-switches-both-directions-at-idle-and-ac0fc484",
+    "caseLabel": "idle-upgrade-strategy-switch",
+    "coverage": [
+      "upgrade-strategy-switch",
+      "stable-workload-identity"
+    ],
+    "file": "test/e2e/Upgrade_Strategy_Switch_test.go",
+    "type": "It",
+    "name": "switches both directions at idle and preserves the active workload",
+    "path": [
+      "Upgrade Strategy Switching",
+      "switches both directions at idle and preserves the active workload"
+    ],
+    "labels": [
+      "upgrade",
+      "rolling",
+      "bluegreen",
+      "slow",
+      "case:idle-upgrade-strategy-switch",
+      "covers:upgrade-strategy-switch",
+      "covers:stable-workload-identity"
+    ],
+    "domainLabels": [
+      "upgrade",
+      "rolling",
+      "bluegreen",
+      "slow"
+    ],
+    "steps": [
+      "recording the initial rolling StatefulSet identity",
+      "switching only the idle strategy from RollingUpdate to BlueGreen",
+      "performing a blue-green upgrade from 2.4.4 to 2.5.5",
+      "switching only the idle strategy from BlueGreen to RollingUpdate",
+      "performing a rolling upgrade from 2.5.5 to 2.6.0 against the same StatefulSet"
+    ],
+    "focused": false,
+    "pending": false,
+    "suiteFile": "",
+    "suiteTitle": ""
+  },
+  {
     "id": "bluegreen-target-drift-restart",
     "generatedId": "upgrade-target-drift-abandons-an-outdated-green-revision-without-0a3dcf0d",
     "caseLabel": "bluegreen-target-drift-restart",

--- a/test/e2e/catalog/suites/Upgrade_Strategy_Switch_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Strategy_Switch_test.md
@@ -1,0 +1,30 @@
+# Upgrade Strategy Switching
+
+Source: `test/e2e/Upgrade_Strategy_Switch_test.go`
+
+Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls visible to `ginkgo outline`.
+
+## Cases
+
+| Case ID | Spec | State | Covers | Labels |
+| --- | --- | --- | --- | --- |
+| `idle-upgrade-strategy-switch` | switches both directions at idle and preserves the active workload | active | `upgrade-strategy-switch`, `stable-workload-identity` | `upgrade`, `rolling`, `bluegreen`, `slow` |
+
+## `idle-upgrade-strategy-switch`
+
+Path: `Upgrade Strategy Switching > switches both directions at idle and preserves the active workload`
+
+State: `active`
+
+Generated fallback ID: `upgrade-strategy-switch-switches-both-directions-at-idle-and-ac0fc484`
+
+Covers: `upgrade-strategy-switch`, `stable-workload-identity`
+
+Labels: `upgrade`, `rolling`, `bluegreen`, `slow`
+
+Recorded checkpoints:
+- recording the initial rolling StatefulSet identity
+- switching only the idle strategy from RollingUpdate to BlueGreen
+- performing a blue-green upgrade from 2.4.4 to 2.5.5
+- switching only the idle strategy from BlueGreen to RollingUpdate
+- performing a rolling upgrade from 2.5.5 to 2.6.0 against the same StatefulSet

--- a/test/e2e/suites.yaml
+++ b/test/e2e/suites.yaml
@@ -728,6 +728,31 @@ suites:
     nightly:
       policy: primary-version-full
 
+  - id: upgrade-strategy-switch
+    title: "Upgrade Strategy Switching"
+    owner: upgrade
+    riskTier: critical
+    isolation: global-mutator
+    files:
+      - test/e2e/Upgrade_Strategy_Switch_test.go
+    labels:
+      - upgrade
+      - rolling
+      - bluegreen
+      - slow
+    coverage:
+      - upgrade-strategy-switch
+      - stable-workload-identity
+    runtime:
+      observed: 15m
+      budget: 25m
+    ci:
+      lanes:
+        - upgrade-bluegreen-core
+      pullRequest: changed-paths
+    nightly:
+      policy: primary-version-full
+
   - id: anti-tamper-policy
     title: "Security: Anti-Tamper Policy"
     owner: security

--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/statusapply"
 	provisionerpkg "github.com/dc-tec/openbao-operator/internal/service/provisioner"
 )
 
@@ -467,6 +468,104 @@ func TestVAP_OpenBaoCluster_AllowsDefaultInitContainer(t *testing.T) {
 
 	if err := k8sClient.Create(ctx, cluster); err != nil {
 		t.Fatalf("expected OpenBaoCluster create without spec.initContainer to succeed, got: %v", err)
+	}
+}
+
+func TestVAP_OpenBaoCluster_GuardsIdleUpgradeStrategySwitches(t *testing.T) {
+	namespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, namespace)
+
+	healthyStatus := func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+		status.Initialized = true
+		status.Phase = openbaov1alpha1.ClusterPhaseRunning
+		status.CurrentVersion = testOpenBaoVersion244
+		status.ReadyReplicas = 3
+		status.AcceptedUpgradeStrategy = openbaov1alpha1.UpdateStrategyRollingUpdate
+		status.Conditions = []metav1.Condition{
+			{
+				Type:               string(openbaov1alpha1.ConditionAvailable),
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				Message:            "all voters are ready",
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+	}
+
+	cluster := newMinimalClusterObj(namespace, "cluster-strategy-switch-idle")
+	cluster.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{
+		Strategy:    openbaov1alpha1.UpdateStrategyRollingUpdate,
+		JWTAuthRole: "upgrade-role",
+	}
+	if err := k8sClient.Create(ctx, cluster); err != nil {
+		t.Fatalf("create strategy-switch cluster: %v", err)
+	}
+	updateClusterStatus(t, cluster, healthyStatus)
+
+	var latest openbaov1alpha1.OpenBaoCluster
+	key := types.NamespacedName{Namespace: namespace, Name: cluster.Name}
+	if err := k8sClient.Get(ctx, key, &latest); err != nil {
+		t.Fatalf("get cluster before RollingUpdate to BlueGreen switch: %v", err)
+	}
+	latest.Spec.Upgrade.Strategy = openbaov1alpha1.UpdateStrategyBlueGreen
+	if err := k8sClient.Update(ctx, &latest); err != nil {
+		t.Fatalf("expected healthy idle RollingUpdate to BlueGreen switch to succeed, got: %v", err)
+	}
+
+	updateClusterStatus(t, &latest, func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+		healthyStatus(status)
+		status.AcceptedUpgradeStrategy = openbaov1alpha1.UpdateStrategyBlueGreen
+		status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseIdle}
+	})
+	if err := statusapply.ApplyOpenBaoClusterOperationLockStatus(
+		ctx,
+		k8sClient,
+		&latest,
+		statusapply.OpenBaoClusterOperationLockStatusApplyOptions{},
+	); err != nil {
+		t.Fatalf("persist cleared operation lock as explicit null: %v", err)
+	}
+	var raw unstructured.Unstructured
+	raw.SetAPIVersion(openbaov1alpha1.GroupVersion.String())
+	raw.SetKind("OpenBaoCluster")
+	if err := k8sClient.Get(ctx, key, &raw); err != nil {
+		t.Fatalf("get raw cluster after explicit-null operation lock apply: %v", err)
+	}
+	operationLock, found, err := unstructured.NestedFieldNoCopy(raw.Object, "status", "operationLock")
+	if err != nil || !found || operationLock != nil {
+		t.Fatalf("expected explicit null status.operationLock, found=%v value=%#v err=%v", found, operationLock, err)
+	}
+	if err := k8sClient.Get(ctx, key, &latest); err != nil {
+		t.Fatalf("get cluster before BlueGreen to RollingUpdate switch: %v", err)
+	}
+	latest.Spec.Upgrade.Strategy = openbaov1alpha1.UpdateStrategyRollingUpdate
+	if err := k8sClient.Update(ctx, &latest); err != nil {
+		t.Fatalf("expected healthy idle BlueGreen to RollingUpdate switch to succeed, got: %v", err)
+	}
+
+	blocked := newMinimalClusterObj(namespace, "cluster-strategy-switch-blocked")
+	blocked.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{
+		Strategy:    openbaov1alpha1.UpdateStrategyRollingUpdate,
+		JWTAuthRole: "upgrade-role",
+	}
+	if err := k8sClient.Create(ctx, blocked); err != nil {
+		t.Fatalf("create blocked strategy-switch cluster: %v", err)
+	}
+	updateClusterStatus(t, blocked, func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+		healthyStatus(status)
+		status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+			Operation: openbaov1alpha1.ClusterOperationBackup,
+			Holder:    "backup-manager",
+		}
+	})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: blocked.Name}, blocked); err != nil {
+		t.Fatalf("get blocked strategy-switch cluster: %v", err)
+	}
+	blocked.Spec.Upgrade.Strategy = openbaov1alpha1.UpdateStrategyBlueGreen
+	updateErr := k8sClient.Update(ctx, blocked)
+	requireAdmissionDenied(t, updateErr)
+	if !strings.Contains(updateErr.Error(), "can change only while the cluster is initialized, healthy") {
+		t.Fatalf("unexpected strategy-switch rejection: %v", updateErr)
 	}
 }
 

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -404,7 +404,7 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	}
 }
 
-func TestKustomizeDefault_OpenBaoClusterPolicyBlocksUpgradeStrategySwitches(t *testing.T) {
+func TestKustomizeDefault_OpenBaoClusterPolicyGuardsUpgradeStrategySwitches(t *testing.T) {
 	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
 	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {
 		gvk := u.GroupVersionKind()
@@ -424,6 +424,10 @@ func TestKustomizeDefault_OpenBaoClusterPolicyBlocksUpgradeStrategySwitches(t *t
 
 	var hasRequestedStrategy bool
 	var hasPreviousStrategy bool
+	var hasStrategyChanged bool
+	var hasIdleStatusGuard bool
+	var idleStatusExpression string
+	var hasHandledRequestsGuard bool
 	for _, variable := range variables {
 		variableMap, ok := variable.(map[string]any)
 		if !ok {
@@ -435,15 +439,28 @@ func TestKustomizeDefault_OpenBaoClusterPolicyBlocksUpgradeStrategySwitches(t *t
 			hasRequestedStrategy = true
 		case "previous_upgrade_strategy":
 			hasPreviousStrategy = true
+		case "upgrade_strategy_changed":
+			hasStrategyChanged = true
+		case "upgrade_strategy_status_idle":
+			hasIdleStatusGuard = true
+			idleStatusExpression, _ = variableMap["expression"].(string)
+		case "upgrade_requests_handled":
+			hasHandledRequestsGuard = true
 		}
 	}
 
-	if !hasRequestedStrategy || !hasPreviousStrategy {
+	if !hasRequestedStrategy || !hasPreviousStrategy || !hasStrategyChanged || !hasIdleStatusGuard || !hasHandledRequestsGuard {
 		t.Fatalf(
-			"expected strategy transition variables in openbao-validate-openbaocluster policy, got requested=%v previous=%v",
+			"expected guarded strategy transition variables, got requested=%v previous=%v changed=%v idle=%v requests=%v",
 			hasRequestedStrategy,
 			hasPreviousStrategy,
+			hasStrategyChanged,
+			hasIdleStatusGuard,
+			hasHandledRequestsGuard,
 		)
+	}
+	if !strings.Contains(idleStatusExpression, "!has(oldObject.status.operationLock) || oldObject.status.operationLock == null") {
+		t.Fatalf("idle strategy transition guard must treat an SSA-cleared operation lock as idle, got %q", idleStatusExpression)
 	}
 
 	validations, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "validations")
@@ -451,26 +468,30 @@ func TestKustomizeDefault_OpenBaoClusterPolicyBlocksUpgradeStrategySwitches(t *t
 		t.Fatalf("read policy validations: found=%v err=%v", found, err)
 	}
 
-	const wantMessage = "spec.upgrade.strategy is immutable after creation; " +
-		"switching between RollingUpdate and BlueGreen is not supported."
-	var foundRule bool
+	wantMessages := []string{
+		"Change only spec.upgrade.strategy first; wait for the operator to accept it before changing version, image, replicas, storage, or restart controls.",
+		"spec.upgrade.strategy can change only while the cluster is initialized, healthy, fully ready, at spec.version, and no upgrade, backup/restore lock, restart/resize, BlueGreen phase, failure, pending Green workload, or safe-mode recovery is active.",
+		"Finish or clear pending spec.upgrade.requests before changing spec.upgrade.strategy.",
+		"Switching to BlueGreen requires spec.upgrade.jwtAuthRole or the default upgrade role created by enabled spec.selfInit.oidc bootstrap.",
+	}
+	foundMessages := make(map[string]bool, len(wantMessages))
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
 		if !ok {
 			continue
 		}
 		message, _ := validationMap["message"].(string)
-		expression, _ := validationMap["expression"].(string)
-		if message == wantMessage &&
-			strings.Contains(expression, "variables.requested_upgrade_strategy") &&
-			strings.Contains(expression, "variables.previous_upgrade_strategy") {
-			foundRule = true
-			break
+		for _, wantMessage := range wantMessages {
+			if message == wantMessage {
+				foundMessages[wantMessage] = true
+			}
 		}
 	}
 
-	if !foundRule {
-		t.Fatalf("openbao-validate-openbaocluster policy is missing the upgrade strategy immutability rule")
+	for _, wantMessage := range wantMessages {
+		if !foundMessages[wantMessage] {
+			t.Fatalf("openbao-validate-openbaocluster policy is missing strategy transition guard %q", wantMessage)
+		}
 	}
 }
 
@@ -799,7 +820,7 @@ func TestKustomizeDefault_OpenBaoRestorePolicyProtectsSecretRefs(t *testing.T) {
 	}
 }
 
-func TestKustomizeDefault_OpenBaoClusterCRDRejectsUpgradeStrategySwitches(t *testing.T) {
+func TestKustomizeDefault_OpenBaoClusterCRDDoesNotMakeUpgradeStrategyImmutable(t *testing.T) {
 	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
 	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {
 		return u.GetAPIVersion() == "apiextensions.k8s.io/v1" &&
@@ -856,12 +877,12 @@ func TestKustomizeDefault_OpenBaoClusterCRDRejectsUpgradeStrategySwitches(t *tes
 			}
 			message, _ := validationMap["message"].(string)
 			rule, _ := validationMap["rule"].(string)
-			if message == wantMessage && strings.Contains(rule, "oldSelf.upgrade.strategy") {
-				return
+			if message == wantMessage || strings.Contains(rule, "oldSelf.upgrade.strategy") {
+				t.Fatalf("v1alpha1 CRD schema still contains the upgrade strategy immutability rule: %#v", validationMap)
 			}
 		}
 
-		t.Fatalf("v1alpha1 CRD schema is missing the upgrade strategy transition rule")
+		return
 	}
 
 	t.Fatal("v1alpha1 version not found in openbaoclusters CRD")

--- a/website/versioned_docs/version-0.4.0/reference/api.md
+++ b/website/versioned_docs/version-0.4.0/reference/api.md
@@ -438,6 +438,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `phase` _[BlueGreenPhase](#bluegreenphase)_ | Phase is the current phase of the blue/green upgrade. |  | Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RestoringReadReplicas RollingBack RollbackCleanup] <br /> |
 | `blueRevision` _string_ | BlueRevision is the hash/name of the currently active cluster. |  |  |
+| `blueControllerRevision` _string_ | BlueControllerRevision is the Kubernetes StatefulSet controller revision<br />of Blue. It identifies an unrevisioned rolling workload after switching to<br />BlueGreen without requiring the existing Pods to be restarted or relabeled. |  | Optional: \{\} <br /> |
 | `blueImage` _string_ | BlueImage is the container image used by the Blue cluster.<br />This ensures the Blue cluster is not actively upgraded when spec.image changes. |  |  |
 | `greenRevision` _string_ | GreenRevision is the hash/name of the next cluster (if upgrade in progress). |  |  |
 | `manualPromotionRequired` _boolean_ | ManualPromotionRequired snapshots whether the current in-flight blue/green<br />upgrade requires an explicit spec.upgrade.requests.promote request before<br />promotion can proceed. It is derived from spec.upgrade.blueGreen.autoPromote<br />when the upgrade starts. |  | Optional: \{\} <br /> |
@@ -1093,6 +1094,7 @@ _Appears in:_
 | `readyReplicas` _integer_ | ReadyReplicas is the number of replicas that are currently Ready. |  | Optional: \{\} <br /> |
 | `readReplicas` _[ReadReplicaStatus](#readreplicastatus)_ | ReadReplicas captures observed state for the read-replica pool. |  | Optional: \{\} <br /> |
 | `currentVersion` _string_ | CurrentVersion is the OpenBao version currently running on the cluster. |  | Optional: \{\} <br /> |
+| `acceptedUpgradeStrategy` _[UpdateStrategyType](#updatestrategytype)_ | AcceptedUpgradeStrategy is the upgrade strategy the operator has accepted<br />after applying idle-state transition guards. While a requested strategy<br />change is blocked, controllers continue using this strategy so an existing<br />operation can finish safely. |  | Enum: [RollingUpdate BlueGreen] <br />Optional: \{\} <br /> |
 | `initialized` _boolean_ | Initialized indicates whether the OpenBao cluster has been initialized.<br />This is set to true after the first pod is initialized using bao operator init<br />or after self-initialization completes. |  | Optional: \{\} <br /> |
 | `selfInitialized` _boolean_ | SelfInitialized indicates whether the cluster was initialized using<br />OpenBao's self-initialization feature. When true, no root token Secret<br />exists for this cluster (the root token was auto-revoked). |  | Optional: \{\} <br /> |
 | `lastBackupTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | LastBackupTime is the timestamp of the last successful backup, if configured.<br />Deprecated: Use Backup.LastBackupTime instead. |  | Optional: \{\} <br /> |
@@ -2069,6 +2071,7 @@ _Validation:_
 - Enum: [RollingUpdate BlueGreen]
 
 _Appears in:_
+- [OpenBaoClusterStatus](#openbaoclusterstatus)
 - [UpgradeConfig](#upgradeconfig)
 
 | Field | Description |

--- a/website/versioned_docs/version-0.4.0/reference/compatibility.md
+++ b/website/versioned_docs/version-0.4.0/reference/compatibility.md
@@ -118,7 +118,7 @@ Always validate new Kubernetes or OpenBao versions in a staging environment befo
 
 <Callout type="warning" title="OpenBao 2.6.0 BlueGreen upgrade limitation">
 
-OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. A 2.6.0 Green peer cannot report Raft Autopilot health to a pre-2.6 Blue leader, so the operator blocks pre-2.6 to 2.6-or-newer `BlueGreen` transitions before creating Green resources until a compatible target is explicitly qualified. Fresh 2.6.0 clusters and rolling upgrades remain validated. Existing `BlueGreen` clusters must wait for a qualified upstream fix or restore a backup into a new target-version cluster.
+OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. A 2.6.0 Green peer cannot report Raft Autopilot health to a pre-2.6 Blue leader, so the operator blocks pre-2.6 to 2.6-or-newer `BlueGreen` transitions before creating Green resources until a compatible target is explicitly qualified. Fresh 2.6.0 clusters and rolling upgrades remain validated. Existing `BlueGreen` clusters can return to a healthy, idle state, change only `spec.upgrade.strategy` to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request 2.6.x.
 
 </Callout>
 

--- a/website/versioned_docs/version-0.4.0/reference/known-limitations.md
+++ b/website/versioned_docs/version-0.4.0/reference/known-limitations.md
@@ -41,11 +41,7 @@ journey: reference
       cells: ['Audit file storage archival', '`spec.auditFileStorage` provides a PVC-backed collector handoff and replay buffer; it does not provide rotation, pruning, tamper-proof retention, or a collector.', 'Mount the audit PVC read-only into a collector and ship records to external retention-controlled storage.'],
     },
     {
-      cells: ['Upgrade strategy switching', 'Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a supported in-place transition today.', 'Choose the strategy before the next rollout and keep it stable. Safe idle-only switching is tracked in [#548](https://github.com/dc-tec/openbao-operator/issues/548).'],
-      emphasis: 'caution',
-    },
-    {
-      cells: ['OpenBao 2.6.0 BlueGreen upgrade', 'OpenBao 2.6.0 cannot exchange Raft Autopilot health with pre-2.6 peers because its internal request-forwarding gRPC service name changed. The operator blocks pre-2.6 to 2.6-or-newer BlueGreen transitions before deploying Green until a compatible target is explicitly qualified.', 'Use a rolling upgrade on clusters already configured for RollingUpdate. Existing BlueGreen clusters must wait for a qualified upstream fix or restore a backup into a new target-version cluster.'],
+      cells: ['OpenBao 2.6.0 BlueGreen upgrade', 'OpenBao 2.6.0 cannot exchange Raft Autopilot health with pre-2.6 peers because its internal request-forwarding gRPC service name changed. The operator blocks pre-2.6 to 2.6-or-newer BlueGreen transitions before deploying Green until a compatible target is explicitly qualified.', 'Return the cluster to a healthy, idle BlueGreen state, change only `spec.upgrade.strategy` to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request 2.6.x. Fresh 2.6.x clusters and rolling upgrades remain supported.'],
       emphasis: 'caution',
     },
   ]}

--- a/website/versioned_docs/version-0.4.0/user-guide/openbaocluster/operations/upgrades.md
+++ b/website/versioned_docs/version-0.4.0/user-guide/openbaocluster/operations/upgrades.md
@@ -38,9 +38,11 @@ journey: operate
   ]}
 />
 
-<Callout type="warning" title="Do not switch strategies on an existing cluster">
+<Callout type="note" title="Switch strategies only while the cluster is idle">
 
-Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a supported in-place transition today. Choose the strategy before the next rollout and keep it stable for that cluster.
+The operator supports `RollingUpdate` to `BlueGreen` and `BlueGreen` to `RollingUpdate` without renaming or replacing the active StatefulSet. Admission allows the change only after initialization, while every voter is Ready, `status.currentVersion` equals `spec.version`, and no upgrade, backup, restore, resize, restart, Green workload, pending request, failure, or safe-mode recovery is active.
+
+Change only `spec.upgrade.strategy`, then wait until `status.acceptedUpgradeStrategy` reports the new value. Change `spec.version` or other workload settings only after that acknowledgment. A strategy change that does not meet these conditions is rejected with recovery guidance.
 
 </Callout>
 
@@ -48,7 +50,7 @@ Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a s
 
 OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. During a pre-2.6 to 2.6.0 `BlueGreen` upgrade, Green peers cannot report Raft Autopilot health to the Blue leader and therefore cannot be promoted safely. The operator rejects pre-2.6 to 2.6-or-newer transitions before creating Green resources until a compatible target is explicitly qualified.
 
-Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If the existing cluster is already configured for `BlueGreen`, wait for an operator release that qualifies an upstream compatibility fix or restore a backup into a new target-version cluster. Safe idle-only strategy switching is tracked in [#548](https://github.com/dc-tec/openbao-operator/issues/548); do not bypass the current immutability check.
+Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If a pre-2.6 cluster is configured for `BlueGreen`, first let the cluster return to a healthy `Idle` state, switch only the strategy to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request the 2.6.0 version change.
 
 </Callout>
 
@@ -85,6 +87,51 @@ Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If the exist
   - with an explicit `spec.upgrade.jwtAuthRole`
 - If you want pre-upgrade snapshots, configure `spec.backup` first and make sure the backup auth path is already working.
 - In the `Hardened` profile, explicitly allow egress to object storage or other external dependencies the upgrade path needs.
+
+## Change the strategy of an existing cluster
+
+Use this sequence in either direction. It deliberately separates the control-plane strategy transition from the next workload change.
+
+1. Finish or recover every active upgrade, backup, restore, resize, restart, promotion, rollback, or safe-mode workflow.
+2. Verify `status.phase=Running`, `status.currentVersion=spec.version`, all voter and configured read replicas are Ready, `Available=True`, and BlueGreen is absent or `Idle` with no Green revision.
+3. Ensure the BlueGreen executor prerequisites are configured before switching to `BlueGreen`: an explicit `spec.upgrade.jwtAuthRole` or the default role created by enabled `selfInit.oidc`, plus a resolvable upgrade executor image. The referenced role must already grant the BlueGreen raft join, configuration, remove-peer, promote, and demote capabilities. Self-init policies are created during initial bootstrap and are not rewritten by a later strategy change, so update the role policy first when a rolling-origin cluster was initialized with rolling-only permissions.
+4. Patch only `spec.upgrade.strategy`.
+5. Wait for `status.acceptedUpgradeStrategy` to equal the requested strategy.
+6. Patch `spec.version`, `spec.image`, replicas, storage, or restart controls in a later request.
+
+<CommandBlock
+  language="bash"
+  label="switch"
+  title="Switch an idle cluster from BlueGreen to RollingUpdate"
+  code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
+  "spec": {
+    "upgrade": {
+      "strategy": "RollingUpdate"
+    }
+  }
+}'
+
+kubectl get openbaocluster <name> -n <namespace> \
+  -o jsonpath='{.status.acceptedUpgradeStrategy}{"\\n"}'`}
+/>
+
+<CommandBlock
+  language="bash"
+  label="switch"
+  title="Switch an idle cluster from RollingUpdate to BlueGreen"
+  code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
+  "spec": {
+    "upgrade": {
+      "strategy": "BlueGreen"
+    }
+  }
+}'
+
+kubectl get openbaocluster <name> -n <namespace> \
+  -o jsonpath='{.status.acceptedUpgradeStrategy}{"\\n"}'`}
+/>
+
+The active StatefulSet and its PVCs remain the stable workload after either transition. A later rolling rollout continues against a revisioned StatefulSet when switching from BlueGreen; a later blue-green rollout treats the original unrevisioned StatefulSet as Blue when switching from RollingUpdate.
 
 <Callout type="note" title="Upgrade auth is separate from backup auth">
 


### PR DESCRIPTION
## Summary

Backport safe, idle-only upgrade strategy switching to the 0.4 release line for OpenBao Operator 0.4.2.

The change allows initialized clusters to move between `RollingUpdate` and `BlueGreen` only after all cluster and administrative workflows are idle. The operator records the accepted strategy in status, preserves the active StatefulSet and PVCs across the transition, and handles a rolling-origin StatefulSet as the initial Blue revision without restarting or relabeling the active Pods.

This provides the supported escape path for pre-2.6 clusters currently configured for `BlueGreen`: switch to `RollingUpdate`, wait for acknowledgment, then request OpenBao 2.6.x separately. The known mixed-version BlueGreen transition remains blocked.

The current and maintained 0.4 documentation, generated API reference, and human 0.4.2 release notes are included.

## Related Issues

Addresses #548 on the 0.4.x release line. The broader main-line follow-up remains separate.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

The CRD gains the additive status fields `status.acceptedUpgradeStrategy` and `status.upgrade.blueGreen.blueControllerRevision`; the 0.4.2 CRDs must be applied before the controller is upgraded.

Existing clusters that do not change strategy are unaffected. Strategy transitions fail closed unless the cluster is initialized, healthy, version-aligned, fully Ready, and free of active upgrade, backup, restore, resize, restart, rollback, Green, request, lock, failure, or safe-mode state.

OpenBao Operator 0.4.1 already supports the validated rolling upgrade to OpenBao 2.6.x. Rolling-only users do not need 0.4.2 unless they intend to change strategy.

## Verification

- `make ci-core`
- `make lint-ast`
- `make verify-generated verify-e2e-manifest`
- `npm --prefix website run build`
- Focused 0.4 backport E2E on Kind/Kubernetes 1.34.3:

  ```sh
  KIND_CLUSTER=openbao-operator-042-strategy-switch \
  KIND_NODE_IMAGE=kindest/node:v1.34.3 \
  E2E_LABEL_FILTER='case:idle-upgrade-strategy-switch' \
  E2E_FAIL_ON_EMPTY=true \
  E2E_SKIP_CLEANUP=true \
  E2E_TIMEOUT=35m \
  E2E_POLL_PROGRESS_AFTER=5m \
  make test-e2e
  ```

  Result: 1 selected, 0 failed, 82 skipped.

## Reviewer Notes

The release notes deliberately call out that 0.4.2 is not required for rolling-only users. After this backport lands, the patch release should be forced through the audited `Release-As: 0.4.2` marker workflow before reviewing the generated release-please PR.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
