### PR TITLE
perf(tooling): reduce devenv base closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,13 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
 
-      - name: Configure the devenv binary cache
+      - name: Configure project and devenv binary caches
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
-          name: devenv
+          name: dc-tec-openbao-operator
+          extraPullNames: devenv
+          authToken: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' || secrets.CACHIX_AUTH_TOKEN == '' }}
 
       - name: Install devenv from the pinned package set
         shell: bash
@@ -385,7 +388,23 @@ jobs:
           nix profile add "${nixpkgs_url}#devenv"
 
       - name: Verify the devenv contract
-        run: devenv test
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="${SECONDS}"
+          devenv test
+          elapsed_seconds="$((SECONDS - started_at))"
+          profile_path="$(realpath .devenv/profile)"
+          closure_size="$(nix path-info -Sh "${profile_path}" | awk '{print $2, $3}')"
+
+          {
+            echo "### Devenv base shell"
+            echo
+            echo "| Measurement | Result |"
+            echo "| --- | ---: |"
+            echo "| Contract duration | ${elapsed_seconds}s |"
+            echo "| Runtime closure | ${closure_size} |"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   lint:
     name: Lint

--- a/devenv.lock
+++ b/devenv.lock
@@ -17,107 +17,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "go-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "go-overlay",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "go-overlay": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "git-hooks": "git-hooks",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786187685,
-        "narHash": "sha256-yM+cGzDhRpvbYI0zpCG/wVha6Jbcs6Jlb647wzYbQEk=",
-        "owner": "purpleclay",
-        "repo": "go-overlay",
-        "rev": "1f5ea3876f1d63709538c395b451f79dc6853229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "purpleclay",
-        "repo": "go-overlay",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1786106723,
@@ -137,23 +36,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "go-overlay": "go-overlay",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -42,16 +42,11 @@ let
     else
       throw "${name} version mismatch: expected ${expected}, nixpkgs provides ${lib.getVersion package}";
 
+  goPackage = exactPackage "Go" goVersion pkgs.go;
+
 in
 {
   name = "openbao-operator";
-
-  languages.go = {
-    enable = true;
-    version = goVersion;
-    delve.enable = false;
-    lsp.enable = false;
-  };
 
   packages = [
     pkgs.bash
@@ -63,6 +58,7 @@ in
     pkgs.git
     pkgs.gnugrep
     pkgs.gnused
+    goPackage
     pkgs.jq
     (exactPackage "Kind" (toolVersion "KIND_VERSION") pkgs.kind)
     (exactPackage "kubectl" (toolVersion "KUBECTL_VERSION") pkgs.kubectl)
@@ -74,9 +70,23 @@ in
     (exactPackage "Hugo" hugoVersion pkgs.hugo)
   ];
 
+  env = {
+    GOROOT = "${goPackage}/share/go";
+    GOTOOLCHAIN = "local";
+  };
+
+  profiles.editor.module = {
+    languages.go = {
+      enable = true;
+      package = goPackage;
+      delve.enable = true;
+      lsp.enable = true;
+    };
+  };
+
   enterShell = ''
     export GOPATH="''${XDG_CACHE_HOME:-$HOME/.cache}/openbao-operator/go"
-    export PATH="$DEVENV_ROOT/bin:$GOPATH/bin:$PATH"
+    export PATH="$DEVENV_PROFILE/bin:$DEVENV_ROOT/bin:$GOPATH/bin:$PATH"
   '';
 
   tasks = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,10 +1,5 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
-  go-overlay:
-    url: github:purpleclay/go-overlay
-    inputs:
-      nixpkgs:
-        follows: nixpkgs
 
 require_version: ">=2.1"

--- a/hack/dev/verify-devenv.sh
+++ b/hack/dev/verify-devenv.sh
@@ -43,9 +43,22 @@ if [[ "${devenv_root}" != "${ROOT_DIR}" ]]; then
   fail "DEVENV_ROOT points to ${devenv_root}, expected ${ROOT_DIR}"
 fi
 
+if [[ -z "${DEVENV_PROFILE:-}" ]]; then
+  fail "DEVENV_PROFILE is not set inside devenv"
+fi
+if [[ "${PATH%%:*}" != "${DEVENV_PROFILE}/bin" ]]; then
+  fail "the active devenv profile must take precedence in PATH"
+fi
+ok "active devenv profile takes precedence in PATH"
+
 if [[ "${GOTOOLCHAIN:-}" != "local" ]]; then
   fail "GOTOOLCHAIN must be local inside devenv, found ${GOTOOLCHAIN:-unset}"
 fi
+
+if [[ "${GOROOT:-}" != /nix/store/*/share/go ]]; then
+  fail "GOROOT must point to the pinned Nix Go package, found ${GOROOT:-unset}"
+fi
+ok "GOROOT points to the pinned Nix Go package (${GOROOT})"
 
 if [[ -z "${GOPATH:-}" ]]; then
   fail "GOPATH is not set inside devenv"

--- a/website/content/contribute/ci.md
+++ b/website/content/contribute/ci.md
@@ -26,8 +26,10 @@ make doctor
 make ci-core
 {{< /command >}}
 
-The advisory `Devenv Contract` job runs on toolchain changes and pushes to `main`. It proves that the pinned shell can
-be constructed on the CI runner and that its version contract passes. The existing required jobs remain the merge
+The advisory `Devenv Contract` job runs on toolchain changes and pushes to `main`. It proves that the pinned base shell
+can be constructed on the CI runner and that its version contract passes. The job pulls from the public project and
+Devenv caches. It publishes newly built paths to the project cache only from pushes to `main` when the repository has
+a per-cache `CACHIX_AUTH_TOKEN`; pull requests are always read-only. The existing required jobs remain the merge
 authority while the project migrates their setup steps incrementally.
 
 | CI concern | Local entry point |

--- a/website/content/contribute/setup.md
+++ b/website/content/contribute/setup.md
@@ -47,6 +47,13 @@ required by the core contributor workflow plus local Git hooks. Specialized targ
 live-reload, mutation, or benchmark tools only when invoked. Treat the hook bypass variables as deliberate one-off
 exceptions, not a normal workflow.
 
+The default shell keeps the runtime and CI toolchain small. Activate the optional editor profile when an editor needs
+Gopls, Delve, or the additional Go editor helpers supplied by Devenv:
+
+{{< command label="develop" title="Enter the shell with Go editor tooling" >}}
+devenv --profile editor shell
+{{< /command >}}
+
 ## Choose a development loop
 
 | Loop | Use it for | Commands |


### PR DESCRIPTION
## Summary

- Replace the Go overlay-backed base language module with the exact Go 1.26.5 package from the primary pinned Nixpkgs input.
- Move Gopls, Delve, and Devenv's additional Go editor helpers into an explicit `editor` profile while keeping the base runtime and CI shell focused.
- Make the active Devenv profile authoritative in `PATH`, ahead of repository-installed fallback tools.
- Pull from the public `dc-tec-openbao-operator` and `devenv` Cachix caches, while permitting publication only on pushes to `main` with a per-cache `CACHIX_AUTH_TOKEN`.
- Report base-shell contract duration and closure size in the Devenv Contract job summary.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

There are no operator runtime, API, CRD, Helm, RBAC, or release artifact changes.

The default shell no longer includes editor-only Go tools. Contributors who need Gopls, Delve, goimports, staticcheck, or the additional editor helpers use `devenv --profile editor shell`. The base and editor profiles use the same exact Go package and export the same `GOROOT` and `GOTOOLCHAIN=local` contract.

Pull requests never receive Cachix credentials. Without `CACHIX_AUTH_TOKEN`, all runs remain read-only. The intended secret is a write token restricted to the `dc-tec-openbao-operator` cache; managed Cachix signing requires no signing-key secret.

## Verification

- `devenv test` (passes; 0.83 seconds fully warm)
- `devenv --profile editor test`
- Verified `go`, `gopls`, `dlv`, `goimports`, `gomodifytags`, `gotests`, `iferr`, `impl`, and `staticcheck` resolve through the editor profile to Nix store paths
- `devenv shell -- make ci-core`
  - 3,414 unit and integration tests passed, with 4 expected skips
  - 69.03% internal coverage
  - license, security, Semgrep, Trivy filesystem and built-image scans, lint, architecture policy, fuzz, OpenBao compatibility, generated-artifact, documentation, and Helm gates passed
- `devenv shell -- make verify-workflows`
- ShellCheck for `hack/dev/verify-devenv.sh`
- `git diff --check`
- Base runtime closure reduced from 3.0 GiB to 2.4 GiB on aarch64-darwin
- The base GC closure contains only 0.49 MiB of NAR data not already signed by `cache.nixos.org`; Cachix avoids storing upstream NixOS-cache paths

## Reviewer Notes

The previous cold Linux Devenv contract spent 6m09s building the base shell, including six editor packages rebuilt through the Go overlay. This PR removes that work and records the new duration and runtime closure in the job summary for direct comparison.

The project cache currently has a shared account budget with approximately 1.8 GB free. The measured project-specific base closure is under 1 MiB on aarch64-darwin; the first authenticated `main` run should still be checked against the Cachix account delta.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
