### PR TITLE
fix(charts): set single-tenant controller watch namespace

### DIFF
--- a/charts/openbao-operator/templates/controller/deployment.yaml
+++ b/charts/openbao-operator/templates/controller/deployment.yaml
@@ -67,6 +67,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if eq .Values.tenancy.mode "single" }}
+            - name: WATCH_NAMESPACE
+              value: {{ .Values.tenancy.targetNamespace | default .Release.Namespace | quote }}
+            {{- end }}
             - name: OPERATOR_NAME_PREFIX
               value: {{ include "openbao-operator.fullname" . }}-
             - name: OPERATOR_SERVICE_ACCOUNT_NAME

--- a/hack/helmchart/main_test.go
+++ b/hack/helmchart/main_test.go
@@ -244,6 +244,42 @@ func TestHelmTemplateRendersNetworkPublicationAuthority(t *testing.T) {
 	}
 }
 
+func TestHelmTemplateWiresControllerTenancyMode(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		args               []string
+		wantWatchNamespace string
+	}{
+		{name: "multi-tenant"},
+		{
+			name:               "single-tenant-target-namespace",
+			args:               []string{"--set", "tenancy.mode=single", "--set", "tenancy.targetNamespace=tenant-openbao"},
+			wantWatchNamespace: "tenant-openbao",
+		},
+		{
+			name:               "single-tenant-release-namespace-default",
+			args:               []string{"--set", "tenancy.mode=single"},
+			wantWatchNamespace: "openbao",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := string(renderChart(t, tt.args...))
+			watchNamespace := "- name: WATCH_NAMESPACE\n              value: "
+
+			if tt.wantWatchNamespace == "" {
+				if strings.Contains(rendered, watchNamespace) {
+					t.Fatal("rendered multi-tenant chart unexpectedly sets WATCH_NAMESPACE")
+				}
+				return
+			}
+
+			if !strings.Contains(rendered, watchNamespace+`"`+tt.wantWatchNamespace+`"`) {
+				t.Fatalf("rendered single-tenant chart does not set WATCH_NAMESPACE=%q", tt.wantWatchNamespace)
+			}
+		})
+	}
+}
+
 func TestHelmTemplateRendersStrictYAML(t *testing.T) {
 	for _, tt := range []struct {
 		name string


### PR DESCRIPTION
## Summary

- Set `WATCH_NAMESPACE` on the controller when `tenancy.mode=single`.
- Derive the value from `tenancy.targetNamespace`, falling back to the Helm release namespace.
- Keep the controller runtime namespace aligned with the existing single-tenant RoleBinding.
- Add Helm rendering coverage for explicit targets, release-namespace fallback, and multi-tenant mode.

The chart previously suppressed the Provisioner and created target-namespace RBAC for single-tenant installs, but it did not pass the namespace to the controller. Because the runtime derives single-tenant mode from `WATCH_NAMESPACE`, those installations continued to use multi-tenant controller behavior.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Single-tenant Helm installations will now enter the runtime's intended single-tenant mode, including namespace-scoped caching and event-driven `Owns()` watches.

Multi-tenant installations are unchanged. This does not change CRDs, APIs, or RBAC permissions.

Users currently setting `WATCH_NAMESPACE` through `controller.extraEnv` as a workaround should remove that override after upgrading to avoid duplicate environment entries.

## Verification

- `go test ./hack/helmchart -count=1`
- `make verify-helm`
- `make helm-test`
- `make lint-ci` through the pre-push hook

## Reviewer Notes

Self-review should focus on these deployment-mode invariants:

- Explicit `tenancy.targetNamespace` values must match both `WATCH_NAMESPACE` and the single-tenant RoleBinding namespace.
- An empty target must use the release namespace for both.
- Multi-tenant renders must not set `WATCH_NAMESPACE`.

The existing documentation already describes `WATCH_NAMESPACE` as matching `tenancy.targetNamespace`, so no documentation update is required. No generated artifacts or dependent changes are involved.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.