### PR TITLE
ci(release): harden rc release automation

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -21,7 +21,14 @@ jobs:
   pr-title-conventional:
     name: PR Title Uses Conventional Commits
     runs-on: ubuntu-24.04
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: >-
+      ${{
+        !endsWith(github.actor, '[bot]')
+        && (
+          github.event.pull_request.head.repo.full_name != github.repository
+          || !startsWith(github.head_ref, 'release-please--branches--')
+        )
+      }}
     steps:
       - name: Validate PR title format
         env:
@@ -50,7 +57,14 @@ jobs:
   pr-template-check:
     name: PR Description Matches Template
     runs-on: ubuntu-24.04
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: >-
+      ${{
+        !endsWith(github.actor, '[bot]')
+        && (
+          github.event.pull_request.head.repo.full_name != github.repository
+          || !startsWith(github.head_ref, 'release-please--branches--')
+        )
+      }}
     steps:
       - name: Validate PR description sections
         env:
@@ -97,7 +111,14 @@ jobs:
   commit-messages-conventional:
     name: PR Commits Use Conventional Commits
     runs-on: ubuntu-24.04
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: >-
+      ${{
+        !endsWith(github.actor, '[bot]')
+        && (
+          github.event.pull_request.head.repo.full_name != github.repository
+          || !startsWith(github.head_ref, 'release-please--branches--')
+        )
+      }}
     steps:
       - name: Informational only (squash-merge model)
         run: |

--- a/.github/workflows/prepare-release-as-pr.yml
+++ b/.github/workflows/prepare-release-as-pr.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: prepare-release-as-pr-${{ inputs.target_branch }}-${{ inputs.version }}
+  group: prepare-release-as-pr-${{ inputs.target_branch }}
   cancel-in-progress: false
 
 jobs:
@@ -26,23 +26,6 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ !github.event.repository.fork }}
     steps:
-      - name: Validate inputs
-        env:
-          TARGET_BRANCH: ${{ inputs.target_branch }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-
-          if ! [[ "${TARGET_BRANCH}" =~ ^(main|release-[0-9]+(\.[0-9]+)*)$ ]]; then
-            echo "target_branch must be main or release-X[.Y...], got '${TARGET_BRANCH}'" >&2
-            exit 1
-          fi
-
-          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
-            echo "version must be SemVer, got '${VERSION}'" >&2
-            exit 1
-          fi
-
       - name: Mint GitHub App token (openbao-operator-release-pr)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -55,36 +38,130 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 
-      - name: Checkout target branch
+      - name: Checkout release tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.target_branch }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Create Release-As marker branch
-        id: marker
+      - name: Validate release request
+        id: request
         env:
           TARGET_BRANCH: ${{ inputs.target_branch }}
           VERSION: ${{ inputs.version }}
+        run: bash hack/ci/validate-release-as-request.sh
+
+      - name: Check for conflicting release state
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          VERSION: ${{ inputs.version }}
+          MARKER_BRANCH: ${{ steps.request.outputs.marker_branch }}
         run: |
           set -euo pipefail
 
-          marker_branch="release-as-${TARGET_BRANCH}-${VERSION}"
-          echo "branch=${marker_branch}" >> "${GITHUB_OUTPUT}"
+          if ! git ls-remote --exit-code --heads origin "refs/heads/${TARGET_BRANCH}" >/dev/null 2>&1; then
+            echo "target branch '${TARGET_BRANCH}' does not exist" >&2
+            exit 1
+          fi
 
