### PR TITLE
docs: forward-port 0.4.x patch updates

### DIFF
--- a/website/versioned_docs/version-0.4.0/reference/api.md
+++ b/website/versioned_docs/version-0.4.0/reference/api.md
@@ -438,6 +438,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `phase` _[BlueGreenPhase](#bluegreenphase)_ | Phase is the current phase of the blue/green upgrade. |  | Enum: [Idle DeployingGreen JoiningMesh Syncing Promoting DemotingBlue Cleanup RestoringReadReplicas RollingBack RollbackCleanup] <br /> |
 | `blueRevision` _string_ | BlueRevision is the hash/name of the currently active cluster. |  |  |
+| `blueControllerRevision` _string_ | BlueControllerRevision is the Kubernetes StatefulSet controller revision<br />of Blue. It identifies an unrevisioned rolling workload after switching to<br />BlueGreen without requiring the existing Pods to be restarted or relabeled. |  | Optional: \{\} <br /> |
 | `blueImage` _string_ | BlueImage is the container image used by the Blue cluster.<br />This ensures the Blue cluster is not actively upgraded when spec.image changes. |  |  |
 | `greenRevision` _string_ | GreenRevision is the hash/name of the next cluster (if upgrade in progress). |  |  |
 | `manualPromotionRequired` _boolean_ | ManualPromotionRequired snapshots whether the current in-flight blue/green<br />upgrade requires an explicit spec.upgrade.requests.promote request before<br />promotion can proceed. It is derived from spec.upgrade.blueGreen.autoPromote<br />when the upgrade starts. |  | Optional: \{\} <br /> |
@@ -1093,6 +1094,7 @@ _Appears in:_
 | `readyReplicas` _integer_ | ReadyReplicas is the number of replicas that are currently Ready. |  | Optional: \{\} <br /> |
 | `readReplicas` _[ReadReplicaStatus](#readreplicastatus)_ | ReadReplicas captures observed state for the read-replica pool. |  | Optional: \{\} <br /> |
 | `currentVersion` _string_ | CurrentVersion is the OpenBao version currently running on the cluster. |  | Optional: \{\} <br /> |
+| `acceptedUpgradeStrategy` _[UpdateStrategyType](#updatestrategytype)_ | AcceptedUpgradeStrategy is the upgrade strategy the operator has accepted<br />after applying idle-state transition guards. While a requested strategy<br />change is blocked, controllers continue using this strategy so an existing<br />operation can finish safely. |  | Enum: [RollingUpdate BlueGreen] <br />Optional: \{\} <br /> |
 | `initialized` _boolean_ | Initialized indicates whether the OpenBao cluster has been initialized.<br />This is set to true after the first pod is initialized using bao operator init<br />or after self-initialization completes. |  | Optional: \{\} <br /> |
 | `selfInitialized` _boolean_ | SelfInitialized indicates whether the cluster was initialized using<br />OpenBao's self-initialization feature. When true, no root token Secret<br />exists for this cluster (the root token was auto-revoked). |  | Optional: \{\} <br /> |
 | `lastBackupTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | LastBackupTime is the timestamp of the last successful backup, if configured.<br />Deprecated: Use Backup.LastBackupTime instead. |  | Optional: \{\} <br /> |
@@ -2069,6 +2071,7 @@ _Validation:_
 - Enum: [RollingUpdate BlueGreen]
 
 _Appears in:_
+- [OpenBaoClusterStatus](#openbaoclusterstatus)
 - [UpgradeConfig](#upgradeconfig)
 
 | Field | Description |

--- a/website/versioned_docs/version-0.4.0/reference/compatibility.md
+++ b/website/versioned_docs/version-0.4.0/reference/compatibility.md
@@ -72,11 +72,14 @@ The current stable release line is intended for real deployments, but it remains
   columns={['Version', 'Validated', 'Support posture', 'Production note']}
   rows={[
     {
-      cells: ['2.5.x', 'PR gate, nightly E2E, and config compatibility checks', 'Best-effort supported on the latest stable line', 'Primary validated target'],
+      cells: ['2.6.x', 'PR gate, nightly E2E, rolling-upgrade coverage, and config compatibility checks', 'Best-effort supported on the latest stable line', 'Primary validated target; pre-2.6 to 2.6.0 BlueGreen upgrades are excluded by the known mixed-version limitation'],
       emphasis: 'recommended',
     },
     {
-      cells: ['2.4.x', 'Nightly config compatibility checks', 'Best-effort supported on the latest stable line', 'Validate workload behavior and upgrade flow in staging before production rollout'],
+      cells: ['2.5.x', 'Nightly config compatibility checks and rolling-upgrade source coverage', 'Best-effort compatibility', 'Validate workload behavior and the upgrade flow in staging before production rollout'],
+    },
+    {
+      cells: ['2.4.x', 'Nightly config compatibility checks', 'Maintenance compatibility only', 'Upgrade to a newer OpenBao release before production rollout'],
     },
     {
       cells: ['2.3.x', 'Not validated', 'Deprecated and out of support scope', 'Upgrade before production use'],
@@ -92,17 +95,17 @@ The current stable release line is intended for real deployments, but it remains
   columns={['Workflow', 'Scope', 'Versions tested']}
   rows={[
     {
-      cells: ['PR Gate', 'Logic, manifests, and primary compatibility path', 'K8s 1.35.1 + OpenBao 2.5.5'],
+      cells: ['PR Gate', 'Logic, manifests, and primary compatibility path', 'K8s 1.35.1 + OpenBao 2.6.0'],
       emphasis: 'recommended',
     },
     {
-      cells: ['Release Gate E2E', 'Stable release lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.5.5'],
+      cells: ['Release Gate E2E', 'Stable release lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.6.0'],
     },
     {
-      cells: ['Nightly E2E', 'Full lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.5.5'],
+      cells: ['Nightly E2E', 'Full lifecycle coverage', 'K8s 1.34.3 and 1.35.1 + OpenBao 2.6.0'],
     },
     {
-      cells: ['Nightly Config Compatibility', 'Render and config compatibility checks', 'OpenBao 2.4.4 and 2.5.5'],
+      cells: ['Nightly Config Compatibility', 'Render and config compatibility checks', 'OpenBao 2.4.4, 2.5.5, and 2.6.0'],
     },
   ]}
 />
@@ -110,6 +113,12 @@ The current stable release line is intended for real deployments, but it remains
 <Callout type="warning" title="Production upgrade rule">
 
 Always validate new Kubernetes or OpenBao versions in a staging environment before upgrading production, even when they are listed as validated and best-effort supported.
+
+</Callout>
+
+<Callout type="warning" title="OpenBao 2.6.0 BlueGreen upgrade limitation">
+
+OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. A 2.6.0 Green peer cannot report Raft Autopilot health to a pre-2.6 Blue leader, so the operator blocks pre-2.6 to 2.6-or-newer `BlueGreen` transitions before creating Green resources until a compatible target is explicitly qualified. Fresh 2.6.0 clusters and rolling upgrades remain validated. Existing `BlueGreen` clusters can return to a healthy, idle state, change only `spec.upgrade.strategy` to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request 2.6.x.
 
 </Callout>
 

--- a/website/versioned_docs/version-0.4.0/reference/known-limitations.md
+++ b/website/versioned_docs/version-0.4.0/reference/known-limitations.md
@@ -41,7 +41,7 @@ journey: reference
       cells: ['Audit file storage archival', '`spec.auditFileStorage` provides a PVC-backed collector handoff and replay buffer; it does not provide rotation, pruning, tamper-proof retention, or a collector.', 'Mount the audit PVC read-only into a collector and ship records to external retention-controlled storage.'],
     },
     {
-      cells: ['Upgrade strategy switching', 'Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a supported in-place transition today.', 'Choose the upgrade strategy before the next rollout and keep it stable for that cluster.'],
+      cells: ['OpenBao 2.6.0 BlueGreen upgrade', 'OpenBao 2.6.0 cannot exchange Raft Autopilot health with pre-2.6 peers because its internal request-forwarding gRPC service name changed. The operator blocks pre-2.6 to 2.6-or-newer BlueGreen transitions before deploying Green until a compatible target is explicitly qualified.', 'Return the cluster to a healthy, idle BlueGreen state, change only `spec.upgrade.strategy` to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request 2.6.x. Fresh 2.6.x clusters and rolling upgrades remain supported.'],
       emphasis: 'caution',
     },
   ]}

--- a/website/versioned_docs/version-0.4.0/user-guide/openbaocluster/configuration/unseal.md
+++ b/website/versioned_docs/version-0.4.0/user-guide/openbaocluster/configuration/unseal.md
@@ -244,7 +244,7 @@ metadata:
   name: bao-hsm
   namespace: openbao
 spec:
-  image: registry.example.com/openbao-hsm-vendor:2.5.5
+  image: registry.example.com/openbao-hsm-vendor:2.6.0
   unseal:
     type: pkcs11
     credentialsSecretRef:

--- a/website/versioned_docs/version-0.4.0/user-guide/openbaocluster/operations/upgrades.md
+++ b/website/versioned_docs/version-0.4.0/user-guide/openbaocluster/operations/upgrades.md
@@ -38,9 +38,19 @@ journey: operate
   ]}
 />
 
-<Callout type="warning" title="Do not switch strategies on an existing cluster">
+<Callout type="note" title="Switch strategies only while the cluster is idle">
 
-Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a supported in-place transition today. Choose the strategy before the next rollout and keep it stable for that cluster.
+The operator supports `RollingUpdate` to `BlueGreen` and `BlueGreen` to `RollingUpdate` without renaming or replacing the active StatefulSet. Admission allows the change only after initialization, while every voter is Ready, `status.currentVersion` equals `spec.version`, and no upgrade, backup, restore, resize, restart, Green workload, pending request, failure, or safe-mode recovery is active.
+
+Change only `spec.upgrade.strategy`, then wait until `status.acceptedUpgradeStrategy` reports the new value. Change `spec.version` or other workload settings only after that acknowledgment. A strategy change that does not meet these conditions is rejected with recovery guidance.
+
+</Callout>
+
+<Callout type="warning" title="OpenBao 2.6.0 cannot complete a mixed-version BlueGreen upgrade">
+
+OpenBao 2.6.0 changed its internal request-forwarding gRPC service name. During a pre-2.6 to 2.6.0 `BlueGreen` upgrade, Green peers cannot report Raft Autopilot health to the Blue leader and therefore cannot be promoted safely. The operator rejects pre-2.6 to 2.6-or-newer transitions before creating Green resources until a compatible target is explicitly qualified.
+
+Fresh 2.6.0 clusters and the `RollingUpdate` path remain supported. If a pre-2.6 cluster is configured for `BlueGreen`, first let the cluster return to a healthy `Idle` state, switch only the strategy to `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and then request the 2.6.0 version change.
 
 </Callout>
 
@@ -77,6 +87,51 @@ Switching an existing cluster between `RollingUpdate` and `BlueGreen` is not a s
   - with an explicit `spec.upgrade.jwtAuthRole`
 - If you want pre-upgrade snapshots, configure `spec.backup` first and make sure the backup auth path is already working.
 - In the `Hardened` profile, explicitly allow egress to object storage or other external dependencies the upgrade path needs.
+
+## Change the strategy of an existing cluster
+
+Use this sequence in either direction. It deliberately separates the control-plane strategy transition from the next workload change.
+
+1. Finish or recover every active upgrade, backup, restore, resize, restart, promotion, rollback, or safe-mode workflow.
+2. Verify `status.phase=Running`, `status.currentVersion=spec.version`, all voter and configured read replicas are Ready, `Available=True`, and BlueGreen is absent or `Idle` with no Green revision.
+3. Ensure the BlueGreen executor prerequisites are configured before switching to `BlueGreen`: an explicit `spec.upgrade.jwtAuthRole` or the default role created by enabled `selfInit.oidc`, plus a resolvable upgrade executor image. The referenced role must already grant the BlueGreen raft join, configuration, remove-peer, promote, and demote capabilities. Self-init policies are created during initial bootstrap and are not rewritten by a later strategy change, so update the role policy first when a rolling-origin cluster was initialized with rolling-only permissions.
+4. Patch only `spec.upgrade.strategy`.
+5. Wait for `status.acceptedUpgradeStrategy` to equal the requested strategy.
+6. Patch `spec.version`, `spec.image`, replicas, storage, or restart controls in a later request.
+
+<CommandBlock
+  language="bash"
+  label="switch"
+  title="Switch an idle cluster from BlueGreen to RollingUpdate"
+  code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
+  "spec": {
+    "upgrade": {
+      "strategy": "RollingUpdate"
+    }
+  }
+}'
+
+kubectl get openbaocluster <name> -n <namespace> \
+  -o jsonpath='{.status.acceptedUpgradeStrategy}{"\\n"}'`}
+/>
+
+<CommandBlock
+  language="bash"
+  label="switch"
+  title="Switch an idle cluster from RollingUpdate to BlueGreen"
+  code={`kubectl patch openbaocluster <name> -n <namespace> --type merge -p '{
+  "spec": {
+    "upgrade": {
+      "strategy": "BlueGreen"
+    }
+  }
+}'
+
+kubectl get openbaocluster <name> -n <namespace> \
+  -o jsonpath='{.status.acceptedUpgradeStrategy}{"\\n"}'`}
+/>
+
+The active StatefulSet and its PVCs remain the stable workload after either transition. A later rolling rollout continues against a revisioned StatefulSet when switching from BlueGreen; a later blue-green rollout treats the original unrevisioned StatefulSet as Blue when switching from RollingUpdate.
 
 <Callout type="note" title="Upgrade auth is separate from backup auth">
 


### PR DESCRIPTION
## Summary

- Forward-port the 0.4.x release-line documentation snapshot updates from `release-0.4` into `main` so subsequent GitHub Pages deployments retain the current stable documentation.
- Document OpenBao 2.6.0 validation and the mixed-version BlueGreen limitation for the 0.4.x line.
- Document idle-state upgrade strategy switching, including the accepted strategy status field and operational procedure.
- Refresh the affected 0.4.x API reference and PKCS#11 example.

## Related Issues

Related pull requests: #547, #552, and #570.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Documentation-only. There are no runtime, API, CRD, Helm, RBAC, security, or upgrade behavior changes.

After merge, the next `main` Pages deployment will publish the refreshed 0.4.x snapshot at the stable documentation routes.

## Verification

- `pnpm --dir website run verify:docs-version 0.4.2`
- `pnpm --dir website run test:e2e` — production Docusaurus build and 25 Playwright smoke tests passed.
- Confirmed all five files match their `release-0.4` counterparts exactly.
- Pre-push `make lint-ci` passed, including all 61 architecture checks.

## Reviewer Notes

The 0.4.x snapshot intentionally retains OpenBao 2.6.0 as that release line's validated target; the 2.6.1 alignment in `main` applies to next/current development documentation.

Review is limited to these five `website/versioned_docs/version-0.4.0` files:

- `reference/api.md`
- `reference/compatibility.md`
- `reference/known-limitations.md`
- `user-guide/openbaocluster/configuration/unseal.md`
- `user-guide/openbaocluster/operations/upgrades.md`

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.