### PR TITLE
fix(release): preserve release-as through squash

### DIFF
--- a/.github/workflows/prepare-release-as-pr.yml
+++ b/.github/workflows/prepare-release-as-pr.yml
@@ -210,7 +210,8 @@ jobs:
 
           ## Reviewer Notes
 
-          Merge this marker PR before reviewing the generated release-please PR.
+          Merge this marker PR before reviewing the generated release-please PR. The Release Please workflow
+          validates the empty squash commit and recovers the exact version from this PR's generated title.
 
           Release-As: ${VERSION}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,8 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ !github.event.repository.fork }}
     steps:
-      - name: Checkout for release-only guard
-        if: ${{ github.event_name == 'push' }}
+      - name: Checkout release tooling and release-only guard
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -69,6 +68,28 @@ jobs:
           echo "Push only changed release artifacts; skipping release-please."
           echo "skip_release_please=true" >> "${GITHUB_OUTPUT}"
 
+      - name: Resolve Release-As override
+        id: release-as
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_BRANCH: ${{ github.ref_name }}
+          DISPATCH_RELEASE_AS: ${{ inputs.release_as || '' }}
+        run: |
+          set -euo pipefail
+
+          commit_subject=""
+          commit_is_empty="false"
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            commit_subject="$(git show -s --format=%s "${GITHUB_SHA}")"
+            if git diff --quiet "${GITHUB_SHA}^" "${GITHUB_SHA}"; then
+              commit_is_empty="true"
+            fi
+          fi
+
+          COMMIT_SUBJECT="${commit_subject}" \
+            COMMIT_IS_EMPTY="${commit_is_empty}" \
+            bash hack/ci/resolve-release-as-override.sh
+
       - name: Mint GitHub App token (openbao-operator-release-pr)
         id: app-token
         if: ${{ steps.release-artifact-guard.outputs.skip_release_please != 'true' }}
@@ -91,7 +112,7 @@ jobs:
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          release-as: ${{ github.event_name == 'workflow_dispatch' && inputs.release_as || '' }}
+          release-as: ${{ steps.release-as.outputs.release_as }}
           skip-github-release: true
 
       - name: Check out release PR branch

--- a/hack/ci/resolve-release-as-override.sh
+++ b/hack/ci/resolve-release-as-override.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${TARGET_BRANCH:?TARGET_BRANCH is required}"
+
+DISPATCH_RELEASE_AS="${DISPATCH_RELEASE_AS:-}"
+COMMIT_SUBJECT="${COMMIT_SUBJECT:-}"
+COMMIT_IS_EMPTY="${COMMIT_IS_EMPTY:-false}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="${ROOT_DIR}/hack/ci/validate-release-as-request.sh"
+
+case "${COMMIT_IS_EMPTY}" in
+  true|false) ;;
+  *)
+    echo "COMMIT_IS_EMPTY must be true or false, got '${COMMIT_IS_EMPTY}'" >&2
+    exit 1
+    ;;
+esac
+
+release_as=""
+case "${EVENT_NAME}" in
+  workflow_dispatch)
+    release_as="${DISPATCH_RELEASE_AS}"
+    ;;
+  push)
+    marker_regex='^chore\((main|release-[0-9]+\.[0-9]+)\): request release ([^[:space:]]+) \(#[1-9][0-9]*\)$'
+    if [[ "${COMMIT_SUBJECT}" =~ ${marker_regex} ]]; then
+      if [[ "${COMMIT_IS_EMPTY}" != "true" ]]; then
+        echo "Release-As marker squash commit must be empty" >&2
+        exit 1
+      fi
+
+      marker_target="${BASH_REMATCH[1]}"
+      release_as="${BASH_REMATCH[2]}"
+      if [[ "${marker_target}" != "${TARGET_BRANCH}" ]]; then
+        echo "marker target '${marker_target}' does not match '${TARGET_BRANCH}'" >&2
+        exit 1
+      fi
+    fi
+    ;;
+  *)
+    echo "unsupported event '${EVENT_NAME}'" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -n "${release_as}" ]]; then
+  env -u GITHUB_OUTPUT \
+    TARGET_BRANCH="${TARGET_BRANCH}" \
+    VERSION="${release_as}" \
+    bash "${VALIDATOR}" >/dev/null
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "release_as=${release_as}" >> "${GITHUB_OUTPUT}"
+else
+  echo "${release_as}"
+fi

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VALIDATOR="${ROOT_DIR}/hack/ci/validate-release-as-request.sh"
+RELEASE_AS_RESOLVER="${ROOT_DIR}/hack/ci/resolve-release-as-override.sh"
 CHART_PREPARER="${ROOT_DIR}/hack/ci/prepare-release-chart.sh"
 SPDX_NORMALIZER="${ROOT_DIR}/hack/ci/normalize-spdx-json.sh"
 POST_RELEASE_VERIFIER="${ROOT_DIR}/hack/ci/verify-post-release.sh"
 RELEASE_WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
