### PR TITLE
test(e2e): exercise operator upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       security_image: ${{ steps.diff.outputs.security_image }}
       fuzz: ${{ steps.diff.outputs.fuzz }}
       e2e: ${{ steps.diff.outputs.e2e }}
+      operator_upgrade_e2e: ${{ steps.diff.outputs.operator_upgrade_e2e }}
       e2e_backup: ${{ steps.diff.outputs.e2e_backup }}
       e2e_upgrade: ${{ steps.diff.outputs.e2e_upgrade }}
       e2e_hardened: ${{ steps.diff.outputs.e2e_hardened }}
@@ -105,7 +106,7 @@ jobs:
               echo "manual_upgrade_e2e=${MANUAL_UPGRADE_E2E}"
               echo "manual_hardened_e2e=${MANUAL_HARDENED_E2E}"
               echo "manual_seal_e2e=${MANUAL_SEAL_E2E}"
-              for key in chart workflow docs go_quality go_toolchain go_tests config_compat security_scan security_image fuzz e2e e2e_backup e2e_upgrade e2e_hardened e2e_seal; do
+              for key in chart workflow docs go_quality go_toolchain go_tests config_compat security_scan security_image fuzz e2e operator_upgrade_e2e e2e_backup e2e_upgrade e2e_hardened e2e_seal; do
                 echo "${key}=false"
               done
             } >> "${GITHUB_OUTPUT}"
@@ -208,6 +209,12 @@ jobs:
             echo "e2e=true" >> "${GITHUB_OUTPUT}"
           else
             echo "e2e=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+          if changed_matches '^(api/stability/v1alpha1\.yaml|charts/openbao-operator/|release-notes/|test/e2e/suites\.yaml|test/fixtures/(api-migration|operator-upgrade)/|Dockerfile(\.init)?$|hack/ci/operator-upgrade-e2e\.sh|Makefile|mk/)'; then
+            echo "operator_upgrade_e2e=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "operator_upgrade_e2e=false" >> "${GITHUB_OUTPUT}"
           fi
 
           if changed_matches '^(internal/service/backup/|internal/service/restore/|cmd/bao-backup/|test/e2e/(e2e_suite_test\.go|framework/.*|helpers/.*|backup_restore_test\.go)|Makefile|mk/)'; then
@@ -668,7 +675,7 @@ jobs:
   build-artifacts:
     name: Build Artifacts
     needs: changes
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_e2e_requested == 'true' || (((needs.changes.outputs.e2e == 'true' || needs.changes.outputs.e2e_seal == 'true' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:full-e2e') || contains(github.event.pull_request.labels.*.name, 'backup') || contains(github.event.pull_request.labels.*.name, 'upgrades') || contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller'))))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository))
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_e2e_requested == 'true' || (((needs.changes.outputs.e2e == 'true' || needs.changes.outputs.operator_upgrade_e2e == 'true' || needs.changes.outputs.e2e_seal == 'true' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:full-e2e') || contains(github.event.pull_request.labels.*.name, 'backup') || contains(github.event.pull_request.labels.*.name, 'upgrades') || contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller'))))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: *runner
     steps:
       - name: Checkout
