### PR TITLE
fix(docs): improve ultrawide layout

### DIFF
--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -7,8 +7,8 @@
   --paper-deep: #e9e5da;
   --text: #142731;
   --text-muted: #5b686c;
+  --green-primary: #336d5c;
   --mint: #87d6be;
-  --mint-strong: #62c9aa;
   --mint-wash: #dff4eb;
   --peach: #fdd0a4;
   --yellow: #fdfccf;
@@ -114,9 +114,9 @@ a {
   display: flex;
   align-items: center;
   gap: 2rem;
-  width: min(100%, 96rem);
+  width: 100%;
   height: 100%;
-  padding: 0 1.5rem;
+  padding: 0 clamp(1rem, 2vw, 3rem);
   margin: 0 auto;
 }
 
@@ -339,6 +339,7 @@ kbd {
 .home-main {
   position: relative;
   overflow: clip;
+  min-height: calc(100svh - var(--header-height));
   background:
     radial-gradient(circle at 78% 4%, rgba(135, 214, 190, 0.13), transparent 21rem),
     radial-gradient(circle at 13% 4%, rgba(253, 208, 164, 0.07), transparent 16rem),
@@ -396,7 +397,7 @@ kbd {
 
 .eyebrow {
   margin: 0 0 0.9rem;
-  color: #34816b;
+  color: var(--green-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.72rem;
   font-weight: 760;
@@ -1313,7 +1314,7 @@ kbd {
   padding: 0.2rem 0 0.2rem 1.3rem;
   margin: 1.8rem 0;
   color: #536366;
-  border-left: 3px solid var(--mint-strong);
+  border-left: 3px solid var(--green-primary);
 }
 
 .article-content table {
@@ -1466,7 +1467,7 @@ kbd {
   margin: 1.7rem 0;
   background: var(--paper-raised);
   border: 1px solid var(--line);
-  border-left: 3px solid var(--mint-strong);
+  border-left: 3px solid var(--green-primary);
   border-radius: 0.3rem;
 }
 
@@ -1846,7 +1847,11 @@ kbd {
 }
 
 .site-footer a:hover {
-  color: var(--mint-strong);
+  color: var(--mint);
+}
+
+.doc-main > .site-footer a:hover {
+  color: var(--green-primary);
 }
 
 .search-dialog {
@@ -2041,6 +2046,24 @@ kbd {
   color: rgba(237, 246, 241, 0.64);
   font-size: 0.68rem;
   border-top: 1px solid rgba(135, 214, 190, 0.1);
+}
+
+@media (min-width: 160rem) {
+  :root {
+    font-size: clamp(1rem, 0.7vw, 1.5rem);
+  }
+}
+
+@media (min-width: 100rem) and (min-height: 60rem) {
+  .home-quiet:not(.home-with-sections) {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .home-quiet:not(.home-with-sections) .home-intro {
+    flex: 1 0 25rem;
+    align-items: center;
+  }
 }
 
 @media (max-width: 76rem) {

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -4,7 +4,7 @@
 {{- $versionHome := .Site.Home.RelPermalink -}}
 {{- $getStartedURL := printf "%sdocs/get-started/" $versionHome -}}
 {{- $compatibilityURL := printf "%sdocs/reference/compatibility/" $versionHome -}}
-<main id="main-content" class="home-main home-quiet">
+<main id="main-content" class="home-main home-quiet{{ if site.Version.IsDefault }} home-with-sections{{ end }}">
   <section class="home-intro">
     <div class="home-intro-copy">
       <h1>OpenBao Operator</h1>


### PR DESCRIPTION
## Summary

The Hugo landing page ended at its content height and the header used a fixed-width shell, which exposed a darker band and made navigation look undersized on 4K displays.

- Keep stable-home sections compact while centering shorter version landing pages.
- Let global navigation use fluid edge gutters and scale typography on ultra-wide screens.
- Align green tokens with the official OpenBao palette.

## Related Issues

Follows #607.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

CSS and Hugo layout only. No API, CRD, Helm, RBAC, security, upgrade, or operational impact.

## Verification

- `make docs-build`
- Responsive cmux browser checks at 390x844, 1440x900, 1848x1344, 2048x1152, 3072x1600, and 3840x2160
- No horizontal overflow, console entries, or browser errors

## Reviewer Notes

Focus on 4K spacing, header gutters, and the stable versus version landing-page balance.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.