### PR TITLE
feat(tooling): make devenv the contributor entry point

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,5 @@
   },
 
   "onCreateCommand": "bash .devcontainer/post-install.sh",
-  "postCreateCommand": "bash -lc 'make bootstrap && make doctor'"
+  "postCreateCommand": "bash -lc 'make bootstrap && make git-hooks-install && make doctor'"
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,8 @@
 ## Verification
 
 <!-- Commands, tests, screenshots, manifests, or cluster checks used to verify this change. -->
-<!-- PR-equivalent local checks are: `make bootstrap`, `make doctor`, `make ci-core`. -->
+<!-- PR-equivalent local checks are `devenv test`, then the `operator:bootstrap`,
+`operator:doctor`, and `operator:ci-core` Devenv tasks. -->
 
 ## Reviewer Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,19 +391,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          started_at="${SECONDS}"
+          base_started_at="${SECONDS}"
           devenv test
-          elapsed_seconds="$((SECONDS - started_at))"
-          profile_path="$(realpath .devenv/profile)"
-          closure_size="$(nix path-info -Sh "${profile_path}" | awk '{print $2, $3}')"
+          base_elapsed_seconds="$((SECONDS - base_started_at))"
+          base_profile_path="$(devenv shell --quiet -- printenv DEVENV_PROFILE)"
+          base_closure_size="$(nix path-info -Sh "${base_profile_path}" | awk '{print $2, $3}')"
+
+          editor_started_at="${SECONDS}"
+          devenv --profile editor test
+          editor_elapsed_seconds="$((SECONDS - editor_started_at))"
+          editor_profile_path="$(devenv --profile editor shell --quiet -- printenv DEVENV_PROFILE)"
+          editor_closure_size="$(nix path-info -Sh "${editor_profile_path}" | awk '{print $2, $3}')"
 
           {
-            echo "### Devenv base shell"
+            echo "### Devenv shell contracts"
             echo
-            echo "| Measurement | Result |"
-            echo "| --- | ---: |"
-            echo "| Contract duration | ${elapsed_seconds}s |"
-            echo "| Runtime closure | ${closure_size} |"
+            echo "| Profile | Contract duration | Runtime closure |"
+            echo "| --- | ---: | ---: |"
+            echo "| Base | ${base_elapsed_seconds}s | ${base_closure_size} |"
+            echo "| Editor | ${editor_elapsed_seconds}s | ${editor_closure_size} |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,7 @@ We welcome AI-assisted contributions. However, all code must meet our quality st
 
 ```sh
 devenv test
-devenv shell
-
-# Run these commands inside the shell.
-make bootstrap
-make doctor
-make ci-core
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv tasks run operator:ci-core
 ```

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ kubectl delete -f https://github.com/dc-tec/openbao-operator/releases/download/X
 We welcome contributions! Please see the [Contributing Guide](https://dc-tec.github.io/openbao-operator/contribute) for details on:
 
 - Setting up your development environment.
-- Running the PR-equivalent local gate (`make bootstrap && make doctor && make ci-core`).
+- Running the PR-equivalent local gate (`devenv test` followed by the `operator:bootstrap`, `operator:doctor`, and
+  `operator:ci-core` Devenv tasks).
 - Our AI-Assisted Contribution Policy.
 
 ## Official OpenBao Documentation

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   ...
@@ -71,7 +72,8 @@ in
   ];
 
   env = {
-    GOROOT = "${goPackage}/share/go";
+    # Match the Go language module's normalized value when the editor profile is active.
+    GOROOT = "${goPackage}/share/go/";
     GOTOOLCHAIN = "local";
   };
 
@@ -90,13 +92,48 @@ in
   '';
 
   tasks = {
+    "operator:git-hooks" = {
+      description = "Configure the repository-local Git hooks path";
+      exec = "make git-hooks-install";
+      status = ''
+        hooks_path="$(git config --local --get core.hooksPath 2>/dev/null || true)"
+        test "$hooks_path" = ".githooks" \
+          && test -x .githooks/pre-commit \
+          && test -x .githooks/pre-push \
+          && test -x hack/dev/pre-commit.sh \
+          && test -x hack/dev/pre-push.sh
+      '';
+      cwd = config.git.root;
+      before = [ "devenv:enterShell" ];
+    };
+
     "operator:verify-toolchain" = {
+      description = "Verify the pinned service-independent toolchain contract";
       exec = "make verify-devenv";
+      cwd = config.git.root;
+      after = [ "operator:git-hooks" ];
       before = [ "devenv:enterTest" ];
     };
 
-    "operator:setup".exec = "make bootstrap";
-    "operator:doctor".exec = "make doctor";
-    "operator:ci-core".exec = "make ci-core";
+    "operator:bootstrap" = {
+      description = "Install repository-managed tools required by the core contributor workflow";
+      exec = "make bootstrap";
+      cwd = config.git.root;
+      after = [ "operator:git-hooks" ];
+    };
+
+    "operator:doctor" = {
+      description = "Check external runtime prerequisites such as Docker and Kubernetes access";
+      exec = "make doctor";
+      cwd = config.git.root;
+      after = [ "operator:git-hooks" ];
+    };
+
+    "operator:ci-core" = {
+      description = "Run the cluster-independent pull-request-equivalent gate";
+      exec = "make ci-core";
+      cwd = config.git.root;
+      after = [ "operator:git-hooks" ];
+    };
   };
 }

