### PR TITLE
docs(architecture): close out 0.5.0 contracts

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -14,10 +14,14 @@ See [Architecture Documentation](docs/architecture/index.md).
 - `L1` Entrypoints/bootstrap: `cmd/*`, `internal/platform/entrypoint`
 - `L2` Controller plumbing: `internal/controller/*`
 - `L3` App orchestration: `internal/app/*`
-- `L4` Services/managers: `internal/service/{backup,restore,upgrade,infra,certs,init,provisioner,opslifecycle,workloadidentity}`
-- `L5` Ports/contracts: `internal/port/{auth,backup,blobstore,imageverify,infra,initmanager,openbao,security}`
-- `L6` Adapters/integrations: `internal/adapter/{kube,openbao,storage,auth,raft,security,storageenv,cluster,config,operationlock,probe,revision}`
-- `L7` Platform/cross-cutting: `internal/platform/{admission,constants,entrypoint,errors,logging,observability,openbaotls,predicates,reconcile,testutil}`
+- `L4` Services/managers:
+  `internal/service/{backup,bootstrap,certs,configuration,identity,init,networking,opslifecycle,provisioner,restore,upgrade,workload,workloadidentity}`
+- `L5` Ports/contracts:
+  `internal/port/{auth,backup,blobstore,imageverify,initmanager,openbao,security,workload}`
+- `L6` Adapters/integrations:
+  `internal/adapter/{auth,cluster,config,kube,openbao,probe,raft,revision,security,storage,storageenv}`
+- `L7` Platform/cross-cutting:
+  `internal/platform/{admission,constants,entrypoint,errors,hardenedcontract,logging,observability,openbaotls,predicates,reconcile,resourceapply,resourceidentity,resourceownership,semver,statusapply,statuspatch,testutil}`
 
 ## Separation of Concerns
 
@@ -101,6 +105,17 @@ Disallowed direction:
 - `L4/L6 -> L2` (service/adapter importing controllers)
 - `L6 -> L4` (adapter importing services/managers)
 - Re-introducing `internal/interfaces` as a generic dependency bucket
+
+## Optional Module Boundaries
+
+- Core lifecycle APIs remain under `openbao.org`; `OpenBaoCluster`, `OpenBaoRestore`, and `OpenBaoTenant` are core.
+- Optional modules own separate API groups and versions. The Claims and Service Offerings module uses
+  `claims.openbao.org`.
+- Optional module packages may depend on stable core APIs and narrow contracts. Core packages must not import
+  optional module packages.
+- Core generation, installation, startup, and reconciliation must work when optional module CRDs and controllers
+  are absent.
+- A module proposal must add architecture-policy and core-only test coverage before it lands.
 
 ## Verification
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -74,6 +74,46 @@ Restores are reconciled through the separate `OpenBaoRestore` controller, which 
 
 </Callout>
 
+## Watch and requeue strategy
+
+The controller registration strategy follows the tenancy RBAC boundary. Single-tenant mode can watch owned child
+resources inside the operator namespace. Multi-tenant mode does not register those child watches because
+controller-runtime would require list and watch access across tenant namespaces.
+
+<DecisionTable
+  kind="reference"
+  title="Reconcile triggers by tenancy mode"
+  columns={['Mode', 'Primary triggers', 'Tradeoff']}
+  rows={[
+    {
+      cells: [
+        'Single-tenant',
+        '`OpenBaoCluster` changes plus owned StatefulSet, Service, ConfigMap, Secret, Job, and ServiceAccount events; AdminOps also watches owned Jobs.',
+        'Child-resource changes enqueue reconciliation quickly because namespace-scoped list and watch permissions stay inside one trust boundary.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'Multi-tenant',
+        'Qualifying `OpenBaoCluster` changes plus explicit progress and retry requeues; the status controller also performs a steady-state refresh.',
+        'Status freshness stays bounded, but arbitrary steady-state child mutation does not enqueue the workload controller. Repair can wait for its next parent event or another explicit workload requeue. This preserves namespace-scoped tenant RBAC and avoids cluster-wide child-resource discovery.',
+      ],
+    },
+  ]}
+/>
+
+Both modes use rate-limited retries. The status controller has a steady-state refresh and safety requeues, while
+workload and AdminOps requeues follow active reconcile progress. The difference is event immediacy, not ownership:
+the same managers still read and reconcile the same named resources when a cluster is processed.
+
+<Callout type="warning" title="Multi-tenant child watches change the trust model">
+
+Adding `Owns` registration for tenant child resources in multi-tenant mode requires a deliberate RBAC and
+architecture change. Update the tenancy model, permissions, tests, and this page together.
+
+</Callout>
+
 ## App orchestration and managers
 
 <DiagramFrame