@@ -695,7 +702,7 @@ jobs:
     name: Build E2E Images Once
     runs-on: *runner
     needs: [changes, build-artifacts]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_e2e_requested == 'true' || (((needs.changes.outputs.e2e == 'true' || needs.changes.outputs.e2e_seal == 'true' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:full-e2e') || contains(github.event.pull_request.labels.*.name, 'backup') || contains(github.event.pull_request.labels.*.name, 'upgrades') || contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller'))))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository))
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_e2e_requested == 'true' || (((needs.changes.outputs.e2e == 'true' || needs.changes.outputs.operator_upgrade_e2e == 'true' || needs.changes.outputs.e2e_seal == 'true' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ci:full-e2e') || contains(github.event.pull_request.labels.*.name, 'backup') || contains(github.event.pull_request.labels.*.name, 'upgrades') || contains(github.event.pull_request.labels.*.name, 'security') || contains(github.event.pull_request.labels.*.name, 'provisioner') || contains(github.event.pull_request.labels.*.name, 'admission') || contains(github.event.pull_request.labels.*.name, 'controller'))))) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository))
     env:
       BUILD_SEAL_FIXTURES: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.manual_full_e2e == 'true' || needs.changes.outputs.manual_seal_e2e == 'true' || needs.changes.outputs.e2e_seal == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:full-e2e')) }}
     permissions:
@@ -859,6 +866,46 @@ jobs:
               echo "pykmip_server_ref=${{ steps.image-repos.outputs.pykmip_server_repo }}:${{ steps.tag.outputs.value }}"
             fi
           } >> "${GITHUB_OUTPUT}"
+
+  operator-upgrade-e2e:
+    name: Operator Upgrade E2E
+    runs-on: *runner
+    needs: build-e2e-images
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup repo tools
+        uses: ./.github/actions/setup-repo-tools
+        with:
+          cache-tools: false
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.1.1
+
+      - name: Install kind (pinned)
+        uses: ./.github/actions/install-kind
+        with:
+          install-dir: bin/
+
+      - name: Login to GHCR (pull)
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upgrade previous stable operator to CI candidate
+        env:
+          OPERATOR_UPGRADE_E2E_MANAGER_SOURCE: ${{ needs.build-e2e-images.outputs.manager_ref }}
+          OPERATOR_UPGRADE_E2E_INIT_SOURCE: ${{ needs.build-e2e-images.outputs.config_init_ref }}
+        run: make test-e2e-operator-upgrade
 
   e2e-matrix:
     name: Plan E2E Matrix
@@ -1154,6 +1201,7 @@ jobs:
       - helm-e2e-smoke
       - build-artifacts
       - build-e2e-images
+      - operator-upgrade-e2e
       - e2e-matrix
       - e2e
     steps:
@@ -1180,6 +1228,7 @@ jobs:
           HELM_E2E_SMOKE: ${{ needs.helm-e2e-smoke.result }}
           BUILD_ARTIFACTS: ${{ needs.build-artifacts.result }}
           BUILD_E2E_IMAGES: ${{ needs.build-e2e-images.result }}
+          OPERATOR_UPGRADE_E2E: ${{ needs.operator-upgrade-e2e.result }}
           E2E_MATRIX: ${{ needs.e2e-matrix.result }}
           E2E: ${{ needs.e2e.result }}
         run: |
@@ -1216,6 +1265,7 @@ jobs:
           helm-e2e-smoke=${HELM_E2E_SMOKE}
           build-artifacts=${BUILD_ARTIFACTS}
           build-e2e-images=${BUILD_E2E_IMAGES}
+          operator-upgrade-e2e=${OPERATOR_UPGRADE_E2E}
           e2e-matrix=${E2E_MATRIX}
           e2e=${E2E}
           EOF

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -478,6 +478,46 @@ jobs:
           path: artifacts/
           retention-days: 7
 
+  operator-upgrade-e2e:
+    name: Operator Upgrade E2E
+    runs-on: *runner
+    needs: build-e2e-images
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup repo tools
+        uses: ./.github/actions/setup-repo-tools
+        with:
+          cache-tools: false
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.1.1
+
+      - name: Install kind (pinned)
+        uses: ./.github/actions/install-kind
+        with:
+          install-dir: bin/
+
+      - name: Login to GHCR (pull)
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upgrade previous stable operator to nightly candidate
+        env:
+          OPERATOR_UPGRADE_E2E_MANAGER_SOURCE: ${{ needs.build-e2e-images.outputs.manager_ref }}
+          OPERATOR_UPGRADE_E2E_INIT_SOURCE: ${{ needs.build-e2e-images.outputs.config_init_ref }}
+        run: make test-e2e-operator-upgrade
+
   docs:
     name: Docs Build
     runs-on: *runner
@@ -584,6 +624,7 @@ jobs:
       - docs
       - helm
       - e2e
+      - operator-upgrade-e2e
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,6 +366,53 @@ jobs:
           path: artifacts/
           retention-days: 7
 
+  operator-upgrade-e2e:
+    name: Operator Upgrade E2E
+    runs-on: *runner
+    needs: [prepare, build]
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 45
+    steps:
+      - name: Checkout release ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup repo tools
+        uses: ./.github/actions/setup-repo-tools
+        with:
+          cache-tools: false
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.1.1
+
+      - name: Install kind (pinned)
+        uses: ./.github/actions/install-kind
+        with:
+          install-dir: bin/
+
+      - name: Login to GHCR (pull)
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upgrade previous stable operator to release candidate
+        env:
+          OPERATOR_UPGRADE_E2E_TARGET_VERSION: ${{ needs.prepare.outputs.version }}
+          OPERATOR_UPGRADE_E2E_MANAGER_SOURCE: >-
+            ${{ needs.prepare.outputs.manager_image }}:${{ needs.prepare.outputs.build_tag }}
+          OPERATOR_UPGRADE_E2E_INIT_SOURCE: >-
+            ${{ needs.prepare.outputs.config_init_image }}:${{ needs.prepare.outputs.build_tag }}
+          OPERATOR_UPGRADE_E2E_HARDENED_INIT_IMAGE: >-
+            ${{ needs.prepare.outputs.config_init_image }}@${{ needs.build.outputs.config_init_digest }}
+        run: make test-e2e-operator-upgrade
+
   verify-provenance:
     name: Verify Image Provenance
     runs-on: *runner
@@ -710,7 +757,15 @@ jobs:
   promote:
     name: Promote + Publish Release
     runs-on: *runner
-    needs: [prepare, build, security-govulncheck, security-images, e2e, verify-provenance, verify-byte-reproducibility]
+    needs:
+      - prepare
+      - build
+      - security-govulncheck
+      - security-images
+      - e2e
+      - operator-upgrade-e2e
+      - verify-provenance
+      - verify-byte-reproducibility
     environment:
       name: release-publish
     permissions:

--- a/docs/contribute/ci.md
+++ b/docs/contribute/ci.md
@@ -77,8 +77,8 @@ make ci-core`}
     {
       cells: [
         "Focused E2E and platform validation",
-        "`make test-e2e-ci ...`, `make helm-e2e-smoke`, or `make test-e2e-existing ...`",
-        "Label filters and the existing-cluster path provide smaller or platform-specific reproductions.",
+        "`make test-e2e-ci ...`, `make helm-e2e-smoke`, `make test-e2e-operator-upgrade`, or `make test-e2e-existing ...`",
+        "Label filters, the previous-stable Development and Hardened upgrade path, and the existing-cluster path provide smaller or platform-specific reproductions.",
       ],
     },
   ]}
@@ -183,6 +183,17 @@ The same manifest owns E2E parallelism. Matrix rows include `parallel_nodes`, an
 Lanes may also declare `prLabelFilter` for pull-request routing. CI uses that optimized filter unless a full E2E run is requested or the run is for `main`; nightly and release-gate profiles continue to use the full lane `labelFilter`.
 
 Nightly E2E routing is manifest-driven. The daily profile runs full coverage on the primary Kubernetes version and compatibility smoke rows on adjacent supported versions. The weekly profile runs full compatibility coverage across supported Kubernetes versions. Maintainers can manually dispatch the release-gate profile, optionally filtered to one lane or one Kubernetes version while preserving the same manifest validation.
+
+Same-repository E2E pull requests, `main`, nightly, and tagged release workflows also run a focused operator-upgrade gate outside
+the normal Ginkgo matrix. It installs the published API stability baseline; creates and seeds active Development and Hardened
+clusters; exercises External TLS, Transit unseal, self-init, and signed helper verification; applies the documented stored-object
+migration and candidate CRDs; then upgrades the Helm release. The gate verifies resource identity, both root-token and JWT data
+continuity, candidate reconciliation, and post-upgrade tenant provisioning. Keep the `release` and `baseline` values in
+`api/stability/v1alpha1.yaml`, the matching release notes, and the migration fixtures synchronized.
+
+Changes to the upgrade harness, its operator-upgrade or API-migration fixtures, the candidate chart, release notes, and API
+stability inputs route directly to this focused gate. Tagged release runs provide the signed candidate init image by immutable
+digest; other lanes use the pinned signed helper digest declared by the harness unless explicitly overridden with another digest.
 
 <CommandBlock
   language="bash"

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -148,7 +148,7 @@ For patch releases, make the source that release-please sees match the release n
     {
       cells: [
         "Pre-flight",
-        "Release-please PR looks correct, docs are updated, new stable release lines have a committed `X.Y.0` docs snapshot, compatibility docs are current, CI is green, full E2E release evidence is clean, nightly regressions are reviewed, and performance findings are either cleared or explicitly accepted by maintainers.",
+        "Release-please PR looks correct, docs are updated, new stable release lines have a committed `X.Y.0` docs snapshot, compatibility docs are current, CI is green, full E2E and previous-stable Development plus Hardened operator-upgrade evidence is clean, nightly regressions are reviewed, and performance findings are either cleared or explicitly accepted by maintainers.",
       ],
       emphasis: "recommended",
     },

--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -160,6 +160,13 @@ make test-e2e`}
         "`make test-e2e-existing ...` with a preconfigured cluster context.",
       ],
     },
+    {
+      cells: [
+        "Operator upgrade compatibility",
+        "Controller, provisioner, CRD, Helm, security-profile, or migration changes that must preserve resources created by the previous stable operator.",
+        "`make test-e2e-operator-upgrade`; the baseline and target release come from `api/stability/v1alpha1.yaml`. The lane upgrades active Development and Hardened clusters, including External TLS, Transit unseal, self-init, signed helper verification, and pre-upgrade data continuity through JWT auth.",
+      ],
+    },
   ]}
 />
 