+RELEASE_PLEASE_WORKFLOW="${ROOT_DIR}/.github/workflows/release-please.yml"
 RELEASE_PR_GATE_WORKFLOW="${ROOT_DIR}/.github/workflows/release-pr-gate.yml"
 
 tmp_dir="$(mktemp -d)"
@@ -41,6 +43,28 @@ expect_invalid_request() {
 
   if TARGET_BRANCH="${target_branch}" VERSION="${version}" bash "${VALIDATOR}" >/dev/null 2>&1; then
     fail "expected target='${target_branch}' version='${version}' to be rejected"
+  fi
+}
+
+resolve_release_as() {
+  local event_name="$1"
+  local target_branch="$2"
+  local dispatch_release_as="$3"
+  local commit_subject="$4"
+  local commit_is_empty="$5"
+
+  env -u GITHUB_OUTPUT \
+    EVENT_NAME="${event_name}" \
+    TARGET_BRANCH="${target_branch}" \
+    DISPATCH_RELEASE_AS="${dispatch_release_as}" \
+    COMMIT_SUBJECT="${commit_subject}" \
+    COMMIT_IS_EMPTY="${commit_is_empty}" \
+    bash "${RELEASE_AS_RESOLVER}"
+}
+
+expect_invalid_release_as_resolution() {
+  if resolve_release_as "$@" >/dev/null 2>&1; then
+    fail "expected Release-As resolution to fail for '$*'"
   fi
 }
 
@@ -79,7 +103,16 @@ assert_not_contains() {
   fi
 }
 
-bash -n "${VALIDATOR}" "${CHART_PREPARER}" "${SPDX_NORMALIZER}" "${POST_RELEASE_VERIFIER}"
+bash -n \
+  "${VALIDATOR}" \
+  "${RELEASE_AS_RESOLVER}" \
+  "${CHART_PREPARER}" \
+  "${SPDX_NORMALIZER}" \
+  "${POST_RELEASE_VERIFIER}"
+
+assert_contains "${RELEASE_PLEASE_WORKFLOW}" "Resolve Release-As override"
+assert_contains "${RELEASE_PLEASE_WORKFLOW}" "bash hack/ci/resolve-release-as-override.sh"
+assert_contains "${RELEASE_PLEASE_WORKFLOW}" 'release-as: ${{ steps.release-as.outputs.release_as }}'
 
 assert_contains "${RELEASE_WORKFLOW}" "Setup Helm 3 compatibility client"
 assert_contains "${RELEASE_WORKFLOW}" 'HELM: ${{ steps.helm4.outputs.helm-path }}'
@@ -149,6 +182,51 @@ expect_invalid_request "release-0.5" "0.6.0"
 expect_invalid_request "main" "0.5"
 expect_invalid_request "main" "00.5.0"
 expect_invalid_request "main" "0.5.0-rc.01"
