### PR TITLE
chore(tooling): add pinned devenv environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       manual_seal_e2e: ${{ steps.diff.outputs.manual_seal_e2e }}
       chart: ${{ steps.diff.outputs.chart }}
       workflow: ${{ steps.diff.outputs.workflow }}
+      toolchain: ${{ steps.diff.outputs.toolchain }}
       docs: ${{ steps.diff.outputs.docs }}
       go_quality: ${{ steps.diff.outputs.go_quality }}
       go_toolchain: ${{ steps.diff.outputs.go_toolchain }}
@@ -106,7 +107,7 @@ jobs:
               echo "manual_upgrade_e2e=${MANUAL_UPGRADE_E2E}"
               echo "manual_hardened_e2e=${MANUAL_HARDENED_E2E}"
               echo "manual_seal_e2e=${MANUAL_SEAL_E2E}"
-              for key in chart workflow docs go_quality go_toolchain go_tests config_compat security_scan security_image fuzz e2e operator_upgrade_e2e e2e_backup e2e_upgrade e2e_hardened e2e_seal; do
+              for key in chart workflow toolchain docs go_quality go_toolchain go_tests config_compat security_scan security_image fuzz e2e operator_upgrade_e2e e2e_backup e2e_upgrade e2e_hardened e2e_seal; do
                 echo "${key}=false"
               done
             } >> "${GITHUB_OUTPUT}"
@@ -155,6 +156,12 @@ jobs:
             echo "workflow=true" >> "${GITHUB_OUTPUT}"
           else
             echo "workflow=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+          if changed_matches '^(devenv\.(nix|yaml|lock)$|\.node-version$|\.hugo-version$|go\.mod$|\.github/tools/(package\.json|pnpm-lock\.yaml)$|hack/dev/verify-devenv\.sh$|Makefile|mk/)'; then
+            echo "toolchain=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "toolchain=false" >> "${GITHUB_OUTPUT}"
           fi
 
           if changed_matches '^(\.hugo-version$|website/|release-notes/|hack/docs/|CHANGELOG\.md|README\.md|CONTRIBUTING\.md|\.github/actions/docs-build/)'; then
@@ -355,6 +362,34 @@ jobs:
 
       - name: Run actionlint
         run: make verify-workflows
+
+  devenv-contract:
+    name: Devenv Contract (advisory)
+    needs: changes
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.toolchain == 'true'
+    runs-on: *runner
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+
+      - name: Configure the devenv binary cache
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: devenv
+
+      - name: Install devenv from the pinned package set
+        shell: bash
+        run: |
+          set -euo pipefail
+          nixpkgs_url="$(awk '/^  nixpkgs:/{getline; sub(/^    url: /, ""); print; exit}' devenv.yaml)"
+          nix profile add "${nixpkgs_url}#devenv"
+
+      - name: Verify the devenv contract
+        run: devenv test
 
   lint:
     name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,12 @@ go.work
 
 # Local development files
 .DS_Store
+.devenv/
+.direnv/
 .gocache
 .pnpm-store/