--- a/hack/ci/operator-upgrade-e2e.sh
+++ b/hack/ci/operator-upgrade-e2e.sh
@@ -495,8 +495,8 @@ echo "Seeding Hardened-profile data through self-initialized JWT auth..." >&2
 
 render_migration_fixture() {
   local fixture="$1"
-  awk -v namespace="${TENANT_NAMESPACE}" '
-    $0 == "  namespace: openbao" { $0 = "  namespace: " namespace }
+  awk -v target_namespace="${TENANT_NAMESPACE}" '
+    $0 == "  namespace: openbao" { $0 = "  namespace: " target_namespace }
     { print }
     $0 == "spec:" { print "  paused: true" }
   ' "${fixture}"

--- a/hack/ci/operator-upgrade-e2e.sh
+++ b/hack/ci/operator-upgrade-e2e.sh
@@ -1,0 +1,684 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STABILITY_FILE="${ROOT_DIR}/api/stability/v1alpha1.yaml"
+FIXTURE_DIR="${ROOT_DIR}/test/fixtures/operator-upgrade"
+MIGRATION_FIXTURE_DIR="${ROOT_DIR}/test/fixtures/api-migration"
+
+FROM_VERSION="${OPERATOR_UPGRADE_E2E_FROM_VERSION:-}"
+if [[ -z "${FROM_VERSION}" ]]; then
+  FROM_VERSION="$(sed -nE 's/^baseline:[[:space:]]*([^[:space:]]+).*$/\1/p' "${STABILITY_FILE}" | head -n1)"
+fi
+TARGET_RELEASE="${OPERATOR_UPGRADE_E2E_TARGET_RELEASE:-}"
+if [[ -z "${TARGET_RELEASE}" ]]; then
+  TARGET_RELEASE="$(sed -nE 's/^release:[[:space:]]*([^[:space:]]+).*$/\1/p' "${STABILITY_FILE}" | head -n1)"
+fi
+TARGET_VERSION="${OPERATOR_UPGRADE_E2E_TARGET_VERSION:-${TARGET_RELEASE}-e2e}"
+VERIFY_ONLY="${OPERATOR_UPGRADE_E2E_VERIFY_ONLY:-false}"
+
+KIND_BIN="${KIND:-kind}"
+KUBECTL_BIN="${KUBECTL:-kubectl}"
+HELM_BIN="${HELM:-helm}"
+DOCKER_BIN="${DOCKER:-docker}"
+CLUSTER_NAME="${OPERATOR_UPGRADE_E2E_KIND_CLUSTER:-openbao-operator-upgrade-e2e}"
+KUBERNETES_VERSION="${OPERATOR_UPGRADE_E2E_KUBERNETES_VERSION:-}"
+if [[ -z "${KUBERNETES_VERSION}" ]]; then
+  KUBERNETES_VERSION="$(
+    sed -nE 's/^[[:space:]]*primary:[[:space:]]*"?([^"[:space:]]+)"?.*$/\1/p' \
+      "${ROOT_DIR}/test/e2e/suites.yaml" | head -n1
+  )"
+fi
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v${KUBERNETES_VERSION}}"
+KEEP_CLUSTER="${OPERATOR_UPGRADE_E2E_KEEP_CLUSTER:-false}"
+
+MANAGER_SOURCE="${OPERATOR_UPGRADE_E2E_MANAGER_SOURCE:-}"
+INIT_SOURCE="${OPERATOR_UPGRADE_E2E_INIT_SOURCE:-}"
+LOCAL_MANAGER_IMAGE="operator-upgrade.local/openbao-operator:${TARGET_VERSION}"
+LOCAL_INIT_IMAGE="operator-upgrade.local/openbao-init:${TARGET_VERSION}"
+
+OPERATOR_NAMESPACE="openbao-operator-system"
+TENANT_NAMESPACE="openbao-upgrade-e2e"
+CLUSTER_RESOURCE="openbaocluster/operator-upgrade"
+PVC_RESOURCE="persistentvolumeclaim/data-operator-upgrade-0"
+TRANSIT_CLUSTER_RESOURCE="openbaocluster/operator-upgrade-transit"
+HARDENED_CLUSTER_RESOURCE="openbaocluster/operator-upgrade-hardened"
+DEFAULT_HARDENED_INIT_IMAGE="ghcr.io/dc-tec/openbao-init@sha256:e08e55a017a2594434dfa8f72860f4185bd4f82cebc3d09eb2e8310c819c4119"
+HARDENED_INIT_IMAGE="${OPERATOR_UPGRADE_E2E_HARDENED_INIT_IMAGE:-${DEFAULT_HARDENED_INIT_IMAGE}}"
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "${command_name} is required" >&2
+    exit 1
+  fi
+}
+
+assert_equal() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${description}: expected ${expected}, got ${actual}" >&2
+    return 1
+  fi
+}
+
+wait_for_statefulset_init_image() {
+  local statefulset_name="$1"
+  local expected_image="$2"
+  local deadline=$((SECONDS + 600))
+  local actual_image=""
+
+  while ((SECONDS < deadline)); do
+    actual_image="$(
+      "${KUBECTL_BIN}" get "statefulset/${statefulset_name}" -n "${TENANT_NAMESPACE}" -o json 2>/dev/null | \
+        jq -r '.spec.template.spec.initContainers[]? | select(.name == "bao-config-init") | .image' || true
+    )"
+    if [[ "${actual_image}" == "${expected_image}" ]]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "StatefulSet ${statefulset_name} init image did not converge to ${expected_image}; got ${actual_image}" >&2
+  return 1
+}
+
+pvc_uid_set() {
+  local cluster_name="$1"
+  local replica_count="$2"
+  local index
+  local uid
+  local uid_lines=""
+
+  for ((index = 0; index < replica_count; index++)); do
+    uid="$(
+      "${KUBECTL_BIN}" get "persistentvolumeclaim/data-${cluster_name}-${index}" \
+        -n "${TENANT_NAMESPACE}" \
+        -o jsonpath='{.metadata.uid}'
+    )"
+    uid_lines+="${uid}"$'\n'
+  done
+
+  jq -Rsc 'split("\n") | map(select(length > 0)) | sort' <<<"${uid_lines}"
+}
+
+assert_resource_absent() {
+  local resource="$1"
+
+  if "${KUBECTL_BIN}" get "${resource}" -n "${TENANT_NAMESPACE}" >/dev/null 2>&1; then
+    echo "Unexpected resource exists: ${TENANT_NAMESPACE}/${resource}" >&2
+    return 1
+  fi
+}
+
+render_hardened_fixture() {
+  awk \
+    -v default_image="${DEFAULT_HARDENED_INIT_IMAGE}" \
+    -v selected_image="${HARDENED_INIT_IMAGE}" '
+      $0 == "    image: \"" default_image "\"" {
+        $0 = "    image: \"" selected_image "\""
+      }
+      { print }
+    ' "${FIXTURE_DIR}/hardened-cluster.yaml"
+}
+
+wait_for_hardened_cluster() {
+  "${KUBECTL_BIN}" wait "${HARDENED_CLUSTER_RESOURCE}" \
+    -n "${TENANT_NAMESPACE}" \
+    --for=condition=Available \
+    --timeout=12m >/dev/null
+  "${KUBECTL_BIN}" wait "${HARDENED_CLUSTER_RESOURCE}" \
+    -n "${TENANT_NAMESPACE}" \
+    --for=jsonpath='{.status.selfInitialized}'=true \
+    --timeout=12m >/dev/null
+  "${KUBECTL_BIN}" wait "${HARDENED_CLUSTER_RESOURCE}" \
+    -n "${TENANT_NAMESPACE}" \
+    --for=condition=ProductionReady \
+    --timeout=12m >/dev/null
+  "${KUBECTL_BIN}" rollout status statefulset/operator-upgrade-hardened \
+    -n "${TENANT_NAMESPACE}" \
+    --timeout=12m >/dev/null
+}
+
+create_transit_credentials_secret() {
+  local token
+  local ca_cert
+
+  token="$(
+    "${KUBECTL_BIN}" get secret/operator-upgrade-transit-root-token \
+      -n "${TENANT_NAMESPACE}" \
+      -o json | jq -er '.data.token'
+  )"
+  ca_cert="$(
+    "${KUBECTL_BIN}" get secret/operator-upgrade-transit-tls-ca \
+      -n "${TENANT_NAMESPACE}" \
+      -o json | jq -er '.data["ca.crt"]'
+  )"
+
+  jq -n \
+    --arg namespace "${TENANT_NAMESPACE}" \
+    --arg token "${token}" \
+    --arg ca_cert "${ca_cert}" \
+    '{
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: "operator-upgrade-transit-credentials",
+        namespace: $namespace
+      },
+      type: "Opaque",
+      data: {
+        token: $token,
+        "ca.crt": $ca_cert
+      }
+    }' | "${KUBECTL_BIN}" apply -f - >/dev/null
+}
+
+create_external_tls_secrets() {
+  local ca_cert
+  local ca_key
+  local server_cert
+  local server_key
+
+  ca_cert="$(
+    "${KUBECTL_BIN}" get secret/operator-upgrade-hardened-ca-material \
+      -n "${TENANT_NAMESPACE}" \
+      -o json | jq -er '.data["tls.crt"]'
+  )"
+  ca_key="$(
+    "${KUBECTL_BIN}" get secret/operator-upgrade-hardened-ca-material \
+      -n "${TENANT_NAMESPACE}" \
+      -o json | jq -er '.data["tls.key"]'
+  )"
+  server_cert="$(
+    "${KUBECTL_BIN}" get secret/operator-upgrade-hardened-server-material \
+      -n "${TENANT_NAMESPACE}" \
+      -o json | jq -er '.data["tls.crt"]'
+  )"
+  server_key="$(
+    "${KUBECTL_BIN}" get secret/operator-upgrade-hardened-server-material \
+      -n "${TENANT_NAMESPACE}" \
+      -o json | jq -er '.data["tls.key"]'
+  )"
+
+  jq -n \
+    --arg namespace "${TENANT_NAMESPACE}" \
+    --arg ca_cert "${ca_cert}" \
+    --arg ca_key "${ca_key}" \
+    '{
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: "operator-upgrade-hardened-tls-ca",
+        namespace: $namespace
+      },
+      type: "Opaque",
+      data: {
+        "ca.crt": $ca_cert,
+        "ca.key": $ca_key
+      }
+    }' | "${KUBECTL_BIN}" apply -f - >/dev/null
+
+  jq -n \
+    --arg namespace "${TENANT_NAMESPACE}" \
+    --arg ca_cert "${ca_cert}" \
+    --arg server_cert "${server_cert}" \
+    --arg server_key "${server_key}" \
+    '{
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: "operator-upgrade-hardened-tls-server",
+        namespace: $namespace
+      },
+      type: "kubernetes.io/tls",
+      data: {
+        "ca.crt": $ca_cert,
+        "tls.crt": $server_cert,
+        "tls.key": $server_key
+      }
+    }' | "${KUBECTL_BIN}" apply -f - >/dev/null
+}
+
+verify_harness() {
+  local required_files=(
+    "${STABILITY_FILE}"
+    "${ROOT_DIR}/release-notes/${TARGET_RELEASE}.md"
+    "${MIGRATION_FIXTURE_DIR}/${FROM_VERSION}-openbaocluster.yaml"
+    "${MIGRATION_FIXTURE_DIR}/${TARGET_RELEASE}-openbaocluster.yaml"
+    "${FIXTURE_DIR}/tenant.yaml"
+    "${FIXTURE_DIR}/cluster.yaml"
+    "${FIXTURE_DIR}/seed-data-job.yaml"
+    "${FIXTURE_DIR}/read-data-job.yaml"
+    "${FIXTURE_DIR}/transit-cluster.yaml"
+    "${FIXTURE_DIR}/transit-config-job.yaml"
+    "${FIXTURE_DIR}/hardened-tls.yaml"
+    "${FIXTURE_DIR}/hardened-cluster.yaml"
+    "${FIXTURE_DIR}/hardened-seed-data-job.yaml"
+    "${FIXTURE_DIR}/hardened-read-data-job.yaml"
+    "${FIXTURE_DIR}/post-upgrade-tenant.yaml"
+  )
+
+  if [[ -z "${FROM_VERSION}" || -z "${TARGET_RELEASE}" ]]; then
+    echo "api stability baseline and release must be set" >&2
+    exit 1
+  fi
+  if ! [[ "${FROM_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "operator upgrade baseline must be a stable semver: ${FROM_VERSION}" >&2
+    exit 1
+  fi
+  if ! [[ "${TARGET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "operator upgrade target must be a semver-compatible image tag: ${TARGET_VERSION}" >&2
+    exit 1
+  fi
+  if ! [[ "${HARDENED_INIT_IMAGE}" =~ ^ghcr\.io/dc-tec/openbao-init@sha256:[0-9a-f]{64}$ ]]; then
+    echo "hardened upgrade helper must be an immutable ghcr.io/dc-tec/openbao-init digest: ${HARDENED_INIT_IMAGE}" >&2
+    exit 1
+  fi
+  for path in "${required_files[@]}"; do
+    if [[ ! -f "${path}" ]]; then
+      echo "operator upgrade E2E input is missing: ${path}" >&2
+      exit 1
+    fi
+  done
+  if ! grep -Fq "### Upgrade from ${FROM_VERSION}" "${ROOT_DIR}/release-notes/${TARGET_RELEASE}.md"; then
+    echo "release notes must document the ${FROM_VERSION} upgrade path" >&2
+    exit 1
+  fi
+  if ! grep -Fq "image: \"${DEFAULT_HARDENED_INIT_IMAGE}\"" "${FIXTURE_DIR}/hardened-cluster.yaml"; then
+    echo "hardened upgrade fixture must use the pinned default helper ${DEFAULT_HARDENED_INIT_IMAGE}" >&2
+    exit 1
+  fi
+
+  echo "Operator upgrade E2E harness verified: ${FROM_VERSION} -> ${TARGET_VERSION}"
+}
+
+verify_harness
+if [[ "${VERIFY_ONLY}" == "true" ]]; then
+  exit 0
+fi
+
+for command_name in "${KIND_BIN}" "${KUBECTL_BIN}" "${HELM_BIN}" "${DOCKER_BIN}" jq python3; do
+  require_command "${command_name}"
+done
+
+WORK_DIR="$(mktemp -d)"
+KUBECONFIG_PATH="${WORK_DIR}/kubeconfig"
+CANDIDATE_CHART="${WORK_DIR}/openbao-operator"
+CLUSTER_CREATED=false
+
+collect_diagnostics() {
+  echo "Collecting operator upgrade diagnostics..." >&2
+  "${KUBECTL_BIN}" get pods -A -o wide >&2 || true
+  "${KUBECTL_BIN}" get openbaotenants -A -o yaml >&2 || true
+  "${KUBECTL_BIN}" get openbaoclusters -A -o yaml >&2 || true
+  "${KUBECTL_BIN}" get certificates,issuers -A -o wide >&2 || true
+  "${KUBECTL_BIN}" get jobs -A -o wide >&2 || true
+  "${KUBECTL_BIN}" get events -A --sort-by=.lastTimestamp >&2 || true
+  for job_name in \
+    operator-upgrade-seed \
+    operator-upgrade-read \
+    operator-upgrade-transit-config \
+    operator-upgrade-hardened-seed \
+    operator-upgrade-hardened-read; do
+    "${KUBECTL_BIN}" logs -n "${TENANT_NAMESPACE}" "job/${job_name}" >&2 || true
+  done
+  "${KUBECTL_BIN}" logs -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=openbao-operator \
+    --all-containers --prefix --tail=200 >&2 || true
+}
+
+cleanup() {
+  local status="$?"
+  if [[ "${status}" -ne 0 && "${CLUSTER_CREATED}" == "true" ]]; then
+    collect_diagnostics
+  fi
+  if [[ "${CLUSTER_CREATED}" == "true" ]]; then
+    if [[ "${KEEP_CLUSTER}" == "true" ]]; then
+      echo "Keeping Kind cluster ${CLUSTER_NAME}; kubeconfig was ${KUBECONFIG_PATH}" >&2
+    else
+      "${KIND_BIN}" delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+    fi
+  fi
+  if [[ "${KEEP_CLUSTER}" != "true" ]]; then
+    rm -rf -- "${WORK_DIR}"
+  fi
+  return "${status}"
+}
+trap cleanup EXIT
+
+if "${KIND_BIN}" get clusters | grep -qx "${CLUSTER_NAME}"; then
+  echo "Kind cluster ${CLUSTER_NAME} already exists; choose another OPERATOR_UPGRADE_E2E_KIND_CLUSTER" >&2
+  exit 1
+fi
+
+echo "Creating Kind ${KUBERNETES_VERSION} cluster ${CLUSTER_NAME}..." >&2
+"${KIND_BIN}" create cluster \
+  --name "${CLUSTER_NAME}" \
+  --image "${KIND_NODE_IMAGE}" \
+  --kubeconfig "${KUBECONFIG_PATH}"
+CLUSTER_CREATED=true
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+prepare_candidate_image() {
+  local source_image="$1"
+  local local_image="$2"
+  local build_target="$3"
+
+  if [[ -n "${source_image}" ]]; then
+    "${DOCKER_BIN}" pull "${source_image}"
+    "${DOCKER_BIN}" tag "${source_image}" "${local_image}"
+  else
+    make "${build_target}" IMG="${local_image}"
+  fi
+  "${KIND_BIN}" load docker-image --name "${CLUSTER_NAME}" "${local_image}"
+}
+
+cd "${ROOT_DIR}"
+prepare_candidate_image "${MANAGER_SOURCE}" "${LOCAL_MANAGER_IMAGE}" docker-build
+prepare_candidate_image "${INIT_SOURCE}" "${LOCAL_INIT_IMAGE}" docker-build-init
+
+echo "Installing cert-manager..." >&2
+"${KUBECTL_BIN}" apply -f \
+  https://github.com/cert-manager/cert-manager/releases/download/v1.19.1/cert-manager.yaml >/dev/null
+"${KUBECTL_BIN}" wait deployment \
+  -n cert-manager \
+  -l app.kubernetes.io/instance=cert-manager \
+  --for=condition=Available \
+  --timeout=5m >/dev/null
+
+echo "Installing released operator ${FROM_VERSION}..." >&2
+"${HELM_BIN}" install openbao-operator oci://ghcr.io/dc-tec/charts/openbao-operator \
+  --version "${FROM_VERSION}" \
+  --namespace "${OPERATOR_NAMESPACE}" \
+  --create-namespace \
+  --wait \
+  --timeout 5m >/dev/null
+
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/tenant.yaml" >/dev/null
+"${KUBECTL_BIN}" wait "openbaotenant/openbao-upgrade-e2e" \
+  -n "${OPERATOR_NAMESPACE}" \
+  --for=jsonpath='{.status.provisioned}'=true \
+  --timeout=5m >/dev/null
+
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/cluster.yaml" >/dev/null
+"${KUBECTL_BIN}" wait "${CLUSTER_RESOURCE}" \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Available \
+  --timeout=10m >/dev/null
+"${KUBECTL_BIN}" wait "secret/operator-upgrade-root-token" \
+  -n "${TENANT_NAMESPACE}" \
+  --for=create \
+  --timeout=2m >/dev/null
+"${KUBECTL_BIN}" rollout status "statefulset/operator-upgrade" \
+  -n "${TENANT_NAMESPACE}" \
+  --timeout=5m >/dev/null
+
+cluster_uid="$("${KUBECTL_BIN}" get "${CLUSTER_RESOURCE}" -n "${TENANT_NAMESPACE}" -o jsonpath='{.metadata.uid}')"
+statefulset_uid="$(
+  "${KUBECTL_BIN}" get statefulset/operator-upgrade \
+    -n "${TENANT_NAMESPACE}" \
+    -o jsonpath='{.metadata.uid}'
+)"
+pvc_uid="$("${KUBECTL_BIN}" get "${PVC_RESOURCE}" -n "${TENANT_NAMESPACE}" -o jsonpath='{.metadata.uid}')"
+
+echo "Seeding OpenBao data before the operator handoff..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/seed-data-job.yaml" >/dev/null
+"${KUBECTL_BIN}" wait job/operator-upgrade-seed \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Complete \
+  --timeout=5m >/dev/null
+
+echo "Provisioning the Transit unseal backend for the Hardened profile..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/transit-cluster.yaml" >/dev/null
+"${KUBECTL_BIN}" wait "${TRANSIT_CLUSTER_RESOURCE}" \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Available \
+  --timeout=10m >/dev/null
+"${KUBECTL_BIN}" wait secret/operator-upgrade-transit-root-token \
+  -n "${TENANT_NAMESPACE}" \
+  --for=create \
+  --timeout=2m >/dev/null
+"${KUBECTL_BIN}" rollout status statefulset/operator-upgrade-transit \
+  -n "${TENANT_NAMESPACE}" \
+  --timeout=5m >/dev/null
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/transit-config-job.yaml" >/dev/null
+"${KUBECTL_BIN}" wait job/operator-upgrade-transit-config \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Complete \
+  --timeout=5m >/dev/null
+create_transit_credentials_secret
+
+echo "Issuing External TLS material for the Hardened profile..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/hardened-tls.yaml" >/dev/null
+"${KUBECTL_BIN}" wait certificate/operator-upgrade-hardened-ca \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Ready \
+  --timeout=3m >/dev/null
+"${KUBECTL_BIN}" wait issuer/operator-upgrade-hardened-ca \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Ready \
+  --timeout=3m >/dev/null
+"${KUBECTL_BIN}" wait certificate/operator-upgrade-hardened-server \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Ready \
+  --timeout=3m >/dev/null
+create_external_tls_secrets
+
+echo "Provisioning a signed, self-initialized Hardened cluster..." >&2
+render_hardened_fixture | "${KUBECTL_BIN}" apply -f - >/dev/null
+wait_for_statefulset_init_image operator-upgrade-hardened "${HARDENED_INIT_IMAGE}"
+wait_for_hardened_cluster
+assert_resource_absent secret/operator-upgrade-hardened-root-token
+assert_resource_absent secret/operator-upgrade-hardened-unseal-key
+
+hardened_cluster_uid="$(
+  "${KUBECTL_BIN}" get "${HARDENED_CLUSTER_RESOURCE}" \
+    -n "${TENANT_NAMESPACE}" \
+    -o jsonpath='{.metadata.uid}'
+)"
+hardened_statefulset_uid="$(
+  "${KUBECTL_BIN}" get statefulset/operator-upgrade-hardened \
+    -n "${TENANT_NAMESPACE}" \
+    -o jsonpath='{.metadata.uid}'
+)"
+hardened_pvc_uids="$(pvc_uid_set operator-upgrade-hardened 3)"
+
+echo "Seeding Hardened-profile data through self-initialized JWT auth..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/hardened-seed-data-job.yaml" >/dev/null
+"${KUBECTL_BIN}" wait job/operator-upgrade-hardened-seed \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Complete \
+  --timeout=5m >/dev/null
+
+render_migration_fixture() {
+  local fixture="$1"
+  awk -v namespace="${TENANT_NAMESPACE}" '
+    $0 == "  namespace: openbao" { $0 = "  namespace: " namespace }
+    { print }
+    $0 == "spec:" { print "  paused: true" }
+  ' "${fixture}"
+}
+
+echo "Migrating stored API fields while ${FROM_VERSION} still owns the cluster..." >&2
+render_migration_fixture "${MIGRATION_FIXTURE_DIR}/${FROM_VERSION}-openbaocluster.yaml" | \
+  "${KUBECTL_BIN}" apply -f - >/dev/null
+migration_uid="$(
+  "${KUBECTL_BIN}" get openbaocluster/api-stability-migration \
+    -n "${TENANT_NAMESPACE}" \
+    -o jsonpath='{.metadata.uid}'
+)"
+render_migration_fixture "${MIGRATION_FIXTURE_DIR}/${TARGET_RELEASE}-openbaocluster.yaml" | \
+  "${KUBECTL_BIN}" apply -f - >/dev/null
+
+migration_json="$("${KUBECTL_BIN}" get openbaocluster/api-stability-migration -n "${TENANT_NAMESPACE}" -o json)"
+jq -e '
+  .spec.paused == true and
+  .spec.tls.acme.domains == ["bao.example.com"] and
+  (.spec.tls.acme | has("domain") | not) and
+  .spec.runtime.restartAt == "2026-08-01T12:00:00Z" and
+  (.spec.maintenance | has("restartAt") | not) and
+  (.spec.upgrade | has("tokenSecretRef") | not)
+' <<<"${migration_json}" >/dev/null
+
+echo "Applying candidate CRDs before the Helm upgrade..." >&2
+make build-crds >/dev/null
+"${KUBECTL_BIN}" apply -f "${ROOT_DIR}/dist/crds.yaml" >/dev/null
+"${KUBECTL_BIN}" wait \
+  --for=condition=Established \
+  crd/openbaoclusters.openbao.org \
+  crd/openbaotenants.openbao.org \
+  crd/openbaorestores.openbao.org \
+  --timeout=2m >/dev/null
+
+cp -R "${ROOT_DIR}/charts/openbao-operator" "${CANDIDATE_CHART}"
+python3 - "${CANDIDATE_CHART}/Chart.yaml" "${TARGET_VERSION}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+chart_path = Path(sys.argv[1])
+version = sys.argv[2]
+contents = chart_path.read_text(encoding="utf-8")
+contents = re.sub(r"(?m)^version:.*$", f"version: {version}", contents, count=1)
+contents = re.sub(r"(?m)^appVersion:.*$", f"appVersion: {version}", contents, count=1)
+chart_path.write_text(contents, encoding="utf-8")
+PY
+
+echo "Upgrading the operator to candidate ${TARGET_VERSION}..." >&2
+"${HELM_BIN}" upgrade openbao-operator "${CANDIDATE_CHART}" \
+  --namespace "${OPERATOR_NAMESPACE}" \
+  --set-string image.repository=operator-upgrade.local/openbao-operator \
+  --set-string "image.tag=${TARGET_VERSION}" \
+  --set-string "operatorVersion=${TARGET_VERSION}" \
+  --set-string 'controller.extraEnv[0].name=OPERATOR_INIT_IMAGE_REPOSITORY' \
+  --set-string 'controller.extraEnv[0].value=operator-upgrade.local/openbao-init' \
+  --wait \
+  --timeout 5m >/dev/null
+
+"${KUBECTL_BIN}" rollout status deployment/openbao-operator-controller \
+  -n "${OPERATOR_NAMESPACE}" \
+  --timeout=5m >/dev/null
+"${KUBECTL_BIN}" rollout status deployment/openbao-operator-provisioner \
+  -n "${OPERATOR_NAMESPACE}" \
+  --timeout=5m >/dev/null
+
+deployments_json="$(
+  "${KUBECTL_BIN}" get deployment \
+    -n "${OPERATOR_NAMESPACE}" \
+    -l app.kubernetes.io/name=openbao-operator \
+    -o json
+)"
+jq -e --arg image "${LOCAL_MANAGER_IMAGE}" --arg version "${TARGET_VERSION}" '
+  .items as $items |
+  ($items | length) == 2 and
+  all($items[];
+    all(.spec.template.spec.containers[];
+      .image == $image and any(.env[]; .name == "OPERATOR_VERSION" and .value == $version)))
+' <<<"${deployments_json}" >/dev/null
+
+wait_for_statefulset_init_image operator-upgrade "${LOCAL_INIT_IMAGE}"
+"${KUBECTL_BIN}" rollout status statefulset/operator-upgrade \
+  -n "${TENANT_NAMESPACE}" \
+  --timeout=10m >/dev/null
+"${KUBECTL_BIN}" wait "${CLUSTER_RESOURCE}" \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Available \
+  --timeout=10m >/dev/null
+
+wait_for_statefulset_init_image operator-upgrade-transit "${LOCAL_INIT_IMAGE}"
+"${KUBECTL_BIN}" rollout status statefulset/operator-upgrade-transit \
+  -n "${TENANT_NAMESPACE}" \
+  --timeout=10m >/dev/null
+"${KUBECTL_BIN}" wait "${TRANSIT_CLUSTER_RESOURCE}" \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Available \
+  --timeout=10m >/dev/null
+
+echo "Reapplying the Hardened contract through candidate admission..." >&2
+render_hardened_fixture | "${KUBECTL_BIN}" apply -f - >/dev/null
+wait_for_statefulset_init_image operator-upgrade-hardened "${HARDENED_INIT_IMAGE}"
+wait_for_hardened_cluster
+
+assert_equal "OpenBaoCluster UID changed during the operator upgrade" "${cluster_uid}" \
+  "$("${KUBECTL_BIN}" get "${CLUSTER_RESOURCE}" -n "${TENANT_NAMESPACE}" -o jsonpath='{.metadata.uid}')"
+assert_equal "StatefulSet UID changed during the operator upgrade" "${statefulset_uid}" \
+  "$("${KUBECTL_BIN}" get statefulset/operator-upgrade -n "${TENANT_NAMESPACE}" -o jsonpath='{.metadata.uid}')"
+assert_equal "PVC UID changed during the operator upgrade" "${pvc_uid}" \
+  "$("${KUBECTL_BIN}" get "${PVC_RESOURCE}" -n "${TENANT_NAMESPACE}" -o jsonpath='{.metadata.uid}')"
+assert_equal "Migration fixture UID changed during the operator upgrade" "${migration_uid}" \
+  "$(
+    "${KUBECTL_BIN}" get openbaocluster/api-stability-migration \
+      -n "${TENANT_NAMESPACE}" \
+      -o jsonpath='{.metadata.uid}'
+  )"
+assert_equal "Hardened OpenBaoCluster UID changed during the operator upgrade" "${hardened_cluster_uid}" \
+  "$(
+    "${KUBECTL_BIN}" get "${HARDENED_CLUSTER_RESOURCE}" \
+      -n "${TENANT_NAMESPACE}" \
+      -o jsonpath='{.metadata.uid}'
+  )"
+assert_equal "Hardened StatefulSet UID changed during the operator upgrade" "${hardened_statefulset_uid}" \
+  "$(
+    "${KUBECTL_BIN}" get statefulset/operator-upgrade-hardened \
+      -n "${TENANT_NAMESPACE}" \
+      -o jsonpath='{.metadata.uid}'
+  )"
+assert_equal "Hardened PVC UIDs changed during the operator upgrade" "${hardened_pvc_uids}" \
+  "$(pvc_uid_set operator-upgrade-hardened 3)"
+assert_resource_absent secret/operator-upgrade-hardened-root-token
+assert_resource_absent secret/operator-upgrade-hardened-unseal-key
+
+statefulset_json="$("${KUBECTL_BIN}" get statefulset/operator-upgrade -n "${TENANT_NAMESPACE}" -o json)"
+jq -e --arg image "${LOCAL_INIT_IMAGE}" '
+  any(.spec.template.spec.initContainers[]; .name == "bao-config-init" and .image == $image)
+' <<<"${statefulset_json}" >/dev/null
+
+hardened_statefulset_json="$(
+  "${KUBECTL_BIN}" get statefulset/operator-upgrade-hardened \
+    -n "${TENANT_NAMESPACE}" \
+    -o json
+)"
+jq -e --arg image "${HARDENED_INIT_IMAGE}" '
+  .spec.replicas == 3 and
+  any(.spec.template.spec.initContainers[]; .name == "bao-config-init" and .image == $image)
+' <<<"${hardened_statefulset_json}" >/dev/null
+
+migration_json="$("${KUBECTL_BIN}" get openbaocluster/api-stability-migration -n "${TENANT_NAMESPACE}" -o json)"
+jq -e '
+  .spec.paused == true and
+  .spec.tls.acme.domains == ["bao.example.com"] and
+  (.spec.tls.acme | has("domain") | not) and
+  .spec.runtime.restartAt == "2026-08-01T12:00:00Z" and
+  (.spec.maintenance | has("restartAt") | not) and
+  (.spec.upgrade | has("tokenSecretRef") | not)
+' <<<"${migration_json}" >/dev/null
+
+echo "Reading the pre-upgrade data through the reconciled workload..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/read-data-job.yaml" >/dev/null
+"${KUBECTL_BIN}" wait job/operator-upgrade-read \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Complete \
+  --timeout=5m >/dev/null
+assert_equal "OpenBao data changed during the operator upgrade" "preserved" \
+  "$("${KUBECTL_BIN}" logs -n "${TENANT_NAMESPACE}" job/operator-upgrade-read | tr -d '\r\n')"
+
+echo "Reading the Hardened pre-upgrade data through JWT auth and verified TLS..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/hardened-read-data-job.yaml" >/dev/null
+"${KUBECTL_BIN}" wait job/operator-upgrade-hardened-read \
+  -n "${TENANT_NAMESPACE}" \
+  --for=condition=Complete \
+  --timeout=5m >/dev/null
+assert_equal "Hardened OpenBao data changed during the operator upgrade" "preserved" \
+  "$("${KUBECTL_BIN}" logs -n "${TENANT_NAMESPACE}" job/operator-upgrade-hardened-read | tr -d '\r\n')"
+
+echo "Exercising the upgraded provisioner with a new tenant..." >&2
+"${KUBECTL_BIN}" apply -f "${FIXTURE_DIR}/post-upgrade-tenant.yaml" >/dev/null
+"${KUBECTL_BIN}" wait openbaotenant/openbao-upgrade-post \
+  -n "${OPERATOR_NAMESPACE}" \
+  --for=jsonpath='{.status.provisioned}'=true \
+  --timeout=5m >/dev/null
+
+echo "Operator upgrade E2E succeeded: ${FROM_VERSION} -> ${TARGET_VERSION}" >&2

