### PR TITLE
fix(deps): update vulnerable brace-expansion

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,7 @@
   },
   "pnpm": {
     "overrides": {
+      "brace-expansion": "5.0.8",
       "lodash": "4.18.1",
       "lodash-es": "4.18.1",
       "serialize-javascript": "7.0.5"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion: 5.0.8
   lodash: 4.18.1
   lodash-es: 4.18.1
   serialize-javascript: 7.0.5
@@ -2465,8 +2466,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.10.44:
     resolution: {integrity: sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==}
@@ -2501,8 +2503,9 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2699,9 +2702,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -9816,7 +9816,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.44: {}
 
@@ -9872,10 +9872,9 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -10083,8 +10082,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -12154,7 +12151,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

Override the transitive `brace-expansion` dependency to `5.0.8` and regenerate the website lockfile with the repository-pinned pnpm version.

This removes the `CVE-2026-14257` finding that currently blocks the Nightly security job and dependency PRs after their Go vulnerability checks pass.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

The override changes the transitive dependency used by Docusaurus through `serve-handler` and `minimatch`. The public website dependency surface is unchanged. The production documentation build and TypeScript check pass with the updated graph.

## Verification

- `npx --yes pnpm@10.34.5 --dir website install --frozen-lockfile`
- `npx --yes pnpm@10.34.5 --dir website why brace-expansion --prod`
- `npx --yes pnpm@10.34.5 --dir website typecheck`
- `npx --yes pnpm@10.34.5 --dir website build`
- `trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed ... .`
- `make lint-ci` through the pre-push hook
- `git diff --check`

The fresh Trivy scan reports zero HIGH/CRITICAL findings in `go.mod` and `website/pnpm-lock.yaml`.

## Reviewer Notes

This is a prerequisite baseline fix for refreshing and merging dependency PR #574. The change is intentionally limited to the security override and generated lockfile.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] Tests are not added because this is a lockfile-only transitive dependency update; the docs build validates compatibility.
- [x] Documentation is not needed because user-facing behavior is unchanged.
- [x] The lockfile was regenerated with pnpm `10.34.5`; no other generated artifacts are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks documented above.
- [x] PR #574 is the dependent follow-up and will be refreshed after this change lands.