+
+release_as="$(
+  resolve_release_as \
+    "push" \
+    "main" \
+    "" \
+    "chore(main): request release 0.5.0-rc.1 (#619)" \
+    "true"
+)"
+[[ "${release_as}" == "0.5.0-rc.1" ]] || fail "failed to recover the squash-safe Release-As version"
+
+release_as="$(
+  resolve_release_as \
+    "workflow_dispatch" \
+    "release-0.5" \
+    "0.5.1" \
+    "" \
+    "false"
+)"
+[[ "${release_as}" == "0.5.1" ]] || fail "failed to preserve the dispatch Release-As version"
+
+release_as="$(resolve_release_as "push" "main" "" "fix(release): normal change (#620)" "false")"
+[[ -z "${release_as}" ]] || fail "normal pushes must not set a Release-As override"
+
+release_as="$(resolve_release_as "workflow_dispatch" "main" "" "" "false")"
+[[ -z "${release_as}" ]] || fail "an empty dispatch override must stay empty"
+
+expect_invalid_release_as_resolution \
+  "push" \
+  "main" \
+  "" \
+  "chore(main): request release 0.5.0-rc.1 (#619)" \
+  "false"
+expect_invalid_release_as_resolution \
+  "push" \
+  "main" \
+  "" \
+  "chore(release-0.5): request release 0.5.1 (#619)" \
+  "true"
+expect_invalid_release_as_resolution \
+  "push" \
+  "main" \
+  "" \
+  "chore(main): request release 0.5.0-rc.01 (#619)" \
+  "true"
 
 marker_branch="$(env -u GITHUB_OUTPUT TARGET_BRANCH=main VERSION=0.5.0-rc.1 bash "${VALIDATOR}")"
 if [[ "${marker_branch}" == release-* ]]; then

--- a/website/content/contribute/release.md
+++ b/website/content/contribute/release.md
@@ -82,8 +82,10 @@ For a patch, use `target_branch=release-X.Y` and a version in that release line.
 missing or mismatched branches, existing tags or releases, open release-please PRs, and conflicting marker state. It
 creates an empty signed-off commit containing `Release-As: <version>` on an `automation/release-as-*` branch.
 
-Merge the marker PR first. The branch-aware `Release Please PR` workflow then opens or updates the actual release PR.
-The direct `release_as` dispatch input remains available, but the marker PR is the preferred auditable path.
+Merge the marker PR first. Because protected branches require squash merges, the branch-aware `Release Please PR`
+workflow validates that the resulting marker commit is empty and recovers the exact version from its generated squash
+subject. It then opens or updates the actual release PR. The direct `release_as` dispatch input remains available, but
+the marker PR is the preferred auditable path.
 
 ## Review and merge the release PR
 


### PR DESCRIPTION
## Summary

- Recover an exact `Release-As` override from the generated subject of an empty squash-merged release marker PR.
- Preserve the existing manual `workflow_dispatch` override and reject malformed, branch-mismatched, or non-empty marker commits.
- Cover the squash-only release flow in automation tests and contributor documentation.

## Related Issues

Follow-up to #618 and the closed invalid stable release PR #620.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] CI, release, or build tooling

## Risk and Compatibility

No runtime, API, CRD, Helm, RBAC, or workload compatibility impact. The change is limited to release-PR automation and fails closed if a marker squash is not empty, does not match the target branch, or contains an invalid version.

## Verification

- `bash hack/ci/test-release-automation.sh`
- Replayed the actual squash subject `chore(main): request release 0.5.0-rc.1 (#619)` against the resolver and confirmed `0.5.0-rc.1`.
- `actionlint .github/workflows/release-please.yml .github/workflows/prepare-release-as-pr.yml`
- `shellcheck hack/ci/resolve-release-as-override.sh hack/ci/test-release-automation.sh`
- `git diff --check`
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv shell -- make verify-workflows docs-build`
- `devenv tasks run operator:ci-core`
- Pre-commit and pre-push hooks

## Reviewer Notes

The prior marker commit contained `Release-As` in its body, but the repository's required squash merge retained only the generated PR subject. This fix deliberately recognizes only the workflow-generated subject shape and additionally requires the squash commit to be tree-identical to its parent.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