--- a/docs/architecture/operation-lifecycle.md
+++ b/docs/architecture/operation-lifecycle.md
@@ -66,20 +66,66 @@ That keeps the shared safety model in one place instead of scattering lock and r
   columns={['Plane', 'Field manager', 'Owned status fields']}
   rows={[
     {
-      cells: ['Observed status', '`openbao-status-controller`', '`status.observedGeneration`, `status.phase`, `status.activeLeader`, `status.readyReplicas`, `status.currentVersion`, `status.conditions`'],
+      cells: ['Observed status', '`openbao-status-controller`', '`status.observedGeneration`, `status.phase`, `status.activeLeader`, `status.readyReplicas`, `status.readReplicas`, `status.currentVersion`, `status.conditions`'],
       emphasis: 'recommended',
     },
     {
       cells: ['Workload status', '`openbao-workload-controller`', '`status.initialized`, `status.selfInitialized`, `status.workload`'],
     },
     {
-      cells: ['AdminOps status', '`openbao-adminops-controller`', '`status.upgrade`, `status.upgradeRequests`, `status.backup`, `status.blueGreen`, `status.breakGlass`, `status.adminOps`'],
+      cells: ['AdminOps status', '`openbao-adminops-controller`', '`status.acceptedUpgradeStrategy`, `status.upgrade`, `status.upgradeRequests`, `status.backup`, `status.blueGreen`, `status.breakGlass`, `status.adminOps`'],
     },
     {
       cells: ['Operation lock status', '`openbao-operationlock-controller`', '`status.operationLock`'],
     },
   ]}
 />
+
+## Server-side apply status contract
+
+Each status plane has one server-side apply field manager. The split prevents an observed-status write from
+claiming workload or AdminOps fields, but it does not make fragments within one plane independent. A writer that
+shares a field manager must read and apply that manager's complete plane.
+
+<DecisionTable
+  kind="reference"
+  title="Status write rules"
+  columns={['Concern', 'Required behavior', 'Why']}
+  rows={[
+    {
+      cells: [
+        'Ownership plane',
+        'Use the field manager assigned in the status ownership table and apply only that manager\'s fields.',
+        'Separate managers preserve sibling planes and make ownership conflicts diagnosable.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'Shared AdminOps plane',
+        'Read the latest object, mutate one concern, and apply the full AdminOps plane.',
+        'Omitting sibling fields from a later apply by the same manager can clear them. Fresh-read and concurrency tests protect upgrade, backup, blue-green, break-glass, and AdminOps state from each other.',
+      ],
+    },
+    {
+      cells: [
+        'Immediate readback',
+        'Use a fresh API read after apply when the same reconcile decision depends on the committed value.',
+        'The controller-runtime cache can lag the API server after a status write.',
+      ],
+    },
+    {
+      cells: [
+        'Operation lock clear',
+        'Clear through the dedicated operation-lock manager and use explicit ownership takeover only when legacy or external ownership conflicts.',
+        'Lock removal must not silently steal unrelated status ownership; force is a conflict recovery path, not the normal write mode.',
+      ],
+    },
+  ]}
+/>
+
+The preservation guarantee has two parts: separate field managers protect sibling status planes, while a
+fresh-read, full-plane mutation protects sibling fields that intentionally share the AdminOps manager.
 
 <DiagramFrame
   title="Coordination model"

--- a/docs/architecture/operator-invariants.md
+++ b/docs/architecture/operator-invariants.md
@@ -1,6 +1,6 @@
 ---
 title: Operator Invariants
-description: Cross-cutting invariants preserved by OpenBao Operator across identity boundaries, production posture, configuration ownership, and lifecycle safety.
+description: Cross-cutting invariants preserved by OpenBao Operator across identity boundaries, production posture, guardrail ownership, module boundaries, and lifecycle safety.
 hide_title: true
 pageType: concept
 journey: architecture
@@ -40,6 +40,13 @@ journey: architecture
     },
     {
       cells: [
+        'Guardrail ownership',
+        'Hardened rules are assigned to the earliest applicable enforcement layer and agree where ownership overlaps.',
+        'This keeps admission and runtime readiness aligned without duplicating every rule in every layer.',
+      ],
+    },
+    {
+      cells: [
         'Integration assumptions',
         'External dependencies surface as explicit status and readiness conditions.',
         'This makes environment assumptions visible before they become runtime failures.',
@@ -50,6 +57,13 @@ journey: architecture
         'Lifecycle safety',
         'Disruptive workflows stay explicit, lock-aware, and separated from steady-state workload reconciliation.',
         'This prevents upgrades, backups, and restores from colliding or becoming invisible side effects.',
+      ],
+    },
+    {
+      cells: [
+        'Module boundaries',
+        'Optional product modules remain separable from the core lifecycle API and controller runtime.',
+        'The core operator must remain installable and usable when an optional module is absent.',
       ],
     },
   ]}
