### PR TITLE
fix(charts): allow provisioner metrics traffic

### DIFF
--- a/charts/openbao-operator/templates/networkpolicy.yaml
+++ b/charts/openbao-operator/templates/networkpolicy.yaml
@@ -44,6 +44,34 @@ spec:
       ports:
         - port: {{ .Values.metrics.port }}
           protocol: TCP
+{{- if and (eq .Values.tenancy.mode "multi") .Values.metrics.enabled (or .Values.metrics.serviceMonitor.enabled .Values.metrics.victoriaMetrics.enabled) }}
+---
+# Allow Provisioner Metrics Traffic
+#
+# This NetworkPolicy allows the configured metrics collector to reach the
+# provisioner metrics endpoint when the chart renders a provisioner scraper.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openbao-operator.fullname" . }}-allow-provisioner-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openbao-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openbao-operator.provisionerSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.metricsAllowedNamespaceLabels | nindent 14 }}
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}
 ---
 # Allow Health Probe Traffic
 #

--- a/hack/helmchart/main_test.go
+++ b/hack/helmchart/main_test.go
@@ -280,6 +280,91 @@ func TestHelmTemplateWiresControllerTenancyMode(t *testing.T) {
 	}
 }
 
+func TestHelmTemplateAllowsOperatorMetricsIngress(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+		kind string
+	}{
+		{
+			name: "service-monitor",
+			args: []string{"--set", "metrics.serviceMonitor.enabled=true"},
+			kind: "ServiceMonitor",
+		},
+		{
+			name: "victoria-metrics",
+			args: []string{"--set", "metrics.victoriaMetrics.enabled=true"},
+			kind: "VMServiceScrape",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{
+				"--set", "tenancy.mode=multi",
+				"--set", "metrics.port=9443",
+				"--set", "networkPolicy.metricsAllowedNamespaceLabels.metrics=monitoring",
+			}
+			args = append(args, tt.args...)
+			rendered := string(renderChart(t, args...))
+
+			assertMetricsNetworkPolicy(t, rendered, "test-openbao-operator-allow-metrics", "controller")
+			assertMetricsNetworkPolicy(t, rendered, "test-openbao-operator-allow-provisioner-metrics", "provisioner")
+			if !hasRenderedObject(rendered, tt.kind, "test-openbao-operator-provisioner-metrics") {
+				t.Fatalf("rendered multi-tenant chart missing provisioner %s", tt.kind)
+			}
+		})
+	}
+}
+
+func TestHelmTemplateOmitsProvisionerMetricsInSingleTenantMode(t *testing.T) {
+	rendered := string(renderChart(
+		t,
+		"--set", "tenancy.mode=single",
+		"--set", "metrics.port=9443",
+		"--set", "networkPolicy.metricsAllowedNamespaceLabels.metrics=monitoring",
+		"--set", "metrics.serviceMonitor.enabled=true",
+		"--set", "metrics.victoriaMetrics.enabled=true",
+	))
+
+	assertMetricsNetworkPolicy(t, rendered, "test-openbao-operator-allow-metrics", "controller")
+	if strings.Contains(rendered, "test-openbao-operator-allow-provisioner-metrics") ||
+		strings.Contains(rendered, "test-openbao-operator-provisioner-metrics") {
+		t.Fatal("rendered single-tenant chart unexpectedly contains provisioner metrics resources")
+	}
+}
+
+func assertMetricsNetworkPolicy(t *testing.T, rendered, name, component string) {
+	t.Helper()
+
+	manifest, ok := findRenderedObject(rendered, "NetworkPolicy", name)
+	if !ok {
+		t.Fatalf("rendered chart missing NetworkPolicy %q", name)
+	}
+	for _, want := range []string{
+		"app.kubernetes.io/name: openbao-operator\n      app.kubernetes.io/component: " + component,
+		"metrics: monitoring",
+		"- port: 9443\n          protocol: TCP",
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("NetworkPolicy %q missing %q:\n%s", name, want, manifest)
+		}
+	}
+}
+
+func hasRenderedObject(rendered, kind, name string) bool {
+	_, ok := findRenderedObject(rendered, kind, name)
+	return ok
+}
+
+func findRenderedObject(rendered, kind, name string) (string, bool) {
+	for _, document := range strings.Split(rendered, "\n---") {
+		if strings.Contains(document, "\nkind: "+kind+"\n") &&
+			strings.Contains(document, "\n  name: "+name+"\n") {
+			return document, true
+		}
+	}
+	return "", false
+}
+
 func TestHelmTemplateRendersStrictYAML(t *testing.T) {
 	for _, tt := range []struct {
 		name string


### PR DESCRIPTION
## Summary

- Add a provisioner-specific metrics ingress `NetworkPolicy` for multi-tenant installations.
- Render the policy only when metrics and a provisioner scraper (`ServiceMonitor` or `VMServiceScrape`) are enabled.
- Cover Prometheus, VictoriaMetrics, and single-tenant omission paths in Helm render tests.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Helm-only, non-breaking change. No API, CRD, RBAC, or upgrade contract changes.

The new policy does not broaden the trusted source set: it reuses `networkPolicy.metricsAllowedNamespaceLabels` and the configured metrics port. It selects only provisioner pods and is omitted in single-tenant mode or when no provisioner metrics scraper is rendered.

## Verification

- `go test ./hack/helmchart -run 'TestHelmTemplate(AllowsOperatorMetricsIngress|OmitsProvisionerMetricsInSingleTenantMode)' -count=1`
- `make lint-ci`
- `make test-ci` (3,393 tests passed, 4 intentional skips; internal coverage 68.84%)
- `make fuzz`
- `make verify-openbao-config-compat docs-build verify-helm helm-test`
- Security, filesystem, rendered-manifest, and built-image scans from the local `ci-core` run
- `make doctor` reports the host Node.js 26/global pnpm mismatch; the repository-pinned pnpm 10.34.5 typecheck and production docs build pass

## Reviewer Notes

The default-deny policy selects both controller and provisioner pods, while the existing metrics allow policy selects only controller pods. This change mirrors that policy for provisioner pods only when the chart also renders the corresponding provisioner scraper.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