+devenv.local.nix
+devenv.local.yaml
 node_modules/
 
 # Kubernetes Generated files - skip generated files, except for vendored files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ We welcome AI-assisted contributions. However, all code must meet our quality st
 ## Local Checks (PR-equivalent)
 
 ```sh
+devenv test
+devenv shell
+
+# Run these commands inside the shell.
 make bootstrap
 make doctor
 make ci-core

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,179 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1786123539,
+        "narHash": "sha256-vKK7JK4WJ92UQUekQ96OilOdY0Rr7A5X+UcAb7ZvDoA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "34a93eec7e71e64e9da1819a684d12f92331d638",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "go-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "go-overlay",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "go-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "git-hooks": "git-hooks",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786187685,
+        "narHash": "sha256-yM+cGzDhRpvbYI0zpCG/wVha6Jbcs6Jlb647wzYbQEk=",
+        "owner": "purpleclay",
+        "repo": "go-overlay",
+        "rev": "1f5ea3876f1d63709538c395b451f79dc6853229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "purpleclay",
+        "repo": "go-overlay",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "github"
+      }
+    },
+    "nixpkgs-helm3": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "go-overlay": "go-overlay",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-helm3": "nixpkgs-helm3"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -24,14 +24,15 @@ let
     else
       throw "${name} version mismatch: expected ${expected}, nixpkgs provides ${lib.getVersion package}";
 
-  helmPackages = import inputs.nixpkgs-helm3 {
-    system = pkgs.stdenv.hostPlatform.system;
-  };
+  # Build Helm 3 with the primary package set instead of mixing Nixpkgs stdenvs.
+  helmFromPinnedDefinition = pkgs.callPackage (
+    inputs.nixpkgs-helm3 + "/pkgs/applications/networking/cluster/helm"
+  ) { };
   helmPackage =
-    if lib.hasPrefix "3." (lib.getVersion helmPackages.kubernetes-helm) then
-      helmPackages.kubernetes-helm
+    if lib.hasPrefix "3." (lib.getVersion helmFromPinnedDefinition) then
+      helmFromPinnedDefinition
     else
-      throw "Helm 3 is required, nixpkgs-helm3 provides ${lib.getVersion helmPackages.kubernetes-helm}";
+      throw "Helm 3 is required, nixpkgs-helm3 provides ${lib.getVersion helmFromPinnedDefinition}";
 in
 {
   name = "openbao-operator";

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,88 @@
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  readVersionFile = path: lib.removeSuffix "\n" (builtins.readFile path);
+
+  goLine =
+    lib.findFirst (line: lib.hasPrefix "go " line) (throw "go.mod does not declare a Go version")
+      (lib.splitString "\n" (builtins.readFile ./go.mod));
+  goVersion = lib.removePrefix "go " goLine;
+  nodeVersion = readVersionFile ./.node-version;
+  hugoVersion = readVersionFile ./.hugo-version;
+  toolsPackage = builtins.fromJSON (builtins.readFile ./.github/tools/package.json);
+  pnpmVersion = lib.removePrefix "pnpm@" toolsPackage.packageManager;
+
+  exactPackage =
+    name: expected: package:
+    if lib.getVersion package == expected then
+      package
+    else
+      throw "${name} version mismatch: expected ${expected}, nixpkgs provides ${lib.getVersion package}";
+
+  helmPackages = import inputs.nixpkgs-helm3 {
+    system = pkgs.stdenv.hostPlatform.system;
+  };
+  helmPackage =
+    if lib.hasPrefix "3." (lib.getVersion helmPackages.kubernetes-helm) then
+      helmPackages.kubernetes-helm
+    else
+      throw "Helm 3 is required, nixpkgs-helm3 provides ${lib.getVersion helmPackages.kubernetes-helm}";
+in
+{
+  name = "openbao-operator";
+
+  languages.go = {
+    enable = true;
+    version = goVersion;
+    delve.enable = false;
+    lsp.enable = false;
+  };
+
+  packages = [
+    pkgs.bash
+    pkgs.coreutils
+    pkgs.curl
+    pkgs.docker-client
+    pkgs.findutils
+    pkgs.gawk
+    pkgs.git
+    pkgs.gnugrep
+    pkgs.gnused
+    pkgs.gnutar
+    pkgs.gzip
+    pkgs.jq
+    pkgs.kind
+    pkgs.kubectl
+    pkgs.gnumake
+    pkgs.python3
+    pkgs.tilt
+    pkgs.trivy
+    pkgs.unzip
+    pkgs.xz
+    pkgs.yq-go
+    helmPackage
+    (exactPackage "Hugo" hugoVersion pkgs.hugo)
+    (exactPackage "Node.js" nodeVersion pkgs.nodejs_22)
+    (exactPackage "pnpm" pnpmVersion pkgs.pnpm_10)
+  ];
+
+  enterShell = ''
+    export PATH="$DEVENV_ROOT/bin:$PATH"
+  '';
+
+  tasks = {
+    "operator:verify-toolchain" = {
+      exec = "make verify-devenv";
+      before = [ "devenv:enterTest" ];
+    };
+
+    "operator:setup".exec = "make bootstrap";
+    "operator:doctor".exec = "make doctor";
+    "operator:ci-core".exec = "make ci-core";
+  };
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,12 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/9bc02893134c733dd85de46ee4fb2fac696b5529
+  nixpkgs-helm3:
+    url: github:NixOS/nixpkgs/nixos-25.11
+  go-overlay:
+    url: github:purpleclay/go-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+
+require_version: ">=2.1"

--- a/hack/dev/verify-devenv.sh
+++ b/hack/dev/verify-devenv.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+fail() {
+  printf 'ERR  %s\n' "$1" >&2
+  exit 1
+}
+
+ok() {
+  printf 'OK   %s\n' "$1"
+}
+
+require_nix_command() {
+  local name="$1"
+  local command_path=""
+  local resolved_path=""
+
+  command_path="$(command -v "${name}" 2>/dev/null || true)"
+  if [[ -z "${command_path}" ]]; then
+    fail "${name} is missing from the devenv environment"
+  fi
+
+  resolved_path="$(realpath "${command_path}")"
+  if [[ "${resolved_path}" != /nix/store/* ]]; then
+    fail "${name} resolved outside the Nix store: ${resolved_path}"
+  fi
+
+  ok "${name}: ${resolved_path}"
+}
+
+if [[ -z "${DEVENV_ROOT:-}" ]]; then
+  fail "DEVENV_ROOT is not set; run this check through 'devenv test' or 'devenv shell'"
+fi
+
+devenv_root="$(cd "${DEVENV_ROOT}" && pwd)"
+if [[ "${devenv_root}" != "${ROOT_DIR}" ]]; then
+  fail "DEVENV_ROOT points to ${devenv_root}, expected ${ROOT_DIR}"
+fi
+
+if [[ "${GOTOOLCHAIN:-}" != "local" ]]; then
+  fail "GOTOOLCHAIN must be local inside devenv, found ${GOTOOLCHAIN:-unset}"
+fi
+
+expected_go="$(sed -n 's/^go //p' go.mod | head -n 1)"
+current_go="$(go env GOVERSION 2>/dev/null || true)"
+if [[ "${current_go}" != "go${expected_go}" ]]; then
+  fail "Go toolchain mismatch: expected go${expected_go}, found ${current_go:-unknown}"
+fi
+ok "Go ${expected_go} matches go.mod"
+
+expected_node="$(tr -d '[:space:]' < .node-version)"
+current_node="$(node --version 2>/dev/null || true)"
+if [[ "${current_node}" != "v${expected_node}" ]]; then
+  fail "Node.js mismatch: expected v${expected_node}, found ${current_node:-unknown}"
+fi
+ok "Node.js ${expected_node} matches .node-version"
+
+expected_pnpm="$(sed -n 's/.*"packageManager": "pnpm@\([^"]*\)".*/\1/p' .github/tools/package.json | head -n 1)"
+current_pnpm="$(pnpm --version 2>/dev/null || true)"
+if [[ "${current_pnpm}" != "${expected_pnpm}" ]]; then
+  fail "pnpm mismatch: expected ${expected_pnpm}, found ${current_pnpm:-unknown}"
+fi
+ok "pnpm ${expected_pnpm} matches packageManager"
+
+expected_hugo="$(tr -d '[:space:]' < .hugo-version)"
+current_hugo="$(hugo version 2>/dev/null || true)"
+if [[ "${current_hugo}" != *"v${expected_hugo}"* ]]; then
+  fail "Hugo mismatch: expected ${expected_hugo}, found ${current_hugo:-unknown}"
+fi
+ok "Hugo ${expected_hugo} matches .hugo-version"
+
+current_helm="$(helm version --short 2>/dev/null || true)"
+if [[ ! "${current_helm}" =~ ^v3\. ]]; then
+  fail "Helm 3 is required, found ${current_helm:-unknown}"
+fi
+ok "Helm 3 contract satisfied (${current_helm})"
+
+current_kubectl="$(kubectl version --client --output=json 2>/dev/null | jq -r '.clientVersion.gitVersion // empty')"
+if [[ ! "${current_kubectl}" =~ ^v1\.([0-9]+)\. ]]; then
+  fail "unable to parse kubectl client version: ${current_kubectl:-unknown}"
+fi
+if (( BASH_REMATCH[1] < 33 )); then
+  fail "kubectl 1.33 or newer is required, found ${current_kubectl}"
+fi
+ok "kubectl compatibility contract satisfied (${current_kubectl})"
+
+for command_name in \
+  bash curl docker git go helm hugo jq kind kubectl make node pnpm python3 tilt trivy yq; do
+  require_nix_command "${command_name}"
+done
+
+printf '\nPinned devenv toolchain contract verified.\n'

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -31,6 +31,10 @@ git-hooks-uninstall: ## Remove the repo-local Git hooks path.
 doctor: ## Validate local prerequisites for the main contributor workflow.
 	@bash hack/dev/doctor.sh
 
+.PHONY: verify-devenv
+verify-devenv: ## Verify the pinned devenv toolchain contract without external service checks.
+	@bash hack/dev/verify-devenv.sh
+
 .PHONY: clean-artifacts
 clean-artifacts: ## Remove known local build, test, documentation, and report artifacts.
 	@$(RM) cover.out coverage.out report.xml

--- a/website/README.md
+++ b/website/README.md
@@ -18,12 +18,8 @@ The site uses a task-oriented product structure:
 ```sh
 ./website/scripts/sync-api-reference.sh --all --check
 