--- a/hack/dev/verify-devenv.sh
+++ b/hack/dev/verify-devenv.sh
@@ -43,6 +43,17 @@ if [[ "${devenv_root}" != "${ROOT_DIR}" ]]; then
   fail "DEVENV_ROOT points to ${devenv_root}, expected ${ROOT_DIR}"
 fi
 
+hooks_path="$(git config --local --get core.hooksPath 2>/dev/null || true)"
+if [[ "${hooks_path}" != ".githooks" ]]; then
+  fail "Devenv must configure core.hooksPath=.githooks, found ${hooks_path:-unset}"
+fi
+for hook in .githooks/pre-commit .githooks/pre-push hack/dev/pre-commit.sh hack/dev/pre-push.sh; do
+  if [[ ! -x "${hook}" ]]; then
+    fail "Devenv-managed Git hook is not executable: ${hook}"
+  fi
+done
+ok "repository-local Git hooks are configured"
+
 if [[ -z "${DEVENV_PROFILE:-}" ]]; then
   fail "DEVENV_PROFILE is not set inside devenv"
 fi
@@ -55,10 +66,11 @@ if [[ "${GOTOOLCHAIN:-}" != "local" ]]; then
   fail "GOTOOLCHAIN must be local inside devenv, found ${GOTOOLCHAIN:-unset}"
 fi
 
-if [[ "${GOROOT:-}" != /nix/store/*/share/go ]]; then
+goroot_path="${GOROOT%/}"
+if [[ "${goroot_path}" != /nix/store/*/share/go ]]; then
   fail "GOROOT must point to the pinned Nix Go package, found ${GOROOT:-unset}"
 fi
-ok "GOROOT points to the pinned Nix Go package (${GOROOT})"
+ok "GOROOT points to the pinned Nix Go package (${goroot_path})"
 
 if [[ -z "${GOPATH:-}" ]]; then
   fail "GOPATH is not set inside devenv"

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -2,8 +2,8 @@
 
 .PHONY: bootstrap
 bootstrap: controller-gen kustomize crd-ref-docs setup-envtest golangci-lint actionlint ginkgo govulncheck govulncheck-ignore go-licenses gotestsum semgrep ast-grep ## Install tools required by the core contributor workflow.
-	@$(MAKE) git-hooks-install
 	@echo "Bootstrap complete."
+	@echo "Devenv configures Git hooks automatically; otherwise run 'make git-hooks-install'."
 	@echo "Run 'make doctor' to validate external prerequisites."
 
 .PHONY: git-hooks-install