--- a/mk/ci.mk
+++ b/mk/ci.mk
@@ -15,7 +15,7 @@ endif
 	@echo "✅ All CI checks passed!"
 
 .PHONY: ci-core
-ci-core: security-ci security-scan-built-images lint-ci verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-vendor verify-generated verify-api-stability-inventory report-crd-compatibility verify-e2e-manifest test-ci fuzz verify-openbao-config-compat docs-build verify-helm helm-test ## Run all CI checks except E2E tests (cluster-independent).
+ci-core: security-ci security-scan-built-images lint-ci verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-vendor verify-generated verify-api-stability-inventory report-crd-compatibility verify-e2e-manifest verify-operator-upgrade-e2e test-ci fuzz verify-openbao-config-compat docs-build verify-helm helm-test ## Run all CI checks except E2E tests (cluster-independent).
 
 CI_MANAGER_SCAN_IMG ?= local/openbao-operator:ci
 CI_INIT_SCAN_IMG ?= local/openbao-init:ci

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -318,6 +318,15 @@ helm-test: helm-sync helm-lint ## Test the Helm chart without requiring a live c
 helm-e2e-smoke: ## Helm chart smoke test against a Kind cluster (installs chart and waits for deployments).
 	@bash hack/ci/helm-e2e-smoke.sh
 