-# On the devcontainer, Hugo is already pinned and installed:
-make docs-serve
-
-# On a Nix workstation:
-nix shell nixpkgs#hugo --command \
-  make docs-serve HUGO=hugo
+# The devenv shell provides the repository-pinned Hugo version.
+devenv shell make docs-serve
 ```
 
 Open <http://127.0.0.1:1313/openbao-operator/>.
@@ -31,7 +27,7 @@ Open <http://127.0.0.1:1313/openbao-operator/>.
 ## Build strictly
 
 ```sh
-nix shell nixpkgs#hugo --command make docs-build HUGO=hugo
+devenv shell make docs-build
 ```
 
 The API sync reads each line's exact `sourceRef` from `data/version_lines.yaml` and splits its generated reference into

--- a/website/content/contribute/ci.md
+++ b/website/content/contribute/ci.md
@@ -4,6 +4,10 @@ description: Map local validation to pull-request, main, nightly, and release wo
 eyebrow: Contribute
 weight: 4
 verifiedBy:
+  - devenv.nix
+  - devenv.yaml
+  - devenv.lock
+  - hack/dev/verify-devenv.sh
   - .github/workflows/ci.yml
   - .github/workflows/nightly.yml
   - .github/workflows/release.yml
@@ -13,13 +17,22 @@ verifiedBy:
 Pull-request CI routes checks by changed path and risk. Nightly and release workflows broaden compatibility, lifecycle, provenance, and reproducibility coverage.
 
 {{< command label="verify" title="Run the local pull-request baseline" >}}
+devenv test
+devenv shell
+
+# Run these commands inside the shell.
 make bootstrap
 make doctor
 make ci-core
 {{< /command >}}
 
+The advisory `Devenv Contract` job runs on toolchain changes and pushes to `main`. It proves that the pinned shell can
+be constructed on the CI runner and that its version contract passes. The existing required jobs remain the merge
+authority while the project migrates their setup steps incrementally.
+
 | CI concern | Local entry point |
 | --- | --- |
+| Pinned environment contract | `devenv test` |
 | Core quality gates | `make ci-core` |
 | Hugo documentation and redirects | `make docs-build` |
 | Vendored dependencies and licenses | `make verify-vendor`, `make license-check` |

--- a/website/content/contribute/setup.md
+++ b/website/content/contribute/setup.md
@@ -4,6 +4,10 @@ description: Bootstrap repository-managed tools and choose a local controller de
 eyebrow: Contribute
 weight: 1
 verifiedBy:
+  - devenv.nix
+  - devenv.yaml
+  - devenv.lock
+  - hack/dev/verify-devenv.sh
   - mk/development.mk
   - mk/deploy.mk
   - mk/build.mk
@@ -13,22 +17,32 @@ verifiedBy:
   - .devcontainer/post-install.sh
 ---
 
-Run the repository-managed bootstrap before changing code. Use a cluster loop only when the behavior depends on admission, RBAC, networking, storage, or workload lifecycle.
+Use the pinned development environment and run the repository-managed bootstrap before changing code. Use a cluster
+loop only when the behavior depends on admission, RBAC, networking, storage, or workload lifecycle.
 
 ## Install prerequisites
 
-The repository currently expects Go 1.26.5, Docker, `kubectl` 1.33 or newer, Helm 3, Trivy, Python 3, and access to a
-Kubernetes cluster. Node.js 22 and pnpm 10.34.5 remain scoped to the repository's AST tooling; the documentation site
-does not use them. The devcontainer installs Hugo 0.164.0; use the documented Nix command on a host workstation.
+Install [Nix](https://nixos.org/download/) and [devenv](https://devenv.sh/getting-started/), then let `devenv.lock`
+select the package set. The environment reads the repository's existing Go, Node.js, pnpm, and Hugo declarations and
+rejects a package set that does not match them. It also supplies Docker CLI, `kubectl` 1.33 or newer, Helm 3, Trivy,
+Python 3, Kind, and Tilt.
 
-Kind and Tilt are optional. Kind provides a reproducible local cluster; Tilt shortens repeated in-cluster rebuilds.
+Docker daemon access and a Kubernetes cluster remain external runtime dependencies. Kind is available for a
+reproducible local cluster; Tilt shortens repeated in-cluster rebuilds. The devcontainer remains a supported fallback
+while it is migrated to the same generated environment contract.
 
-{{< command label="verify" title="Bootstrap and inspect the workstation" >}}
+{{< command label="verify" title="Validate and enter the development environment" >}}
+devenv test
+devenv shell
+
+# Run these commands inside the shell.
 make bootstrap
 make doctor
 {{< /command >}}
 
-`make bootstrap` installs repository-managed tools and local Git hooks. Treat the hook bypass variables as deliberate one-off exceptions, not a normal workflow.
+`devenv test` validates the pinned, service-independent toolchain contract. `make bootstrap` then installs the
+repository-managed Go and AST tools plus local Git hooks. Treat the hook bypass variables as deliberate one-off
+exceptions, not a normal workflow.
 
 ## Choose a development loop
 
@@ -58,6 +72,9 @@ kubectl get pods -n openbao-operator-system
 ## Establish the local baseline
 
 {{< command label="verify" title="Run the PR-equivalent core gate" >}}
+devenv shell
+
+# Run these commands inside the shell.
 make bootstrap
 make doctor
 make ci-core


### PR DESCRIPTION
## Summary

Add a pinned devenv development environment as the first step toward converging local contributor and CI toolchains.

The environment derives the repository's declared Go, Node.js, pnpm, and Hugo versions, supplies the shared system tools used by contributor workflows, and verifies that those commands resolve from the Nix store. Make remains the canonical command interface.

This also adds an advisory, path-aware CI job that builds and verifies the devenv contract on Linux without changing the existing required CI graph. Contributor and documentation workflows now describe devenv as the preferred local environment.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm chart, RBAC, security-policy, upgrade, or runtime behavior changes.

The existing required CI jobs, Docker and Buildx artifact paths, and Make targets remain authoritative. The new devenv CI job is advisory and is intentionally excluded from `ci-required` during the initial adoption period. The existing devcontainer remains available as a fallback.

## Verification

Passed:

- `devenv test`
- `devenv shell make verify-devenv`
- `devenv eval --system x86_64-linux languages.go.version languages.go.package packages`
- `devenv shell make bootstrap`
- `devenv shell make doctor`
- `devenv shell make docs-build`
- `devenv shell make verify-workflows`
- `shellcheck hack/dev/verify-devenv.sh`
- `git diff --check`
- Pre-push `make lint-ci`

`make ci-core` was attempted. Semgrep completed successfully, but Trivy stopped while resolving Maven metadata because Maven Central returned HTTP 429 with `Retry-After: 1800`. The full core gate therefore did not complete locally.

## Reviewer Notes

The main nixpkgs input is pinned to a commit that provides the repository's exact Node.js 22.23.1, pnpm 10.34.5, and Hugo 0.164.0 versions. Helm comes from a separately locked NixOS 25.11 input so that the environment continues to provide Helm 3 rather than Helm 4.

The intended follow-up sequence is:

1. Observe and graduate the advisory Linux environment-contract job.
2. Generate the devcontainer from the devenv contract and remove its parallel installers.
3. Migrate a low-risk required CI consumer, starting with documentation.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