@@ -144,6 +158,53 @@ Related reading: <SiteLink docId="security/infrastructure/rbac">RBAC Architectur
 
 Related reading: <SiteLink docId="security/fundamentals/profiles">Security Profiles</SiteLink>, <SiteLink docId="security/workload/tls">TLS and Identity</SiteLink>, and <SiteLink docId="user-guide/openbaocluster/configuration/self-init">Self-Initialization</SiteLink>.
 
+## Hardened guardrail ownership
+
+Hardened rules fail at the earliest layer that has enough information to decide them. The layers do not need to
+repeat every rule: request authorization belongs at admission, while runtime readiness covers the smaller set of
+violations that must remain visible after an object has already been accepted or restored.
+
+<DecisionTable
+  kind="reference"
+  title="Hardened enforcement layers"
+  columns={['Layer', 'Responsibility', 'Agreement contract']}
+  rows={[
+    {
+      cells: [
+        'CRD schema and CEL',
+        'Own general structural and cross-field validity that is independent of the Hardened profile.',
+        'No profile-specific Hardened rule is assigned to this layer today. New ownership requires catalog coverage and an explicit reason that schema evaluation has enough context.',
+      ],
+    },
+    {
+      cells: [
+        'ValidatingAdmissionPolicy',
+        'Own Hardened request-time safety and authorization checks that can be decided at the API boundary.',
+        'Policy messages and dry-run API-server fixtures map back to stable rule IDs in the Hardened contract catalog.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'Runtime readiness',
+        'Re-evaluate the subset whose violation must remain observable during reconciliation.',
+        'Rules shared with admission use same-rule verdict fixtures. Runtime-only and admission-only rules stay explicit instead of being forced into false symmetry.',
+      ],
+    },
+  ]}
+/>
+
+`internal/platform/hardenedcontract` is the registry for stable rule IDs, enforcement ownership, and shared fixture
+identity. Agreement means that layers which claim the same rule reach the same allow or deny verdict for that
+rule's fixtures. It does not require the layers to use the same expression, status message, or available context.
+
+<Callout type="note" title="Ownership changes are contract changes">
+
+Moving a Hardened rule between layers, adding a second owner, or changing a shared verdict requires catalog,
+policy, runtime, and agreement-test updates in the same change.
+
+</Callout>
+
 ## Integration invariants
 
 <DecisionTable
@@ -177,6 +238,52 @@ Related reading: <SiteLink docId="security/fundamentals/profiles">Security Profi
 />
 
 Related reading: <SiteLink docId="reference/status-and-events">Status and Events</SiteLink>, <SiteLink docId="user-guide/openbaocluster/configuration/observability">Observability</SiteLink>, and <SiteLink docId="user-guide/openbaocluster/operations/backups">Configure Backups</SiteLink>.
+
+## Optional module invariants
+
+Optional product modules may build on the lifecycle core, but they do not become hidden prerequisites for it.
+This is a landing contract for future module code and APIs; it does not imply that an optional module ships in
+the current release.
+
+<DecisionTable
+  kind="reference"
+  title="Core and module separation"
+  columns={['Invariant', 'Design effect', 'Landing evidence']}
+  rows={[
+    {
+      cells: [
+        'Core API ownership remains stable.',
+        '`OpenBaoCluster`, `OpenBaoRestore`, and `OpenBaoTenant` remain in the core `openbao.org` API group.',
+        'Core API review and compatibility checks.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'Optional modules own separate API groups and versions.',
+        'A module can evolve, install, and be reviewed without expanding the core API group.',
+        'Module-specific CRDs, generated artifacts, install wiring, and API tests.',
+      ],
+    },
+    {
+      cells: [
+        'Dependencies point from modules to stable core contracts.',
+        'Module packages may consume core APIs and narrow contracts; core packages must not import module packages.',
+        'Generated architecture policy and dependency reports.',
+      ],
+    },
+    {
+      cells: [
+        'The core works when module CRDs are absent.',
+        'Core build, installation, startup, and reconciliation cannot require optional API discovery or module controllers.',
+        'Core-only generation, installation, startup, and reconcile tests.',
+      ],
+    },
+  ]}
+/>
+
+The Claims and Service Offerings design applies this contract with the planned `claims.openbao.org` API group.
+See <SiteLink docId="design/claims-and-service-offerings">Claims and Service Offerings</SiteLink>.
 
 ## Lifecycle safety invariants
 