-          if git ls-remote --exit-code --heads origin "${marker_branch}" >/dev/null 2>&1; then
-            git fetch origin "refs/heads/${marker_branch}:refs/remotes/origin/${marker_branch}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "tag '${VERSION}' already exists" >&2
+            exit 1
+          fi
+
+          existing_release="$(
+            gh release list \
+              --repo "${REPO}" \
+              --limit 100 \
+              --json tagName \
+              --jq ".[] | select(.tagName == \"${VERSION}\") | .tagName"
+          )"
+          if [[ -n "${existing_release}" ]]; then
+            echo "GitHub Release '${VERSION}' already exists" >&2
+            exit 1
+          fi
+
+          release_pr="$(
+            gh pr list \
+              --repo "${REPO}" \
+              --state open \
+              --base "${TARGET_BRANCH}" \
+              --head "release-please--branches--${TARGET_BRANCH}" \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          if [[ -n "${release_pr}" ]]; then
+            echo "release-please PR #${release_pr} is already open for '${TARGET_BRANCH}'" >&2
+            exit 1
+          fi
+
+          open_markers="$(
+            gh pr list \
+              --repo "${REPO}" \
+              --state open \
+              --base "${TARGET_BRANCH}" \
+              --json number,headRefName \
+              --jq '
+                .[]
+                | select(
+                    (.headRefName | startswith("automation/release-as-"))
+                    or (.headRefName | startswith("release-as-"))
+                  )
+                | [.number, .headRefName]
+                | @tsv
+              '
+          )"
+          conflicting_marker=""
+          while IFS=$'\t' read -r marker_number marker_head; do
+            if [[ -n "${marker_number}" && "${marker_head}" != "${MARKER_BRANCH}" ]]; then
+              conflicting_marker="${marker_number}"
+              break
+            fi
+          done <<< "${open_markers}"
+          if [[ -n "${conflicting_marker}" ]]; then
+            echo "release marker PR #${conflicting_marker} is already open for '${TARGET_BRANCH}'" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --heads origin "refs/heads/${MARKER_BRANCH}" >/dev/null 2>&1; then
+            existing_marker="$(
+              gh pr list \
+                --repo "${REPO}" \
+                --state open \
+                --base "${TARGET_BRANCH}" \
+                --head "${MARKER_BRANCH}" \
+                --json number \
+                --jq '.[0].number // empty'
+            )"
+            if [[ -z "${existing_marker}" ]]; then
+              echo "marker branch '${MARKER_BRANCH}' exists without an open matching PR" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Create Release-As marker branch
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          VERSION: ${{ inputs.version }}
+          MARKER_BRANCH: ${{ steps.request.outputs.marker_branch }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin "refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+          if git ls-remote --exit-code --heads origin "refs/heads/${MARKER_BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${MARKER_BRANCH}:refs/remotes/origin/${MARKER_BRANCH}"
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git switch -c "${marker_branch}"
+          git switch -C "${MARKER_BRANCH}" "origin/${TARGET_BRANCH}"
           git commit --allow-empty -s \
             -m "Release ${VERSION}" \
             -m "Release-As: ${VERSION}"
-          git push --force-with-lease="refs/heads/${marker_branch}" origin "HEAD:${marker_branch}"
+          git push --force-with-lease="refs/heads/${MARKER_BRANCH}" origin "HEAD:${MARKER_BRANCH}"
 
       - name: Open or update marker PR
         env:
@@ -92,7 +169,7 @@ jobs:
           REPO: ${{ github.repository }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           VERSION: ${{ inputs.version }}
-          MARKER_BRANCH: ${{ steps.marker.outputs.branch }}
+          MARKER_BRANCH: ${{ steps.request.outputs.marker_branch }}
         run: |
           set -euo pipefail
 
@@ -108,9 +185,39 @@ jobs:
 
           body="$(mktemp)"
           cat > "${body}" <<EOF
-          This PR adds an empty release marker commit for release-please.
+          ## Summary
 
-          After this PR merges into \`${TARGET_BRANCH}\`, the Release Please PR workflow should open or update the release PR for \`${VERSION}\`.
+          Add an auditable empty release marker commit for release-please.
+
+          After this PR merges into \`${TARGET_BRANCH}\`, the Release Please PR workflow opens or updates the
+          release PR for \`${VERSION}\`.
+
+          ## Related Issues
+
+          None.
+
+          ## Type of Change
+
+          - [x] CI, release, or build tooling
+
+          ## Risk and Compatibility
+
+          No runtime, API, CRD, Helm, RBAC, or compatibility impact.
+
+          ## Verification
+
+          - Release request inputs and repository state were validated by the workflow.
+
+          ## Reviewer Notes
+
+          Merge this marker PR before reviewing the generated release-please PR.
+
+          Release-As: ${VERSION}
+
+          ## Checklist
+
+          - [x] The target branch and requested version are correct.
+          - [x] No conflicting tag, release, release PR, or marker PR exists.
           EOF
 
           if [[ -n "${existing_pr}" ]]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      - 'release-[0-9]*.[0-9]*'
       - '!release-please--branches--*'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      - 'release-[0-9]*.[0-9]*'
       - '!release-please--branches--*'
     paths:
       - 'CHANGELOG.md'

--- a/docs/contribute/release-management.md
+++ b/docs/contribute/release-management.md
@@ -89,6 +89,14 @@ GitHub Actions runs workflow definitions from the branch that receives the push.
 
 </Callout>
 
+<Callout type="important" title="Create a release line after its first stable release">
+
+Cut prereleases and the first stable `X.Y.0` release from a frozen `main`. Create `release-X.Y` from the
+published stable commit only after `X.Y.0` completes. The release branch then becomes the source for narrowly
+scoped `X.Y.Z` patch releases while normal development resumes on `main`.
+
+</Callout>
+
 <CommandBlock
   language="bash"
   label="configure"
@@ -118,8 +126,15 @@ make docs-refresh-version DOCS_VERSION=X.Y.0`}
 # target_branch: main        # or release-0.2
 # version: 0.1.0-rc.6       # or 0.2.1`}
 >
-  This workflow creates a tiny PR containing an empty `Release-As: <version>` commit. Merge that marker PR first; the branch-aware Release Please workflow then opens or updates the real release PR.
+  This workflow validates the requested release line and repository state, then creates a tiny PR containing an
+  empty `Release-As: <version>` commit. Merge that marker PR first; the branch-aware Release Please workflow then
+  opens or updates the real release PR.
 </CommandBlock>
+
+The marker branch uses the `automation/release-as-*` namespace, outside the `release-X.Y` namespace watched by
+Release Please. Preparing or updating the marker therefore cannot create a release PR before the marker merges.
+The workflow also rejects a missing target branch, a version for the wrong release line, an existing tag or GitHub
+Release, an open release-please PR, and conflicting marker state.
 
 <Callout type="note" title="`workflow_dispatch` `release_as` path">
 
@@ -129,7 +144,15 @@ make docs-refresh-version DOCS_VERSION=X.Y.0`}
 
 <Callout type="note" title="Helm chart changelog">
 
-Release-please remains the source of truth for release notes. After release-please opens or updates a release PR, the `Release Please PR` workflow syncs `charts/openbao-operator/Chart.yaml` so Artifact Hub receives `artifacthub.io/changes`, image metadata, prerelease state, and security-update state from the release-please changelog.
+Release-please remains the source of truth for release notes. After release-please opens or updates a release PR,
+the `Release Please PR` workflow syncs `charts/openbao-operator/Chart.yaml` so Artifact Hub receives
+`artifacthub.io/changes`, image metadata, prerelease state, and security-update state from the release-please
+changelog.
+
+For a prerelease, Artifact Hub metadata contains only that exact changelog section. For the matching stable
+release, metadata rolls up and deduplicates the stable and `X.Y.Z-*` prerelease sections. This keeps the generated
+changelog incremental while giving the stable chart a complete change list. Security-scoped entries and dependency
+fixes that identify vulnerabilities, CVEs, or GHSAs set `artifacthub.io/containsSecurityUpdates`.
 
 </Callout>
 

--- a/hack/ci/prepare-release-chart.sh
+++ b/hack/ci/prepare-release-chart.sh
@@ -73,6 +73,13 @@ def change_kind(section):
     return "changed"
 
 
+def is_security_description(description):
+    normalized = description.lower()
+    if re.match(r"^[a-z0-9_,./-]*security[a-z0-9_,./-]*\s*:", normalized):
+        return True
+    return bool(re.search(r"\b(cve-[0-9-]+|ghsa-[0-9a-z-]+|vulnerab\w*)\b", normalized))
+
+
 def clean_description(raw):
     value = re.sub(r"\s+\(\[#\d+\]\([^)]+\)\)", "", raw)
     value = re.sub(r"\s+\(\[[0-9a-f]{7,40}\]\([^)]+\)\)", "", value)
@@ -82,23 +89,7 @@ def clean_description(raw):
     return value
 
 
-def release_changes(changelog):
-    lines = changelog.splitlines()
-    start = None
-    for index, line in enumerate(lines):
-        if heading_version(line) == version:
-            start = index + 1
-            break
-
-    if start is None:
-        raise SystemExit(f"release {version} was not found in {changelog_path}")
-
-    end = len(lines)
-    for index in range(start, len(lines)):
-        if lines[index].startswith("## "):
-            end = index
-            break
-
+def section_changes(lines, start, end):
     changes = []
     current_kind = "changed"
     current_change = None
@@ -114,8 +105,7 @@ def release_changes(changelog):
         if bullet_match:
             description = clean_description(bullet_match.group(1))
             if description:
-                kind = "security" if re.match(r"^security\s*:", description, re.IGNORECASE) else current_kind
-                current_change = {"kind": kind, "description": description}
+                current_change = {"kind": current_kind, "description": description}
                 changes.append(current_change)
             continue
 
@@ -124,6 +114,49 @@ def release_changes(changelog):
             if continuation:
                 current_change["description"] = f"{current_change['description']} {continuation}"
 
+    for change in changes:
+        if is_security_description(change["description"]):
+            change["kind"] = "security"
+
+    return changes
+
+
+def release_changes(changelog):
+    lines = changelog.splitlines()
+    headings = []
+    for index, line in enumerate(lines):
+        heading = heading_version(line)
+        if heading is not None:
+            headings.append((index, heading))
+
+    if not any(heading == version for _, heading in headings):
+        raise SystemExit(f"release {version} was not found in {changelog_path}")
+
+    stable_version = re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) is not None
+    changes = []
+    for position, (heading_index, heading) in enumerate(headings):
+        include = heading == version
+        if stable_version and heading.startswith(f"{version}-"):
+            include = True
+        if not include:
+            continue
+
+        start = heading_index + 1
+        end = headings[position + 1][0] if position + 1 < len(headings) else len(lines)
+        changes.extend(section_changes(lines, start, end))
+
+    deduplicated = []
+    seen = {}
+    for change in changes:
+        description = change["description"]
+        if description in seen:
+            if change["kind"] == "security":
+                deduplicated[seen[description]]["kind"] = "security"
+            continue
+        seen[description] = len(deduplicated)
+        deduplicated.append(change)
+
+    changes = deduplicated
     if not changes:
         changes.append({"kind": "changed", "description": f"Release {version}"})
 

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="${ROOT_DIR}/hack/ci/validate-release-as-request.sh"
+CHART_PREPARER="${ROOT_DIR}/hack/ci/prepare-release-chart.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fail() {
+  echo "release automation test failed: $*" >&2
+  exit 1
+}
+
+expect_valid_request() {
+  local target_branch="$1"
+  local version="$2"
+  local expected_branch="$3"
+  local actual_branch
+
+  actual_branch="$(TARGET_BRANCH="${target_branch}" VERSION="${version}" bash "${VALIDATOR}")"
+  [[ "${actual_branch}" == "${expected_branch}" ]] || {
+    fail "expected marker '${expected_branch}', got '${actual_branch}'"
+  }
+}
+
+expect_invalid_request() {
+  local target_branch="$1"
+  local version="$2"
+
+  if TARGET_BRANCH="${target_branch}" VERSION="${version}" bash "${VALIDATOR}" >/dev/null 2>&1; then
+    fail "expected target='${target_branch}' version='${version}' to be rejected"
+  fi
+}
+
+write_chart_fixture() {
+  local chart_file="$1"
+
+  cat > "${chart_file}" <<'EOF'
+apiVersion: v2
+name: openbao-operator
+version: 0.5.0
+annotations:
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/containsSecurityUpdates: 'false'
+  artifacthub.io/changes: |
+    - kind: changed
+      description: "stale"
+  artifacthub.io/images: |
+    - name: openbao-operator
+      image: ghcr.io/example/openbao-operator:stale
+EOF
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fq -- "${expected}" "${file}" || fail "expected '${expected}' in ${file}"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq -- "${unexpected}" "${file}"; then
+    fail "did not expect '${unexpected}' in ${file}"
+  fi
+}
+
+bash -n "${VALIDATOR}" "${CHART_PREPARER}"
+
+expect_valid_request "main" "0.5.0-rc.1" "automation/release-as-main-0.5.0-rc.1"
+expect_valid_request "release-0.5" "0.5.1" "automation/release-as-release-0.5-0.5.1"
+expect_invalid_request "release-as-main-0.5.0" "0.5.0"
+expect_invalid_request "release-0.5.1" "0.5.1"
+expect_invalid_request "release-0.5" "0.6.0"
+expect_invalid_request "main" "0.5"
+expect_invalid_request "main" "00.5.0"
+expect_invalid_request "main" "0.5.0-rc.01"
+
+marker_branch="$(TARGET_BRANCH=main VERSION=0.5.0-rc.1 bash "${VALIDATOR}")"
+if [[ "${marker_branch}" == release-* ]]; then
+  fail "marker branch '${marker_branch}' overlaps the release branch namespace"
+fi
+
+for workflow in release-please.yml release-tag.yml; do
+  if grep -Fq -- "- 'release-*'" "${ROOT_DIR}/.github/workflows/${workflow}"; then
+    fail "${workflow} uses the broad release-* branch trigger"
+  fi
+done
+
+output_file="${tmp_dir}/github-output"
+GITHUB_OUTPUT="${output_file}" TARGET_BRANCH=main VERSION=0.5.0-rc.1 bash "${VALIDATOR}"
+assert_contains "${output_file}" "marker_branch=automation/release-as-main-0.5.0-rc.1"
+
+changelog_file="${tmp_dir}/CHANGELOG.md"
+cat > "${changelog_file}" <<'EOF'
+# Changelog
+
+## [0.5.0](https://example.test/0.5.0) (2026-08-04)
+
+### Bug Fixes
+
+* **release:** finalize stable metadata
+* **backup:** add immutable backup evidence
+
+## [0.5.0-rc.2](https://example.test/0.5.0-rc.2) (2026-08-03)
+
+### Features
+
+* **backup:** add immutable backup evidence
+* **controller:** add rc2-only reconciliation guard
+
+## [0.5.0-rc.1](https://example.test/0.5.0-rc.1) (2026-08-02)
+
+### Bug Fixes
+
+* **deps:** resolve security vulnerabilities in example dependencies
+
+### Features
+
+* **backup:** add immutable backup evidence
+
+## [0.4.0](https://example.test/0.4.0) (2026-07-01)
+
+### Features
+
+* **legacy:** older release entry
+EOF
+
+rc_chart_dir="${tmp_dir}/rc-chart"
+mkdir -p "${rc_chart_dir}"
+write_chart_fixture "${rc_chart_dir}/Chart.yaml"
+CHART_DIR="${rc_chart_dir}" \
+  CHANGELOG_FILE="${changelog_file}" \
+  CHART_VERSION="0.5.0-rc.1" \
+  OWNER="dc-tec" \
+  bash "${CHART_PREPARER}"
+
+assert_contains "${rc_chart_dir}/Chart.yaml" 'artifacthub.io/prerelease: "true"'
+assert_contains "${rc_chart_dir}/Chart.yaml" "artifacthub.io/containsSecurityUpdates: 'true'"
+assert_contains "${rc_chart_dir}/Chart.yaml" "kind: security"
+assert_contains "${rc_chart_dir}/Chart.yaml" "deps: resolve security vulnerabilities in example dependencies"
+assert_contains "${rc_chart_dir}/Chart.yaml" "backup: add immutable backup evidence"
+assert_not_contains "${rc_chart_dir}/Chart.yaml" "release: finalize stable metadata"
+assert_not_contains "${rc_chart_dir}/Chart.yaml" "controller: add rc2-only reconciliation guard"
+
+stable_chart_dir="${tmp_dir}/stable-chart"
+mkdir -p "${stable_chart_dir}"
+write_chart_fixture "${stable_chart_dir}/Chart.yaml"
+CHART_DIR="${stable_chart_dir}" \
+  CHANGELOG_FILE="${changelog_file}" \
+  CHART_VERSION="0.5.0" \
+  OWNER="dc-tec" \
+  bash "${CHART_PREPARER}"
+
+stable_chart="${stable_chart_dir}/Chart.yaml"
+assert_contains "${stable_chart}" 'artifacthub.io/prerelease: "false"'
+assert_contains "${stable_chart}" "artifacthub.io/containsSecurityUpdates: 'true'"
+assert_contains "${stable_chart}" "release: finalize stable metadata"
+assert_contains "${stable_chart}" "backup: add immutable backup evidence"
+assert_contains "${stable_chart}" "controller: add rc2-only reconciliation guard"
+assert_contains "${stable_chart}" "deps: resolve security vulnerabilities in example dependencies"
+assert_not_contains "${stable_chart}" "legacy: older release entry"
+
+backup_change_count="$(grep -Fc "backup: add immutable backup evidence" "${stable_chart}")"
+[[ "${backup_change_count}" == "1" ]] || fail "expected rolled-up changes to be deduplicated"
+
+echo "release automation tests passed"

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -20,7 +20,12 @@ expect_valid_request() {
   local expected_branch="$3"
   local actual_branch
 
-  actual_branch="$(TARGET_BRANCH="${target_branch}" VERSION="${version}" bash "${VALIDATOR}")"
+  actual_branch="$(
+    env -u GITHUB_OUTPUT \
+      TARGET_BRANCH="${target_branch}" \
+      VERSION="${version}" \
+      bash "${VALIDATOR}"
+  )"
   [[ "${actual_branch}" == "${expected_branch}" ]] || {
     fail "expected marker '${expected_branch}', got '${actual_branch}'"
   }
@@ -81,7 +86,7 @@ expect_invalid_request "main" "0.5"
 expect_invalid_request "main" "00.5.0"
 expect_invalid_request "main" "0.5.0-rc.01"
 
-marker_branch="$(TARGET_BRANCH=main VERSION=0.5.0-rc.1 bash "${VALIDATOR}")"
+marker_branch="$(env -u GITHUB_OUTPUT TARGET_BRANCH=main VERSION=0.5.0-rc.1 bash "${VALIDATOR}")"
 if [[ "${marker_branch}" == release-* ]]; then
   fail "marker branch '${marker_branch}' overlaps the release branch namespace"
 fi

--- a/hack/ci/validate-release-as-request.sh
+++ b/hack/ci/validate-release-as-request.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${TARGET_BRANCH:?TARGET_BRANCH is required}"
+: "${VERSION:?VERSION is required}"
+
+if ! [[ "${TARGET_BRANCH}" =~ ^(main|release-[0-9]+\.[0-9]+)$ ]]; then
+  echo "target_branch must be main or release-X.Y, got '${TARGET_BRANCH}'" >&2
+  exit 1
+fi
+
+semver_core='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+semver_prerelease='(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'
+semver_build='(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'
+semver_regex="^${semver_core}${semver_prerelease}${semver_build}$"
+if ! [[ "${VERSION}" =~ ${semver_regex} ]]; then
+  echo "version must be SemVer, got '${VERSION}'" >&2
+  exit 1
+fi
+
+if [[ "${VERSION}" == *-* ]]; then
+  prerelease="${VERSION#*-}"
+  prerelease="${prerelease%%+*}"
+  IFS='.' read -r -a prerelease_identifiers <<< "${prerelease}"
+  for identifier in "${prerelease_identifiers[@]}"; do
+    if [[ "${identifier}" =~ ^[0-9]+$ && "${identifier}" != "0" && "${identifier}" == 0* ]]; then
+      echo "numeric prerelease identifiers must not contain leading zeroes, got '${VERSION}'" >&2
+      exit 1
+    fi
+  done
+fi
+
+version_core="${VERSION%%[-+]*}"
+IFS='.' read -r version_major version_minor _ <<< "${version_core}"
+version_line="${version_major}.${version_minor}"
+if [[ "${TARGET_BRANCH}" != "main" && "${TARGET_BRANCH}" != "release-${version_line}" ]]; then
+  echo "version '${VERSION}' does not belong to release line '${TARGET_BRANCH}'" >&2
+  exit 1
+fi
+
+marker_branch="automation/release-as-${TARGET_BRANCH}-${VERSION}"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "marker_branch=${marker_branch}" >> "${GITHUB_OUTPUT}"
+else
+  echo "${marker_branch}"
+fi

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -148,8 +148,12 @@ verify-tidy: ## Verify go.mod/go.sum are tidy (does not modify tracked files).
 verify-go-toolchain-sync: ## Verify go.mod, Dockerfile builders, and the devcontainer use the same Go version.
 	@bash hack/ci/verify-go-toolchain-sync.sh
 
+.PHONY: verify-release-automation
+verify-release-automation: ## Test release request validation and Artifact Hub metadata generation.
+	@bash hack/ci/test-release-automation.sh
+
 .PHONY: verify-workflows
-verify-workflows: actionlint ## Validate GitHub Actions workflows with the repo-pinned actionlint.
+verify-workflows: actionlint verify-release-automation ## Validate workflows and release automation.
 	@"$(ACTIONLINT)" .github/workflows/*.yml
 
 .PHONY: verify-vendor


### PR DESCRIPTION
## Summary

Harden the release automation before the 0.5.0 release candidate:

- move Release-As marker branches outside the release branch trigger namespace
- validate SemVer and release-line alignment, serialize requests, and reject conflicting release state
- keep generated release-please PRs compatible with PR standards without exempting fork branches
- roll prerelease changes and security metadata into the matching stable Artifact Hub entry
- document the RC-to-stable branch sequence and add focused regression coverage

The root cause of the premature release PR behavior was that marker branches named `release-as-*` matched the broad `release-*` workflow trigger.

## Related Issues

None.

## Type of Change

- [x] CI, release, or build tooling

## Risk and Compatibility

No runtime, API, CRD, Helm values, RBAC, or workload compatibility changes.

Release preparation becomes intentionally stricter: `Prepare Release-As PR` now rejects mismatched release lines and existing tags, releases, generated release PRs, or conflicting marker state.

## Verification

- `make verify-workflows`
- `make lint-ci`
- generated-artifact, API stability, CRD compatibility, and E2E manifest verification
- 3,346 unit and integration tests; coverage gate passed at 68.55%
- focused release automation regression tests
- Semgrep and filesystem security scans
- docs production build
- Helm lint, render, and chart tests
- fuzz targets, including isolated reruns of the backup authentication target

## Reviewer Notes

After this PR merges, let Release Please process the merge, then close #534 and delete its generated branch before starting the audited `0.5.0-rc.1` Release-As marker flow.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [ ] Any dependent changes have been merged, published, or clearly called out.