### PR TITLE
fix(provisioner): clean up tenant governance resources

### DIFF
--- a/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
+++ b/charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
@@ -79,6 +79,7 @@ rules:
     verbs:
       - get
       - patch
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -94,6 +95,7 @@ rules:
     verbs:
       - get
       - patch
+      - delete
 
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/config/rbac/provisioner_minimal_role.yaml
+++ b/config/rbac/provisioner_minimal_role.yaml
@@ -94,6 +94,7 @@ rules:
     verbs:
       - get
       - patch
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -109,6 +110,7 @@ rules:
     verbs:
       - get
       - patch
+      - delete
 
   # 3. Tenant onboarding resources (Server-Side Apply)
   # SECURITY: The Provisioner uses Server-Side Apply (PATCH) against fixed resource names.

--- a/docs/architecture/provisioner-manager.md
+++ b/docs/architecture/provisioner-manager.md
@@ -144,7 +144,13 @@ The tenant `RoleBinding` is also the explicit handoff marker into the cluster co
       emphasis: 'recommended',
     },
     {
-      cells: ['Namespace emptied of managed clusters', 'Remove provisioned Role, RoleBinding, Secret allowlist roles, and default quota resources.'],
+      cells: ['Another active tenant claim remains', 'Preserve the shared namespace resources and remove only the deleting claim finalizer.'],
+    },
+    {
+      cells: ['Namespace emptied of managed clusters', 'Remove provisioned Role, RoleBinding, Secret allowlist roles, ResourceQuota, and LimitRange resources.'],
+    },
+    {
+      cells: ['Namespace policy', 'Leave Pod Security labels unchanged because the Provisioner does not record enough prior state to restore platform-owned labels safely.'],
     },
     {
       cells: ['Finalizer removal', 'Only remove the tenant finalizer after namespace-scoped provisioning artifacts are cleaned up.'],

--- a/docs/reference/status-and-events.md
+++ b/docs/reference/status-and-events.md
@@ -202,7 +202,7 @@ Expect `Normal` events for routine progression and accepted operator input. Expe
 | Type | Reason | Notes |
 | :--- | :--- | :--- |
 | `Normal` | `TenantProvisioned` | Tenant namespace RBAC was provisioned successfully. |
-| `Normal` | `TenantRBACCleaned` | Tenant namespace RBAC was cleaned up during deletion. |
+| `Normal` | `TenantRBACCleaned` | Tenant namespace RBAC, ResourceQuota, and LimitRange were cleaned up during deletion. |
 | `Warning` | `TenantProvisioningBlocked` | Provisioning is blocked by guardrails, missing prerequisites, or dependency readiness checks. |
 | `Warning` | `TenantProvisioningFailed` | Provisioning failed while applying tenant RBAC. |
 

--- a/internal/app/provisioner/provisioner.go
+++ b/internal/app/provisioner/provisioner.go
@@ -22,7 +22,7 @@ type Provisioner interface {
 	EnsureTenantRBAC(ctx context.Context, tenant *openbaov1alpha1.OpenBaoTenant) error
 	EnsureTenantSecretRBAC(ctx context.Context, namespace string) error
 	IsTenantNamespaceProvisioned(ctx context.Context, namespace string) (bool, error)
-	CleanupTenantRBAC(ctx context.Context, namespace string) error
+	CleanupTenantResources(ctx context.Context, namespace string) error
 }
 
 // ProvisionerDependencies groups the runtime collaborators required to build the tenant provisioner.

--- a/internal/app/provisioner/tenant_reconcile.go
+++ b/internal/app/provisioner/tenant_reconcile.go
@@ -178,6 +178,18 @@ func reconcileDeletion(
 
 	logger.Info("OpenBaoTenant is being deleted", "target_namespace", targetNS)
 
+	hasOtherClaim, err := hasOtherActiveTenantClaim(ctx, runtime, tenant, targetNS)
+	if err != nil {
+		return recon.Result{}, err
+	}
+	if hasOtherClaim {
+		logger.Info(
+			"Another active OpenBaoTenant targets this namespace; preserving shared tenant resources",
+			"target_namespace", targetNS,
+		)
+		return removeTenantFinalizer(ctx, runtime.Client, tenant, key)
+	}
+
 	// Keep tenant RBAC while OpenBaoCluster finalizers may still need it.
 	clusterList := &openbaov1alpha1.OpenBaoClusterList{}
 	if err := runtime.Client.List(ctx, clusterList, client.InNamespace(targetNS)); err != nil {
@@ -190,20 +202,74 @@ func reconcileDeletion(
 		return recon.Result{RequeueAfter: resolveRequeueShort(runtime)}, nil
 	}
 
-	logger.Info("No OpenBaoClusters found; cleaning up tenant RBAC", "target_namespace", targetNS)
-	if err := runtime.Provisioner.CleanupTenantRBAC(ctx, targetNS); err != nil {
-		return recon.Result{}, fmt.Errorf("failed to cleanup tenant RBAC for namespace %s: %w", targetNS, err)
+	logger.Info("No OpenBaoClusters found; cleaning up tenant resources", "target_namespace", targetNS)
+	if err := runtime.Provisioner.CleanupTenantResources(ctx, targetNS); err != nil {
+		return recon.Result{}, fmt.Errorf("failed to cleanup tenant resources for namespace %s: %w", targetNS, err)
 	}
 	logging.LogAuditEvent(logger, logging.EventTenantRBACCleaned, map[string]string{
 		"tenant_namespace": tenant.Namespace,
 		"tenant_name":      tenant.Name,
 		"target_namespace": targetNS,
 	})
-	runtime.emitTenantNormalEvent(tenant, ReasonTenantRBACCleaned, fmt.Sprintf("Cleaned tenant RBAC for namespace %s", targetNS))
+	runtime.emitTenantNormalEvent(
+		tenant,
+		ReasonTenantRBACCleaned,
+		fmt.Sprintf("Cleaned tenant RBAC, ResourceQuota, and LimitRange for namespace %s", targetNS),
+	)
 
+	return removeTenantFinalizer(ctx, runtime.Client, tenant, key)
+}
+
+func hasOtherActiveTenantClaim(
+	ctx context.Context,
+	runtime TenantRuntime,
+	tenant *openbaov1alpha1.OpenBaoTenant,
+	targetNS string,
+) (bool, error) {
+	reader := runtime.APIReader
+	if reader == nil {
+		reader = runtime.Client
+	}
+
+	claimNamespaces := []string{targetNS}
+	if runtime.OperatorNamespace != "" && runtime.OperatorNamespace != targetNS {
+		claimNamespaces = append(claimNamespaces, runtime.OperatorNamespace)
+	}
+
+	for _, claimNamespace := range claimNamespaces {
+		tenantList := &openbaov1alpha1.OpenBaoTenantList{}
+		if err := reader.List(ctx, tenantList, client.InNamespace(claimNamespace)); err != nil {
+			return false, fmt.Errorf(
+				"failed to list OpenBaoTenants in namespace %s while cleaning up namespace %s: %w",
+				claimNamespace,
+				targetNS,
+				err,
+			)
+		}
+
+		for i := range tenantList.Items {
+			other := &tenantList.Items[i]
+			if other.Namespace == tenant.Namespace && other.Name == tenant.Name {
+				continue
+			}
+			if other.DeletionTimestamp.IsZero() && other.Spec.TargetNamespace == targetNS {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func removeTenantFinalizer(
+	ctx context.Context,
+	c client.Client,
+	tenant *openbaov1alpha1.OpenBaoTenant,
+	key types.NamespacedName,
+) (recon.Result, error) {
 	original := tenant.DeepCopy()
 	controllerutil.RemoveFinalizer(tenant, openbaov1alpha1.OpenBaoTenantFinalizer)
-	if err := runtime.Client.Patch(ctx, tenant, client.MergeFrom(original)); err != nil {
+	if err := c.Patch(ctx, tenant, client.MergeFrom(original)); err != nil {
 		return recon.Result{}, fmt.Errorf("failed to remove finalizer from OpenBaoTenant %s: %w", key, err)
 	}
 

--- a/internal/app/provisioner/tenant_reconcile_test.go
+++ b/internal/app/provisioner/tenant_reconcile_test.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"errors"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -31,11 +32,16 @@ import (
 
 type failingTenantProvisioner struct {
 	Provisioner
-	err error
+	ensureErr  error
+	cleanupErr error
 }
 
 func (p failingTenantProvisioner) EnsureTenantRBAC(context.Context, *openbaov1alpha1.OpenBaoTenant) error {
-	return p.err
+	return p.ensureErr
+}
+
+func (p failingTenantProvisioner) CleanupTenantResources(context.Context, string) error {
+	return p.cleanupErr
 }
 
 func expectEventContains(t *testing.T, recorder *events.FakeRecorder, parts ...string) {
@@ -341,7 +347,7 @@ func TestReconcileOpenBaoTenant_ProvisioningFailure(t *testing.T) {
 	}
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns"}}
 	runtime := newTenantRuntime(t, tenant, ns)
-	runtime.Provisioner = failingTenantProvisioner{Provisioner: runtime.Provisioner, err: provisioningErr}
+	runtime.Provisioner = failingTenantProvisioner{Provisioner: runtime.Provisioner, ensureErr: provisioningErr}
 	req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
 
 	result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
@@ -400,6 +406,11 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 
 	t.Run("removes finalizer after cleanup", func(t *testing.T) {
 		now := metav1.Now()
+		podSecurityLabels := map[string]string{
+			"pod-security.kubernetes.io/enforce": "restricted",
+			"pod-security.kubernetes.io/audit":   "restricted",
+			"pod-security.kubernetes.io/warn":    "restricted",
+		}
 		tenant := &openbaov1alpha1.OpenBaoTenant{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "tenant",
@@ -409,8 +420,11 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 			},
 			Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
 		}
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns"}}
-		runtime := newTenantRuntime(t, tenant, ns)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns", Labels: podSecurityLabels}}
+		quota := provisionermanager.GenerateTenantResourceQuota("tenant-ns", nil)
+		limitRange := provisionermanager.GenerateTenantLimitRange("tenant-ns", nil)
+		runtime := newTenantRuntime(t, tenant, ns, quota, limitRange)
+		runtime.APIReader = nil
 		recorder := events.NewFakeRecorder(10)
 		runtime.Recorder = recorder
 		req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
@@ -431,8 +445,222 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		} else if controllerutil.ContainsFinalizer(updated, openbaov1alpha1.OpenBaoTenantFinalizer) {
 			t.Fatalf("expected finalizer to be removed")
 		}
+		for _, obj := range []client.Object{
+			&corev1.ResourceQuota{},
+			&corev1.LimitRange{},
+		} {
+			name := provisionermanager.TenantResourceQuotaName
+			if _, ok := obj.(*corev1.LimitRange); ok {
+				name = provisionermanager.TenantLimitRangeName
+			}
+			getErr := runtime.Client.Get(context.Background(), types.NamespacedName{Namespace: "tenant-ns", Name: name}, obj)
+			if !apierrors.IsNotFound(getErr) {
+				t.Fatalf("expected %T %s to be deleted, got %v", obj, name, getErr)
+			}
+		}
+		updatedNamespace := &corev1.Namespace{}
+		if getErr := runtime.Client.Get(context.Background(), types.NamespacedName{Name: "tenant-ns"}, updatedNamespace); getErr != nil {
+			t.Fatalf("get namespace after cleanup: %v", getErr)
+		}
+		if got := updatedNamespace.Labels; !maps.Equal(got, podSecurityLabels) {
+			t.Fatalf("namespace labels = %#v, want unchanged %#v", got, podSecurityLabels)
+		}
 
 		expectEventContains(t, recorder, "Normal", ReasonTenantRBACCleaned)
+	})
+
+	t.Run("retains finalizer when tenant claim listing fails", func(t *testing.T) {
+		now := metav1.Now()
+		tenant := &openbaov1alpha1.OpenBaoTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tenant",
+				Namespace:         "openbao-operator-system",
+				Finalizers:        []string{openbaov1alpha1.OpenBaoTenantFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+		}
+		runtime := newTenantRuntime(t, tenant)
+		listErr := errors.New("tenant list unavailable")
+		runtime.APIReader = fake.NewClientBuilder().
+			WithScheme(newTenantScheme(t)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+					return listErr
+				},
+			}).
+			Build()
+		req := types.NamespacedName{Name: tenant.Name, Namespace: tenant.Namespace}
+
+		result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
+		if err == nil || !errors.Is(err, listErr) {
+			t.Fatalf("ReconcileOpenBaoTenant() error = %v, want tenant list error", err)
+		}
+		if result != (recon.Result{}) {
+			t.Fatalf("result=%v, want zero", result)
+		}
+
+		updated := &openbaov1alpha1.OpenBaoTenant{}
+		if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
+			t.Fatalf("get tenant after list failure: %v", getErr)
+		}
+		if !controllerutil.ContainsFinalizer(updated, openbaov1alpha1.OpenBaoTenantFinalizer) {
+			t.Fatal("expected finalizer to remain after tenant list failure")
+		}
+	})
+
+	t.Run("retains finalizer when cleanup fails", func(t *testing.T) {
+		now := metav1.Now()
+		tenant := &openbaov1alpha1.OpenBaoTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tenant",
+				Namespace:         "openbao-operator-system",
+				Finalizers:        []string{openbaov1alpha1.OpenBaoTenantFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+		}
+		runtime := newTenantRuntime(t, tenant)
+		cleanupErr := errors.New("quota deletion denied")
+		runtime.Provisioner = failingTenantProvisioner{
+			Provisioner: runtime.Provisioner,
+			cleanupErr:  cleanupErr,
+		}
+		req := types.NamespacedName{Name: tenant.Name, Namespace: tenant.Namespace}
+
+		result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
+		if err == nil || !errors.Is(err, cleanupErr) {
+			t.Fatalf("ReconcileOpenBaoTenant() error = %v, want cleanup error", err)
+		}
+		if result != (recon.Result{}) {
+			t.Fatalf("result=%v, want zero", result)
+		}
+
+		updated := &openbaov1alpha1.OpenBaoTenant{}
+		if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
+			t.Fatalf("get tenant after cleanup failure: %v", getErr)
+		}
+		if !controllerutil.ContainsFinalizer(updated, openbaov1alpha1.OpenBaoTenantFinalizer) {
+			t.Fatal("expected finalizer to remain after cleanup failure")
+		}
+	})
+
+	t.Run("preserves resources for another active authorized claim", func(t *testing.T) {
+		now := metav1.Now()
+		deletingTenant := &openbaov1alpha1.OpenBaoTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "deleting-tenant",
+				Namespace:         "openbao-operator-system",
+				Finalizers:        []string{openbaov1alpha1.OpenBaoTenantFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+		}
+		activeTenant := &openbaov1alpha1.OpenBaoTenant{
+			ObjectMeta: metav1.ObjectMeta{Name: "active-tenant", Namespace: "tenant-ns"},
+			Spec:       openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+		}
+		quota := provisionermanager.GenerateTenantResourceQuota("tenant-ns", nil)
+		limitRange := provisionermanager.GenerateTenantLimitRange("tenant-ns", nil)
+		runtime := newTenantRuntime(t, deletingTenant, activeTenant, quota, limitRange)
+		req := types.NamespacedName{Name: deletingTenant.Name, Namespace: deletingTenant.Namespace}
+
+		result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
+		if err != nil {
+			t.Fatalf("ReconcileOpenBaoTenant() error = %v", err)
+		}
+		if result != (recon.Result{}) {
+			t.Fatalf("result=%v, want zero", result)
+		}
+		if getErr := runtime.Client.Get(context.Background(), req, &openbaov1alpha1.OpenBaoTenant{}); !apierrors.IsNotFound(getErr) {
+			t.Fatalf("expected deleting tenant to finalize, got %v", getErr)
+		}
+		for _, obj := range []client.Object{&corev1.ResourceQuota{}, &corev1.LimitRange{}} {
+			name := provisionermanager.TenantResourceQuotaName
+			if _, ok := obj.(*corev1.LimitRange); ok {
+				name = provisionermanager.TenantLimitRangeName
+			}
+			if getErr := runtime.Client.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: "tenant-ns", Name: name},
+				obj,
+			); getErr != nil {
+				t.Fatalf("expected shared %T %s to remain: %v", obj, name, getErr)
+			}
+		}
+	})
+}
+
+func TestReconcileOpenBaoTenant_DeletionClaimCollisions(t *testing.T) {
+	setAdmissionReady(t, true)
+
+	t.Run("ignores unauthorized active claim", func(t *testing.T) {
+		now := metav1.Now()
+		deletingTenant := &openbaov1alpha1.OpenBaoTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "deleting-tenant",
+				Namespace:         "openbao-operator-system",
+				Finalizers:        []string{openbaov1alpha1.OpenBaoTenantFinalizer},
+				DeletionTimestamp: &now,
+			},
+			Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+		}
+		unauthorizedTenant := &openbaov1alpha1.OpenBaoTenant{
+			ObjectMeta: metav1.ObjectMeta{Name: "unauthorized-tenant", Namespace: "other-ns"},
+			Spec:       openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+		}
+		quota := provisionermanager.GenerateTenantResourceQuota("tenant-ns", nil)
+		limitRange := provisionermanager.GenerateTenantLimitRange("tenant-ns", nil)
+		runtime := newTenantRuntime(t, deletingTenant, unauthorizedTenant, quota, limitRange)
+		req := types.NamespacedName{Name: deletingTenant.Name, Namespace: deletingTenant.Namespace}
+
+		if _, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime); err != nil {
+			t.Fatalf("ReconcileOpenBaoTenant() error = %v", err)
+		}
+		for _, obj := range []client.Object{&corev1.ResourceQuota{}, &corev1.LimitRange{}} {
+			name := provisionermanager.TenantResourceQuotaName
+			if _, ok := obj.(*corev1.LimitRange); ok {
+				name = provisionermanager.TenantLimitRangeName
+			}
+			getErr := runtime.Client.Get(
+				context.Background(),
+				types.NamespacedName{Namespace: "tenant-ns", Name: name},
+				obj,
+			)
+			if !apierrors.IsNotFound(getErr) {
+				t.Fatalf("expected %T %s to be deleted, got %v", obj, name, getErr)
+			}
+		}
+	})
+
+	t.Run("co-deleting claims do not block cleanup", func(t *testing.T) {
+		now := metav1.Now()
+		newDeletingTenant := func(name string) *openbaov1alpha1.OpenBaoTenant {
+			return &openbaov1alpha1.OpenBaoTenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              name,
+					Namespace:         "openbao-operator-system",
+					Finalizers:        []string{openbaov1alpha1.OpenBaoTenantFinalizer},
+					DeletionTimestamp: &now,
+				},
+				Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: "tenant-ns"},
+			}
+		}
+		first := newDeletingTenant("tenant-one")
+		second := newDeletingTenant("tenant-two")
+		quota := provisionermanager.GenerateTenantResourceQuota("tenant-ns", nil)
+		limitRange := provisionermanager.GenerateTenantLimitRange("tenant-ns", nil)
+		runtime := newTenantRuntime(t, first, second, quota, limitRange)
+
+		for _, tenant := range []*openbaov1alpha1.OpenBaoTenant{first, second} {
+			key := types.NamespacedName{Name: tenant.Name, Namespace: tenant.Namespace}
+			if _, err := ReconcileOpenBaoTenant(context.Background(), key, logr.Discard(), runtime); err != nil {
+				t.Fatalf("ReconcileOpenBaoTenant(%s) error = %v", tenant.Name, err)
+			}
+			if getErr := runtime.Client.Get(context.Background(), key, &openbaov1alpha1.OpenBaoTenant{}); !apierrors.IsNotFound(getErr) {
+				t.Fatalf("expected %s to finalize, got %v", tenant.Name, getErr)
+			}
+		}
 	})
 }
 
