### PR TITLE
test(e2e): emulate TLSRoute readiness

### DIFF
--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -50,6 +50,7 @@ const (
 	invalidUpgradeJWTAuthRole  = "invalid-upgrade-role"
 	e2eAdminPolicyName         = "e2e-admin"
 	e2eAdminRoleName           = "e2e-admin"
+	e2eGatewayControllerName   = gatewayv1.GatewayController("openbao.org/e2e-gateway")
 )
 
 type serviceAvailabilityStats struct {
@@ -123,7 +124,7 @@ func ensureGatewayClassReady(
 	gatewayClass := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: gatewayv1.GatewayClassSpec{
-			ControllerName: gatewayv1.GatewayController("openbao.org/e2e-gateway"),
+			ControllerName: e2eGatewayControllerName,
 		},
 	}
 	Expect(c.Create(ctx, gatewayClass)).To(Succeed())
@@ -158,6 +159,44 @@ func ensureGatewayClassReady(
 		}
 
 		g.Expect(c.Status().Patch(ctx, current, client.MergeFrom(original))).To(Succeed())
+	}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+}
+
+func markTLSRouteReady(
+	ctx context.Context,
+	c client.Client,
+	namespace, name string,
+) {
+	Eventually(func(g Gomega) {
+		route := &gatewayv1.TLSRoute{}
+		g.Expect(c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, route)).To(Succeed())
+		g.Expect(route.Spec.ParentRefs).To(HaveLen(1))
+
+		original := route.DeepCopy()
+		route.Status.Parents = []gatewayv1.RouteParentStatus{
+			{
+				ParentRef:      route.Spec.ParentRefs[0],
+				ControllerName: e2eGatewayControllerName,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(gatewayv1.RouteConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(gatewayv1.RouteReasonAccepted),
+						ObservedGeneration: route.Generation,
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(gatewayv1.RouteConditionResolvedRefs),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(gatewayv1.RouteReasonResolvedRefs),
+						ObservedGeneration: route.Generation,
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+
+		g.Expect(c.Status().Patch(ctx, route, client.MergeFrom(original))).To(Succeed())
 	}, framework.DefaultWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
 }
 
@@ -3371,6 +3410,12 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 					},
 				}
 				Expect(admin.Create(ctx, passthroughCluster)).To(Succeed())
+				markTLSRouteReady(
+					ctx,
+					admin,
+					tenantNamespace,
+					fmt.Sprintf("%s-tlsroute", passthroughCluster.Name),
+				)
 
 				Eventually(func(g Gomega) {
 					updated := &openbaov1alpha1.OpenBaoCluster{}


### PR DESCRIPTION
## Summary

Restore the post-merge Gateway E2E lane after #602 made managed Route attachment part of the `GatewayIntegrationReady` contract.

The Gateway test uses a fake controller: it already publishes ready status for its `GatewayClass` and `Gateway`, but it did not publish status for the generated `TLSRoute`. The fixture now reports current-generation `Accepted=True` and `ResolvedRefs=True` conditions for that Route before asserting cluster readiness.

## Related Issues

Follow-up to #602 and the failed post-merge [E2E (Upgrade Gateway) job](https://github.com/dc-tec/openbao-operator/actions/runs/31257530848/job/93103740767).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No runtime, API, CRD, Helm, RBAC, security, upgrade, or operational behavior changes. This only completes the fake Gateway controller fixture used by the TLS passthrough E2E.

## Verification

- `make bootstrap`
- E2E package compile with the `e2e` build tag
- `make verify-e2e-manifest`
- Focused E2E lint: 0 issues
- Pre-push `make lint-ci`: 61 architecture checks passed, 0 lint issues
- GitHub's Upgrade Gateway lane is the authoritative Kind reproduction

## Reviewer Notes

Focus on whether the fixture publishes the same controller identity, parent reference, current Route generation, and Route conditions required by the production readiness validator. The HTTPRoute fixture is intentionally unchanged because that spec does not assert Gateway readiness and passed in the failed main run.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.