### PR TITLE
chore(ci): make GHCR cleanup graph-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             echo "docs=false" >> "${GITHUB_OUTPUT}"
           fi
 
-          if changed_matches '^(internal/|cmd/|api/|config/|test/|docs/reference/api\.md|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/(ci/|helm(chart|values)/|boilerplate\.go\.txt)|\.golangci\.yml|\.github/tools/)'; then
+          if changed_matches '^(internal/|cmd/|api/|config/|test/|docs/reference/api\.md|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/(ci/|tools/|helm(chart|values)/|boilerplate\.go\.txt)|\.golangci\.yml|\.github/tools/)'; then
             echo "go_quality=true" >> "${GITHUB_OUTPUT}"
           else
             echo "go_quality=false" >> "${GITHUB_OUTPUT}"
@@ -174,7 +174,7 @@ jobs:
             echo "go_toolchain=false" >> "${GITHUB_OUTPUT}"
           fi
 
-          if changed_matches '^(internal/|cmd/|api/|config/|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/helm(chart|values)/|test/(integration/|unit/))'; then
+          if changed_matches '^(internal/|cmd/|api/|config/|go\.(mod|sum)$|vendor/|Makefile|mk/|hack/(tools/|helm(chart|values)/)|test/(integration/|unit/))'; then
             echo "go_tests=true" >> "${GITHUB_OUTPUT}"
           else
             echo "go_tests=false" >> "${GITHUB_OUTPUT}"
@@ -186,7 +186,7 @@ jobs:
             echo "config_compat=false" >> "${GITHUB_OUTPUT}"
           fi
 
-          if changed_matches '^(internal/|cmd/|api/|config/|charts/|Dockerfile(\..*)?$|hack/ci/|go\.(mod|sum)$|vendor/|\.trivyignore|\.trivy\.yaml|Makefile|mk/)'; then
+          if changed_matches '^(internal/|cmd/|api/|config/|charts/|Dockerfile(\..*)?$|hack/(ci/|tools/)|go\.(mod|sum)$|vendor/|\.trivyignore|\.trivy\.yaml|Makefile|mk/)'; then
             echo "security_scan=true" >> "${GITHUB_OUTPUT}"
           else
             echo "security_scan=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ghcr-housekeeping.yml
+++ b/.github/workflows/ghcr-housekeeping.yml
@@ -13,6 +13,10 @@ on:
         description: "Optional safety brake override for this run (>0)"
         required: false
         type: string
+      max_delete_total:
+        description: "Optional global deletion budget override for this run (>0)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -44,6 +48,8 @@ jobs:
           MODE_VAR: ${{ vars.GHCR_HOUSEKEEPING_MODE }}
           MAX_INPUT: ${{ github.event.inputs.max_delete_per_package }}
           MAX_VAR: ${{ vars.GHCR_HOUSEKEEPING_MAX_DELETE_PER_PACKAGE }}