@@ -489,7 +717,7 @@ func TestReconcileOpenBaoTenant_FinalizerAddUsesMergePatch(t *testing.T) {
 	}
 }
 
-func TestReconcileOpenBaoTenant_FinalizerRemoveUsesMergePatch(t *testing.T) {
+func TestReconcileOpenBaoTenant_FinalizerRemoveFailureUsesMergePatchAndRetainsFinalizer(t *testing.T) {
 	setAdmissionReady(t, true)
 
 	now := metav1.Now()
@@ -506,6 +734,7 @@ func TestReconcileOpenBaoTenant_FinalizerRemoveUsesMergePatch(t *testing.T) {
 
 	var patches int
 	var updates int
+	patchErr := errors.New("finalizer patch failed")
 	c := fake.NewClientBuilder().
 		WithScheme(newTenantScheme(t)).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoTenant{}).
@@ -518,6 +747,7 @@ func TestReconcileOpenBaoTenant_FinalizerRemoveUsesMergePatch(t *testing.T) {
 			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				if obj.GetName() == tenant.Name && obj.GetNamespace() == tenant.Namespace {
 					patches++
+					return patchErr
 				}
 				return c.Patch(ctx, obj, patch, opts...)
 			},
@@ -527,8 +757,8 @@ func TestReconcileOpenBaoTenant_FinalizerRemoveUsesMergePatch(t *testing.T) {
 	req := types.NamespacedName{Name: "tenant", Namespace: "openbao-operator-system"}
 
 	result, err := ReconcileOpenBaoTenant(context.Background(), req, logr.Discard(), runtime)
-	if err != nil {
-		t.Fatalf("ReconcileOpenBaoTenant() error = %v", err)
+	if err == nil || !errors.Is(err, patchErr) {
+		t.Fatalf("ReconcileOpenBaoTenant() error = %v, want finalizer patch error", err)
 	}
 	if result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
@@ -538,5 +768,13 @@ func TestReconcileOpenBaoTenant_FinalizerRemoveUsesMergePatch(t *testing.T) {
 	}
 	if patches != 1 {
 		t.Fatalf("Patch() calls = %d, want 1", patches)
+	}
+
+	updated := &openbaov1alpha1.OpenBaoTenant{}
+	if getErr := runtime.Client.Get(context.Background(), req, updated); getErr != nil {
+		t.Fatalf("get tenant after finalizer patch failure: %v", getErr)
+	}
+	if !controllerutil.ContainsFinalizer(updated, openbaov1alpha1.OpenBaoTenantFinalizer) {
+		t.Fatal("expected finalizer to remain after patch failure")
 	}
 }

--- a/internal/controller/provisioner/namespace_provisioner_integration_test.go
+++ b/internal/controller/provisioner/namespace_provisioner_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ func TestNamespaceProvisioner_SetupWithManager_ProvisionsTenantNamespace(t *test
 	})
 }
 
-func TestNamespaceProvisioner_SetupWithManager_CleansUpTenantRBACOnDelete(t *testing.T) {
+func TestNamespaceProvisioner_SetupWithManager_CleansUpTenantResourcesOnDelete(t *testing.T) {
 	setAdmissionReady(t)
 
 	ctx := context.Background()
@@ -78,6 +79,16 @@ func TestNamespaceProvisioner_SetupWithManager_CleansUpTenantRBACOnDelete(t *tes
 
 	tenantKey := types.NamespacedName{Namespace: operatorNamespace, Name: tenant.Name}
 	current := waitForTenantProvisioned(t, ctx, liveClient, tenantKey)
+	quotaKey := types.NamespacedName{
+		Namespace: "tenant-cleanup",
+		Name:      provisionersvc.TenantResourceQuotaName,
+	}
+	limitRangeKey := types.NamespacedName{
+		Namespace: "tenant-cleanup",
+		Name:      provisionersvc.TenantLimitRangeName,
+	}
+	require.NoError(t, liveClient.Get(ctx, quotaKey, &corev1.ResourceQuota{}))
+	require.NoError(t, liveClient.Get(ctx, limitRangeKey, &corev1.LimitRange{}))
 	require.NoError(t, liveClient.Delete(ctx, current))
 
 	waitForNotFound(t, ctx, liveClient, types.NamespacedName{
@@ -91,5 +102,17 @@ func TestNamespaceProvisioner_SetupWithManager_CleansUpTenantRBACOnDelete(t *tes
 		Name:      "openbao-operator-controller",
 		Namespace: operatorNamespace,
 	}))
+	waitForNotFound(t, ctx, liveClient, quotaKey, &corev1.ResourceQuota{})
+	waitForNotFound(t, ctx, liveClient, limitRangeKey, &corev1.LimitRange{})
 	waitForNotFound(t, ctx, liveClient, tenantKey, &openbaov1alpha1.OpenBaoTenant{})
+
+	namespace := &corev1.Namespace{}
+	require.NoError(t, liveClient.Get(ctx, types.NamespacedName{Name: "tenant-cleanup"}, namespace))
+	for _, key := range []string{
+		"pod-security.kubernetes.io/enforce",
+		"pod-security.kubernetes.io/audit",
+		"pod-security.kubernetes.io/warn",
+	} {
+		require.Equal(t, "restricted", namespace.Labels[key], "Pod Security label %s must remain after cleanup", key)
+	}
 }

--- a/internal/service/provisioner/manager_cleanup.go
+++ b/internal/service/provisioner/manager_cleanup.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IsTenantNamespaceProvisioned returns true if the tenant namespace has been provisioned
@@ -28,8 +31,37 @@ func (m *Manager) IsTenantNamespaceProvisioned(ctx context.Context, namespace st
 	return true, nil
 }
 
-// CleanupTenantRBAC removes the Role and RoleBinding from the given namespace.
-func (m *Manager) CleanupTenantRBAC(ctx context.Context, namespace string) error {
+// CleanupTenantResources removes the operator-managed governance and RBAC resources from the given namespace.
+func (m *Manager) CleanupTenantResources(ctx context.Context, namespace string) error {
+	governanceResources := []struct {
+		kind   string
+		name   string
+		object client.Object
+	}{
+		{
+			kind: "ResourceQuota",
+			name: TenantResourceQuotaName,
+			object: &corev1.ResourceQuota{ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      TenantResourceQuotaName,
+			}},
+		},
+		{
+			kind: "LimitRange",
+			name: TenantLimitRangeName,
+			object: &corev1.LimitRange{ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      TenantLimitRangeName,
+			}},
+		},
+	}
+	for _, resource := range governanceResources {
+		m.logger.Info("Deleting tenant "+resource.kind, "namespace", namespace, "name", resource.name)
+		if err := m.client.Delete(ctx, resource.object); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete %s %s/%s: %w", resource.kind, namespace, resource.name, err)
+		}
+	}
+
 	for _, name := range []string{
 		TenantSecretsReaderRoleBindingName,
 		TenantSecretsWriterRoleBindingName,

--- a/internal/service/provisioner/manager_test.go
+++ b/internal/service/provisioner/manager_test.go
@@ -22,6 +22,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // testScheme is a shared scheme used across tests.
@@ -464,15 +465,23 @@ func TestEnsureTenantRBAC_HandlesAlreadyExistsGracefully(t *testing.T) {
 	}
 }
 
-func TestCleanupTenantRBAC_DeletesRoleAndRoleBinding(t *testing.T) {
+func TestCleanupTenantResources_DeletesRBACAndGovernanceResources(t *testing.T) {
 	namespace := testNamespace
+	podSecurityLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce": "restricted",
+		"pod-security.kubernetes.io/audit":   "restricted",
+		"pod-security.kubernetes.io/warn":    "restricted",
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: podSecurityLabels}}
 	existingRole := GenerateTenantRole(namespace)
 	existingRoleBinding := GenerateTenantRoleBinding(namespace, OperatorServiceAccount{
 		Name:      "controller-manager",
 		Namespace: "openbao-operator-system",
 	})
+	existingQuota := GenerateTenantResourceQuota(namespace, nil)
+	existingLimitRange := GenerateTenantLimitRange(namespace, nil)
 
-	k8sClient := newTestClient(t, existingRole, existingRoleBinding)
+	k8sClient := newTestClient(t, ns, existingRole, existingRoleBinding, existingQuota, existingLimitRange)
 	logger := logr.Discard()
 	manager, err := NewManager(k8sClient, logger)
 	if err != nil {
@@ -481,33 +490,33 @@ func TestCleanupTenantRBAC_DeletesRoleAndRoleBinding(t *testing.T) {
 
 	ctx := context.Background()
 
-	err = manager.CleanupTenantRBAC(ctx, namespace)
+	err = manager.CleanupTenantResources(ctx, namespace)
 	if err != nil {
-		t.Fatalf("CleanupTenantRBAC() error = %v", err)
+		t.Fatalf("CleanupTenantResources() error = %v", err)
 	}
 
-	// Verify RoleBinding was deleted
-	roleBinding := &rbacv1.RoleBinding{}
-	err = k8sClient.Get(ctx, types.NamespacedName{
-		Namespace: namespace,
-		Name:      TenantRoleBindingName,
-	}, roleBinding)
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("expected RoleBinding to be deleted, got error: %v", err)
+	for _, obj := range []client.Object{
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: TenantRoleBindingName, Namespace: namespace}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: TenantRoleName, Namespace: namespace}},
+		&corev1.ResourceQuota{ObjectMeta: metav1.ObjectMeta{Name: TenantResourceQuotaName, Namespace: namespace}},
+		&corev1.LimitRange{ObjectMeta: metav1.ObjectMeta{Name: TenantLimitRangeName, Namespace: namespace}},
+	} {
+		key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+		if getErr := k8sClient.Get(ctx, key, obj); !apierrors.IsNotFound(getErr) {
+			t.Errorf("expected %T %s to be deleted, got error: %v", obj, key, getErr)
+		}
 	}
 
-	// Verify Role was deleted
-	role := &rbacv1.Role{}
-	err = k8sClient.Get(ctx, types.NamespacedName{
-		Namespace: namespace,
-		Name:      TenantRoleName,
-	}, role)
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("expected Role to be deleted, got error: %v", err)
+	updatedNamespace := &corev1.Namespace{}
+	if getErr := k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, updatedNamespace); getErr != nil {
+		t.Fatalf("get namespace after cleanup: %v", getErr)
+	}
+	if !reflect.DeepEqual(updatedNamespace.Labels, podSecurityLabels) {
+		t.Fatalf("namespace labels = %#v, want unchanged %#v", updatedNamespace.Labels, podSecurityLabels)
 	}
 }
 