+.PHONY: verify-operator-upgrade-e2e
+verify-operator-upgrade-e2e: ## Verify the previous-stable Development and Hardened operator upgrade harness.
+	@bash -n hack/ci/operator-upgrade-e2e.sh
+	@OPERATOR_UPGRADE_E2E_VERIFY_ONLY=true bash hack/ci/operator-upgrade-e2e.sh
+
+.PHONY: test-e2e-operator-upgrade
+test-e2e-operator-upgrade: ## Upgrade previous-stable Development and Hardened resources to the local candidate in Kind.
+	@bash hack/ci/operator-upgrade-e2e.sh
+
 .PHONY: helm-template
 helm-template: helm-sync ## Template the Helm chart with default values (useful for debugging).
 	@helm template openbao-operator charts/openbao-operator \

--- a/test/fixtures/operator-upgrade/cluster.yaml
+++ b/test/fixtures/operator-upgrade/cluster.yaml
@@ -1,0 +1,29 @@
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoCluster
+metadata:
+  name: operator-upgrade
+  namespace: openbao-upgrade-e2e
+spec:
+  version: "2.6.1"
+  image: "ghcr.io/openbao/openbao:2.6.1"
+  replicas: 1
+  profile: Development
+  initContainer:
+    enabled: true
+  tls:
+    enabled: true
+    mode: OperatorManaged
+    rotationPeriod: "720h"
+  storage:
+    size: "1Gi"
+  network:
+    apiServerCIDR: "10.96.0.0/12"
+    ingressRules:
+      - from:
+          - podSelector:
+              matchLabels:
+                role: operator-upgrade-verifier
+        ports:
+          - protocol: TCP
+            port: 8200
+  deletionPolicy: Retain