+          MAX_TOTAL_INPUT: ${{ github.event.inputs.max_delete_total }}
+          MAX_TOTAL_VAR: ${{ vars.GHCR_HOUSEKEEPING_MAX_DELETE_TOTAL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -84,8 +90,26 @@ jobs:
             max_delete="${MAX_VAR}"
           fi
 
-          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
-          echo "max_delete_per_package=${max_delete}" >> "${GITHUB_OUTPUT}"
+          max_delete_total="100"
+          if [[ -n "${MAX_TOTAL_INPUT:-}" ]]; then
+            if ! [[ "${MAX_TOTAL_INPUT}" =~ ^[0-9]+$ ]] || [[ "${MAX_TOTAL_INPUT}" -le 0 ]]; then
+              echo "max_delete_total must be a positive integer; got '${MAX_TOTAL_INPUT}'" >&2
+              exit 1
+            fi
+            max_delete_total="${MAX_TOTAL_INPUT}"
+          elif [[ -n "${MAX_TOTAL_VAR:-}" ]]; then
+            if ! [[ "${MAX_TOTAL_VAR}" =~ ^[0-9]+$ ]] || [[ "${MAX_TOTAL_VAR}" -le 0 ]]; then
+              echo "GHCR_HOUSEKEEPING_MAX_DELETE_TOTAL must be a positive integer; got '${MAX_TOTAL_VAR}'" >&2
+              exit 1
+            fi
+            max_delete_total="${MAX_TOTAL_VAR}"
+          fi
+
+          {
+            echo "mode=${mode}"
+            echo "max_delete_per_package=${max_delete}"
+            echo "max_delete_total=${max_delete_total}"
+          } >> "${GITHUB_OUTPUT}"
 
           owner="${GITHUB_REPOSITORY_OWNER}"
           owner_kind="user"
@@ -117,9 +141,11 @@ jobs:
           go run ./hack/tools/ghcr_housekeeping \
             --owner "${{ steps.cfg.outputs.owner }}" \
             --owner-kind "${{ steps.cfg.outputs.owner_kind }}" \
+            --registry-user "${GITHUB_ACTOR}" \
             --mode "${{ steps.cfg.outputs.mode }}" \
             --policy-file hack/tools/ghcr_housekeeping/policy.json \
             --max-delete-per-package "${{ steps.cfg.outputs.max_delete_per_package }}" \
+            --max-delete-total "${{ steps.cfg.outputs.max_delete_total }}" \
             --report-json dist/housekeeping-report.json
 
       - name: Upload housekeeping report

--- a/hack/tools/ghcr_housekeeping/graph.go
+++ b/hack/tools/ghcr_housekeeping/graph.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	mediaTypeOCIImageIndex    = "application/vnd.oci.image.index.v1+json"
+	mediaTypeDockerImageIndex = "application/vnd.docker.distribution.manifest.list.v2+json"
+	ociGraphRuleName          = "oci-graph-orphan"
+	dispositionNone           = graphDisposition("")
+	dispositionReachable      = graphDisposition("reachable")
+	dispositionGrace          = graphDisposition("grace")
+	dispositionCandidate      = graphDisposition("candidate")
+)
+
+var ociReferrerTagRegexp = regexp.MustCompile(`^sha256-([0-9a-f]{64})$`)
+
+type manifestGraphClient interface {
+	ManifestReferences(ctx context.Context, owner, pkg, digest string) ([]manifestReference, error)
+}
+
+type manifestReference struct {
+	Digest    string
+	MediaType string
+}
+
+type ociGraphResult struct {
+	Reachable map[string]struct{}
+	Roots     int
+}
+
+type graphDisposition string
+
+func resolveOCIGraph(
+	ctx context.Context,
+	owner, pkg string,
+	versions []packageVersion,
+	client manifestGraphClient,
+) (ociGraphResult, error) {
+	result := ociGraphResult{Reachable: make(map[string]struct{})}
+	if client == nil {
+		return result, errors.New("OCI graph client is required")
+	}
+
+	referrerBySubject := make(map[string]packageVersion)
+	roots := make([]packageVersion, 0)
+	for _, version := range versions {
+		normalTags, subjects := splitGraphTags(version.Tags)
+		if len(normalTags) > 0 {
+			roots = append(roots, version)
+		}
+		for _, subject := range subjects {
+			if existing, ok := referrerBySubject[subject]; ok && existing.ID != version.ID {
+				return result, fmt.Errorf(
+					"subject %s has multiple OCI referrer indexes (%d and %d)",
+					subject,
+					existing.ID,
+					version.ID,
+				)
+			}
+			referrerBySubject[subject] = version
+		}
+	}
+	result.Roots = len(roots)
+
+	queue := make([]string, 0, len(roots))
+	queued := make(map[string]struct{})
+	fetched := make(map[string]struct{})
+
+	var markReachable func(digest string, fetch bool)
+	markReachable = func(digest string, fetch bool) {
+		digest = strings.TrimSpace(digest)
+		if digest == "" {
+			return
+		}
+		result.Reachable[digest] = struct{}{}
+		if fetch {
+			if _, ok := queued[digest]; !ok {
+				queued[digest] = struct{}{}
+				queue = append(queue, digest)
+			}
+		}
+		if referrer, ok := referrerBySubject[digest]; ok {
+			if _, reachable := result.Reachable[referrer.Name]; !reachable {
+				markReachable(referrer.Name, true)
+			}
+		}
+	}
+
+	for _, root := range roots {
+		markReachable(root.Name, true)
+	}
+
+	for len(queue) > 0 {
+		digest := queue[0]
+		queue = queue[1:]
+		if _, ok := fetched[digest]; ok {
+			continue
+		}
+		fetched[digest] = struct{}{}
+
+		references, err := client.ManifestReferences(ctx, owner, pkg, digest)
+		if err != nil {
+			return result, fmt.Errorf("resolve manifest %s: %w", digest, err)
+		}
+		for _, reference := range references {
+			shouldFetch := reference.MediaType == "" || isImageIndexMediaType(reference.MediaType)
+			markReachable(reference.Digest, shouldFetch)
+		}
+	}
+
+	return result, nil
+}
+
+func splitGraphTags(tags []string) ([]string, []string) {
+	normalTags := make([]string, 0, len(tags))
+	subjects := make([]string, 0, 1)
+	for _, tag := range tags {
+		match := ociReferrerTagRegexp.FindStringSubmatch(tag)
+		if len(match) == 2 {
+			subjects = append(subjects, "sha256:"+match[1])
+			continue
+		}
+		normalTags = append(normalTags, tag)
+	}
+	return normalTags, subjects
+}
+
+func isImageIndexMediaType(mediaType string) bool {
+	return mediaType == mediaTypeOCIImageIndex || mediaType == mediaTypeDockerImageIndex
+}
+
+func graphCandidate(
+	version packageVersion,
+	normalTags []string,
+	reachable map[string]struct{},
+	orphanTTLDays int,
+	now time.Time,
+) (candidateReport, graphDisposition) {
+	isGraphManaged := len(version.Tags) == 0 || len(normalTags) == 0
+	if !isGraphManaged {
+		return candidateReport{}, dispositionNone
+	}
+	if _, ok := reachable[version.Name]; ok {
+		return candidateReport{}, dispositionReachable
+	}
+
+	ageDays := versionAgeDays(version, now)
+	if ageDays < orphanTTLDays {
+		return candidateReport{}, dispositionGrace
+	}
+
+	kind := candidateKindOCIOrphan
+	if len(version.Tags) > 0 {
+		kind = candidateKindOCIReferrerOrphan
+	}
+	return candidateReport{
+		ID:              version.ID,
+		Name:            version.Name,
+		Kind:            kind,
+		UpdatedAt:       version.UpdatedAt.UTC().Format(time.RFC3339),
+		AgeDays:         ageDays,
+		RequiredAgeDays: orphanTTLDays,
+		Tags:            append([]string{}, version.Tags...),
+		MatchedRules:    []string{ociGraphRuleName},
+	}, dispositionCandidate
+}
+
+func versionAgeDays(version packageVersion, now time.Time) int {
+	ageDays := int(now.Sub(version.UpdatedAt).Hours() / 24)
+	if ageDays < 0 {
+		return 0
+	}
+	return ageDays
+}

--- a/hack/tools/ghcr_housekeeping/graph_test.go
+++ b/hack/tools/ghcr_housekeeping/graph_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveOCIGraphFollowsRootsIndexesAndReferrers(t *testing.T) {
+	t.Parallel()
+
+	root := testDigest("a")
+	child := testDigest("b")
+	referrerIndex := testDigest("c")
+	artifact := testDigest("d")
+	orphan := testDigest("e")
+	detachedSubject := testDigest("f")
+	detachedReferrerIndex := testDigest("1")
+
+	versions := []packageVersion{
+		{ID: 1, Name: root, Tags: []string{"edge"}},
+		{ID: 2, Name: child},
+		{ID: 3, Name: referrerIndex, Tags: []string{referrerTag(root)}},
+		{ID: 4, Name: artifact},
+		{ID: 5, Name: orphan},
+		{ID: 6, Name: detachedReferrerIndex, Tags: []string{referrerTag(detachedSubject)}},
+	}
+	client := &fakeManifestGraphClient{
+		references: map[string][]manifestReference{
+			root: {
+				{Digest: child, MediaType: "application/vnd.oci.image.manifest.v1+json"},
+			},
+			referrerIndex: {
+				{Digest: artifact, MediaType: "application/vnd.oci.image.manifest.v1+json"},
+			},
+		},
+	}
+
+	result, err := resolveOCIGraph(
+		context.Background(),
+		"dc-tec",
+		"openbao-operator",
+		versions,
+		client,
+	)
+	if err != nil {
+		t.Fatalf("resolveOCIGraph() error = %v", err)
+	}
+	if result.Roots != 1 {
+		t.Fatalf("roots = %d, want 1", result.Roots)
+	}
+	for _, digest := range []string{root, child, referrerIndex, artifact} {
+		if _, ok := result.Reachable[digest]; !ok {
+			t.Errorf("reachable set is missing %s", digest)
+		}
+	}
+	for _, digest := range []string{orphan, detachedReferrerIndex} {
+		if _, ok := result.Reachable[digest]; ok {
+			t.Errorf("reachable set unexpectedly contains %s", digest)
+		}
+	}
+	if got := strings.Join(client.calls, ","); got != root+","+referrerIndex {
+		t.Fatalf("manifest calls = %q, want root then referrer index", got)
+	}
+}
+
+func TestResolveOCIGraphFailsClosedOnManifestError(t *testing.T) {
+	t.Parallel()
+
+	root := testDigest("a")
+	client := &fakeManifestGraphClient{errors: map[string]error{root: errors.New("registry unavailable")}}
+	_, err := resolveOCIGraph(
+		context.Background(),
+		"dc-tec",
+		"openbao-operator",
+		[]packageVersion{{ID: 1, Name: root, Tags: []string{"edge"}}},
+		client,
+	)
+	if err == nil || !strings.Contains(err.Error(), "registry unavailable") {
+		t.Fatalf("resolveOCIGraph() error = %v, want registry failure", err)
+	}
+}
+
+func TestSplitGraphTagsKeepsLegacyCosignTagAsRoot(t *testing.T) {
+	t.Parallel()
+
+	subject := testDigest("a")
+	normalTags, subjects := splitGraphTags([]string{
+		referrerTag(subject),
+		referrerTag(subject) + ".sig",
+		"edge",
+	})
+	if got := strings.Join(normalTags, ","); got != referrerTag(subject)+".sig,edge" {
+		t.Fatalf("normal tags = %q", got)
+	}
+	if len(subjects) != 1 || subjects[0] != subject {
+		t.Fatalf("subjects = %v", subjects)
+	}
+}
+
+func TestGraphCandidateClassifiesReachableGraceAndOrphan(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	reachableDigest := testDigest("a")
+	reachable := map[string]struct{}{reachableDigest: {}}
+
+	_, disposition := graphCandidate(
+		packageVersion{ID: 1, Name: reachableDigest, UpdatedAt: now.AddDate(0, 0, -90)},
+		nil,
+		reachable,
+		30,
+		now,
+	)
+	if disposition != dispositionReachable {
+		t.Fatalf("reachable disposition = %q, want reachable", disposition)
+	}
+
+	_, disposition = graphCandidate(
+		packageVersion{ID: 2, Name: testDigest("b"), UpdatedAt: now.AddDate(0, 0, -29)},
+		nil,
+		reachable,
+		30,
+		now,
+	)
+	if disposition != dispositionGrace {
+		t.Fatalf("young orphan disposition = %q, want grace", disposition)
+	}
+
+	candidate, disposition := graphCandidate(
+		packageVersion{ID: 3, Name: testDigest("c"), UpdatedAt: now.AddDate(0, 0, -31)},
+		nil,
+		reachable,
+		30,
+		now,
+	)
+	if disposition != dispositionCandidate {
+		t.Fatalf("old orphan disposition = %q, want candidate", disposition)
+	}
+	if candidate.Kind != candidateKindOCIOrphan || candidate.RequiredAgeDays != 30 {
+		t.Fatalf("orphan candidate = %#v", candidate)
+	}
+
+	candidate, disposition = graphCandidate(
+		packageVersion{
+			ID:        5,
+			Name:      testDigest("e"),
+			UpdatedAt: now.AddDate(0, 0, -31),
+			Tags:      []string{referrerTag(testDigest("f"))},
+		},
+		nil,
+		reachable,
+		30,
+		now,
+	)
+	if disposition != dispositionCandidate || candidate.Kind != candidateKindOCIReferrerOrphan {
+		t.Fatalf("detached referrer candidate = %#v, disposition = %q", candidate, disposition)
+	}
+
+	_, disposition = graphCandidate(
+		packageVersion{ID: 4, Name: testDigest("d"), Tags: []string{"edge"}, UpdatedAt: now.AddDate(0, 0, -90)},
+		[]string{"edge"},
+		reachable,
+		30,
+		now,
+	)
+	if disposition != "" {
+		t.Fatalf("normal tagged version disposition = %q, want policy evaluation", disposition)
+	}
+}
+
+func TestRunHousekeepingPlansGraphOrphansWithinGlobalBudget(t *testing.T) {
+	t.Parallel()
+
+	_, rules := testPolicy(t)
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	root := testDigest("a")
+	child := testDigest("b")
+	oldOrphan := testDigest("c")
+	youngOrphan := testDigest("d")
+	client := &fakePackageClient{versionsByPackage: map[string][]packageVersion{
+		"openbao-operator": {
+			{ID: 1, Name: root, UpdatedAt: now.AddDate(0, 0, -1), Tags: []string{"edge"}},
+			{ID: 2, Name: child, UpdatedAt: now.AddDate(0, 0, -1)},
+			{ID: 3, Name: oldOrphan, UpdatedAt: now.AddDate(0, 0, -40)},
+			{ID: 4, Name: youngOrphan, UpdatedAt: now.AddDate(0, 0, -20)},
+			{ID: 5, Name: testDigest("e"), UpdatedAt: now.AddDate(0, 0, -8), Tags: []string{"e2e-123-1"}},
+		},
+	}}
+	graphClient := &fakeManifestGraphClient{references: map[string][]manifestReference{
+		root: {
+			{Digest: child, MediaType: "application/vnd.oci.image.manifest.v1+json"},
+		},
+	}}
+	policy := policyConfig{
+		ProtectUnknown: true,
+		OCIGraph: ociGraphPolicy{
+			Enabled:       true,
+			OrphanTTLDays: 30,
+		},
+	}
+	opts := options{
+		Owner:               "dc-tec",
+		OwnerKind:           ownerKindUser,
+		Packages:            []string{"openbao-operator"},
+		Mode:                modeDryRun,
+		PolicyFile:          "test-policy.json",
+		MaxDeletePerPackage: 100,
+		MaxDeleteTotal:      1,
+		ReportJSON:          "dist/report.json",
+	}
+
+	report, err := runHousekeeping(context.Background(), opts, policy, rules, client, graphClient, now)
+	if err != nil {
+		t.Fatalf("runHousekeeping() error = %v", err)
+	}
+	got := report.Packages[0]
+	if got.Candidates != 2 || got.TaggedCandidates != 1 || got.OrphanCandidates != 1 {
+		t.Fatalf(
+			"candidate counts = total:%d tagged:%d orphan:%d",
+			got.Candidates,
+			got.TaggedCandidates,
+			got.OrphanCandidates,
+		)
+	}
+	if got.KeptGraphReachable != 1 || got.KeptOrphanGrace != 1 || got.KeptProtected != 1 {
+		t.Fatalf(
+			"retention counts = reachable:%d grace:%d protected:%d",
+			got.KeptGraphReachable,
+			got.KeptOrphanGrace,
+			got.KeptProtected,
+		)
+	}
+	if got.Planned != 1 {
+		t.Fatalf("planned = %d, want 1", got.Planned)
+	}
+	for _, candidate := range got.CandidateItems {
+		if candidate.ID == 3 && candidate.Planned {
+			t.Fatalf("orphan was planned before a tagged candidate: %#v", candidate)
+		}
+		if candidate.ID == 5 && !candidate.Planned {
+			t.Fatalf("tagged candidate was not planned first: %#v", candidate)
+		}
+	}
+}
+
+type fakeManifestGraphClient struct {
+	references map[string][]manifestReference
+	errors     map[string]error
+	calls      []string
+}
+
+func (f *fakeManifestGraphClient) ManifestReferences(
+	_ context.Context,
+	_, _ string,
+	digest string,
+) ([]manifestReference, error) {
+	f.calls = append(f.calls, digest)
+	if err := f.errors[digest]; err != nil {
+		return nil, err
+	}
+	return append([]manifestReference{}, f.references[digest]...), nil
+}
+
+func testDigest(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}
+
+func referrerTag(digest string) string {
+	return strings.Replace(digest, ":", "-", 1)
+}

--- a/hack/tools/ghcr_housekeeping/main.go
+++ b/hack/tools/ghcr_housekeeping/main.go
@@ -18,29 +18,33 @@ import (
 )
 
 const (
-	defaultOwner                  = "dc-tec"
-	defaultOwnerKind              = "org"
-	defaultPolicyPath             = "hack/tools/ghcr_housekeeping/policy.json"
-	defaultReportPath             = "dist/housekeeping-report.json"
-	defaultMode                   = "dry-run"
-	defaultMaxDelete              = 100
-	ownerKindOrg                  = "org"
-	ownerKindUser                 = "user"
-	modeDryRun                    = "dry-run"
-	modeEnforce                   = "enforce"
-	actionKeep                    = "keep"
-	actionDeleteAfter             = "delete_after"
-	githubAPIBaseURL              = "https://api.github.com"
-	githubAPIVersion              = "2022-11-28"
-	perPage                       = 100
-	requestTimeout                = 30 * time.Second
-	summaryEnvVar                 = "GITHUB_STEP_SUMMARY"
-	defaultErrorMessage           = "unknown API error"
-	unknownReasonUntagged         = unknownReason("untagged")
-	unknownReasonUnmatchedTag     = unknownReason("unmatched_tag")
-	unknownReasonNoTransientMatch = unknownReason("no_transient_match")
-	summaryTableHeader            = "| Package | Scanned | Candidates | Deleted | Kept protected | Kept unknown | " +
-		"Unknown untagged | Unknown unmatched | Unknown no-transient | Errors |\n"
+	defaultOwner                   = "dc-tec"
+	defaultOwnerKind               = "org"
+	defaultPolicyPath              = "hack/tools/ghcr_housekeeping/policy.json"
+	defaultReportPath              = "dist/housekeeping-report.json"
+	defaultMode                    = "dry-run"
+	defaultMaxDelete               = 100
+	defaultMaxDeleteTotal          = 100
+	ownerKindOrg                   = "org"
+	ownerKindUser                  = "user"
+	modeDryRun                     = "dry-run"
+	modeEnforce                    = "enforce"
+	actionKeep                     = "keep"
+	actionDeleteAfter              = "delete_after"
+	candidateKindTaggedTransient   = "tagged_transient"
+	candidateKindOCIReferrerOrphan = "oci_referrer_orphan"
+	candidateKindOCIOrphan         = "oci_orphan"
+	githubAPIBaseURL               = "https://api.github.com"
+	githubAPIVersion               = "2022-11-28"
+	perPage                        = 100
+	requestTimeout                 = 30 * time.Second
+	summaryEnvVar                  = "GITHUB_STEP_SUMMARY"
+	defaultErrorMessage            = "unknown API error"
+	unknownReasonUntagged          = unknownReason("untagged")
+	unknownReasonUnmatchedTag      = unknownReason("unmatched_tag")
+	unknownReasonNoTransientMatch  = unknownReason("no_transient_match")
+	summaryTableHeader             = "| Package | Scanned | Candidates | Tagged | OCI orphans | Planned | Deleted | " +
+		"Kept protected | Kept active | Kept reachable | Orphan grace | Kept unknown | Errors |\n"
 )
 
 var defaultPackages = []string{
@@ -84,16 +88,24 @@ func (m *multiStringFlag) Set(value string) error {
 type options struct {
 	Owner               string
 	OwnerKind           string
+	RegistryUser        string
 	Packages            []string
 	Mode                string
 	PolicyFile          string
 	MaxDeletePerPackage int
+	MaxDeleteTotal      int
 	ReportJSON          string
 }
 
 type policyConfig struct {
-	ProtectUnknown bool         `json:"protect_unknown"`
-	Rules          []policyRule `json:"rules"`
+	ProtectUnknown bool           `json:"protect_unknown"`
+	OCIGraph       ociGraphPolicy `json:"oci_graph"`
+	Rules          []policyRule   `json:"rules"`
+}
+
+type ociGraphPolicy struct {
+	Enabled       bool `json:"enabled"`
+	OrphanTTLDays int  `json:"orphan_ttl_days"`
 }
 
 type policyRule struct {
@@ -123,14 +135,22 @@ type runReport struct {
 	OwnerKind           string `json:"owner_kind"`
 	PolicyFile          string `json:"policy_file"`
 	MaxDeletePerPackage int    `json:"max_delete_per_package"`
+	MaxDeleteTotal      int    `json:"max_delete_total"`
 }
 
 type packageReport struct {
 	Name                        string            `json:"name"`
 	ScannedVersions             int               `json:"scanned_versions"`
 	Candidates                  int               `json:"candidates"`
+	TaggedCandidates            int               `json:"tagged_candidates"`
+	OrphanCandidates            int               `json:"orphan_candidates"`
+	Planned                     int               `json:"planned"`
 	Deleted                     int               `json:"deleted"`
 	KeptProtected               int               `json:"kept_protected"`
+	KeptActiveTransient         int               `json:"kept_active_transient"`
+	KeptGraphReachable          int               `json:"kept_graph_reachable"`
+	KeptOrphanGrace             int               `json:"kept_orphan_grace"`
+	GraphRoots                  int               `json:"graph_roots"`
 	KeptUnknown                 int               `json:"kept_unknown"`
 	KeptUnknownUntagged         int               `json:"kept_unknown_untagged"`
 	KeptUnknownUnmatchedTag     int               `json:"kept_unknown_unmatched_tag"`
@@ -142,11 +162,13 @@ type packageReport struct {
 type candidateReport struct {
 	ID              int64    `json:"id"`
 	Name            string   `json:"name"`
+	Kind            string   `json:"kind"`
 	UpdatedAt       string   `json:"updated_at"`
 	AgeDays         int      `json:"age_days"`
 	RequiredAgeDays int      `json:"required_age_days"`
 	Tags            []string `json:"tags"`
 	MatchedRules    []string `json:"matched_rules"`
+	Planned         bool     `json:"planned"`
 }
 
 type packageClient interface {
@@ -217,7 +239,17 @@ func main() {
 	}
 
 	now := time.Now().UTC()
-	report, runErr := runHousekeeping(context.Background(), opts, policy, rules, client, now)
+	registryClient := &githubContainerRegistryClient{
+		baseURL:      defaultRegistryBaseURL,
+		tokenURL:     defaultRegistryTokenURL,
+		githubToken:  token,
+		registryUser: opts.RegistryUser,
+		httpClient: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+
+	report, runErr := runHousekeeping(context.Background(), opts, policy, rules, client, registryClient, now)
 
 	if err := writeReportJSON(opts.ReportJSON, report); err != nil {
 		fmt.Fprintf(os.Stderr, "ghcr_housekeeping: write report %s: %v\n", opts.ReportJSON, err)
@@ -243,6 +275,12 @@ func parseOptions() (options, error) {
 
 	flag.StringVar(&opts.Owner, "owner", defaultOwner, "Package owner (org/user)")
 	flag.StringVar(&opts.OwnerKind, "owner-kind", defaultOwnerKind, "Owner type: org or user")
+	flag.StringVar(
+		&opts.RegistryUser,
+		"registry-user",
+		strings.TrimSpace(os.Getenv("GITHUB_ACTOR")),
+		"GitHub username used to request private GHCR pull tokens (defaults to GITHUB_ACTOR or owner)",
+	)
 	flag.Var(&pkgFlags, "package", "Container package name (repeatable). Defaults to operator image packages")
 	flag.StringVar(&opts.Mode, "mode", defaultMode, "Run mode: dry-run or enforce")
 	flag.StringVar(&opts.PolicyFile, "policy-file", defaultPolicyPath, "Policy JSON file path")
@@ -250,13 +288,20 @@ func parseOptions() (options, error) {
 		&opts.MaxDeletePerPackage,
 		"max-delete-per-package",
 		defaultMaxDelete,
-		"Safety brake: max candidates allowed per package in enforce mode",
+		"Safety brake: max tagged candidates and planned deletions per package in enforce mode",
+	)
+	flag.IntVar(
+		&opts.MaxDeleteTotal,
+		"max-delete-total",
+		defaultMaxDeleteTotal,
+		"Safety brake: max planned deletions across all packages in one run",
 	)
 	flag.StringVar(&opts.ReportJSON, "report-json", defaultReportPath, "Output JSON report path")
 	flag.Parse()
 
 	opts.Owner = strings.TrimSpace(opts.Owner)
 	opts.OwnerKind = strings.TrimSpace(opts.OwnerKind)
+	opts.RegistryUser = strings.TrimSpace(opts.RegistryUser)
 	opts.Mode = strings.TrimSpace(opts.Mode)
 	opts.PolicyFile = strings.TrimSpace(opts.PolicyFile)
 	opts.ReportJSON = strings.TrimSpace(opts.ReportJSON)
@@ -269,6 +314,9 @@ func parseOptions() (options, error) {
 
 	if opts.Owner == "" {
 		return opts, errors.New("--owner is required")
+	}
+	if opts.RegistryUser == "" {
+		opts.RegistryUser = opts.Owner
 	}
 	if opts.OwnerKind != ownerKindOrg && opts.OwnerKind != ownerKindUser {
 		return opts, fmt.Errorf("--owner-kind must be %q or %q", ownerKindOrg, ownerKindUser)
@@ -284,6 +332,9 @@ func parseOptions() (options, error) {
 	}
 	if opts.MaxDeletePerPackage <= 0 {
 		return opts, errors.New("--max-delete-per-package must be > 0")
+	}
+	if opts.MaxDeleteTotal <= 0 {
+		return opts, errors.New("--max-delete-total must be > 0")
 	}
 	for _, pkg := range opts.Packages {
 		if strings.TrimSpace(pkg) == "" {
@@ -306,6 +357,11 @@ func loadPolicy(path string) (policyConfig, []compiledRule, error) {
 	}
 	if len(cfg.Rules) == 0 {
 		return cfg, nil, fmt.Errorf("policy %s has no rules", path)
+	}
+	if cfg.OCIGraph.Enabled {
+		if cfg.OCIGraph.OrphanTTLDays <= 0 {
+			return cfg, nil, fmt.Errorf("policy %s OCI graph orphan_ttl_days must be > 0", path)
+		}
 	}
 
 	compiled := make([]compiledRule, 0, len(cfg.Rules))
@@ -352,6 +408,7 @@ func runHousekeeping(
 	policy policyConfig,
 	rules []compiledRule,
 	client packageClient,
+	graphClient manifestGraphClient,
 	now time.Time,
 ) (housekeepingReport, error) {
 	report := housekeepingReport{
@@ -362,6 +419,7 @@ func runHousekeeping(
 			OwnerKind:           opts.OwnerKind,
 			PolicyFile:          opts.PolicyFile,
 			MaxDeletePerPackage: opts.MaxDeletePerPackage,
+			MaxDeleteTotal:      opts.MaxDeleteTotal,
 		},
 		Packages: make([]packageReport, 0, len(opts.Packages)),
 	}
@@ -373,7 +431,7 @@ func runHousekeeping(
 			continue
 		}
 
-		result := processPackage(ctx, opts, policy, rules, client, now, pkg)
+		result := processPackage(ctx, opts, policy, rules, client, graphClient, now, pkg)
 		if len(result.Errors) > 0 {
 			problems = append(problems, result.Errors...)
 		}
@@ -383,42 +441,20 @@ func runHousekeeping(
 	if len(problems) > 0 {
 		return report, errors.New(strings.Join(problems, "; "))
 	}
+
+	if opts.Mode == modeEnforce {
+		problems = append(problems, validateTaggedCandidateSafety(&report, opts.MaxDeletePerPackage)...)
+	}
+	if len(problems) > 0 {
+		return report, errors.New(strings.Join(problems, "; "))
+	}
+	planDeletions(&report, opts.MaxDeletePerPackage, opts.MaxDeleteTotal)
 	if opts.Mode == modeDryRun {
 		return report, nil
 	}
 
-	for i := range report.Packages {
-		pkgReport := &report.Packages[i]
-		if len(pkgReport.CandidateItems) <= opts.MaxDeletePerPackage {
-			continue
-		}
-		errMsg := fmt.Sprintf(
-			"%s: candidate count %d exceeds max-delete-per-package=%d; use workflow_dispatch override to continue",
-			pkgReport.Name,
-			len(pkgReport.CandidateItems),
-			opts.MaxDeletePerPackage,
-		)
-		pkgReport.Errors = append(pkgReport.Errors, errMsg)
-		problems = append(problems, errMsg)
-	}
-	if len(problems) > 0 {
-		return report, errors.New(strings.Join(problems, "; "))
-	}
-
-	for i := range report.Packages {
-		pkgReport := &report.Packages[i]
-		for _, candidate := range pkgReport.CandidateItems {
-			if err := client.DeletePackageVersion(ctx, opts.OwnerKind, opts.Owner, pkgReport.Name, candidate.ID); err != nil {
-				errMsg := fmt.Sprintf("%s: delete version %d failed: %v", pkgReport.Name, candidate.ID, err)
-				pkgReport.Errors = append(pkgReport.Errors, errMsg)
-				problems = append(problems, errMsg)
-				continue
-			}
-			pkgReport.Deleted++
-		}
-	}
-	if len(problems) > 0 {
-		return report, errors.New(strings.Join(problems, "; "))
+	if err := applyDeletionPlan(ctx, opts, client, &report); err != nil {
+		return report, err
 	}
 
 	return report, nil
@@ -430,6 +466,7 @@ func processPackage(
 	policy policyConfig,
 	rules []compiledRule,
 	client packageClient,
+	graphClient manifestGraphClient,
 	now time.Time,
 	pkg string,
 ) packageReport {
@@ -446,8 +483,41 @@ func processPackage(
 
 	result.ScannedVersions = len(versions)
 	candidates := make([]candidateReport, 0)
+	graph := ociGraphResult{Reachable: make(map[string]struct{})}
+	if policy.OCIGraph.Enabled {
+		graph, err = resolveOCIGraph(ctx, opts.Owner, pkg, versions, graphClient)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: resolve OCI graph failed: %v", pkg, err))
+			return result
+		}
+		result.GraphRoots = graph.Roots
+	}
 
 	for _, version := range versions {
+		if policy.OCIGraph.Enabled {
+			normalTags, _ := splitGraphTags(version.Tags)
+			candidate, disposition := graphCandidate(
+				version,
+				normalTags,
+				graph.Reachable,
+				policy.OCIGraph.OrphanTTLDays,
+				now,
+			)
+			switch disposition {
+			case dispositionReachable:
+				result.KeptGraphReachable++
+				continue
+			case dispositionGrace:
+				result.KeptOrphanGrace++
+				continue
+			case dispositionCandidate:
+				result.OrphanCandidates++
+				candidates = append(candidates, candidate)
+				continue
+			}
+			version.Tags = normalTags
+		}
+
 		eval := evaluateVersion(version, rules, policy.ProtectUnknown, now)
 		switch {
 		case eval.Unknown:
@@ -465,15 +535,19 @@ func processPackage(
 		case eval.Protected:
 			result.KeptProtected++
 		case eval.Candidate:
+			result.TaggedCandidates++
 			candidates = append(candidates, candidateReport{
 				ID:              version.ID,
 				Name:            version.Name,
+				Kind:            candidateKindTaggedTransient,
 				UpdatedAt:       version.UpdatedAt.UTC().Format(time.RFC3339),
 				AgeDays:         eval.AgeDays,
 				RequiredAgeDays: eval.RequiredAgeDays,
 				Tags:            append([]string{}, version.Tags...),
 				MatchedRules:    append([]string{}, eval.MatchedRules...),
 			})
+		case eval.RequiredAgeDays > 0:
+			result.KeptActiveTransient++
 		}
 	}
 
@@ -571,22 +645,28 @@ func renderSummary(report housekeepingReport) string {
 	b.WriteString(fmt.Sprintf("- Mode: `%s`\n", report.Run.Mode))
 	b.WriteString(fmt.Sprintf("- Timestamp: `%s`\n", report.Run.TimestampUTC))
 	b.WriteString(fmt.Sprintf("- Owner: `%s` (%s)\n", report.Run.Owner, report.Run.OwnerKind))
-	b.WriteString(fmt.Sprintf("- Max delete per package: `%d`\n\n", report.Run.MaxDeletePerPackage))
+	b.WriteString(fmt.Sprintf("- Max delete per package: `%d`\n", report.Run.MaxDeletePerPackage))
+	b.WriteString(fmt.Sprintf("- Max delete total: `%d`\n\n", report.Run.MaxDeleteTotal))
 	b.WriteString(summaryTableHeader)
-	b.WriteString("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	b.WriteString(
+		"| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
+	)
 	for _, pkg := range report.Packages {
 		b.WriteString(
 			fmt.Sprintf(
-				"| `%s` | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+				"| `%s` | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
 				pkg.Name,
 				pkg.ScannedVersions,
 				pkg.Candidates,
+				pkg.TaggedCandidates,
+				pkg.OrphanCandidates,
+				pkg.Planned,
 				pkg.Deleted,
 				pkg.KeptProtected,
+				pkg.KeptActiveTransient,
+				pkg.KeptGraphReachable,
+				pkg.KeptOrphanGrace,
 				pkg.KeptUnknown,
-				pkg.KeptUnknownUntagged,
-				pkg.KeptUnknownUnmatchedTag,
-				pkg.KeptUnknownNoTransientMatch,
 				len(pkg.Errors),
 			),
 		)

--- a/hack/tools/ghcr_housekeeping/main_test.go
+++ b/hack/tools/ghcr_housekeeping/main_test.go
@@ -248,10 +248,11 @@ func TestRunHousekeepingEnforceStopsAboveSafetyBrake(t *testing.T) {
 		Mode:                modeEnforce,
 		PolicyFile:          "test-policy.json",
 		MaxDeletePerPackage: 1,
+		MaxDeleteTotal:      1,
 		ReportJSON:          "dist/report.json",
 	}
 
-	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, now)
+	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, nil, now)
 	if err == nil {
 		t.Fatalf("expected safety-brake error in enforce mode")
 	}
@@ -293,10 +294,11 @@ func TestRunHousekeepingDryRunNeverDeletes(t *testing.T) {
 		Mode:                modeDryRun,
 		PolicyFile:          "test-policy.json",
 		MaxDeletePerPackage: 1,
+		MaxDeleteTotal:      1,
 		ReportJSON:          "dist/report.json",
 	}
 
-	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, now)
+	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, nil, now)
 	if err != nil {
 		t.Fatalf("runHousekeeping dry-run returned error: %v", err)
 	}
@@ -334,10 +336,11 @@ func TestRunHousekeepingEnforceAbortsAllDeletesWhenOnePackageExceedsSafetyBrake(
 		Mode:                modeEnforce,
 		PolicyFile:          "test-policy.json",
 		MaxDeletePerPackage: 1,
+		MaxDeleteTotal:      1,
 		ReportJSON:          "dist/report.json",
 	}
 
-	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, now)
+	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, nil, now)
 	if err == nil {
 		t.Fatalf("expected safety-brake error in enforce mode")
 	}
@@ -370,10 +373,11 @@ func TestRunHousekeepingTracksUnknownBreakdown(t *testing.T) {
 		Mode:                modeDryRun,
 		PolicyFile:          "test-policy.json",
 		MaxDeletePerPackage: 100,
+		MaxDeleteTotal:      100,
 		ReportJSON:          "dist/report.json",
 	}
 
-	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, now)
+	report, err := runHousekeeping(context.Background(), opts, cfg, rules, client, nil, now)
 	if err != nil {
 		t.Fatalf("runHousekeeping returned error: %v", err)
 	}
@@ -570,6 +574,32 @@ func testPolicy(t *testing.T) (policyConfig, []compiledRule) {
 		t.Fatalf("loadPolicy() error = %v", err)
 	}
 	return loadedCfg, rules
+}
+
+func TestRepositoryPolicyEnablesOCIOrphanGrace(t *testing.T) {
+	t.Parallel()
+
+	cfg, _, err := loadPolicy("policy.json")
+	if err != nil {
+		t.Fatalf("loadPolicy(policy.json) error = %v", err)
+	}
+	if !cfg.OCIGraph.Enabled || cfg.OCIGraph.OrphanTTLDays != 30 {
+		t.Fatalf("OCI graph policy = %#v, want enabled with 30-day grace", cfg.OCIGraph)
+	}
+}
+
+func TestLoadPolicyRejectsInvalidOCIOrphanTTL(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "policy.json")
+	raw := `{"protect_unknown":true,"oci_graph":{"enabled":true,"orphan_ttl_days":0},` +
+		`"rules":[{"name":"semver","pattern":"^v$","action":"keep"}]}`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	if _, _, err := loadPolicy(path); err == nil || !strings.Contains(err.Error(), "orphan_ttl_days must be > 0") {
+		t.Fatalf("loadPolicy() error = %v, want invalid orphan TTL", err)
+	}
 }
 
 func TestRenderSummaryIncludesTable(t *testing.T) {

--- a/hack/tools/ghcr_housekeeping/planner.go
+++ b/hack/tools/ghcr_housekeeping/planner.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+type candidatePosition struct {
+	PackageIndex   int
+	CandidateIndex int
+}
+
+func validateTaggedCandidateSafety(report *housekeepingReport, maxPerPackage int) []string {
+	problems := make([]string, 0)
+	for i := range report.Packages {
+		pkgReport := &report.Packages[i]
+		if pkgReport.TaggedCandidates <= maxPerPackage {
+			continue
+		}
+		errMsg := fmt.Sprintf(
+			"%s: tagged candidate count %d exceeds max-delete-per-package=%d; use workflow_dispatch override to continue",
+			pkgReport.Name,
+			pkgReport.TaggedCandidates,
+			maxPerPackage,
+		)
+		pkgReport.Errors = append(pkgReport.Errors, errMsg)
+		problems = append(problems, errMsg)
+	}
+	return problems
+}
+
+func planDeletions(report *housekeepingReport, maxPerPackage, maxTotal int) {
+	positions := make([]candidatePosition, 0)
+	for packageIndex := range report.Packages {
+		pkgReport := &report.Packages[packageIndex]
+		pkgReport.Planned = 0
+		for candidateIndex := range pkgReport.CandidateItems {
+			pkgReport.CandidateItems[candidateIndex].Planned = false
+			positions = append(positions, candidatePosition{
+				PackageIndex:   packageIndex,
+				CandidateIndex: candidateIndex,
+			})
+		}
+	}
+	positions = sortedCandidatePositions(report, positions)
+
+	plannedPerPackage := make([]int, len(report.Packages))
+	plannedTotal := 0
+	for _, position := range positions {
+		if plannedTotal >= maxTotal {
+			break
+		}
+		if plannedPerPackage[position.PackageIndex] >= maxPerPackage {
+			continue
+		}
+
+		pkgReport := &report.Packages[position.PackageIndex]
+		pkgReport.CandidateItems[position.CandidateIndex].Planned = true
+		pkgReport.Planned++
+		plannedPerPackage[position.PackageIndex]++
+		plannedTotal++
+	}
+}
+
+func sortedCandidatePositions(report *housekeepingReport, positions []candidatePosition) []candidatePosition {
+	sort.Slice(positions, func(i, j int) bool {
+		leftPosition := positions[i]
+		rightPosition := positions[j]
+		leftPackage := &report.Packages[leftPosition.PackageIndex]
+		rightPackage := &report.Packages[rightPosition.PackageIndex]
+		left := leftPackage.CandidateItems[leftPosition.CandidateIndex]
+		right := rightPackage.CandidateItems[rightPosition.CandidateIndex]
+		if candidatePriority(left.Kind) != candidatePriority(right.Kind) {
+			return candidatePriority(left.Kind) < candidatePriority(right.Kind)
+		}
+		if left.UpdatedAt != right.UpdatedAt {
+			return left.UpdatedAt < right.UpdatedAt
+		}
+		if leftPackage.Name != rightPackage.Name {
+			return leftPackage.Name < rightPackage.Name
+		}
+		return left.ID < right.ID
+	})
+	return positions
+}
+
+func candidatePriority(kind string) int {
+	if kind == candidateKindTaggedTransient {
+		return 0
+	}
+	if kind == candidateKindOCIReferrerOrphan {
+		return 1
+	}
+	if kind == candidateKindOCIOrphan {
+		return 2
+	}
+	return 3
+}
+
+func applyDeletionPlan(
+	ctx context.Context,
+	opts options,
+	client packageClient,
+	report *housekeepingReport,
+) error {
+	positions := make([]candidatePosition, 0)
+	for packageIndex := range report.Packages {
+		for candidateIndex, candidate := range report.Packages[packageIndex].CandidateItems {
+			if candidate.Planned {
+				positions = append(positions, candidatePosition{
+					PackageIndex:   packageIndex,
+					CandidateIndex: candidateIndex,
+				})
+			}
+		}
+	}
+	for _, position := range sortedCandidatePositions(report, positions) {
+		pkgReport := &report.Packages[position.PackageIndex]
+		candidate := pkgReport.CandidateItems[position.CandidateIndex]
+		if err := client.DeletePackageVersion(
+			ctx,
+			opts.OwnerKind,
+			opts.Owner,
+			pkgReport.Name,
+			candidate.ID,
+		); err != nil {
+			errMsg := fmt.Sprintf("%s: delete version %d failed: %v", pkgReport.Name, candidate.ID, err)
+			pkgReport.Errors = append(pkgReport.Errors, errMsg)
+			return errors.New(errMsg)
+		}
+		pkgReport.Deleted++
+	}
+	return nil
+}

--- a/hack/tools/ghcr_housekeeping/planner_test.go
+++ b/hack/tools/ghcr_housekeeping/planner_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPlanDeletionsAppliesGlobalAndPerPackageBudgets(t *testing.T) {
+	t.Parallel()
+
+	report := housekeepingReport{Packages: []packageReport{
+		{
+			Name: "package-b",
+			CandidateItems: []candidateReport{
+				{ID: 2, UpdatedAt: "2026-01-01T00:00:00Z"},
+				{ID: 4, UpdatedAt: "2026-01-03T00:00:00Z"},
+			},
+		},
+		{
+			Name: "package-a",
+			CandidateItems: []candidateReport{
+				{ID: 1, UpdatedAt: "2026-01-01T00:00:00Z"},
+				{ID: 3, UpdatedAt: "2026-01-02T00:00:00Z"},
+				{ID: 5, UpdatedAt: "2026-01-04T00:00:00Z"},
+			},
+		},
+	}}
+
+	planDeletions(&report, 2, 3)
+
+	if report.Packages[0].Planned != 1 || report.Packages[1].Planned != 2 {
+		t.Fatalf(
+			"planned counts = [%d,%d], want [1,2]",
+			report.Packages[0].Planned,
+			report.Packages[1].Planned,
+		)
+	}
+	planned := map[int64]bool{}
+	for _, pkg := range report.Packages {
+		for _, candidate := range pkg.CandidateItems {
+			planned[candidate.ID] = candidate.Planned
+		}
+	}
+	for _, id := range []int64{1, 2, 3} {
+		if !planned[id] {
+			t.Errorf("candidate %d was not planned", id)
+		}
+	}
+	for _, id := range []int64{4, 5} {
+		if planned[id] {
+			t.Errorf("candidate %d was planned past the budget", id)
+		}
+	}
+}
+
+func TestApplyDeletionPlanStopsAfterFirstError(t *testing.T) {
+	t.Parallel()
+
+	report := housekeepingReport{Packages: []packageReport{
+		{
+			Name: "openbao-operator",
+			CandidateItems: []candidateReport{
+				{ID: 1, Planned: true},
+				{ID: 2, Planned: true},
+			},
+		},
+	}}
+	client := &fakePackageClient{deleteErrors: map[int64]error{1: errors.New("forbidden")}}
+	opts := options{Owner: "dc-tec", OwnerKind: ownerKindUser}
+
+	err := applyDeletionPlan(context.Background(), opts, client, &report)
+	if err == nil {
+		t.Fatalf("applyDeletionPlan() error = nil, want failure")
+	}
+	if len(client.deleteCalls) != 1 || client.deleteCalls[0] != 1 {
+		t.Fatalf("delete calls = %v, want only the first candidate", client.deleteCalls)
+	}
+	if report.Packages[0].Deleted != 0 || len(report.Packages[0].Errors) != 1 {
+		t.Fatalf("package report = %#v", report.Packages[0])
+	}
+}
+
+func TestPlanDeletionsPrioritizesTaggedTransientsOverOrphans(t *testing.T) {
+	t.Parallel()
+
+	report := housekeepingReport{Packages: []packageReport{
+		{
+			Name: "openbao-operator",
+			CandidateItems: []candidateReport{
+				{ID: 1, Kind: candidateKindOCIOrphan, UpdatedAt: "2026-01-01T00:00:00Z"},
+				{ID: 2, Kind: candidateKindTaggedTransient, UpdatedAt: "2026-07-01T00:00:00Z"},
+				{ID: 3, Kind: candidateKindOCIReferrerOrphan, UpdatedAt: "2026-02-01T00:00:00Z"},
+			},
+		},
+	}}
+
+	planDeletions(&report, 100, 2)
+	if report.Packages[0].CandidateItems[0].Planned {
+		t.Fatalf("untagged orphan was planned before higher-priority candidates")
+	}
+	if !report.Packages[0].CandidateItems[1].Planned {
+		t.Fatalf("tagged transient was not planned")
+	}
+	if !report.Packages[0].CandidateItems[2].Planned {
+		t.Fatalf("detached referrer index was not planned before untagged orphan")
+	}
+}
+
+func TestApplyDeletionPlanUsesPlannerPriority(t *testing.T) {
+	t.Parallel()
+
+	report := housekeepingReport{Packages: []packageReport{
+		{
+			Name: "openbao-operator",
+			CandidateItems: []candidateReport{
+				{ID: 1, Kind: candidateKindOCIOrphan, UpdatedAt: "2026-01-01T00:00:00Z", Planned: true},
+			},
+		},
+		{
+			Name: "pr-e2e-openbao-operator",
+			CandidateItems: []candidateReport{
+				{ID: 2, Kind: candidateKindTaggedTransient, UpdatedAt: "2026-07-01T00:00:00Z", Planned: true},
+			},
+		},
+	}}
+	client := &fakePackageClient{}
+	opts := options{Owner: "dc-tec", OwnerKind: ownerKindUser}
+
+	if err := applyDeletionPlan(context.Background(), opts, client, &report); err != nil {
+		t.Fatalf("applyDeletionPlan() error = %v", err)
+	}
+	if len(client.deleteCalls) != 2 || client.deleteCalls[0] != 2 || client.deleteCalls[1] != 1 {
+		t.Fatalf("delete calls = %v, want tagged candidate before orphan", client.deleteCalls)
+	}
+}
+
+func TestValidateTaggedCandidateSafetyIgnoresOCIOrphanBacklog(t *testing.T) {
+	t.Parallel()
+
+	report := housekeepingReport{Packages: []packageReport{
+		{Name: "openbao-operator", TaggedCandidates: 1, OrphanCandidates: 500, Candidates: 501},
+	}}
+	if problems := validateTaggedCandidateSafety(&report, 100); len(problems) != 0 {
+		t.Fatalf("validateTaggedCandidateSafety() problems = %v, want none", problems)
+	}
+
+	report.Packages[0].TaggedCandidates = 101
+	if problems := validateTaggedCandidateSafety(&report, 100); len(problems) != 1 {
+		t.Fatalf("validateTaggedCandidateSafety() problems = %v, want one", problems)
+	}
+}

--- a/hack/tools/ghcr_housekeeping/policy.json
+++ b/hack/tools/ghcr_housekeeping/policy.json
@@ -1,5 +1,9 @@
 {
   "protect_unknown": true,
+  "oci_graph": {
+    "enabled": true,
+    "orphan_ttl_days": 30
+  },
   "rules": [
     {
       "name": "semver",

--- a/hack/tools/ghcr_housekeeping/registry.go
+++ b/hack/tools/ghcr_housekeeping/registry.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	defaultRegistryBaseURL  = "https://ghcr.io"
+	defaultRegistryTokenURL = "https://ghcr.io/token"
+	registryService         = "ghcr.io"
+	manifestAcceptHeader    = "application/vnd.oci.image.index.v1+json, " +
+		"application/vnd.oci.image.manifest.v1+json, " +
+		"application/vnd.docker.distribution.manifest.list.v2+json, " +
+		"application/vnd.docker.distribution.manifest.v2+json"
+)
+
+type githubContainerRegistryClient struct {
+	baseURL      string
+	tokenURL     string
+	githubToken  string
+	registryUser string
+	httpClient   *http.Client
+	tokens       map[string]string
+}
+
+func (c *githubContainerRegistryClient) ManifestReferences(
+	ctx context.Context,
+	owner, pkg, digest string,
+) ([]manifestReference, error) {
+	if !strings.HasPrefix(digest, "sha256:") {
+		return nil, fmt.Errorf("unsupported manifest digest %q", digest)
+	}
+
+	repository := strings.TrimSpace(owner) + "/" + strings.TrimSpace(pkg)
+	token, err := c.repositoryToken(ctx, repository)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s/v2/%s/%s/manifests/%s",
+		strings.TrimRight(c.baseURL, "/"),
+		url.PathEscape(strings.TrimSpace(owner)),
+		url.PathEscape(strings.TrimSpace(pkg)),
+		url.PathEscape(digest),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create manifest request: %w", err)
+	}
+	req.Header.Set("Accept", manifestAcceptHeader)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manifest: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch manifest failed (%d): %s", resp.StatusCode, extractAPIErrorMessage(resp))
+	}
+
+	var manifest struct {
+		Manifests []struct {
+			Digest    string `json:"digest"`
+			MediaType string `json:"mediaType"`
+		} `json:"manifests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+
+	references := make([]manifestReference, 0, len(manifest.Manifests))
+	for _, item := range manifest.Manifests {
+		digest := strings.TrimSpace(item.Digest)
+		if digest == "" {
+			return nil, errors.New("manifest contains an empty child digest")
+		}
+		references = append(references, manifestReference{
+			Digest:    digest,
+			MediaType: strings.TrimSpace(item.MediaType),
+		})
+	}
+	return references, nil
+}
+
+func (c *githubContainerRegistryClient) repositoryToken(ctx context.Context, repository string) (string, error) {
+	if c.tokens == nil {
+		c.tokens = make(map[string]string)
+	}
+	if token := c.tokens[repository]; token != "" {
+		return token, nil
+	}
+
+	endpoint, err := url.Parse(c.tokenURL)
+	if err != nil {
+		return "", fmt.Errorf("parse registry token URL: %w", err)
+	}
+	query := endpoint.Query()
+	query.Set("service", registryService)
+	query.Set("scope", "repository:"+repository+":pull")
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("create registry token request: %w", err)
+	}
+	if strings.TrimSpace(c.githubToken) != "" {
+		req.SetBasicAuth(c.registryUser, c.githubToken)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request registry token: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("request registry token failed (%d): %s", resp.StatusCode, extractAPIErrorMessage(resp))
+	}
+
+	var payload struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode registry token: %w", err)
+	}
+	token := strings.TrimSpace(payload.Token)
+	if token == "" {
+		token = strings.TrimSpace(payload.AccessToken)
+	}
+	if token == "" {
+		return "", errors.New("registry token response did not include a token")
+	}
+
+	c.tokens[repository] = token
+	return token, nil
+}

--- a/hack/tools/ghcr_housekeeping/registry_test.go
+++ b/hack/tools/ghcr_housekeeping/registry_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestContainerRegistryClientListsManifestReferencesAndCachesToken(t *testing.T) {
+	t.Parallel()
+
+	tokenRequests := 0
+	manifestRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/token":
+			tokenRequests++
+			username, password, ok := r.BasicAuth()
+			if !ok || username != "github-actions[bot]" || password != "github-token" {
+				t.Fatalf("unexpected registry token credentials: username=%q ok=%t", username, ok)
+			}
+			if got := r.URL.Query().Get("scope"); got != "repository:dc-tec/openbao-operator:pull" {
+				t.Fatalf("scope = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "registry-token"})
+		case strings.HasPrefix(r.URL.Path, "/v2/dc-tec/openbao-operator/manifests/"):
+			manifestRequests++
+			if got := r.Header.Get("Authorization"); got != "Bearer registry-token" {
+				t.Fatalf("authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"schemaVersion": 2,
+				"mediaType":     mediaTypeOCIImageIndex,
+				"manifests": []map[string]string{
+					{"digest": testDigest("b"), "mediaType": "application/vnd.oci.image.manifest.v1+json"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &githubContainerRegistryClient{
+		baseURL:      server.URL,
+		tokenURL:     server.URL + "/token",
+		githubToken:  "github-token",
+		registryUser: "github-actions[bot]",
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+	}
+
+	for range 2 {
+		references, err := client.ManifestReferences(
+			context.Background(),
+			"dc-tec",
+			"openbao-operator",
+			testDigest("a"),
+		)
+		if err != nil {
+			t.Fatalf("ManifestReferences() error = %v", err)
+		}
+		if len(references) != 1 || references[0].Digest != testDigest("b") {
+			t.Fatalf("references = %#v", references)
+		}
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("token requests = %d, want 1", tokenRequests)
+	}
+	if manifestRequests != 2 {
+		t.Fatalf("manifest requests = %d, want 2", manifestRequests)
+	}
+}
+
+func TestContainerRegistryClientFailsOnMissingManifest(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "registry-token"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := &githubContainerRegistryClient{
+		baseURL:    server.URL,
+		tokenURL:   server.URL + "/token",
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	_, err := client.ManifestReferences(
+		context.Background(),
+		"dc-tec",
+		"openbao-operator",
+		testDigest("a"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "fetch manifest failed (404)") {
+		t.Fatalf("ManifestReferences() error = %v, want not found", err)
+	}
+}


### PR DESCRIPTION
## Summary

Make GHCR housekeeping understand the OCI image and artifact graph before classifying package versions for deletion.

- Treat human and channel tags as retention roots, then retain referenced image manifests, OCI referrer indexes, and attached provenance/signature artifacts.
- Classify only detached graph objects older than the 30-day orphan grace as cleanup candidates.
- Apply a deterministic global deletion plan with tagged transient images first, detached referrer indexes second, and untagged orphans last.
- Add a 100-version global batch limit while retaining the existing per-package safety brake and fail-closed behavior.
- Route Go tools through the Go-quality, test, and filesystem-security CI lanes when they change.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, or RBAC compatibility impact.

The housekeeping workflow now reads manifests from GHCR to resolve reachability. Registry or graph-resolution failures stop the run before deletion. Enforce mode stops on the first deletion error and is bounded by both per-package and global deletion budgets.

## Verification

- `make bootstrap`
- `make lint-ci`
- `make verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-vendor verify-generated`
- `make test-ci`
- `GOFLAGS=-mod=vendor go test -race ./hack/tools/ghcr_housekeeping`
- `make vulncheck semgrep-ci security-scan-fs`
- Live dry-run inventory across all configured GHCR packages: every version accounted for, 100 globally planned, and no deletions performed.

## Reviewer Notes

Please focus on the OCI fallback referrer-tag handling, reachability roots, deletion-priority guarantees, and CI routing for `hack/tools/`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

Documentation and generated artifacts are unaffected. This change has no dependent changes.