-func TestCleanupTenantRBAC_HandlesNotFoundGracefully(t *testing.T) {
+func TestCleanupTenantResources_HandlesNotFoundGracefully(t *testing.T) {
 	namespace := testNamespace
 	k8sClient := newTestClient(t)
 	logger := logr.Discard()
@@ -519,9 +528,181 @@ func TestCleanupTenantRBAC_HandlesNotFoundGracefully(t *testing.T) {
 	ctx := context.Background()
 
 	// Should not error when resources don't exist
-	err = manager.CleanupTenantRBAC(ctx, namespace)
+	err = manager.CleanupTenantResources(ctx, namespace)
 	if err != nil {
-		t.Fatalf("CleanupTenantRBAC() error = %v", err)
+		t.Fatalf("CleanupTenantResources() error = %v", err)
+	}
+}
+
+func TestCleanupTenantResources_DeletesGovernanceResourcesWithoutReadingThem(t *testing.T) {
+	namespace := testNamespace
+	quota := GenerateTenantResourceQuota(namespace, nil)
+	limitRange := GenerateTenantLimitRange(namespace, nil)
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(quota, limitRange).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				switch obj.(type) {
+				case *corev1.ResourceQuota, *corev1.LimitRange:
+					return errors.New("unexpected governance resource read")
+				default:
+					return c.Get(ctx, key, obj, opts...)
+				}
+			},
+		}).
+		Build()
+	manager, err := NewManager(k8sClient, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewManager() failed: %v", err)
+	}
+
+	if err := manager.CleanupTenantResources(context.Background(), namespace); err != nil {
+		t.Fatalf("CleanupTenantResources() error = %v", err)
+	}
+}
+
+func TestCleanupTenantResources_ReturnsGovernanceDeleteError(t *testing.T) {
+	deleteErr := apierrors.NewForbidden(
+		corev1.Resource("resourcequotas"),
+		TenantResourceQuotaName,
+		errors.New("delete denied"),
+	)
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+				return deleteErr
+			},
+		}).
+		Build()
+	manager, err := NewManager(k8sClient, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewManager() failed: %v", err)
+	}
+
+	err = manager.CleanupTenantResources(context.Background(), testNamespace)
+	if err == nil || !errors.Is(err, deleteErr) {
+		t.Fatalf("CleanupTenantResources() error = %v, want delete error", err)
+	}
+	for _, want := range []string{"ResourceQuota", testNamespace, TenantResourceQuotaName} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("CleanupTenantResources() error = %q, want it to contain %q", err, want)
+		}
+	}
+}
+
+func TestIsTenantNamespaceProvisioned(t *testing.T) {
+	t.Run("rejects empty namespace", func(t *testing.T) {
+		manager, err := NewManager(newTestClient(t), logr.Discard())
+		if err != nil {
+			t.Fatalf("NewManager() failed: %v", err)
+		}
+		if _, err := manager.IsTenantNamespaceProvisioned(context.Background(), ""); err == nil {
+			t.Fatal("IsTenantNamespaceProvisioned() error = nil, want namespace validation error")
+		}
+	})
+
+	t.Run("reports missing RoleBinding", func(t *testing.T) {
+		manager, err := NewManager(newTestClient(t), logr.Discard())
+		if err != nil {
+			t.Fatalf("NewManager() failed: %v", err)
+		}
+		provisioned, err := manager.IsTenantNamespaceProvisioned(context.Background(), testNamespace)
+		if err != nil || provisioned {
+			t.Fatalf("IsTenantNamespaceProvisioned() = (%v, %v), want (false, nil)", provisioned, err)
+		}
+	})
+
+	t.Run("reports existing RoleBinding", func(t *testing.T) {
+		binding := GenerateTenantRoleBinding(testNamespace, OperatorServiceAccount{Name: "controller", Namespace: "operator"})
+		manager, err := NewManager(newTestClient(t, binding), logr.Discard())
+		if err != nil {
+			t.Fatalf("NewManager() failed: %v", err)
+		}
+		provisioned, err := manager.IsTenantNamespaceProvisioned(context.Background(), testNamespace)
+		if err != nil || !provisioned {
+			t.Fatalf("IsTenantNamespaceProvisioned() = (%v, %v), want (true, nil)", provisioned, err)
+		}
+	})
+
+	t.Run("returns RoleBinding read error", func(t *testing.T) {
+		readErr := errors.New("RoleBinding read failed")
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+					return readErr
+				},
+			}).
+			Build()
+		manager, err := NewManager(k8sClient, logr.Discard())
+		if err != nil {
+			t.Fatalf("NewManager() failed: %v", err)
+		}
+		if _, err := manager.IsTenantNamespaceProvisioned(context.Background(), testNamespace); !errors.Is(err, readErr) {
+			t.Fatalf("IsTenantNamespaceProvisioned() error = %v, want read error", err)
+		}
+	})
+}
+
+func TestCleanupTenantResources_ReturnsRBACOperationError(t *testing.T) {
+	operatorSA := OperatorServiceAccount{Name: "controller", Namespace: "operator"}
+	for _, tc := range []struct {
+		name      string
+		operation string
+		object    client.Object
+	}{
+		{
+			name:      "RoleBinding delete",
+			operation: "delete",
+			object:    GenerateTenantSecretsReaderRoleBinding(testNamespace, operatorSA),
+		},
+		{
+			name:      "Role delete",
+			operation: "delete",
+			object:    GenerateTenantSecretsReaderRole(testNamespace, nil),
+		},
+		{
+			name:      "RoleBinding get",
+			operation: "get",
+			object:    GenerateTenantSecretsReaderRoleBinding(testNamespace, operatorSA),
+		},
+		{
+			name:      "Role get",
+			operation: "get",
+			object:    GenerateTenantSecretsReaderRole(testNamespace, nil),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rbacErr := errors.New("RBAC operation failed")
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tc.object).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if tc.operation == "get" && key.Name == tc.object.GetName() {
+							return rbacErr
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+					Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+						if tc.operation == "delete" && obj.GetName() == tc.object.GetName() {
+							return rbacErr
+						}
+						return c.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+			manager, err := NewManager(k8sClient, logr.Discard())
+			if err != nil {
+				t.Fatalf("NewManager() failed: %v", err)
+			}
+
+			if err := manager.CleanupTenantResources(context.Background(), testNamespace); !errors.Is(err, rbacErr) {
+				t.Fatalf("CleanupTenantResources() error = %v, want RBAC operation error", err)
+			}
+		})
 	}
 }
 

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -975,6 +975,65 @@ func TestKustomizeDefault_ProvisionerRoleDoesNotReadServiceAccounts(t *testing.T
 	}
 }
 