--- a/test/fixtures/operator-upgrade/hardened-cluster.yaml
+++ b/test/fixtures/operator-upgrade/hardened-cluster.yaml
@@ -1,0 +1,77 @@
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoCluster
+metadata:
+  name: operator-upgrade-hardened
+  namespace: openbao-upgrade-e2e
+spec:
+  version: "2.6.1"
+  image: "ghcr.io/openbao/openbao:2.6.1"
+  replicas: 3
+  profile: Hardened
+  initContainer:
+    enabled: true
+    image: "ghcr.io/dc-tec/openbao-init@sha256:e08e55a017a2594434dfa8f72860f4185bd4f82cebc3d09eb2e8310c819c4119"
+  selfInit:
+    enabled: true
+    oidc:
+      enabled: true
+    requests:
+      - name: enable-upgrade-kv
+        operation: update
+        path: sys/mounts/secret
+        secretEngine:
+          type: kv
+          description: Operator upgrade continuity data
+          options:
+            version: "2"
+      - name: create-upgrade-policy
+        operation: update
+        path: sys/policies/acl/operator-upgrade-hardened
+        policy:
+          policy: |
+            path "secret/*" { capabilities = ["create", "read", "update", "delete", "list"] }
+            path "secret/data/*" { capabilities = ["create", "read", "update", "delete", "list"] }
+            path "secret/metadata/*" { capabilities = ["read", "list", "delete"] }
+      - name: create-upgrade-role
+        operation: update
+        path: auth/jwt-operator/role/operator-upgrade-hardened
+        data:
+          role_type: jwt
+          user_claim: sub
+          bound_audiences:
+            - openbao-internal
+          bound_subject: system:serviceaccount:openbao-upgrade-e2e:default
+          token_policies:
+            - operator-upgrade-hardened
+          ttl: 1h
+  tls:
+    enabled: true
+    mode: External
+  service:
+    type: ClusterIP
+  unseal:
+    type: transit
+    transit:
+      address: https://operator-upgrade-transit.openbao-upgrade-e2e.svc:8200
+      mountPath: transit
+      keyName: operator-upgrade-hardened
+      tlsCACert: /etc/bao/seal-creds/ca.crt
+    credentialsSecretRef:
+      name: operator-upgrade-transit-credentials
+  storage:
+    size: "1Gi"
+  network:
+    apiServerCIDR: "10.96.0.0/12"
+    egressRules:
+      - to:
+          - podSelector:
+              matchLabels:
+                openbao.org/cluster: operator-upgrade-transit
+        ports:
+          - protocol: TCP
+            port: 8200
+    trustedIngressPeers:
+      - podSelector:
+          matchLabels:
+            role: operator-upgrade-hardened-verifier
+  deletionPolicy: Retain

