### PR TITLE
fix(release): preserve SPDX schema validity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -739,7 +739,22 @@ jobs:
             dist/primary/sbom-openbao-init.spdx.json
             dist/primary/sbom-openbao-backup.spdx.json
             dist/primary/sbom-openbao-upgrade.spdx.json
-          retention-days: 7
+          retention-days: 30
+
+      - name: Upload rebuild validation assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-rebuild-validation-assets
+          path: |
+            dist/rebuild/install.yaml
+            dist/rebuild/crds.yaml
+            dist/rebuild/checksums.txt
+            dist/rebuild/openbao-operator-${{ needs.prepare.outputs.chart_version }}.tgz
+            dist/rebuild/sbom-openbao-operator.spdx.json
+            dist/rebuild/sbom-openbao-init.spdx.json
+            dist/rebuild/sbom-openbao-backup.spdx.json
+            dist/rebuild/sbom-openbao-upgrade.spdx.json
+          retention-days: 30
 
       - name: Upload reproducibility report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/devenv.nix
+++ b/devenv.nix
@@ -44,6 +44,22 @@ let
       throw "${name} version mismatch: expected ${expected}, nixpkgs provides ${lib.getVersion package}";
 
   goPackage = exactPackage "Go" goVersion pkgs.go;
+  spdxSchema22 = pkgs.fetchurl {
+    url = "https://raw.githubusercontent.com/spdx/spdx-spec/a05c12a2dd4652b1396fd2659f2cd3ea1f37faba/schemas/spdx-schema.json";
+    hash = "sha256-yDKNFMM2Iaa+kXVprUwyPTcCIEEu263cN8zx6T48qIo=";
+  };
+  spdxSchema23 = pkgs.fetchurl {
+    url = "https://raw.githubusercontent.com/spdx/spdx-spec/aadf3b0b8dbbabdb4d880b0fc714255fea436ff7/schemas/spdx-schema.json";
+    hash = "sha256-I5IIt6woezz12amvI/nWmGOXEQKl4Vh6J6OYtDSQuJs=";
+  };
+  spdxFixture22 = pkgs.fetchurl {
+    url = "https://raw.githubusercontent.com/spdx/spdx-spec/a05c12a2dd4652b1396fd2659f2cd3ea1f37faba/examples/SPDXJSONExample-v2.2.spdx.json";
+    hash = "sha256-4FusyQ1y2fUwu+aLdspor9duoLBzuUXHvJdfUiBRrOw=";
+  };
+  spdxFixture23 = pkgs.fetchurl {
+    url = "https://raw.githubusercontent.com/anchore/syft/2293641e3bd628a01bb37639318d62c0ebe89b39/syft/format/spdxjson/testdata/identify/2.3.json";
+    hash = "sha256-OaBZ+Nf1kvK7H1DQrjH1aKlEcUBdyLEq+OOMCQSsvAU=";
+  };
 
 in
 {
@@ -51,6 +67,7 @@ in
 
   packages = [
     pkgs.bash
+    pkgs.check-jsonschema
     pkgs.coreutils
     pkgs.curl
     pkgs.docker-client
@@ -75,6 +92,10 @@ in
     # Match the Go language module's normalized value when the editor profile is active.
     GOROOT = "${goPackage}/share/go/";
     GOTOOLCHAIN = "local";
+    SPDX_SCHEMA_2_2 = "${spdxSchema22}";
+    SPDX_SCHEMA_2_3 = "${spdxSchema23}";
+    SPDX_FIXTURE_2_2 = "${spdxFixture22}";
+    SPDX_FIXTURE_2_3 = "${spdxFixture23}";
   };
 
   profiles.editor.module = {
@@ -131,6 +152,14 @@ in
       exec = "make verify-devenv";
       cwd = config.git.root;
       after = [ "devenv:git-hooks:install" ];
+      before = [ "devenv:enterTest" ];
+    };
+
+    "operator:verify-spdx-normalizer" = {
+      description = "Validate deterministic SPDX normalization against SPDX 2.2 and 2.3";
+      exec = "make verify-spdx-normalizer";
+      cwd = config.git.root;
+      after = [ "operator:verify-toolchain" ];
       before = [ "devenv:enterTest" ];
     };
 

--- a/hack/ci/normalize-spdx-json.sh
+++ b/hack/ci/normalize-spdx-json.sh
@@ -33,17 +33,19 @@ def sort_list(entries, keys):
 def canonicalize(node):
     if isinstance(node, dict):
         out = {k: canonicalize(v) for k, v in node.items()}
-        out["packages"] = sort_list(out.get("packages"), ("SPDXID", "name", "versionInfo"))
-        out["relationships"] = sort_list(
-            out.get("relationships"),
-            ("spdxElementId", "relationshipType", "relatedSpdxElement", "comment"),
+        sortable_fields = (
+            ("packages", ("SPDXID", "name", "versionInfo")),
+            (
+                "relationships",
+                ("spdxElementId", "relationshipType", "relatedSpdxElement", "comment"),
+            ),
+            ("files", ("SPDXID", "fileName")),
+            ("annotations", ("SPDXID", "annotationDate", "comment")),
+            ("hasExtractedLicensingInfos", ("licenseId", "name", "comment")),
         )
-        out["files"] = sort_list(out.get("files"), ("SPDXID", "fileName"))
-        out["annotations"] = sort_list(out.get("annotations"), ("SPDXID", "annotationDate", "comment"))
-        out["hasExtractedLicensingInfos"] = sort_list(
-            out.get("hasExtractedLicensingInfos"),
-            ("licenseId", "name", "comment"),
-        )
+        for field, keys in sortable_fields:
+            if field in out:
+                out[field] = sort_list(out[field], keys)
         return out
     if isinstance(node, list):
         return [canonicalize(v) for v in node]

--- a/hack/ci/test-normalize-spdx-json.sh
+++ b/hack/ci/test-normalize-spdx-json.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NORMALIZER="${ROOT_DIR}/hack/ci/normalize-spdx-json.sh"
+
+: "${SPDX_SCHEMA_2_2:?SPDX_SCHEMA_2_2 is required; run through devenv}"
+: "${SPDX_SCHEMA_2_3:?SPDX_SCHEMA_2_3 is required; run through devenv}"
+: "${SPDX_FIXTURE_2_2:?SPDX_FIXTURE_2_2 is required; run through devenv}"
+: "${SPDX_FIXTURE_2_3:?SPDX_FIXTURE_2_3 is required; run through devenv}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fail() {
+  echo "SPDX normalizer test failed: $*" >&2
+  exit 1
+}
+
+validate_fixture() {
+  local version="$1"
+  local source="$2"
+  local schema="$3"
+  local target="${tmp_dir}/spdx-${version}.json"
+  local first="${tmp_dir}/spdx-${version}.first.json"
+  local invalid="${tmp_dir}/spdx-${version}.invalid.json"
+
+  cp "${source}" "${target}"
+  chmod u+w "${target}"
+  check-jsonschema --schemafile "${schema}" "${target}" >/dev/null
+
+  SOURCE_DATE_EPOCH=1700000000 bash "${NORMALIZER}" "${target}"
+  check-jsonschema --schemafile "${schema}" "${target}" >/dev/null
+
+  cp "${target}" "${first}"
+  SOURCE_DATE_EPOCH=1700000000 bash "${NORMALIZER}" "${target}"
+  cmp -s "${first}" "${target}" || fail "SPDX ${version} normalization is not idempotent"
+
+  cp "${target}" "${invalid}"
+  chmod u+w "${invalid}"
+  python3 - "${invalid}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+document = json.loads(path.read_text(encoding="utf-8"))
+document["creationInfo"]["packages"] = None
+path.write_text(json.dumps(document), encoding="utf-8")
+PY
+  if check-jsonschema --schemafile "${schema}" "${invalid}" >/dev/null 2>&1; then
+    fail "SPDX ${version} schema check accepted an injected creationInfo field"
+  fi
+}
+
+bash -n "${NORMALIZER}"
+validate_fixture "2.2" "${SPDX_FIXTURE_2_2}" "${SPDX_SCHEMA_2_2}"
+validate_fixture "2.3" "${SPDX_FIXTURE_2_3}" "${SPDX_SCHEMA_2_3}"
+
+echo "SPDX normalizer schema tests passed"

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VALIDATOR="${ROOT_DIR}/hack/ci/validate-release-as-request.sh"
 CHART_PREPARER="${ROOT_DIR}/hack/ci/prepare-release-chart.sh"
+SPDX_NORMALIZER="${ROOT_DIR}/hack/ci/normalize-spdx-json.sh"
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
@@ -75,7 +76,52 @@ assert_not_contains() {
   fi
 }
 
-bash -n "${VALIDATOR}" "${CHART_PREPARER}"
+bash -n "${VALIDATOR}" "${CHART_PREPARER}" "${SPDX_NORMALIZER}"
+
+spdx_fixture="${tmp_dir}/normalizer.spdx.json"
+cat > "${spdx_fixture}" <<'EOF'
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2040-01-01T00:00:00Z",
+    "creators": ["Tool: release-automation-test"]
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://example.test/original",
+  "files": [
+    {
+      "SPDXID": "SPDXRef-File-A",
+      "checksums": [{"algorithm": "SHA256", "checksumValue": "aa"}],
+      "fileName": "a"
+    }
+  ],
+  "name": "normalizer-test",
+  "packages": [],
+  "relationships": []
+}
+EOF
+SOURCE_DATE_EPOCH=1700000000 bash "${SPDX_NORMALIZER}" "${spdx_fixture}"
+python3 - "${spdx_fixture}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+checksum = document["files"][0]["checksums"][0]
+if set(checksum) != {"algorithm", "checksumValue"}:
+    raise SystemExit(f"normalizer added fields to checksum object: {sorted(checksum)}")
+creation_info = document["creationInfo"]
+unexpected = {
+    "packages",
+    "relationships",
+    "files",
+    "annotations",
+    "hasExtractedLicensingInfos",
+}.intersection(creation_info)
+if unexpected:
+    raise SystemExit(f"normalizer added fields to creationInfo: {sorted(unexpected)}")
+PY
 
 expect_valid_request "main" "0.5.0-rc.1" "automation/release-as-main-0.5.0-rc.1"
 expect_valid_request "release-0.5" "0.5.1" "automation/release-as-release-0.5-0.5.1"