+func TestKustomizeDefault_ProvisionerRoleDeletesOnlyFixedTenantGovernanceResources(t *testing.T) {
+	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
+	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {
+		return u.GetAPIVersion() == "rbac.authorization.k8s.io/v1" &&
+			u.GetKind() == "ClusterRole" &&
+			u.GetName() == "openbao-operator-provisioner-role"
+	})
+
+	if len(objs) != 1 {
+		t.Fatalf("expected exactly one provisioner ClusterRole, got %d", len(objs))
+	}
+	rules, found, err := unstructured.NestedSlice(objs[0].Object, "rules")
+	if err != nil || !found {
+		t.Fatalf("read provisioner rules: found=%v err=%v", found, err)
+	}
+
+	for _, tc := range []struct {
+		resource string
+		name     string
+	}{
+		{resource: "resourcequotas", name: "openbao-operator-tenant-quota"},
+		{resource: "limitranges", name: "openbao-operator-tenant-limits"},
+	} {
+		t.Run(tc.resource, func(t *testing.T) {
+			foundScopedDelete := false
+			for _, rule := range rules {
+				ruleMap, ok := rule.(map[string]any)
+				if !ok {
+					continue
+				}
+				resources, _, _ := unstructured.NestedStringSlice(ruleMap, "resources")
+				verbs, _, _ := unstructured.NestedStringSlice(ruleMap, "verbs")
+				if !containsString(resources, tc.resource) || !containsString(verbs, "delete") {
+					continue
+				}
+
+				resourceNames, _, _ := unstructured.NestedStringSlice(ruleMap, "resourceNames")
+				if len(resourceNames) != 1 || resourceNames[0] != tc.name {
+					t.Fatalf("provisioner %s delete must be scoped to %q, got %#v", tc.resource, tc.name, ruleMap)
+				}
+				for _, wantVerb := range []string{"get", "patch", "delete"} {
+					if !containsString(verbs, wantVerb) {
+						t.Fatalf("provisioner %s rule missing %q: %#v", tc.resource, wantVerb, ruleMap)
+					}
+				}
+				for _, forbiddenVerb := range []string{"create", "list", "update", "watch"} {
+					if containsString(verbs, forbiddenVerb) {
+						t.Fatalf("provisioner %s scoped rule must not grant %q: %#v", tc.resource, forbiddenVerb, ruleMap)
+					}
+				}
+				foundScopedDelete = true
+			}
+			if !foundScopedDelete {
+				t.Fatalf("provisioner ClusterRole missing resourceNames-scoped delete for %s", tc.resource)
+			}
+		})
+	}
+}
+
 func TestKustomizeDefault_ControllerRoleReadsGatewayAPIByGetOnly(t *testing.T) {
 	yamlBytes := kustomizeBuild(t, filepath.Join("..", "..", "config", "default"))
 	objs := parseYAMLToUnstructured(t, yamlBytes, func(u *unstructured.Unstructured) bool {


### PR DESCRIPTION
## Summary

- Delete the operator-managed tenant `ResourceQuota` and `LimitRange` before removing the tenant finalizer.
- Preserve shared namespace resources while another active, authorized `OpenBaoTenant` claim targets the namespace.
- Keep Pod Security Admission labels unchanged because the operator does not retain the namespace's pre-provisioning label state.
- Add fail-closed deletion-path coverage, manager-driven envtest coverage, scoped RBAC, generated Helm RBAC, and documentation updates.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This is non-breaking and does not change the API or CRDs. Provisioner RBAC gains `delete` only for the fixed operator-managed `ResourceQuota` and `LimitRange` names; it does not gain list, watch, create, or update access. Cleanup remains fail-closed: the finalizer is retained when claim discovery or resource deletion fails. Pod Security namespace labels are intentionally not mutated.

## Verification

- `make bootstrap`
- `make ci-core`
  - Semgrep: 0 findings
  - Trivy filesystem and four built-image scans: 0 HIGH/CRITICAL findings
  - golangci-lint: 0 issues
  - architecture rules: 61 passed
  - Go/integration suite: 3,414 passed, 4 intentional skips
  - internal coverage: 68.99% (minimum 68.0%)
  - full fuzz matrix
  - OpenBao config compatibility: 2.4.4, 2.5.5, and 2.6.1
  - documentation build, RBAC sync, Helm lint/render tests
- Manager-driven envtest verifies quota and LimitRange deletion while Pod Security labels remain unchanged.
- `make doctor` was run; repository-pinned tooling is correct, but the host has Node 26 instead of Node 22, global pnpm 11 instead of 10.34.5, and global Semgrep 1.172 instead of 1.157. The pinned pnpm 10.34.5 and Semgrep 1.157 were used by the successful gate.

## Reviewer Notes

The cleanup checks only the target namespace and configured operator namespace for competing tenant claims, satisfying the runtime client's namespace-scoping policy. Claims already being deleted do not block cleanup, preventing finalizer deadlocks. Pod Security cleanup is deliberately out of scope.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