--- a/test/fixtures/operator-upgrade/hardened-read-data-job.yaml
+++ b/test/fixtures/operator-upgrade/hardened-read-data-job.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: operator-upgrade-hardened-read
+  namespace: openbao-upgrade-e2e
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        role: operator-upgrade-hardened-verifier
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bao
+          image: ghcr.io/openbao/openbao:2.6.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              token="$(bao write -field=token auth/jwt-operator/login \
+                role=operator-upgrade-hardened \
+                jwt=@/var/run/secrets/openbao/token)"
+              export BAO_TOKEN="${token}"
+              bao kv get -field=value secret/operator-upgrade-hardened
+          env:
+            - name: BAO_ADDR
+              value: https://operator-upgrade-hardened.openbao-upgrade-e2e.svc:8200
+            - name: BAO_CACERT
+              value: /var/run/secrets/openbao-ca/ca.crt
+          volumeMounts:
+            - name: openbao-token
+              mountPath: /var/run/secrets/openbao
+              readOnly: true
+            - name: openbao-ca
+              mountPath: /var/run/secrets/openbao-ca
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: openbao-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: openbao-internal
+                  expirationSeconds: 3600
+                  path: token
+        - name: openbao-ca
+          secret:
+            secretName: operator-upgrade-hardened-tls-ca
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/test/fixtures/operator-upgrade/hardened-seed-data-job.yaml
+++ b/test/fixtures/operator-upgrade/hardened-seed-data-job.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: operator-upgrade-hardened-seed
+  namespace: openbao-upgrade-e2e
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        role: operator-upgrade-hardened-verifier
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bao
+          image: ghcr.io/openbao/openbao:2.6.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              token="$(bao write -field=token auth/jwt-operator/login \
+                role=operator-upgrade-hardened \
+                jwt=@/var/run/secrets/openbao/token)"
+              export BAO_TOKEN="${token}"
+              bao kv put secret/operator-upgrade-hardened value=preserved
+          env:
+            - name: BAO_ADDR
+              value: https://operator-upgrade-hardened.openbao-upgrade-e2e.svc:8200
+            - name: BAO_CACERT
+              value: /var/run/secrets/openbao-ca/ca.crt
+          volumeMounts:
+            - name: openbao-token
+              mountPath: /var/run/secrets/openbao
+              readOnly: true
+            - name: openbao-ca
+              mountPath: /var/run/secrets/openbao-ca
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: openbao-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: openbao-internal
+                  expirationSeconds: 3600
+                  path: token
+        - name: openbao-ca
+          secret:
+            secretName: operator-upgrade-hardened-tls-ca
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/test/fixtures/operator-upgrade/hardened-tls.yaml
+++ b/test/fixtures/operator-upgrade/hardened-tls.yaml
@@ -1,0 +1,52 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: operator-upgrade-hardened-selfsigned
+  namespace: openbao-upgrade-e2e
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: operator-upgrade-hardened-ca
+  namespace: openbao-upgrade-e2e
+spec:
+  isCA: true
+  commonName: operator-upgrade-hardened-ca
+  secretName: operator-upgrade-hardened-ca-material
+  issuerRef:
+    kind: Issuer
+    name: operator-upgrade-hardened-selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: operator-upgrade-hardened-ca
+  namespace: openbao-upgrade-e2e
+spec:
+  ca:
+    secretName: operator-upgrade-hardened-ca-material
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: operator-upgrade-hardened-server
+  namespace: openbao-upgrade-e2e
+spec:
+  secretName: operator-upgrade-hardened-server-material
+  commonName: operator-upgrade-hardened.openbao-upgrade-e2e.svc
+  dnsNames:
+    - localhost
+    - operator-upgrade-hardened.openbao-upgrade-e2e.svc
+    - "*.operator-upgrade-hardened.openbao-upgrade-e2e.svc"
+    - "*.openbao-upgrade-e2e.svc"
+    - openbao-cluster-operator-upgrade-hardened.local
+    - operator-upgrade-hardened-0.operator-upgrade-hardened.openbao-upgrade-e2e.svc
+    - operator-upgrade-hardened-1.operator-upgrade-hardened.openbao-upgrade-e2e.svc
+    - operator-upgrade-hardened-2.operator-upgrade-hardened.openbao-upgrade-e2e.svc
+  ipAddresses:
+    - 127.0.0.1
+  issuerRef:
+    kind: Issuer
+    name: operator-upgrade-hardened-ca

