### PR TITLE
ci(e2e): pin stable upgrade helper image

### DIFF
--- a/hack/ci/operator-upgrade-e2e.sh
+++ b/hack/ci/operator-upgrade-e2e.sh
@@ -44,7 +44,8 @@ CLUSTER_RESOURCE="openbaocluster/operator-upgrade"
 PVC_RESOURCE="persistentvolumeclaim/data-operator-upgrade-0"
 TRANSIT_CLUSTER_RESOURCE="openbaocluster/operator-upgrade-transit"
 HARDENED_CLUSTER_RESOURCE="openbaocluster/operator-upgrade-hardened"
-DEFAULT_HARDENED_INIT_IMAGE="ghcr.io/dc-tec/openbao-init@sha256:e08e55a017a2594434dfa8f72860f4185bd4f82cebc3d09eb2e8310c819c4119"
+HARDENED_INIT_IMAGE_REPOSITORY="ghcr.io/dc-tec/openbao-init"
+DEFAULT_HARDENED_INIT_IMAGE="${HARDENED_INIT_IMAGE_REPOSITORY}@sha256:94fd43850f0e7ba9b101f513004668598823f319964abb94e56f5b8195fe25e4"
 HARDENED_INIT_IMAGE="${OPERATOR_UPGRADE_E2E_HARDENED_INIT_IMAGE:-${DEFAULT_HARDENED_INIT_IMAGE}}"
 
 require_command() {
@@ -53,6 +54,42 @@ require_command() {
     echo "${command_name} is required" >&2
     exit 1
   fi
+}
+
+verify_hardened_init_image() {
+  local baseline_ref="${HARDENED_INIT_IMAGE_REPOSITORY}:${FROM_VERSION}"
+  local baseline_digest=""
+  local expected_image=""
+
+  if [[ -n "${OPERATOR_UPGRADE_E2E_HARDENED_INIT_IMAGE:-}" ]]; then
+    if ! "${DOCKER_BIN}" buildx imagetools inspect "${HARDENED_INIT_IMAGE}" >/dev/null; then
+      echo "hardened upgrade helper does not resolve: ${HARDENED_INIT_IMAGE}" >&2
+      return 1
+    fi
+    echo "Verified overridden Hardened upgrade helper: ${HARDENED_INIT_IMAGE}"
+    return 0
+  fi
+
+  if ! baseline_digest="$(
+    "${DOCKER_BIN}" buildx imagetools inspect "${baseline_ref}" \
+      --format '{{json .Manifest.Digest}}' | tr -d '"'
+  )"; then
+    echo "failed to resolve baseline Hardened upgrade helper: ${baseline_ref}" >&2
+    return 1
+  fi
+  if ! [[ "${baseline_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "baseline Hardened upgrade helper returned an invalid digest: ${baseline_digest}" >&2
+    return 1
+  fi
+
+  expected_image="${HARDENED_INIT_IMAGE_REPOSITORY}@${baseline_digest}"
+  if [[ "${DEFAULT_HARDENED_INIT_IMAGE}" != "${expected_image}" ]]; then
+    echo "default Hardened upgrade helper does not match ${baseline_ref}" >&2
+    echo "expected ${expected_image}, got ${DEFAULT_HARDENED_INIT_IMAGE}" >&2
+    return 1
+  fi
+
+  echo "Verified baseline Hardened upgrade helper: ${DEFAULT_HARDENED_INIT_IMAGE}"
 }
 
 assert_equal() {
@@ -305,6 +342,7 @@ fi
 for command_name in "${KIND_BIN}" "${KUBECTL_BIN}" "${HELM_INSTALL_BIN}" "${HELM_BIN}" "${DOCKER_BIN}" jq python3; do
   require_command "${command_name}"
 done
+verify_hardened_init_image
 
 WORK_DIR="$(mktemp -d)"
 KUBECONFIG_PATH="${WORK_DIR}/kubeconfig"

--- a/test/fixtures/operator-upgrade/hardened-cluster.yaml
+++ b/test/fixtures/operator-upgrade/hardened-cluster.yaml
@@ -10,7 +10,7 @@ spec:
   profile: Hardened
   initContainer:
     enabled: true
-    image: "ghcr.io/dc-tec/openbao-init@sha256:e08e55a017a2594434dfa8f72860f4185bd4f82cebc3d09eb2e8310c819c4119"
+    image: "ghcr.io/dc-tec/openbao-init@sha256:94fd43850f0e7ba9b101f513004668598823f319964abb94e56f5b8195fe25e4"
   selfInit:
     enabled: true
     oidc:


### PR DESCRIPTION
## Summary

- Pin the Hardened upgrade helper to the immutable digest published for `openbao-init:0.4.2`.
- Verify that the stable baseline tag resolves to the committed digest before creating the Kind cluster.
- Verify custom `OPERATOR_UPGRADE_E2E_HARDENED_INIT_IMAGE` overrides before use.

GHCR housekeeping removed the transient digest previously used by the fixture. The missing image caused the Operator Upgrade E2E job to enter `ImagePullBackOff`.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or operational behavior changes. The E2E harness now performs one GHCR manifest lookup before cluster creation.

## Verification

- `BUILDKIT_PROGRESS=plain make test-e2e-operator-upgrade`
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`

## Reviewer Notes

Review the fail-fast digest check in `hack/ci/operator-upgrade-e2e.sh`. It prevents a deleted or moved baseline image from failing later as a Kubernetes pull timeout.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