@@ -242,6 +349,11 @@ If a change weakens one of these invariants, update the related architecture, se
       label: 'Security overview',
       description: 'User-facing security model behind these invariants.',
       docId: 'security/index',
+    },
+    {
+      label: 'Claims and Service Offerings',
+      description: 'Optional-module and API-group boundaries for the planned self-service layer.',
+      docId: 'design/claims-and-service-offerings',
     },
   ]}
 />

--- a/docs/design/claims-and-service-offerings.mdx
+++ b/docs/design/claims-and-service-offerings.mdx
@@ -78,6 +78,53 @@ The same-cluster path resolves service intent through a bounded pipeline:
 The concrete workload remains visible and owned. Claim-managed clusters are machine-distinguishable from directly
 managed clusters through ownership labels and admission protection.
 
+## API and module boundary
+
+Claims and Service Offerings are an optional product module above the core lifecycle API. Their planned public
+resources use the `claims.openbao.org` API group and own their versions independently from the core `openbao.org`
+resources.
+
+<DecisionTable
+  kind="reference"
+  title="Claims module contract"
+  columns={['Concern', 'Decision', 'Effect']}
+  rows={[
+    {
+      cells: [
+        'Public API group',
+        'Claims, offerings, profiles, and module-owned supporting resources use `claims.openbao.org`.',
+        'The self-service API can evolve without expanding or version-coupling the core lifecycle group.',
+      ],
+      emphasis: 'recommended',
+    },
+    {
+      cells: [
+        'Core lifecycle API',
+        '`OpenBaoCluster`, `OpenBaoRestore`, and `OpenBaoTenant` remain in `openbao.org`.',
+        'Direct lifecycle users retain one stable core API surface.',
+      ],
+    },
+    {
+      cells: [
+        'Dependency direction',
+        'The Claims module may consume stable core APIs and narrow contracts. Core packages must not import Claims module packages.',
+        'The module builds on the lifecycle core without making the core depend on the self-service layer.',
+      ],
+    },
+    {
+      cells: [
+        'Optional installation',
+        'Core generation, installation, startup, and reconciliation work without Claims CRDs or controllers.',
+        'Operators can deploy the lifecycle core alone; module discovery cannot become a core startup prerequisite.',
+      ],
+    },
+  ]}
+/>
+
+This is a landing contract, not a statement that the module ships in the current release. The integration branch
+must align its API packages, generated CRDs, install wiring, architecture rules, and core-only tests with this
+boundary before the feature is proposed for release.
+
 ## Current implementation status
 
 The same-cluster path is in integration. The implementation branch is `integration/claims-service`.


### PR DESCRIPTION
## Summary

Close out the source architecture documentation for the 0.5.0 release cycle:

- define Hardened guardrail ownership across CRD/CEL, admission, and runtime readiness
- document server-side apply status planes, full-plane mutation, and sibling-field preservation
- document the single-tenant watch and multi-tenant requeue tradeoff
- establish optional-module isolation and the planned `claims.openbao.org` API group
- refresh the agent architecture inventory to match the current package layout

This keeps the durable source documentation aligned with the contracts already present in the operator before the release snapshot is generated.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Documentation and agent guidance only. There are no runtime, API, CRD, Helm, RBAC, or upgrade behavior changes.

The Claims API-group decision is a future landing contract; this change does not ship the optional module in 0.5.0.

## Verification

- `make docs-build`
- `make generate-ast-rules`
- `make verify-arch-policy`
- `make test-ast`
- `make lint-ast`
- `make report-internal-deps` (no policy warnings)
- `make lint-ci` (pre-push hook, zero lint issues and 61 architecture tests passed)
- `git diff --check`

## Reviewer Notes

Please focus on:

- the explicit limitation that multi-tenant status refresh does not make arbitrary child-resource drift enqueue workload reconciliation
- the full-plane SSA rule for writers sharing the AdminOps field manager
- `claims.openbao.org` and the one-way optional-module dependency boundary

The generated 0.5.0 documentation snapshot is intentionally excluded and can follow after these source decisions are accepted.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] Tests are not required for documentation-only behavior; the relevant docs and architecture checks passed.
- [x] I have updated documentation.
- [x] I confirmed generated artifacts are unaffected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks and documented them above.
- [x] There are no dependent changes required for this PR.