--- a/test/fixtures/operator-upgrade/post-upgrade-tenant.yaml
+++ b/test/fixtures/operator-upgrade/post-upgrade-tenant.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbao-upgrade-post
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+---
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoTenant
+metadata:
+  name: openbao-upgrade-post
+  namespace: openbao-operator-system
+spec:
+  targetNamespace: openbao-upgrade-post

--- a/test/fixtures/operator-upgrade/read-data-job.yaml
+++ b/test/fixtures/operator-upgrade/read-data-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: operator-upgrade-read
+  namespace: openbao-upgrade-e2e
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        role: operator-upgrade-verifier
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bao
+          image: ghcr.io/openbao/openbao:2.6.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - bao kv get -field=value secret/operator-upgrade
+          env:
+            - name: BAO_ADDR
+              value: https://operator-upgrade.openbao-upgrade-e2e.svc:8200
+            - name: BAO_SKIP_VERIFY
+              value: "true"
+            - name: BAO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: operator-upgrade-root-token
+                  key: token
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/test/fixtures/operator-upgrade/seed-data-job.yaml
+++ b/test/fixtures/operator-upgrade/seed-data-job.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: operator-upgrade-seed
+  namespace: openbao-upgrade-e2e
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        role: operator-upgrade-verifier
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bao
+          image: ghcr.io/openbao/openbao:2.6.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if ! bao secrets list -format=json | grep -q '"secret/"'; then
+                bao secrets enable -path=secret kv-v2
+              fi
+              bao kv put secret/operator-upgrade value=preserved
+          env:
+            - name: BAO_ADDR
+              value: https://operator-upgrade.openbao-upgrade-e2e.svc:8200
+            - name: BAO_SKIP_VERIFY
+              value: "true"
+            - name: BAO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: operator-upgrade-root-token
+                  key: token
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/test/fixtures/operator-upgrade/tenant.yaml
+++ b/test/fixtures/operator-upgrade/tenant.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbao-upgrade-e2e
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+---
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoTenant
+metadata:
+  name: openbao-upgrade-e2e
+  namespace: openbao-operator-system
+spec:
+  targetNamespace: openbao-upgrade-e2e

--- a/test/fixtures/operator-upgrade/transit-cluster.yaml
+++ b/test/fixtures/operator-upgrade/transit-cluster.yaml
@@ -1,0 +1,32 @@
+apiVersion: openbao.org/v1alpha1
+kind: OpenBaoCluster
+metadata:
+  name: operator-upgrade-transit
+  namespace: openbao-upgrade-e2e
+spec:
+  version: "2.6.1"
+  image: "ghcr.io/openbao/openbao:2.6.1"
+  replicas: 1
+  profile: Development
+  initContainer:
+    enabled: true
+  tls:
+    enabled: true
+    mode: OperatorManaged
+    rotationPeriod: "720h"
+  storage:
+    size: "1Gi"
+  network:
+    apiServerCIDR: "10.96.0.0/12"
+    ingressRules:
+      - from:
+          - podSelector:
+              matchLabels:
+                role: operator-upgrade-transit-config
+          - podSelector:
+              matchLabels:
+                openbao.org/cluster: operator-upgrade-hardened
+        ports:
+          - protocol: TCP
+            port: 8200
+  deletionPolicy: Retain

--- a/test/fixtures/operator-upgrade/transit-config-job.yaml
+++ b/test/fixtures/operator-upgrade/transit-config-job.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: operator-upgrade-transit-config
+  namespace: openbao-upgrade-e2e
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        role: operator-upgrade-transit-config
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bao
+          image: ghcr.io/openbao/openbao:2.6.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if ! bao secrets list -format=json | grep -q '"transit/"'; then
+                bao secrets enable -path=transit transit
+              fi
+              if ! bao read transit/keys/operator-upgrade-hardened >/dev/null 2>&1; then
+                bao write -f transit/keys/operator-upgrade-hardened type=aes256-gcm96
+              fi
+          env:
+            - name: BAO_ADDR
+              value: https://operator-upgrade-transit.openbao-upgrade-e2e.svc:8200
+            - name: BAO_SKIP_VERIFY
+              value: "true"
+            - name: BAO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: operator-upgrade-transit-root-token
+                  key: token
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL


### PR DESCRIPTION
## Summary

Add a live operator-upgrade gate that installs OpenBao Operator 0.4.2, seeds managed clusters, upgrades the Helm release to the candidate, and verifies reconciliation and data continuity.

The gate covers Development, Transit, and a three-replica Hardened profile with External TLS, Transit unseal, self-init, signed helper verification, and JWT-authenticated data checks. It runs for same-repository CI, main, nightly, and tagged release validation.

Release validation passes the signed candidate init image by immutable digest. Other lanes use a pinned signed helper digest, and the harness rejects mutable helper tags. Changes to the upgrade harness, API migration fixtures, operator-upgrade fixtures, chart, release notes, and API stability inputs route directly to the focused gate.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD schema, Helm values, or runtime RBAC behavior changes.

The main impact is additional CI and release runtime. Release promotion now fails closed when upgrading from the previous stable operator does not preserve managed workloads and stored data. The baseline is intentionally fixed at 0.4.2 for the 0.5.0 release line.

## Verification

- `make test-e2e-operator-upgrade` — passed `0.4.2 -> 0.5.0-e2e` across Development, Transit, and Hardened profiles
- `make verify-workflows`
- `make verify-operator-upgrade-e2e`
- `make verify-e2e-manifest` — 20 suites, 83 cases
- `make verify-helm helm-test`
- `shellcheck hack/ci/operator-upgrade-e2e.sh`
- `make docs-build DOCS_PNPM='npx --yes -p node@22.23.1 -p pnpm@10.34.5 -- pnpm'`
- `make security-scan-fs` — zero HIGH/CRITICAL findings
- Targeted Semgrep scan — zero findings
- Pre-push `make lint-ci` — zero lint issues, 61 architecture tests passed
- `git diff --check`
- Confirmed the temporary Kind cluster was removed

## Reviewer Notes

`make ci-core` currently stops at the known `license-check` issue: `go-licenses` v2.0.1 with Go 1.26.5 reports standard-library packages as lacking module information. Change-specific validation is green.

Reviewers should focus on the release-time candidate helper digest, the dedicated fixture routing in `.github/workflows/ci.yml`, and the Hardened profile lifecycle in `hack/ci/operator-upgrade-e2e.sh`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