--- a/website/content/contribute/_index.md
+++ b/website/content/contribute/_index.md
@@ -25,9 +25,10 @@ Contributions may use AI assistance, but the submitter remains responsible for c
 </ol>
 
 {{< command label="verify" title="PR-equivalent local gate" >}}
-make bootstrap
-make doctor
-make ci-core
+devenv test
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv tasks run operator:ci-core
 {{< /command >}}
 
 ## Contributor routes

--- a/website/content/contribute/ci.md
+++ b/website/content/contribute/ci.md
@@ -18,24 +18,22 @@ Pull-request CI routes checks by changed path and risk. Nightly and release work
 
 {{< command label="verify" title="Run the local pull-request baseline" >}}
 devenv test
-devenv shell
-
-# Run these commands inside the shell.
-make bootstrap
-make doctor
-make ci-core
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv tasks run operator:ci-core
 {{< /command >}}
 
-The advisory `Devenv Contract` job runs on toolchain changes and pushes to `main`. It proves that the pinned base shell
-can be constructed on the CI runner and that its version contract passes. The job pulls from the public project and
-Devenv caches. It publishes newly built paths to the project cache only from pushes to `main` when the repository has
-a per-cache `CACHIX_AUTH_TOKEN`; pull requests are always read-only. The existing required jobs remain the merge
-authority while the project migrates their setup steps incrementally.
+The advisory `Devenv Contract` job runs on toolchain changes and pushes to `main`. It proves that the pinned base and
+editor-profile shells can be constructed on the CI runner and that their version contracts pass. Base and editor
+duration and closure measurements remain separate. The job pulls from the public project and Devenv caches. It
+publishes newly built paths to the project cache only from pushes to `main` when the repository has a per-cache
+`CACHIX_AUTH_TOKEN`; pull requests are always read-only. The existing required jobs remain the merge authority while
+the project migrates their setup steps incrementally.
 
 | CI concern | Local entry point |
 | --- | --- |
 | Pinned environment contract | `devenv test` |
-| Core quality gates | `make ci-core` |
+| Core quality gates | `devenv tasks run operator:ci-core` |
 | Hugo documentation and redirects | `make docs-build` |
 | Vendored dependencies and licenses | `make verify-vendor`, `make license-check` |
 | Static and filesystem security | `make semgrep-ci`, `make security-ci` |

--- a/website/content/contribute/release.md
+++ b/website/content/contribute/release.md
@@ -44,10 +44,11 @@ For a patch, make the conventional commit or squash title describe the user-visi
 to generate the changelog.
 
 {{< command label="verify" title="Check release automation locally" >}}
-make bootstrap
-make doctor
-make ci-core
-make verify-workflows
+devenv test
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv tasks run operator:ci-core
+devenv shell -- make verify-workflows
 {{< /command >}}
 
 Also confirm that compatibility guidance, generated API surfaces, and release notes match the candidate. Review current

--- a/website/content/contribute/setup.md
+++ b/website/content/contribute/setup.md
@@ -35,17 +35,19 @@ while it is migrated to the same generated environment contract.
 
 {{< command label="verify" title="Validate and enter the development environment" >}}
 devenv test
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
 devenv shell
-
-# Run these commands inside the shell.
-make bootstrap
-make doctor
 {{< /command >}}
 
-`devenv test` validates the pinned, service-independent toolchain contract. `make bootstrap` then installs the tools
-required by the core contributor workflow plus local Git hooks. Specialized targets install their debugger,
-live-reload, mutation, or benchmark tools only when invoked. Treat the hook bypass variables as deliberate one-off
-exceptions, not a normal workflow.
+`devenv test` validates the pinned, service-independent toolchain contract. Entering or testing the environment also
+configures the repository-local Git hooks idempotently. `operator:bootstrap` installs the additional repository-managed
+tools required by the core contributor workflow, while `operator:doctor` checks external services such as Docker and
+Kubernetes access. Run `devenv tasks list` to inspect the supported contributor entry points. Specialized Make targets
+install their debugger, live-reload, mutation, or benchmark tools only when invoked.
+
+Outside Devenv, `make bootstrap`, `make git-hooks-install`, and `make doctor` remain explicit fallbacks. Treat the hook
+bypass variables as deliberate one-off exceptions, not a normal workflow.
 
 The default shell keeps the runtime and CI toolchain small. Activate the optional editor profile when an editor needs
 Gopls, Delve, or the additional Go editor helpers supplied by Devenv:
@@ -63,8 +65,11 @@ devenv --profile editor shell
 | Tilt | Repeated in-cluster controller edits | `make tilt-up`, then `make tilt-down` |
 
 {{< command label="apply" title="Run the controller on the host" >}}
-make bootstrap
-make doctor
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv shell
+
+# Run these commands inside the shell.
 make install
 make run-controller
 {{< /command >}}
@@ -82,12 +87,10 @@ kubectl get pods -n openbao-operator-system
 ## Establish the local baseline
 
 {{< command label="verify" title="Run the PR-equivalent core gate" >}}
-devenv shell
-
-# Run these commands inside the shell.
-make bootstrap
-make doctor
-make ci-core
+devenv test
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv tasks run operator:ci-core
 {{< /command >}}
 
 Use targeted tests during development, then rerun the core gate before review. If controller boundaries change, also regenerate and verify the architecture rules.

--- a/website/content/contribute/testing.md
+++ b/website/content/contribute/testing.md
@@ -22,9 +22,10 @@ Start at the lowest-cost layer that can prove the contract. Move upward when the
 The controller-runtime fake client is not a replacement for the API server. Use EnvTest when the test depends on validation, defaulting, subresources, watches, cache wiring, `Generation`, or `ResourceVersion`.
 
 {{< command label="verify" title="Run the baseline before review" >}}
-make bootstrap
-make doctor
-make ci-core
+devenv test
+devenv tasks run operator:bootstrap
+devenv tasks run operator:doctor
+devenv tasks run operator:ci-core
 {{< /command >}}
 
 ## Run specialized lanes


### PR DESCRIPTION
## Summary

Make Devenv the stable contributor entry point while keeping Make as the underlying command graph.

- configure repository-local Git hooks idempotently when Devenv enters or tests the environment
- expose documented `operator:bootstrap`, `operator:doctor`, and `operator:ci-core` tasks with repository-root execution
- keep explicit Make fallbacks for non-Devenv and devcontainer workflows
- validate and measure the base and editor profiles independently in CI
- normalize `GOROOT` so the editor profile composes with the pinned base environment
- update contributor, testing, CI, release, README, and PR-template guidance

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or runtime behavior changes.

The existing Make targets remain available as implementation details and explicit non-Devenv fallbacks. The devcontainer continues to install hooks explicitly until it is migrated to the generated environment contract.

## Verification

- `devenv test`
- `devenv --profile editor test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks --no-tui run operator:ci-core` (3,414 tests plus lint, security, fuzz, docs, workflow, Helm, and generated-artifact gates)
- `devenv shell -- make verify-workflows docs-build`
- hook lifecycle negative test: uninstall hooks, run `make bootstrap`, confirm hooks remain absent, then run `devenv test` and confirm `core.hooksPath=.githooks`
- pre-push `make lint-ci` (61 architecture rules)
- ShellCheck for `hack/dev/verify-devenv.sh`
- `jq empty .devcontainer/devcontainer.json`
- `git diff --check`

## Reviewer Notes

The Devenv CLI currently reports that 2.2.1 is available while the environment uses 2.1.2. Updating that pin is intentionally left for a focused follow-up because it can change evaluation and task behavior independently of this lifecycle slice.

The CI contract retrieves `DEVENV_PROFILE` from each shell rather than reading `.devenv/profile`, because the latter continues to point at the base profile after an editor-profile invocation.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