--- a/hack/dev/verify-devenv.sh
+++ b/hack/dev/verify-devenv.sh
@@ -136,8 +136,15 @@ fi
 ok "Tilt matches tool-versions.env (${current_tilt})"
 
 for command_name in \
-  bash curl docker git go helm hugo jq kind kubectl make python3 tilt trivy; do
+  bash check-jsonschema curl docker git go helm hugo jq kind kubectl make python3 tilt trivy; do
   require_nix_command "${command_name}"
 done
+
+for schema_path in "${SPDX_SCHEMA_2_2:-}" "${SPDX_SCHEMA_2_3:-}"; do
+  if [[ "${schema_path}" != /nix/store/* || ! -f "${schema_path}" ]]; then
+    fail "SPDX schemas must resolve to immutable Nix store files, found ${schema_path:-unset}"
+  fi
+done
+ok "SPDX 2.2 and 2.3 schemas resolve to immutable Nix store files"
 
 printf '\nPinned devenv toolchain contract verified.\n'

--- a/mk/ci.mk
+++ b/mk/ci.mk
@@ -15,7 +15,7 @@ endif
 	@echo "✅ All CI checks passed!"
 
 .PHONY: ci-core
-ci-core: security-ci security-scan-built-images lint-ci verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-vendor verify-generated verify-api-stability-inventory report-crd-compatibility verify-e2e-manifest verify-operator-upgrade-e2e test-ci fuzz verify-openbao-config-compat docs-build verify-helm helm-test ## Run all CI checks except E2E tests (cluster-independent).
+ci-core: security-ci security-scan-built-images lint-ci verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-spdx-normalizer verify-vendor verify-generated verify-api-stability-inventory report-crd-compatibility verify-e2e-manifest verify-operator-upgrade-e2e test-ci fuzz verify-openbao-config-compat docs-build verify-helm helm-test ## Run all CI checks except E2E tests (cluster-independent).
 
 CI_MANAGER_SCAN_IMG ?= local/openbao-operator:ci
 CI_INIT_SCAN_IMG ?= local/openbao-init:ci

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -130,6 +130,10 @@ verify-go-toolchain-sync: ## Verify go.mod and Dockerfile builders use the same 
 verify-release-automation: ## Test release request validation and Artifact Hub metadata generation.
 	@bash hack/ci/test-release-automation.sh
 
+.PHONY: verify-spdx-normalizer
+verify-spdx-normalizer: ## Validate deterministic SPDX normalization against the SPDX 2.2 and 2.3 schemas.
+	@bash hack/ci/test-normalize-spdx-json.sh
+
 .PHONY: verify-workflows
 verify-workflows: actionlint verify-release-automation ## Validate workflows and release automation.
 	@"$(ACTIONLINT)" .github/workflows/*.yml


### PR DESCRIPTION
## Summary

- preserve absent SPDX fields while sorting deterministic SPDX arrays
- gate the normalizer with a fast nested-object regression and hash-pinned SPDX 2.2/2.3 schema fixtures
- retain primary and rebuild release evidence for 30 days so the unpublished release-evidence tool can be validated against the 0.5.0 release

The previous recursive canonicalizer added `packages`, `relationships`, `files`, `annotations`, and `hasExtractedLicensingInfos` with null values to every JSON object. Those additions made otherwise valid SPDX documents fail the official JSON schemas.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, runtime, or upgrade behavior changes.

Normalized SBOM bytes and content-derived document namespaces will intentionally differ from 0.4.2 because invalid injected fields are removed. Release publication still promotes only the byte-verified primary assets. The rebuild artifact is retained separately and cannot enter the promotion path.

## Verification

- `devenv test`
- `devenv shell -- make verify-workflows verify-spdx-normalizer`
- `bash hack/ci/test-release-automation.sh`
- `git diff --check`
- full native pre-push hook
- corrected Bash and Go implementations validated against the official SPDX 2.2 and 2.3 schemas
- unrelated SPDX 2.2 specification and Syft SPDX 2.3 fixtures validated before and after normalization
- unpublished release-evidence tree: `go test -count=1 -race ./...`, `go vet ./...`, and `go build ./...`

## Reviewer Notes

The Operator 0.5.0 release continues to use the corrected repository-local scripts. The unpublished release-evidence tool is not introduced into this workflow. After 0.5.0, the retained rebuild assets will be compared with the public primary release assets before the standalone tool is published.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] Documentation is not needed because this changes internal release validation and artifact retention only.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.