### PR TITLE
fix(lifecycle): require ownership proof for managed jobs

### DIFF
--- a/internal/platform/resourceownership/ownership.go
+++ b/internal/platform/resourceownership/ownership.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
@@ -36,6 +38,34 @@ func HasControllerOwnerReference(obj client.Object, owner client.Object) bool {
 		}
 	}
 	return false
+}
+
+// HasManagedControllerOwnerProof reports whether obj has both the exact
+// controller owner reference and the reserved owner UID annotation for owner.
+// The annotation prevents namespace users from claiming operator ownership
+// when the managed-resource admission policy is enforced.
+func HasManagedControllerOwnerProof(
+	obj client.Object,
+	owner client.Object,
+	ownerGVK schema.GroupVersionKind,
+) bool {
+	if obj == nil || owner == nil || owner.GetUID() == "" || ownerGVK.Empty() {
+		return false
+	}
+	if obj.GetNamespace() != owner.GetNamespace() {
+		return false
+	}
+
+	ref := metav1.GetControllerOfNoCopy(obj)
+	if ref == nil ||
+		ref.APIVersion != ownerGVK.GroupVersion().String() ||
+		ref.Kind != ownerGVK.Kind ||
+		ref.Name != owner.GetName() ||
+		ref.UID != owner.GetUID() {
+		return false
+	}
+
+	return HasOwnerUIDAnnotation(obj, owner)
 }
 
 // HasOwnerUIDAnnotation reports whether obj carries the retained-resource
@@ -90,6 +120,42 @@ func RequireOwnerProof(action string, obj client.Object, owner client.Object) er
 		name = obj.GetName()
 	}
 	return fmt.Errorf("%s %s %s/%s requires OpenBaoCluster owner proof", strings.TrimSpace(action), kindOf(obj), namespace, name)
+}
+
+// RequireManagedControllerOwnerProof rejects an object that does not have the
+// exact managed controller ownership proof for owner.
+func RequireManagedControllerOwnerProof(
+	action string,
+	obj client.Object,
+	owner client.Object,
+	ownerGVK schema.GroupVersionKind,
+) error {
+	if HasManagedControllerOwnerProof(obj, owner, ownerGVK) {
+		return nil
+	}
+
+	namespace, name := "", ""
+	if obj != nil {
+		namespace = obj.GetNamespace()
+		name = obj.GetName()
+	}
+	ownerNamespace, ownerName, ownerUID := "", "", ""
+	if owner != nil {
+		ownerNamespace = owner.GetNamespace()
+		ownerName = owner.GetName()
+		ownerUID = string(owner.GetUID())
+	}
+	return fmt.Errorf(
+		"%s %s %s/%s requires managed controller owner %s %s/%s with UID %q",
+		strings.TrimSpace(action),
+		kindOf(obj),
+		namespace,
+		name,
+		ownerGVK.Kind,
+		ownerNamespace,
+		ownerName,
+		ownerUID,
+	)
 }
 
 func kindOf(obj client.Object) string {

--- a/internal/platform/resourceownership/ownership_test.go
+++ b/internal/platform/resourceownership/ownership_test.go
@@ -3,6 +3,7 @@ package resourceownership
 import (
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -91,5 +92,101 @@ func TestSetOwnerUIDAnnotation(t *testing.T) {
 	}
 	if got := obj.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != string(owner.UID) {
 		t.Fatalf("owner UID annotation = %q, want %q", got, owner.UID)
+	}
+}
+
+func TestHasManagedControllerOwnerProof(t *testing.T) {
+	owner := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default", UID: types.UID("cluster-uid")},
+	}
+	ownerGVK := openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster")
+	controller := true
+	exactRef := metav1.OwnerReference{
+		APIVersion: ownerGVK.GroupVersion().String(),
+		Kind:       ownerGVK.Kind,
+		Name:       owner.Name,
+		UID:        owner.UID,
+		Controller: &controller,
+	}
+
+	tests := []struct {
+		name        string
+		namespace   string
+		ownerRef    *metav1.OwnerReference
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "exact controller reference and reserved annotation",
+			namespace:   owner.Namespace,
+			ownerRef:    &exactRef,
+			annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: string(owner.UID)},
+			want:        true,
+		},
+		{
+			name:      "controller reference without reserved annotation",
+			namespace: owner.Namespace,
+			ownerRef:  &exactRef,
+		},
+		{
+			name:        "reserved annotation without controller reference",
+			namespace:   owner.Namespace,
+			annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: string(owner.UID)},
+		},
+		{
+			name:      "different namespace",
+			namespace: "other",
+			ownerRef:  &exactRef,
+			annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: string(owner.UID),
+			},
+		},
+		{
+			name:      "wrong controller kind",
+			namespace: owner.Namespace,
+			ownerRef: func() *metav1.OwnerReference {
+				ref := exactRef
+				ref.Kind = "OpenBaoRestore"
+				return &ref
+			}(),
+			annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: string(owner.UID)},
+		},
+		{
+			name:      "wrong controller name",
+			namespace: owner.Namespace,
+			ownerRef: func() *metav1.OwnerReference {
+				ref := exactRef
+				ref.Name = "other"
+				return &ref
+			}(),
+			annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: string(owner.UID)},
+		},
+		{
+			name:      "wrong controller UID",
+			namespace: owner.Namespace,
+			ownerRef: func() *metav1.OwnerReference {
+				ref := exactRef
+				ref.UID = "other-uid"
+				return &ref
+			}(),
+			annotations: map[string]string{constants.AnnotationOpenBaoOwnerUID: string(owner.UID)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:        "job",
+				Namespace:   tt.namespace,
+				Annotations: tt.annotations,
+			}}
+			if tt.ownerRef != nil {
+				job.OwnerReferences = []metav1.OwnerReference{*tt.ownerRef}
+			}
+
+			if got := HasManagedControllerOwnerProof(job, owner, ownerGVK); got != tt.want {
+				t.Fatalf("HasManagedControllerOwnerProof() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/service/backup/events_test.go
+++ b/internal/service/backup/events_test.go
@@ -96,7 +96,7 @@ func TestProcessBackupJobResult_EmitsCompletedEvent(t *testing.T) {
 	cluster := newTestClusterWithBackup("backup-events-success", "default")
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
-	job := &batchv1.Job{
+	job := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -107,7 +107,7 @@ func TestProcessBackupJobResult_EmitsCompletedEvent(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 
 	recorder := events.NewFakeRecorder(10)
 	k8sClient := newTestClient(t, cluster, job)
@@ -140,7 +140,7 @@ func TestProcessBackupJobResult_EmitsFailedEvent(t *testing.T) {
 	cluster := newTestClusterWithBackup("backup-events-failed", "default")
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
-	job := &batchv1.Job{
+	job := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -148,7 +148,7 @@ func TestProcessBackupJobResult_EmitsFailedEvent(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Failed: 1,
 		},
-	}
+	}, cluster)
 
 	recorder := events.NewFakeRecorder(10)
 	k8sClient := newTestClient(t, cluster, job)

--- a/internal/service/backup/job.go
+++ b/internal/service/backup/job.go
@@ -13,12 +13,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/workloadidentity"
 )
 
@@ -198,13 +198,23 @@ func (m *Manager) ensureBackupJob(ctx context.Context, logger logr.Logger, clust
 		}
 
 		// Set OwnerReference for garbage collection
-		if err := controllerutil.SetControllerReference(cluster, job, m.scheme); err != nil {
-			return false, fmt.Errorf("failed to set owner reference on backup Job %s/%s: %w", cluster.Namespace, jobName, err)
+		if err := opslifecycle.PrepareManagedJobOwner(job, cluster, m.scheme); err != nil {
+			return false, fmt.Errorf("failed to prepare backup Job ownership %s/%s: %w", cluster.Namespace, jobName, err)
 		}
 
 		if err := m.client.Create(ctx, job); err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				logger.V(1).Info("Backup Job already exists after create attempt", "job", jobName)
+				if _, readErr := opslifecycle.ReadManagedJob(
+					ctx,
+					m.reader,
+					types.NamespacedName{Namespace: cluster.Namespace, Name: jobName},
+					cluster,
+					openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+					"use existing backup",
+				); readErr != nil {
+					return false, fmt.Errorf("backup Job create collided with an untrusted existing Job: %w", readErr)
+				}
+				logger.V(1).Info("Backup Job already exists after create attempt; ownership verified", "job", jobName)
 				return true, nil
 			}
 			return false, fmt.Errorf("failed to create backup Job %s/%s: %w", cluster.Namespace, jobName, err)
@@ -221,6 +231,14 @@ func (m *Manager) ensureBackupJob(ctx context.Context, logger logr.Logger, clust
 		}
 		m.emitNormalEvent(cluster, ReasonBackupJobCreated, "Created backup Job %s", jobName)
 		return true, nil
+	}
+	if err := opslifecycle.RequireManagedJobOwner(
+		"observe backup",
+		job,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+	); err != nil {
+		return false, err
 	}
 
 	// Job exists - check its status
@@ -252,12 +270,10 @@ type backupJobProcessResult struct {
 
 // processBackupJobResult processes the result of a completed backup Job and updates cluster status.
 func (m *Manager) processBackupJobResult(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, jobName string) (backupJobProcessResult, error) {
-	job := &batchv1.Job{}
-
-	err := m.reader.Get(ctx, types.NamespacedName{
+	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      jobName,
-	}, job)
+	}, cluster, openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"), "process backup")
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -278,12 +294,27 @@ func (m *Manager) processBackupJob(
 	if job == nil {
 		return backupJobProcessResult{}, nil
 	}
+	if err := opslifecycle.RequireManagedJobOwner(
+		"process backup",
+		job,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+	); err != nil {
+		return backupJobProcessResult{}, err
+	}
 	jobName := job.Name
 	// Check Job status
 	if kube.JobSucceeded(job) {
 		// Job succeeded - extract result from Job annotations
 		// The backup key is stored in the Job annotation by the manager when creating the job
-		backupKey := job.Annotations["openbao.org/backup-key"]
+		backupKey := strings.TrimSpace(job.Annotations["openbao.org/backup-key"])
+		if backupKey == "" {
+			return backupJobProcessResult{}, fmt.Errorf(
+				"refusing to process successful backup Job %s/%s without openbao.org/backup-key",
+				job.Namespace,
+				job.Name,
+			)
+		}
 
 		// Check if we've already processed this specific job success
 		// to avoid updating status on every reconcile

--- a/internal/service/backup/job_test.go
+++ b/internal/service/backup/job_test.go
@@ -722,6 +722,9 @@ func TestEnsureBackupJob_CreateAlreadyExists(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*batchv1.Job); ok {
+					if err := c.Create(ctx, obj, opts...); err != nil {
+						return err
+					}
 					return apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, obj.GetName())
 				}
 				return c.Create(ctx, obj, opts...)
@@ -743,12 +746,59 @@ func TestEnsureBackupJob_CreateAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestEnsureBackupJob_CreateAlreadyExistsRejectsForeignJob(t *testing.T) {
+	ctx := context.Background()
+	cluster := newTestClusterWithBackup("test-cluster", "default")
+	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
+	jobName := backupJobName(cluster, scheduled)
+	foreignJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      jobName,
+		Namespace: cluster.Namespace,
+	}}
+	firstJobRead := true
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cluster, foreignJob).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*batchv1.Job); ok && firstJobRead {
+					firstJobRead = false
+					return apierrors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*batchv1.Job); ok {
+					return apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, obj.GetName())
+				}
+				return nil
+			},
+		}).
+		Build()
+	manager := NewManager(
+		k8sClient,
+		testScheme,
+		portopenbao.ClientConfig{},
+		security.NewImageVerifier(logr.Discard(), k8sClient, nil),
+		"",
+	)
+
+	created, err := manager.ensureBackupJob(ctx, logr.Discard(), cluster, jobName, scheduled)
+	assert.False(t, created)
+	assert.ErrorContains(t, err, "collided with an untrusted existing Job")
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoCluster")
+
+	preserved := &batchv1.Job{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(foreignJob), preserved))
+}
+
 func TestEnsureBackupJob_JobAlreadyRunning(t *testing.T) {
 	cluster := newTestClusterWithBackup("test-cluster", "default")
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	runningJob := &batchv1.Job{
+	runningJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -756,7 +806,7 @@ func TestEnsureBackupJob_JobAlreadyRunning(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Active: 1,
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -781,7 +831,7 @@ func TestEnsureBackupJob_JobCompleted(t *testing.T) {
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	completedJob := &batchv1.Job{
+	completedJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -789,7 +839,7 @@ func TestEnsureBackupJob_JobCompleted(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -814,7 +864,7 @@ func TestEnsureBackupJob_JobFailed(t *testing.T) {
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	failedJob := &batchv1.Job{
+	failedJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -829,7 +879,7 @@ func TestEnsureBackupJob_JobFailed(t *testing.T) {
 				},
 			},
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -854,7 +904,7 @@ func TestProcessBackupJobResult_JobSucceeded(t *testing.T) {
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	succeededJob := &batchv1.Job{
+	succeededJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -865,7 +915,7 @@ func TestProcessBackupJobResult_JobSucceeded(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -911,13 +961,62 @@ func TestProcessBackupJobResult_JobSucceeded(t *testing.T) {
 	}
 }
 
+func TestProcessBackupJobResult_RejectsForeignSucceededJob(t *testing.T) {
+	cluster := newTestClusterWithBackup("test-cluster", "default")
+	jobName := backupJobName(cluster, time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC))
+	foreignJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: cluster.Namespace,
+			Annotations: map[string]string{
+				"openbao.org/backup-key": "attacker-controlled-key",
+			},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	k8sClient := newTestClient(t, cluster, foreignJob)
+	manager := withTestAdminOpsStatusPersistence(
+		NewManager(k8sClient, testScheme, portopenbao.ClientConfig{}, security.NewImageVerifier(logr.Discard(), k8sClient, nil), ""),
+		k8sClient,
+	)
+
+	result, err := manager.processBackupJobResult(context.Background(), logr.Discard(), cluster, jobName)
+	assert.Equal(t, backupJobProcessResult{}, result)
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoCluster")
+	assert.Nil(t, cluster.Status.Backup.LastBackupTime)
+	assert.Empty(t, cluster.Status.Backup.LastBackupName)
+}
+
+func TestProcessBackupJobResult_RejectsSuccessfulJobWithoutBackupKey(t *testing.T) {
+	cluster := newTestClusterWithBackup("test-cluster", "default")
+	jobName := backupJobName(cluster, time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC))
+	succeededJob := managedBackupJobForCluster(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: cluster.Namespace,
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}, cluster)
+	k8sClient := newTestClient(t, cluster, succeededJob)
+	manager := withTestAdminOpsStatusPersistence(
+		NewManager(k8sClient, testScheme, portopenbao.ClientConfig{}, security.NewImageVerifier(logr.Discard(), k8sClient, nil), ""),
+		k8sClient,
+	)
+
+	result, err := manager.processBackupJobResult(context.Background(), logr.Discard(), cluster, jobName)
+	assert.Equal(t, backupJobProcessResult{}, result)
+	assert.ErrorContains(t, err, "without openbao.org/backup-key")
+	assert.Nil(t, cluster.Status.Backup.LastBackupTime)
+	assert.Empty(t, cluster.Status.Backup.LastBackupName)
+}
+
 func TestProcessBackupJobResult_JobFailed(t *testing.T) {
 	cluster := newTestClusterWithBackup("test-cluster", "default")
 	cluster.Status.Backup.ConsecutiveFailures = 0
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	failedJob := &batchv1.Job{
+	failedJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -925,7 +1024,7 @@ func TestProcessBackupJobResult_JobFailed(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Failed: 1,
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -998,7 +1097,7 @@ func TestProcessBackupJobResult_JobFailedIdempotent(t *testing.T) {
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	failedJob := &batchv1.Job{
+	failedJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -1006,7 +1105,7 @@ func TestProcessBackupJobResult_JobFailedIdempotent(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Failed: 1,
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -1093,7 +1192,7 @@ func TestProcessBackupJobResult_JobRunning(t *testing.T) {
 	scheduled := time.Date(2025, 1, 15, 3, 0, 0, 0, time.UTC)
 	jobName := backupJobName(cluster, scheduled)
 
-	runningJob := &batchv1.Job{
+	runningJob := managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
@@ -1101,7 +1200,7 @@ func TestProcessBackupJobResult_JobRunning(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Active: 1,
 		},
-	}
+	}, cluster)
 
 	ctx := context.Background()
 	logger := logr.Discard()

--- a/internal/service/backup/manager_execution_test.go
+++ b/internal/service/backup/manager_execution_test.go
@@ -35,9 +35,7 @@ func TestExecuteAndProcessBackup_FailedCurrentJobSkipsRetention(t *testing.T) {
 
 	jobName := backupJobName(cluster, scheduledTime)
 	failedJob := newBackupJobForCluster(cluster, jobName, scheduledTime)
-	failedJob.Annotations = map[string]string{
-		"openbao.org/backup-key": "backups/default/retention-cluster/2025-01-02T03-00-00Z-partial.snap",
-	}
+	failedJob.Annotations["openbao.org/backup-key"] = "backups/default/retention-cluster/2025-01-02T03-00-00Z-partial.snap"
 	failedJob.Status = batchv1.JobStatus{Failed: 1}
 	credentials := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "backup-creds", Namespace: cluster.Namespace},
@@ -145,7 +143,7 @@ func TestCheckBackupDue_RetriesTransientLockReleaseFailure(t *testing.T) {
 
 	jobName := backupJobName(cluster, completedAt)
 	succeededJob := newBackupJobForCluster(cluster, jobName, completedAt)
-	succeededJob.Annotations = map[string]string{"openbao.org/backup-key": backupKey}
+	succeededJob.Annotations["openbao.org/backup-key"] = backupKey
 	succeededJob.Status = batchv1.JobStatus{Succeeded: 1}
 
 	k8sClient := newTestClient(t, cluster, succeededJob)
@@ -205,9 +203,7 @@ func TestReconcile_ProcessesOwnedBackupBeforePendingOperations(t *testing.T) {
 
 	completedAt := time.Now().UTC().Add(-time.Minute)
 	job := newBackupJobForCluster(cluster, "backup-before-upgrade-complete", completedAt)
-	job.Annotations = map[string]string{
-		"openbao.org/backup-key": "backups/default/backup-before-upgrade/complete.snap",
-	}
+	job.Annotations["openbao.org/backup-key"] = "backups/default/backup-before-upgrade/complete.snap"
 	job.Status = batchv1.JobStatus{Succeeded: 1}
 	restore := &openbaov1alpha1.OpenBaoRestore{
 		ObjectMeta: metav1.ObjectMeta{
@@ -283,9 +279,7 @@ func TestReconcile_ProcessesOwnedTerminalJobFromSingleObservation(t *testing.T) 
 		Holder:    backupOperationLockHolder,
 	}
 	job := newBackupJobForCluster(cluster, "terminal-list-race-complete", time.Now().UTC().Add(-time.Minute))
-	job.Annotations = map[string]string{
-		"openbao.org/backup-key": "backups/default/terminal-list-race/complete.snap",
-	}
+	job.Annotations["openbao.org/backup-key"] = "backups/default/terminal-list-race/complete.snap"
 	job.Status = batchv1.JobStatus{Succeeded: 1}
 
 	k8sClient := newTestClient(t, cluster, job)
@@ -328,9 +322,7 @@ func TestReconcile_OwnedBackupClearsCrashRecoveredManualTrigger(t *testing.T) {
 		Holder:    backupOperationLockHolder,
 	}
 	job := newBackupJobForCluster(cluster, "manual-crash-recovery-complete", time.Now().UTC().Add(-time.Minute))
-	job.Annotations = map[string]string{
-		"openbao.org/backup-key": "backups/default/manual-crash-recovery/complete.snap",
-	}
+	job.Annotations["openbao.org/backup-key"] = "backups/default/manual-crash-recovery/complete.snap"
 	job.Status = batchv1.JobStatus{Succeeded: 1}
 
 	k8sClient := newTestClient(t, cluster, job)
@@ -373,9 +365,7 @@ func TestReconcile_AppliesRetentionOnceForNewSuccessfulJob(t *testing.T) {
 
 	completedAt := time.Now().UTC().Add(-time.Minute)
 	job := newBackupJobForCluster(cluster, "async-retention-complete", completedAt)
-	job.Annotations = map[string]string{
-		"openbao.org/backup-key": "backups/default/async-retention/complete.snap",
-	}
+	job.Annotations["openbao.org/backup-key"] = "backups/default/async-retention/complete.snap"
 	job.Status = batchv1.JobStatus{Succeeded: 1}
 	credentials := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "backup-creds", Namespace: cluster.Namespace},
@@ -440,7 +430,7 @@ func TestReconcile_DisabledBackupFinishesOwnedOperation(t *testing.T) {
 			objects := []client.Object{cluster}
 			if testCase.jobStatus != nil {
 				job := newBackupJobForCluster(cluster, "disabled-backup-complete", time.Now().UTC().Add(-time.Minute))
-				job.Annotations = map[string]string{"openbao.org/backup-key": testCase.wantLastKey}
+				job.Annotations["openbao.org/backup-key"] = testCase.wantLastKey
 				job.Status = *testCase.jobStatus
 				objects = append(objects, job)
 			}

--- a/internal/service/backup/manager_jobs.go
+++ b/internal/service/backup/manager_jobs.go
@@ -12,6 +12,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 )
 
 // hasPreUpgradeBackupJob checks if there's a pre-upgrade backup job running or pending for this cluster.
@@ -26,7 +27,7 @@ func (m *Manager) hasPreUpgradeBackupJob(ctx context.Context, cluster *openbaov1
 		constants.LabelOpenBaoBackupType: "pre-upgrade",
 	})
 
-	if err := m.client.List(ctx, jobList,
+	if err := m.reader.List(ctx, jobList,
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	); err != nil {
@@ -36,6 +37,14 @@ func (m *Manager) hasPreUpgradeBackupJob(ctx context.Context, cluster *openbaov1
 	// Check if there's a running or pending job (not yet succeeded or failed).
 	for i := range jobList.Items {
 		job := &jobList.Items[i]
+		if err := opslifecycle.RequireManagedJobOwner(
+			"observe pre-upgrade backup",
+			job,
+			cluster,
+			openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		); err != nil {
+			return false, err
+		}
 		// If job hasn't succeeded or failed, it's still running or pending.
 		if !kube.JobSucceeded(job) && !kube.JobFailed(job) {
 			return true, nil
@@ -70,6 +79,14 @@ func (m *Manager) observeBackupJobs(ctx context.Context, cluster *openbaov1alpha
 	observation := backupJobObservation{}
 	for i := range jobList.Items {
 		job := &jobList.Items[i]
+		if err := opslifecycle.RequireManagedJobOwner(
+			"observe backup",
+			job,
+			cluster,
+			openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		); err != nil {
+			return backupJobObservation{}, err
+		}
 		if !kube.JobSucceeded(job) && !kube.JobFailed(job) {
 			observation.hasActive = true
 			continue

--- a/internal/service/backup/manager_metrics.go
+++ b/internal/service/backup/manager_metrics.go
@@ -13,6 +13,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 )
 
 func (m *Manager) syncBackupMetrics(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, metrics *Metrics) error {
@@ -77,7 +78,7 @@ func (m *Manager) collectBackupJobMetricsSnapshot(ctx context.Context, cluster *
 		constants.LabelOpenBaoComponent: ComponentBackup,
 	})
 
-	if err := m.client.List(ctx, jobList,
+	if err := m.reader.List(ctx, jobList,
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	); err != nil {
@@ -87,6 +88,14 @@ func (m *Manager) collectBackupJobMetricsSnapshot(ctx context.Context, cluster *
 	var snapshot backupJobMetricsSnapshot
 	for i := range jobList.Items {
 		job := &jobList.Items[i]
+		if err := opslifecycle.RequireManagedJobOwner(
+			"collect backup metrics from",
+			job,
+			cluster,
+			openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		); err != nil {
+			return backupJobMetricsSnapshot{}, err
+		}
 
 		switch {
 		case kube.JobSucceeded(job):

--- a/internal/service/backup/manager_preconditions_test.go
+++ b/internal/service/backup/manager_preconditions_test.go
@@ -26,6 +26,7 @@ func basePreconditionsCluster() *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-a",
 			Namespace: "tenant-a",
+			UID:       "cluster-a-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version: "2.4.4",
@@ -56,19 +57,20 @@ func backupJobForCluster(cluster *openbaov1alpha1.OpenBaoCluster, name string, p
 		labels[constants.LabelOpenBaoBackupType] = "pre-upgrade"
 	}
 
-	return &batchv1.Job{
+	return managedBackupJobForCluster(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
 			Namespace:         cluster.Namespace,
 			Labels:            labels,
 			CreationTimestamp: metav1.NewTime(time.Now().UTC()),
 		},
-	}
+	}, cluster)
 }
 
 func newManagerWithClient(c client.Client) *Manager {
 	return &Manager{
 		client: c,
+		reader: c,
 		scheme: testScheme,
 	}
 }

--- a/internal/service/backup/manager_test_helpers_test.go
+++ b/internal/service/backup/manager_test_helpers_test.go
@@ -13,6 +13,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/port/blobstore"
 )
 
@@ -76,7 +77,7 @@ func withTestAdminOpsStatusPersistence(manager *Manager, k8sClient client.Client
 }
 
 func newBackupJobForCluster(cluster *openbaov1alpha1.OpenBaoCluster, name string, createdAt time.Time) *batchv1.Job {
-	return &batchv1.Job{
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
 			Namespace:         cluster.Namespace,
@@ -85,6 +86,27 @@ func newBackupJobForCluster(cluster *openbaov1alpha1.OpenBaoCluster, name string
 			Labels:            backupLabels(cluster),
 		},
 	}
+	job.Labels[constants.LabelOpenBaoBackupType] = string(JobTypeScheduled)
+	return managedBackupJobForCluster(job, cluster)
+}
+
+func managedBackupJobForCluster(
+	job *batchv1.Job,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) *batchv1.Job {
+	controller := true
+	job.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}}
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations[constants.AnnotationOpenBaoOwnerUID] = string(cluster.UID)
+	return job
 }
 
 func ptrToTime(value time.Time) *metav1.Time {

--- a/internal/service/opslifecycle/job_ownership.go
+++ b/internal/service/opslifecycle/job_ownership.go
@@ -1,0 +1,70 @@
+package opslifecycle
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
+)
+
+// PrepareManagedJobOwner stamps the controller reference and reserved owner
+// UID annotation used to prove lifecycle Job provenance.
+func PrepareManagedJobOwner(job *batchv1.Job, owner client.Object, scheme *runtime.Scheme) error {
+	if job == nil {
+		return fmt.Errorf("job is required")
+	}
+	if scheme == nil {
+		return fmt.Errorf("scheme is required")
+	}
+	if err := resourceownership.RequireOwnerUID(owner); err != nil {
+		return err
+	}
+	if err := controllerutil.SetControllerReference(owner, job, scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference: %w", err)
+	}
+	if err := resourceownership.SetOwnerUIDAnnotation(job, owner); err != nil {
+		return fmt.Errorf("failed to set owner UID annotation: %w", err)
+	}
+	return nil
+}
+
+// RequireManagedJobOwner rejects a lifecycle Job that lacks exact managed
+// controller ownership proof.
+func RequireManagedJobOwner(
+	action string,
+	job *batchv1.Job,
+	owner client.Object,
+	ownerGVK schema.GroupVersionKind,
+) error {
+	return resourceownership.RequireManagedControllerOwnerProof(action, job, owner, ownerGVK)
+}
+
+// ReadManagedJob reads a lifecycle Job and validates its provenance before a
+// caller interprets its status or performs a mutation.
+func ReadManagedJob(
+	ctx context.Context,
+	reader client.Reader,
+	key client.ObjectKey,
+	owner client.Object,
+	ownerGVK schema.GroupVersionKind,
+	action string,
+) (*batchv1.Job, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("reader is required")
+	}
+
+	job := &batchv1.Job{}
+	if err := reader.Get(ctx, key, job); err != nil {
+		return nil, err
+	}
+	if err := RequireManagedJobOwner(action, job, owner, ownerGVK); err != nil {
+		return nil, err
+	}
+	return job, nil
+}

--- a/internal/service/opslifecycle/job_ownership_test.go
+++ b/internal/service/opslifecycle/job_ownership_test.go
@@ -1,0 +1,119 @@
+package opslifecycle
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+func TestPrepareManagedJobOwner(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	owner := testJobOwner()
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "backup",
+		Namespace: owner.Namespace,
+	}}
+
+	if err := PrepareManagedJobOwner(job, owner, scheme); err != nil {
+		t.Fatalf("PrepareManagedJobOwner() error = %v", err)
+	}
+	if err := RequireManagedJobOwner(
+		"observe backup",
+		job,
+		owner,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+	); err != nil {
+		t.Fatalf("RequireManagedJobOwner() error = %v", err)
+	}
+	if got := job.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != string(owner.UID) {
+		t.Fatalf("owner UID annotation = %q, want %q", got, owner.UID)
+	}
+}
+
+func TestReadManagedJobRejectsIncompleteOwnershipProof(t *testing.T) {
+	t.Parallel()
+
+	owner := testJobOwner()
+	ownerGVK := openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster")
+	controllerRef := *metav1.NewControllerRef(owner, ownerGVK)
+
+	tests := []struct {
+		name        string
+		status      batchv1.JobStatus
+		ownerRefs   []metav1.OwnerReference
+		annotations map[string]string
+	}{
+		{
+			name:   "active foreign Job",
+			status: batchv1.JobStatus{Active: 1},
+		},
+		{
+			name:      "succeeded Job with spoofable owner reference only",
+			status:    batchv1.JobStatus{Succeeded: 1},
+			ownerRefs: []metav1.OwnerReference{controllerRef},
+		},
+		{
+			name:   "failed Job with reserved annotation only",
+			status: batchv1.JobStatus{Failed: 1},
+			annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: string(owner.UID),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			if err := batchv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("AddToScheme() error = %v", err)
+			}
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "lifecycle-job",
+					Namespace:       owner.Namespace,
+					OwnerReferences: tt.ownerRefs,
+					Annotations:     tt.annotations,
+				},
+				Status: tt.status,
+			}
+			reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build()
+
+			_, err := ReadManagedJob(
+				context.Background(),
+				reader,
+				client.ObjectKeyFromObject(job),
+				owner,
+				ownerGVK,
+				"observe lifecycle",
+			)
+			if err == nil {
+				t.Fatal("ReadManagedJob() error = nil, want ownership error")
+			}
+		})
+	}
+}
+
+func testJobOwner() *openbaov1alpha1.OpenBaoCluster {
+	return &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name:      "example",
+		Namespace: "default",
+		UID:       types.UID("cluster-uid"),
+	}}
+}

--- a/internal/service/restore/events_test.go
+++ b/internal/service/restore/events_test.go
@@ -72,6 +72,7 @@ func newRestoreEventCluster() *openbaov1alpha1.OpenBaoCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Replicas: 3,
@@ -84,6 +85,7 @@ func newRestoreEventResource() *openbaov1alpha1.OpenBaoRestore {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test-restore",
 			Namespace:       "default",
+			UID:             "test-restore-uid",
 			ResourceVersion: "1",
 		},
 		Spec: openbaov1alpha1.OpenBaoRestoreSpec{

--- a/internal/service/restore/manager_running.go
+++ b/internal/service/restore/manager_running.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/security"
@@ -33,11 +31,10 @@ func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore
 
 	// Check if job already exists
 	jobName := restoreJobName(restore)
-	job := &batchv1.Job{}
-	err := m.client.Get(ctx, types.NamespacedName{
+	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
 		Namespace: restore.Namespace,
 		Name:      jobName,
-	}, job)
+	}, restore, openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"), "observe restore")
 
 	if apierrors.IsNotFound(err) {
 		done, err := m.renewRunningRestoreLock(ctx, logger, restore, cluster)
@@ -222,14 +219,23 @@ func (m *Manager) createRestoreJob(
 		return m.failRestore(ctx, logger, restore, fmt.Sprintf("failed to build restore job: %v", err))
 	}
 
-	// Set owner reference.
-	if err := controllerutil.SetControllerReference(restore, job, m.scheme); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set controller reference: %w", err)
+	if err := opslifecycle.PrepareManagedJobOwner(job, restore, m.scheme); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to prepare restore Job ownership: %w", err)
 	}
 
 	if err := m.client.Create(ctx, job); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			logger.V(1).Info("Restore job already exists after create attempt; proceeding", "job", jobName)
+			if _, readErr := opslifecycle.ReadManagedJob(
+				ctx,
+				m.reader,
+				types.NamespacedName{Namespace: restore.Namespace, Name: jobName},
+				restore,
+				openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"),
+				"use existing restore",
+			); readErr != nil {
+				return ctrl.Result{}, fmt.Errorf("restore Job create collided with an untrusted existing Job: %w", readErr)
+			}
+			logger.V(1).Info("Restore job already exists after create attempt; ownership verified", "job", jobName)
 			return ctrl.Result{RequeueAfter: restoreRequeueJobCheck}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to create restore job: %w", err)

--- a/internal/service/restore/manager_status.go
+++ b/internal/service/restore/manager_status.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,28 +181,20 @@ func (m *Manager) handleDeletion(ctx context.Context, logger logr.Logger, restor
 }
 
 func (m *Manager) deleteRestoreJob(ctx context.Context, logger logr.Logger, restore *openbaov1alpha1.OpenBaoRestore) (bool, error) {
-	job := &batchv1.Job{}
 	jobKey := types.NamespacedName{Namespace: restore.Namespace, Name: restoreJobName(restore)}
-	if err := m.reader.Get(ctx, jobKey, job); err != nil {
+	job, err := opslifecycle.ReadManagedJob(
+		ctx,
+		m.reader,
+		jobKey,
+		restore,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"),
+		"delete restore",
+	)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, fmt.Errorf("failed to get restore Job during deletion: %w", err)
-	}
-	if !metav1.IsControlledBy(job, restore) {
-		controllerOwner := "none"
-		if ref := metav1.GetControllerOfNoCopy(job); ref != nil {
-			controllerOwner = fmt.Sprintf("%s %s with UID %q", ref.Kind, ref.Name, ref.UID)
-		}
-		return false, fmt.Errorf(
-			"refusing to delete restore Job %s/%s because it is not controlled by the current OpenBaoRestore %s/%s with UID %q; found controller owner %s; delete or rename the foreign Job, then retry restore deletion",
-			job.Namespace,
-			job.Name,
-			restore.Namespace,
-			restore.Name,
-			restore.UID,
-			controllerOwner,
-		)
 	}
 
 	if job.DeletionTimestamp.IsZero() {

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/security"
@@ -82,6 +81,28 @@ func setTestResourceVersion(obj metav1.Object) {
 	if obj.GetResourceVersion() == "" {
 		obj.SetResourceVersion("1")
 	}
+	if obj.GetUID() == "" {
+		obj.SetUID(types.UID(obj.GetName() + "-uid"))
+	}
+}
+
+func managedRestoreJobForRestore(
+	job *batchv1.Job,
+	restore *openbaov1alpha1.OpenBaoRestore,
+) *batchv1.Job {
+	controller := true
+	job.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoRestore",
+		Name:       restore.Name,
+		UID:        restore.UID,
+		Controller: &controller,
+	}}
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations[constants.AnnotationOpenBaoOwnerUID] = string(restore.UID)
+	return job
 }
 
 // TestRestoreJobName tests the deterministic job name generation.
@@ -826,6 +847,9 @@ func TestHandleRunning_RestoreJobAlreadyExistsDuringCreate(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*batchv1.Job); ok {
+					if err := c.Create(ctx, obj, opts...); err != nil {
+						return err
+					}
 					return apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, obj.GetName())
 				}
 				return c.Create(ctx, obj, opts...)
@@ -839,6 +863,48 @@ func TestHandleRunning_RestoreJobAlreadyExistsDuringCreate(t *testing.T) {
 	result, err := mgr.handleRunning(context.Background(), testLogger(), restore)
 	require.NoError(t, err)
 	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+}
+
+func TestHandleRunning_RejectsForeignSucceededJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-cluster",
+		Namespace: "default",
+	}}
+	setTestResourceVersion(cluster)
+	restore := &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: "default",
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{Cluster: cluster.Name},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseRunning,
+		},
+	}
+	setTestResourceVersion(restore)
+	foreignJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      restoreJobName(restore),
+			Namespace: restore.Namespace,
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, foreignJob).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoRestore{}).
+		Build()
+	mgr := NewManager(k8sClient, scheme, nil, security.NewImageVerifier(testLogger(), k8sClient, nil), "")
+
+	_, err := mgr.handleRunning(context.Background(), testLogger(), restore)
+	require.ErrorContains(t, err, "requires managed controller owner OpenBaoRestore")
+	assert.Equal(t, openbaov1alpha1.RestorePhaseRunning, restore.Status.Phase)
+	assert.Nil(t, restore.Status.CompletionTime)
 }
 
 func TestHandleRunning_FailedJobSetsActionableMessage(t *testing.T) {
@@ -878,7 +944,7 @@ func TestHandleRunning_FailedJobSetsActionableMessage(t *testing.T) {
 	}
 	setTestResourceVersion(restore)
 
-	job := &batchv1.Job{
+	job := managedRestoreJobForRestore(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      restoreJobName(restore),
 			Namespace: "default",
@@ -893,7 +959,7 @@ func TestHandleRunning_FailedJobSetsActionableMessage(t *testing.T) {
 				},
 			},
 		},
-	}
+	}, restore)
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -963,7 +1029,7 @@ func TestHandleRunning_SucceededJobWaitsForSteadyReadReplicaRestore(t *testing.T
 	}
 	setTestResourceVersion(restore)
 
-	job := &batchv1.Job{
+	job := managedRestoreJobForRestore(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      restoreJobName(restore),
 			Namespace: "default",
@@ -971,7 +1037,7 @@ func TestHandleRunning_SucceededJobWaitsForSteadyReadReplicaRestore(t *testing.T
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, restore)
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1046,7 +1112,7 @@ func TestHandleRunning_SucceededJobCompletesAfterSteadyReadReplicaRestore(t *tes
 	}
 	setTestResourceVersion(restore)
 
-	job := &batchv1.Job{
+	job := managedRestoreJobForRestore(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      restoreJobName(restore),
 			Namespace: "default",
@@ -1054,7 +1120,7 @@ func TestHandleRunning_SucceededJobCompletesAfterSteadyReadReplicaRestore(t *tes
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, restore)
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1925,8 +1991,10 @@ func TestHandleDeletion_WaitsForRestoreJobBeforeLockRelease(t *testing.T) {
 		},
 	}
 	setTestResourceVersion(cluster)
-	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: restoreJobName(restore), Namespace: restore.Namespace}}
-	require.NoError(t, controllerutil.SetControllerReference(restore, job, scheme))
+	job := managedRestoreJobForRestore(
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: restoreJobName(restore), Namespace: restore.Namespace}},
+		restore,
+	)
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2011,8 +2079,7 @@ func TestHandleDeletion_RejectsForeignRestoreJob(t *testing.T) {
 
 	_, err := mgr.handleDeletion(context.Background(), testLogger(), restore)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "not controlled by the current OpenBaoRestore")
-	assert.ErrorContains(t, err, "delete or rename the foreign Job")
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoRestore")
 
 	currentJob := &batchv1.Job{}
 	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKeyFromObject(job), currentJob))

--- a/internal/service/upgrade/bluegreen/hooks.go
+++ b/internal/service/upgrade/bluegreen/hooks.go
@@ -38,7 +38,7 @@ func (m *Manager) ensureValidationHookJob(
 	backoffLimit := int32(0)
 	ttlSeconds := ptr.To(int32(jobTTLSeconds))
 
-	return ensureJob(ctx, m.client, m.scheme, logger, cluster, jobName, func(jobName string) (*batchv1.Job, error) {
+	return ensureJob(ctx, m.client, m.reader, m.scheme, logger, cluster, jobName, func(jobName string) (*batchv1.Job, error) {
 		image := hook.Image
 		verifiedDigest, err := m.verifyOperatorImageDigest(
 			ctx,

--- a/internal/service/upgrade/bluegreen/hooks_test.go
+++ b/internal/service/upgrade/bluegreen/hooks_test.go
@@ -114,6 +114,7 @@ func TestEnsurePrePromotionHookJob_ImageVerification(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
 					Namespace: "default",
+					UID:       "test-cluster-uid",
 				},
 				Spec: openbaov1alpha1.OpenBaoClusterSpec{
 					OperatorImageVerification: tt.config,
@@ -183,6 +184,7 @@ func TestEnsurePrePromotionHookJob_AppliesRestrictedPodSecurityDefaults(t *testi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			ImagePullSecrets: []corev1.LocalObjectReference{

--- a/internal/service/upgrade/bluegreen/job.go
+++ b/internal/service/upgrade/bluegreen/job.go
@@ -13,10 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
@@ -32,6 +32,7 @@ type buildJobFunc func(jobName string) (*batchv1.Job, error)
 func ensureJob(
 	ctx context.Context,
 	c client.Client,
+	reader client.Reader,
 	scheme *runtime.Scheme,
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
@@ -42,6 +43,9 @@ func ensureJob(
 	if cluster == nil {
 		return nil, fmt.Errorf("cluster is required")
 	}
+	if reader == nil {
+		reader = c
+	}
 	if jobName == "" {
 		return nil, fmt.Errorf("jobName is required")
 	}
@@ -50,8 +54,15 @@ func ensureJob(
 	}
 
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
-	job := &batchv1.Job{}
-	if err := c.Get(ctx, jobKey, job); err != nil {
+	job, err := opslifecycle.ReadManagedJob(
+		ctx,
+		reader,
+		jobKey,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		"observe blue-green upgrade",
+	)
+	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get Job %s/%s: %w", cluster.Namespace, jobName, err)
 		}
@@ -61,19 +72,26 @@ func ensureJob(
 			return nil, err
 		}
 
-		if err := controllerutil.SetControllerReference(cluster, built, scheme); err != nil {
-			return nil, fmt.Errorf("failed to set owner reference on Job %s/%s: %w", cluster.Namespace, jobName, err)
+		if err := opslifecycle.PrepareManagedJobOwner(built, cluster, scheme); err != nil {
+			return nil, fmt.Errorf("failed to prepare Job ownership %s/%s: %w", cluster.Namespace, jobName, err)
 		}
 
 		logger.Info("Creating Job", append([]any{"job", jobName}, createLogKeysAndValues...)...)
 		if err := c.Create(ctx, built); err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				logger.V(1).Info("Job already exists after create attempt", "job", jobName)
-				return &JobResult{
-					Name:    jobName,
-					Exists:  true,
-					Running: true,
-				}, nil
+				existing, readErr := opslifecycle.ReadManagedJob(
+					ctx,
+					reader,
+					jobKey,
+					cluster,
+					openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+					"use existing blue-green upgrade",
+				)
+				if readErr != nil {
+					return nil, fmt.Errorf("job create collided with an untrusted existing Job: %w", readErr)
+				}
+				logger.V(1).Info("Job already exists after create attempt; ownership verified", "job", jobName)
+				return jobResultFromJob(existing), nil
 			}
 			return nil, fmt.Errorf("failed to create Job %s/%s: %w", cluster.Namespace, jobName, err)
 		}
@@ -85,12 +103,17 @@ func ensureJob(
 		}, nil
 	}
 
+	return jobResultFromJob(job), nil
+}
+
+func jobResultFromJob(job *batchv1.Job) *JobResult {
+	jobName := job.Name
 	if kube.JobSucceeded(job) {
 		return &JobResult{
 			Name:      jobName,
 			Exists:    true,
 			Succeeded: true,
-		}, nil
+		}
 	}
 
 	if kube.JobFailed(job) {
@@ -98,17 +121,17 @@ func ensureJob(
 			Name:   jobName,
 			Exists: true,
 			Failed: true,
-		}, nil
+		}
 	}
 
 	return &JobResult{
 		Name:    jobName,
 		Exists:  true,
 		Running: true,
-	}, nil
+	}
 }
 
-func getJobStatus(ctx context.Context, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster, jobName string) (*JobResult, error) {
+func getJobStatus(ctx context.Context, reader client.Reader, cluster *openbaov1alpha1.OpenBaoCluster, jobName string) (*JobResult, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("cluster is required")
 	}
@@ -117,21 +140,22 @@ func getJobStatus(ctx context.Context, c client.Client, cluster *openbaov1alpha1
 	}
 
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
-	job := &batchv1.Job{}
-	if err := c.Get(ctx, jobKey, job); err != nil {
+	job, err := opslifecycle.ReadManagedJob(
+		ctx,
+		reader,
+		jobKey,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		"observe blue-green upgrade",
+	)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return &JobResult{Name: jobName, Exists: false}, nil
 		}
 		return nil, fmt.Errorf("failed to get Job %s/%s: %w", cluster.Namespace, jobName, err)
 	}
 
-	if kube.JobSucceeded(job) {
-		return &JobResult{Name: jobName, Exists: true, Succeeded: true}, nil
-	}
-	if kube.JobFailed(job) {
-		return &JobResult{Name: jobName, Exists: true, Failed: true}, nil
-	}
-	return &JobResult{Name: jobName, Exists: true, Running: true}, nil
+	return jobResultFromJob(job), nil
 }
 
 func preUpgradeSnapshotJobName(cluster *openbaov1alpha1.OpenBaoCluster) string {

--- a/internal/service/upgrade/bluegreen/job_alreadyexists_test.go
+++ b/internal/service/upgrade/bluegreen/job_alreadyexists_test.go
@@ -28,6 +28,7 @@ func TestEnsureJob_CreateAlreadyExists(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 	}
 
@@ -36,6 +37,9 @@ func TestEnsureJob_CreateAlreadyExists(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*batchv1.Job); ok {
+					if err := c.Create(ctx, obj, opts...); err != nil {
+						return err
+					}
 					return apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, obj.GetName())
 				}
 				return c.Create(ctx, obj, opts...)
@@ -46,6 +50,7 @@ func TestEnsureJob_CreateAlreadyExists(t *testing.T) {
 	jobName := "upgrade-test-job"
 	result, err := ensureJob(
 		context.Background(),
+		k8sClient,
 		k8sClient,
 		scheme,
 		logr.Discard(),
@@ -68,4 +73,27 @@ func TestEnsureJob_CreateAlreadyExists(t *testing.T) {
 	assert.True(t, result.Running)
 	assert.False(t, result.Succeeded)
 	assert.False(t, result.Failed)
+}
+
+func TestGetJobStatusRejectsForeignSucceededJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-cluster",
+		Namespace: "default",
+		UID:       "test-cluster-uid",
+	}}
+	foreignJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-test-job",
+			Namespace: cluster.Namespace,
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(foreignJob).Build()
+
+	result, err := getJobStatus(context.Background(), k8sClient, cluster, foreignJob.Name)
+	require.Nil(t, result)
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoCluster")
 }

--- a/internal/service/upgrade/bluegreen/job_helpers.go
+++ b/internal/service/upgrade/bluegreen/job_helpers.go
@@ -52,6 +52,7 @@ func (m *Manager) runExecutorJobStep(ctx context.Context, logger logr.Logger, cl
 	result, err := upgrade.EnsureExecutorJob(
 		ctx,
 		m.client,
+		m.reader,
 		m.scheme,
 		logger,
 		cluster,

--- a/internal/service/upgrade/bluegreen/job_helpers_test.go
+++ b/internal/service/upgrade/bluegreen/job_helpers_test.go
@@ -35,6 +35,7 @@ func TestRunExecutorJob_FailedJob_RetriesWithRunIDWhenEnabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
+			UID:       "test-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version: "2.4.4",
@@ -63,13 +64,13 @@ func TestRunExecutorJob_FailedJob_RetriesWithRunIDWhenEnabled(t *testing.T) {
 	}
 
 	jobName := upgrade.ExecutorJobName(cluster.Name, ActionJoinGreenNonVoters, "", "blue", "green")
-	job := &batchv1.Job{
+	job := managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
 		},
 		Status: batchv1.JobStatus{Failed: 1},
-	}
+	}, cluster)
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -126,6 +127,7 @@ func TestRunExecutorJob_FailedJob_DoesNotRetryWhenAutoRollbackDisabled(t *testin
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
+			UID:       "test-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version: "2.4.4",
@@ -157,13 +159,13 @@ func TestRunExecutorJob_FailedJob_DoesNotRetryWhenAutoRollbackDisabled(t *testin
 	}
 
 	jobName := upgrade.ExecutorJobName(cluster.Name, ActionJoinGreenNonVoters, "", "blue", "green")
-	job := &batchv1.Job{
+	job := managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
 		},
 		Status: batchv1.JobStatus{Failed: 1},
-	}
+	}, cluster)
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -216,6 +218,7 @@ func TestRunExecutorJob_FailedJob_TriggersAbortWhenMaxFailuresReached(t *testing
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
+			UID:       "test-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version: "2.4.4",
@@ -244,13 +247,13 @@ func TestRunExecutorJob_FailedJob_TriggersAbortWhenMaxFailuresReached(t *testing
 	}
 
 	jobName := upgrade.ExecutorJobName(cluster.Name, ActionJoinGreenNonVoters, "", "blue", "green")
-	job := &batchv1.Job{
+	job := managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
 		},
 		Status: batchv1.JobStatus{Failed: 1},
-	}
+	}, cluster)
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/internal/service/upgrade/bluegreen/lifecycle.go
+++ b/internal/service/upgrade/bluegreen/lifecycle.go
@@ -61,7 +61,11 @@ func (m *Manager) ensureBlueGreenPreUpgradeSnapshotComplete(
 		return requeueAfterOutcome(constants.RequeueShort), true, nil
 	}
 
-	jobStatus, err := getJobStatus(ctx, m.client, cluster, jobName)
+	reader := m.reader
+	if reader == nil {
+		reader = m.client
+	}
+	jobStatus, err := getJobStatus(ctx, reader, cluster, jobName)
 	if err != nil {
 		return phaseOutcome{}, true, fmt.Errorf("failed to check pre-upgrade snapshot job status: %w", err)
 	}

--- a/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
+++ b/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
@@ -60,7 +60,7 @@ func markPodReadyUnsealed(pod *corev1.Pod) {
 }
 
 func succeededExecutorJob(cluster *openbaov1alpha1.OpenBaoCluster, action upgrade.ExecutorAction) *batchv1.Job {
-	return &batchv1.Job{
+	return managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      upgrade.ExecutorJobName(cluster.Name, action, "", cluster.Status.BlueGreen.BlueRevision, cluster.Status.BlueGreen.GreenRevision),
 			Namespace: cluster.Namespace,
@@ -72,11 +72,11 @@ func succeededExecutorJob(cluster *openbaov1alpha1.OpenBaoCluster, action upgrad
 			}},
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 }
 
 func succeededExecutorJobWithRunID(cluster *openbaov1alpha1.OpenBaoCluster, action upgrade.ExecutorAction, runID string) *batchv1.Job {
-	return &batchv1.Job{
+	return managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      upgrade.ExecutorJobName(cluster.Name, action, runID, cluster.Status.BlueGreen.BlueRevision, cluster.Status.BlueGreen.GreenRevision),
 			Namespace: cluster.Namespace,
@@ -88,11 +88,11 @@ func succeededExecutorJobWithRunID(cluster *openbaov1alpha1.OpenBaoCluster, acti
 			}},
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 }
 
 func failedExecutorJobWithRunID(cluster *openbaov1alpha1.OpenBaoCluster, action upgrade.ExecutorAction, runID string) *batchv1.Job {
-	return &batchv1.Job{
+	return managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      upgrade.ExecutorJobName(cluster.Name, action, runID, cluster.Status.BlueGreen.BlueRevision, cluster.Status.BlueGreen.GreenRevision),
 			Namespace: cluster.Namespace,
@@ -104,7 +104,7 @@ func failedExecutorJobWithRunID(cluster *openbaov1alpha1.OpenBaoCluster, action 
 			}},
 			Failed: 1,
 		},
-	}
+	}, cluster)
 }
 
 type clusterOpsStub struct {
@@ -535,7 +535,7 @@ func TestHandlePhaseSyncing_Branches(t *testing.T) {
 		blueRevision := cluster.Status.BlueGreen.BlueRevision
 		greenRevision := cluster.Status.BlueGreen.GreenRevision
 		waitSyncedJob := succeededExecutorJob(cluster, ActionWaitGreenSynced)
-		hookJob := &batchv1.Job{
+		hookJob := managedBlueGreenJob(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cluster.Name + "-validation-hook",
 				Namespace: cluster.Namespace,
@@ -547,7 +547,7 @@ func TestHandlePhaseSyncing_Branches(t *testing.T) {
 				}},
 				Failed: 1,
 			},
-		}
+		}, cluster)
 		greenStatefulSet := &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cluster.Name + "-" + cluster.Status.BlueGreen.GreenRevision,

--- a/internal/service/upgrade/bluegreen/manager_test_helpers_test.go
+++ b/internal/service/upgrade/bluegreen/manager_test_helpers_test.go
@@ -1,10 +1,14 @@
 package bluegreen
 
 import (
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/port/backup"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	"github.com/dc-tec/openbao-operator/internal/port/openbao"
@@ -13,6 +17,25 @@ import (
 )
 
 const deploymentNameSuffix = "green"
+
+func managedBlueGreenJob(
+	job *batchv1.Job,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) *batchv1.Job {
+	controller := true
+	job.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}}
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations[constants.AnnotationOpenBaoOwnerUID] = string(cluster.UID)
+	return job
+}
 
 func newManagerWithClientFactory(
 	c client.Client,

--- a/internal/service/upgrade/bluegreen/rollback_workflow.go
+++ b/internal/service/upgrade/bluegreen/rollback_workflow.go
@@ -26,6 +26,7 @@ func (m *Manager) ensureRollbackExecutorJob(
 	result, err := upgrade.EnsureExecutorJob(
 		ctx,
 		m.client,
+		m.reader,
 		m.scheme,
 		logger,
 		cluster,

--- a/internal/service/upgrade/bluegreen/snapshot_job.go
+++ b/internal/service/upgrade/bluegreen/snapshot_job.go
@@ -42,7 +42,7 @@ func (m *Manager) ensurePreUpgradeSnapshotJob(
 		return nil, err
 	}
 
-	return ensureJob(ctx, m.client, m.scheme, logger, cluster, jobName, func(jobName string) (*batchv1.Job, error) {
+	return ensureJob(ctx, m.client, m.reader, m.scheme, logger, cluster, jobName, func(jobName string) (*batchv1.Job, error) {
 		verifiedExecutorDigest, err := snapshothelpers.ResolvePreUpgradeSnapshotExecutorDigest(
 			ctx,
 			logger,

--- a/internal/service/upgrade/bluegreen/snapshot_job_test.go
+++ b/internal/service/upgrade/bluegreen/snapshot_job_test.go
@@ -356,6 +356,7 @@ func TestHandlePhaseIdle_RespectsTopLevelPreUpgradeSnapshot(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Version:  "2.5.0",
@@ -384,12 +385,12 @@ func TestHandlePhaseIdle_RespectsTopLevelPreUpgradeSnapshot(t *testing.T) {
 
 	jobName := preUpgradeSnapshotJobName(cluster)
 	cluster.Status.BlueGreen.PreUpgradeSnapshotJobName = jobName
-	runningJob := &batchv1.Job{
+	runningJob := managedBlueGreenJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
 		},
-	}
+	}, cluster)
 	require.NoError(t, fakeClient.Create(context.Background(), runningJob))
 
 	outcome, err := mgr.handlePhaseIdle(context.Background(), testLogger(), cluster, "")

--- a/internal/service/upgrade/job.go
+++ b/internal/service/upgrade/job.go
@@ -10,12 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 )
 
 const (
@@ -50,6 +50,7 @@ type executorJobResult struct {
 func EnsureExecutorJob(
 	ctx context.Context,
 	c client.Client,
+	reader client.Reader,
 	scheme *runtime.Scheme,
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
@@ -61,7 +62,7 @@ func EnsureExecutorJob(
 	operatorImageVerifier imageverify.Verifier,
 	platform string,
 ) (*JobResult, error) {
-	result, err := ensureUpgradeExecutorJob(ctx, c, scheme, logger, cluster, action, runID, blueRevision, greenRevision, clientConfig, operatorImageVerifier, platform)
+	result, err := ensureUpgradeExecutorJob(ctx, c, reader, scheme, logger, cluster, action, runID, blueRevision, greenRevision, clientConfig, operatorImageVerifier, platform)
 	if err != nil {
 		return nil, err
 	}
@@ -83,6 +84,7 @@ func ExecutorJobName(clusterName string, action ExecutorAction, runID string, bl
 func ensureUpgradeExecutorJob(
 	ctx context.Context,
 	c client.Client,
+	reader client.Reader,
 	scheme *runtime.Scheme,
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
@@ -97,12 +99,22 @@ func ensureUpgradeExecutorJob(
 	if cluster == nil {
 		return nil, fmt.Errorf("cluster is required")
 	}
+	if reader == nil {
+		reader = c
+	}
 
 	jobName := upgradeExecutorJobName(cluster.Name, action, runID, blueRevision, greenRevision)
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
 
-	job := &batchv1.Job{}
-	if err := c.Get(ctx, jobKey, job); err != nil {
+	job, err := opslifecycle.ReadManagedJob(
+		ctx,
+		reader,
+		jobKey,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		"observe upgrade",
+	)
+	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get upgrade Job %s/%s: %w", cluster.Namespace, jobName, err)
 		}
@@ -131,18 +143,26 @@ func ensureUpgradeExecutorJob(
 			return nil, fmt.Errorf("failed to build upgrade Job %s/%s: %w", cluster.Namespace, jobName, err)
 		}
 
-		if err := controllerutil.SetControllerReference(cluster, job, scheme); err != nil {
-			return nil, fmt.Errorf("failed to set owner reference on upgrade Job %s/%s: %w", cluster.Namespace, jobName, err)
+		if err := opslifecycle.PrepareManagedJobOwner(job, cluster, scheme); err != nil {
+			return nil, fmt.Errorf("failed to prepare upgrade Job ownership %s/%s: %w", cluster.Namespace, jobName, err)
 		}
 
 		logger.Info("Creating upgrade executor Job", "job", jobName, "action", action, "runID", runID)
 		if err := c.Create(ctx, job); err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				logger.V(1).Info("Upgrade executor Job already exists after create attempt", "job", jobName)
-				return &executorJobResult{
-					Name:    jobName,
-					Running: true,
-				}, nil
+				existing, readErr := opslifecycle.ReadManagedJob(
+					ctx,
+					reader,
+					jobKey,
+					cluster,
+					openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+					"use existing upgrade",
+				)
+				if readErr != nil {
+					return nil, fmt.Errorf("upgrade Job create collided with an untrusted existing Job: %w", readErr)
+				}
+				logger.V(1).Info("Upgrade executor Job already exists after create attempt; ownership verified", "job", jobName)
+				return executorResultFromJob(existing), nil
 			}
 			return nil, fmt.Errorf("failed to create upgrade Job %s/%s: %w", cluster.Namespace, jobName, err)
 		}
@@ -153,22 +173,27 @@ func ensureUpgradeExecutorJob(
 		}, nil
 	}
 
+	return executorResultFromJob(job), nil
+}
+
+func executorResultFromJob(job *batchv1.Job) *executorJobResult {
+	jobName := job.Name
 	if kube.JobSucceeded(job) {
 		return &executorJobResult{
 			Name:      jobName,
 			Succeeded: true,
-		}, nil
+		}
 	}
 
 	if kube.JobFailed(job) {
 		return &executorJobResult{
 			Name:   jobName,
 			Failed: true,
-		}, nil
+		}
 	}
 
 	return &executorJobResult{
 		Name:    jobName,
 		Running: true,
-	}, nil
+	}
 }

--- a/internal/service/upgrade/job_test.go
+++ b/internal/service/upgrade/job_test.go
@@ -44,6 +44,7 @@ func TestBuildUpgradeExecutorJob_SecurityContext(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Upgrade: &openbaov1alpha1.UpgradeConfig{
@@ -125,6 +126,7 @@ func TestBuildUpgradeExecutorJob_AllowsOIDCWithoutUpgradeConfig(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Replicas: 3,
@@ -186,6 +188,7 @@ func TestBuildUpgradeExecutorJob_SetsResourceRequirements(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Upgrade: &openbaov1alpha1.UpgradeConfig{
@@ -325,6 +328,7 @@ func TestEnsureExecutorJob_CreateAlreadyExists(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Replicas: 3,
@@ -340,6 +344,9 @@ func TestEnsureExecutorJob_CreateAlreadyExists(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*batchv1.Job); ok {
+					if err := c.Create(ctx, obj, opts...); err != nil {
+						return err
+					}
 					return apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, obj.GetName())
 				}
 				return c.Create(ctx, obj, opts...)
@@ -349,6 +356,7 @@ func TestEnsureExecutorJob_CreateAlreadyExists(t *testing.T) {
 
 	result, err := EnsureExecutorJob(
 		context.Background(),
+		k8sClient,
 		k8sClient,
 		scheme,
 		logr.Discard(),
@@ -371,6 +379,48 @@ func TestEnsureExecutorJob_CreateAlreadyExists(t *testing.T) {
 	assert.False(t, result.Failed)
 }
 
+func TestEnsureExecutorJob_RejectsForeignSucceededJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-cluster",
+		Namespace: "default",
+		UID:       "test-cluster-uid",
+	}}
+	jobName := ExecutorJobName(
+		cluster.Name,
+		ExecutorActionRollingStepDownLeader,
+		"run-1",
+		"",
+		"",
+	)
+	foreignJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: cluster.Namespace},
+		Status:     batchv1.JobStatus{Succeeded: 1},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(foreignJob).Build()
+
+	result, err := EnsureExecutorJob(
+		context.Background(),
+		k8sClient,
+		k8sClient,
+		scheme,
+		logr.Discard(),
+		cluster,
+		ExecutorActionRollingStepDownLeader,
+		"run-1",
+		"",
+		"",
+		portopenbao.ClientConfig{},
+		nil,
+		"",
+	)
+	require.Nil(t, result)
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoCluster")
+}
+
 func TestEnsureExecutorJob_VerifiesDefaultUpgradeExecutorImageForHardenedCluster(t *testing.T) {
 	t.Setenv(constants.EnvOperatorVersion, "0.1.0")
 
@@ -382,6 +432,7 @@ func TestEnsureExecutorJob_VerifiesDefaultUpgradeExecutorImageForHardenedCluster
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: "default",
+			UID:       "test-cluster-uid",
 		},
 		Spec: openbaov1alpha1.OpenBaoClusterSpec{
 			Profile:  openbaov1alpha1.ProfileHardened,
@@ -399,6 +450,7 @@ func TestEnsureExecutorJob_VerifiesDefaultUpgradeExecutorImageForHardenedCluster
 
 	result, err := EnsureExecutorJob(
 		context.Background(),
+		k8sClient,
 		k8sClient,
 		scheme,
 		logr.Discard(),

--- a/internal/service/upgrade/rolling/events_test.go
+++ b/internal/service/upgrade/rolling/events_test.go
@@ -164,12 +164,12 @@ func TestPrepareFailedUpgradeRetry_EmitsRetryEvents(t *testing.T) {
 	}
 
 	targetPod := fmt.Sprintf("%s-%d", cluster.Name, cluster.Status.Upgrade.CurrentPartition-1)
-	staleJob := &batchv1.Job{
+	staleJob := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, targetPod, "", ""),
 			Namespace: cluster.Namespace,
 		},
-	}
+	}, cluster)
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
@@ -330,7 +330,7 @@ func TestHandlePreUpgradeSnapshot_EmitsSnapshotEvents(t *testing.T) {
 			},
 		}
 		jobName := (&Manager{}).backupJobName(cluster)
-		job := &batchv1.Job{
+		job := managedRollingJob(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      jobName,
 				Namespace: cluster.Namespace,
@@ -345,7 +345,7 @@ func TestHandlePreUpgradeSnapshot_EmitsSnapshotEvents(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Succeeded: 1,
 			},
-		}
+		}, cluster)
 
 		recorder := events.NewFakeRecorder(10)
 		k8sClient := fake.NewClientBuilder().

--- a/internal/service/upgrade/rolling/manager.go
+++ b/internal/service/upgrade/rolling/manager.go
@@ -79,6 +79,13 @@ func (m *Manager) WithReader(reader client.Reader) *Manager {
 	return m
 }
 
+func (m *Manager) jobReader() client.Reader {
+	if m.reader != nil {
+		return m.reader
+	}
+	return m.client
+}
+
 // WithAdminOpsStatusMutator configures the adminops-plane status persistence hook.
 func (m *Manager) WithAdminOpsStatusMutator(mutator adminOpsStatusMutator) *Manager {
 	if mutator != nil {

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +15,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
@@ -109,8 +109,15 @@ func (m *Manager) cleanupStepDownJobForRetry(ctx context.Context, logger logr.Lo
 	jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, targetPod, "", "")
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
 
-	job := &batchv1.Job{}
-	if err := m.client.Get(ctx, jobKey, job); err != nil {
+	job, err := opslifecycle.ReadManagedJob(
+		ctx,
+		m.jobReader(),
+		jobKey,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		"delete stale step-down",
+	)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}

--- a/internal/service/upgrade/rolling/retry_test.go
+++ b/internal/service/upgrade/rolling/retry_test.go
@@ -261,12 +261,12 @@ func TestPrepareFailedUpgradeRetry_WaitsForStatefulSetTemplateToMatchRetryTarget
 
 	targetPod := "test-cluster-1"
 	jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, targetPod, "", "")
-	staleJob := &batchv1.Job{
+	staleJob := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
 		},
-	}
+	}, cluster)
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
@@ -706,12 +706,12 @@ func TestPrepareFailedUpgradeRetry_SuccessClearsFailureAndRemovesRetrySignal(t *
 			}
 
 			jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, targetPod, "", "")
-			staleJob := &batchv1.Job{
+			staleJob := managedRollingJob(&batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
 					Namespace: cluster.Namespace,
 				},
-			}
+			}, cluster)
 			sts := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cluster.Name,

--- a/internal/service/upgrade/rolling/rollout_leader.go
+++ b/internal/service/upgrade/rolling/rollout_leader.go
@@ -16,6 +16,7 @@ import (
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/core"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
@@ -55,9 +56,17 @@ func (m *Manager) stepDownLeader(ctx context.Context, logger logr.Logger, cluste
 	jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, podName, "", "")
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
 
-	stepDownJob := &batchv1.Job{}
+	var stepDownJob *batchv1.Job
 	jobExists := true
-	if err := m.client.Get(ctx, jobKey, stepDownJob); err != nil {
+	stepDownJob, err := opslifecycle.ReadManagedJob(
+		ctx,
+		m.jobReader(),
+		jobKey,
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		"observe rolling step-down",
+	)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			jobExists = false
 		} else {
@@ -91,6 +100,7 @@ func (m *Manager) stepDownLeader(ctx context.Context, logger logr.Logger, cluste
 	result, err := upgrade.EnsureExecutorJob(
 		ctx,
 		m.client,
+		m.jobReader(),
 		m.scheme,
 		logger,
 		cluster,

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -56,7 +56,7 @@ func TestStepDownLeader_DoesNotTimeoutFromUpgradeStart(t *testing.T) {
 	}
 
 	jobName := upgrade.ExecutorJobName(name, upgrade.ExecutorActionRollingStepDownLeader, podName, "", "")
-	job := &batchv1.Job{
+	job := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              jobName,
 			Namespace:         ns,
@@ -65,7 +65,7 @@ func TestStepDownLeader_DoesNotTimeoutFromUpgradeStart(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Active: 1,
 		},
-	}
+	}, cluster)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build()
 	mgr := newManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
@@ -108,7 +108,7 @@ func TestStepDownLeader_TimesOutBasedOnJobAge(t *testing.T) {
 	}
 
 	jobName := upgrade.ExecutorJobName(name, upgrade.ExecutorActionRollingStepDownLeader, podName, "", "")
-	job := &batchv1.Job{
+	job := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              jobName,
 			Namespace:         ns,
@@ -117,7 +117,7 @@ func TestStepDownLeader_TimesOutBasedOnJobAge(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Active: 1,
 		},
-	}
+	}, cluster)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job).Build()
 	mgr := newManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
@@ -169,7 +169,7 @@ func TestStepDownLeader_FailsWhenSucceededJobStillLeavesTargetAsLeader(t *testin
 	}
 
 	jobName := upgrade.ExecutorJobName(name, upgrade.ExecutorActionRollingStepDownLeader, podName, "", "")
-	job := &batchv1.Job{
+	job := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              jobName,
 			Namespace:         ns,
@@ -178,7 +178,7 @@ func TestStepDownLeader_FailsWhenSucceededJobStillLeavesTargetAsLeader(t *testin
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -251,7 +251,7 @@ func TestStepDownLeader_VerifiesTransferViaAPIWhenLabelsLag(t *testing.T) {
 	}
 
 	jobName := upgrade.ExecutorJobName(name, upgrade.ExecutorActionRollingStepDownLeader, podName, "", "")
-	job := &batchv1.Job{
+	job := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              jobName,
 			Namespace:         ns,
@@ -260,7 +260,7 @@ func TestStepDownLeader_VerifiesTransferViaAPIWhenLabelsLag(t *testing.T) {
 		Status: batchv1.JobStatus{
 			Succeeded: 1,
 		},
-	}
+	}, cluster)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/service/upgrade/rolling/snapshot_create.go
+++ b/internal/service/upgrade/rolling/snapshot_create.go
@@ -7,13 +7,14 @@ import (
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
 	portbackup "github.com/dc-tec/openbao-operator/internal/port/backup"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	snapshothelpers "github.com/dc-tec/openbao-operator/internal/service/upgrade/snapshot"
 )
@@ -38,7 +39,17 @@ func (m *Manager) createPreUpgradeBackupJob(ctx context.Context, logger logr.Log
 
 	if err := m.client.Create(ctx, job); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			logger.V(1).Info("Pre-upgrade backup job already exists after create attempt", "job", jobName)
+			if _, readErr := opslifecycle.ReadManagedJob(
+				ctx,
+				m.jobReader(),
+				client.ObjectKey{Namespace: cluster.Namespace, Name: jobName},
+				cluster,
+				openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+				"use existing pre-upgrade backup",
+			); readErr != nil {
+				return false, fmt.Errorf("pre-upgrade backup Job create collided with an untrusted existing Job: %w", readErr)
+			}
+			logger.V(1).Info("Pre-upgrade backup job already exists after create attempt; ownership verified", "job", jobName)
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to create backup job: %w", err)
@@ -97,10 +108,8 @@ func (m *Manager) buildPreUpgradeBackupJob(
 		return nil, fmt.Errorf("failed to build backup job: %w", err)
 	}
 
-	if m.scheme != nil {
-		if err := controllerutil.SetControllerReference(cluster, job, m.scheme); err != nil {
-			return nil, fmt.Errorf("failed to set owner reference on backup job: %w", err)
-		}
+	if err := opslifecycle.PrepareManagedJobOwner(job, cluster, m.scheme); err != nil {
+		return nil, fmt.Errorf("failed to prepare backup Job ownership: %w", err)
 	}
 
 	return job, nil

--- a/internal/service/upgrade/rolling/snapshot_job.go
+++ b/internal/service/upgrade/rolling/snapshot_job.go
@@ -15,6 +15,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/kube"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	snapshothelpers "github.com/dc-tec/openbao-operator/internal/service/upgrade/snapshot"
 )
 
@@ -22,12 +23,11 @@ import (
 // It returns the job name and classified state when present, or an empty name when no current-attempt Job exists.
 func (m *Manager) findExistingPreUpgradeBackupJob(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) (string, snapshothelpers.JobState, error) {
 	expectedJobName := m.backupJobName(cluster)
-	job := &batchv1.Job{}
-
-	if err := m.client.Get(ctx, types.NamespacedName{
+	job, err := opslifecycle.ReadManagedJob(ctx, m.jobReader(), types.NamespacedName{
 		Name:      expectedJobName,
 		Namespace: cluster.Namespace,
-	}, job); err != nil {
+	}, cluster, openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"), "observe pre-upgrade backup")
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", snapshothelpers.JobStateNone, nil
 		}
@@ -55,7 +55,7 @@ func (m *Manager) countFailedPreUpgradeBackupJobs(ctx context.Context, cluster *
 		constants.LabelOpenBaoBackupType: constants.BackupTypePreUpgrade,
 	})
 
-	if err := m.client.List(ctx, jobList,
+	if err := m.jobReader().List(ctx, jobList,
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	); err != nil {
@@ -67,6 +67,14 @@ func (m *Manager) countFailedPreUpgradeBackupJobs(ctx context.Context, cluster *
 		job := &jobList.Items[i]
 		if !isCurrentAttemptPreUpgradeBackupJobName(job.Name, expectedJobName) {
 			continue
+		}
+		if err := opslifecycle.RequireManagedJobOwner(
+			"count failed pre-upgrade backup",
+			job,
+			cluster,
+			openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+		); err != nil {
+			return 0, err
 		}
 		if kube.JobFailed(job) {
 			count++
@@ -88,12 +96,16 @@ func isCurrentAttemptPreUpgradeBackupJobName(name string, expected string) bool 
 }
 
 // deletePreUpgradeBackupJob deletes a specific pre-upgrade backup job.
-func (m *Manager) deletePreUpgradeBackupJob(ctx context.Context, jobName, namespace string) error {
-	job := &batchv1.Job{}
-	if err := m.client.Get(ctx, types.NamespacedName{
+func (m *Manager) deletePreUpgradeBackupJob(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	jobName string,
+) error {
+	job, err := opslifecycle.ReadManagedJob(ctx, m.jobReader(), types.NamespacedName{
 		Name:      jobName,
-		Namespace: namespace,
-	}, job); err != nil {
+		Namespace: cluster.Namespace,
+	}, cluster, openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"), "delete pre-upgrade backup")
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil // Already deleted
 		}

--- a/internal/service/upgrade/rolling/snapshot_job_test.go
+++ b/internal/service/upgrade/rolling/snapshot_job_test.go
@@ -75,8 +75,30 @@ func newPreUpgradeSnapshotCluster() *openbaov1alpha1.OpenBaoCluster {
 	}
 }
 
-func newPreUpgradeSnapshotJob(status batchv1.JobStatus) *batchv1.Job {
-	return &batchv1.Job{
+func managedRollingJob(
+	job *batchv1.Job,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) *batchv1.Job {
+	if cluster.UID == "" {
+		cluster.UID = types.UID(cluster.Name + "-uid")
+	}
+	controller := true
+	job.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: openbaov1alpha1.GroupVersion.String(),
+		Kind:       "OpenBaoCluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+		Controller: &controller,
+	}}
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations[constants.AnnotationOpenBaoOwnerUID] = string(cluster.UID)
+	return job
+}
+
+func newPreUpgradeSnapshotJob(cluster *openbaov1alpha1.OpenBaoCluster, status batchv1.JobStatus) *batchv1.Job {
+	return managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pre-upgrade-backup-test-cluster-gen0",
 			Namespace: "test-ns",
@@ -89,7 +111,7 @@ func newPreUpgradeSnapshotJob(status batchv1.JobStatus) *batchv1.Job {
 			},
 		},
 		Status: status,
-	}
+	}, cluster)
 }
 
 func newPreUpgradeSnapshotManager(cluster *openbaov1alpha1.OpenBaoCluster, objects ...client.Object) *Manager {
@@ -381,6 +403,9 @@ func TestHandlePreUpgradeSnapshot_CreateAlreadyExists(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*batchv1.Job); ok {
+					if err := c.Create(ctx, obj, opts...); err != nil {
+						return err
+					}
 					return apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, obj.GetName())
 				}
 				return c.Create(ctx, obj, opts...)
@@ -393,6 +418,69 @@ func TestHandlePreUpgradeSnapshot_CreateAlreadyExists(t *testing.T) {
 	complete, err := manager.handlePreUpgradeSnapshot(context.Background(), testLogger(), cluster)
 	assert.NoError(t, err, "AlreadyExists on create should be treated as idempotent")
 	assert.False(t, complete, "snapshot should remain in-progress when create races")
+}
+
+func TestHandlePreUpgradeSnapshot_RejectsForeignSucceededJob(t *testing.T) {
+	cluster := newPreUpgradeSnapshotCluster()
+	scheme := runtime.NewScheme()
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	foreignJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      (&Manager{}).backupJobName(cluster),
+			Namespace: cluster.Namespace,
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, foreignJob).
+		Build()
+	manager := NewManager(
+		k8sClient,
+		scheme,
+		backup.NewUpgradeStrategyRuntime(k8sClient, scheme),
+		portopenbao.ClientConfig{},
+		security.NewImageVerifier(testLogger(), k8sClient, nil),
+		"",
+	)
+
+	complete, err := manager.handlePreUpgradeSnapshot(context.Background(), testLogger(), cluster)
+	assert.False(t, complete)
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoCluster")
+}
+
+func TestDeletePreUpgradeBackupJob_RejectsAndPreservesForeignJob(t *testing.T) {
+	cluster := newPreUpgradeSnapshotCluster()
+	scheme := runtime.NewScheme()
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	foreignJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      (&Manager{}).backupJobName(cluster),
+		Namespace: cluster.Namespace,
+	}}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(foreignJob).
+		Build()
+	manager := NewManager(
+		k8sClient,
+		scheme,
+		backup.NewUpgradeStrategyRuntime(k8sClient, scheme),
+		portopenbao.ClientConfig{},
+		security.NewImageVerifier(testLogger(), k8sClient, nil),
+		"",
+	)
+
+	err := manager.deletePreUpgradeBackupJob(context.Background(), cluster, foreignJob.Name)
+	assert.ErrorContains(t, err, "requires managed controller owner OpenBaoCluster")
+
+	preserved := &batchv1.Job{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKeyFromObject(foreignJob), preserved))
 }
 
 func TestHandlePreUpgradeSnapshot_CreatesJobWithOIDCDefaultRole(t *testing.T) {
@@ -543,7 +631,7 @@ func TestHandlePreUpgradeSnapshot_ExistingJobStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster := newPreUpgradeSnapshotCluster()
-			manager := newPreUpgradeSnapshotManager(cluster, newPreUpgradeSnapshotJob(tt.jobStatus))
+			manager := newPreUpgradeSnapshotManager(cluster, newPreUpgradeSnapshotJob(cluster, tt.jobStatus))
 
 			complete, err := manager.handlePreUpgradeSnapshot(context.Background(), testLogger(), cluster)
 			assert.NoError(t, err)
@@ -590,7 +678,7 @@ func TestHandlePreUpgradeSnapshot_JobFailed(t *testing.T) {
 			// Exact name is required for strict lookup in findExistingPreUpgradeBackupJob.
 			name = "pre-upgrade-backup-test-cluster-gen0"
 		}
-		failedJobs = append(failedJobs, &batchv1.Job{
+		failedJobs = append(failedJobs, managedRollingJob(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "test-ns",
@@ -607,7 +695,7 @@ func TestHandlePreUpgradeSnapshot_JobFailed(t *testing.T) {
 				Succeeded: 0,
 				Failed:    1,
 			},
-		})
+		}, cluster))
 	}
 
 	scheme := runtime.NewScheme()
@@ -664,7 +752,7 @@ func TestHandlePreUpgradeSnapshot_JobFailedRetriesOnFirstFailure(t *testing.T) {
 	}
 
 	// Create single failed backup job - should trigger retry, not error
-	failedJob := &batchv1.Job{
+	failedJob := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pre-upgrade-backup-test-cluster-gen0",
 			Namespace: "test-ns",
@@ -681,7 +769,7 @@ func TestHandlePreUpgradeSnapshot_JobFailedRetriesOnFirstFailure(t *testing.T) {
 			Succeeded: 0,
 			Failed:    1,
 		},
-	}
+	}, cluster)
 
 	scheme := runtime.NewScheme()
 	_ = batchv1.AddToScheme(scheme)
@@ -737,7 +825,7 @@ func TestHandlePreUpgradeSnapshot_IgnoresFailedJobsFromPreviousGenerations(t *te
 		},
 	}
 
-	currentFailedJob := &batchv1.Job{
+	currentFailedJob := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pre-upgrade-backup-test-cluster-gen7",
 			Namespace: "test-ns",
@@ -752,9 +840,9 @@ func TestHandlePreUpgradeSnapshot_IgnoresFailedJobsFromPreviousGenerations(t *te
 		Status: batchv1.JobStatus{
 			Failed: 1,
 		},
-	}
+	}, cluster)
 
-	staleFailedJob1 := &batchv1.Job{
+	staleFailedJob1 := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pre-upgrade-backup-test-cluster-gen6",
 			Namespace: "test-ns",
@@ -769,9 +857,9 @@ func TestHandlePreUpgradeSnapshot_IgnoresFailedJobsFromPreviousGenerations(t *te
 		Status: batchv1.JobStatus{
 			Failed: 1,
 		},
-	}
+	}, cluster)
 
-	staleFailedJob2 := &batchv1.Job{
+	staleFailedJob2 := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pre-upgrade-backup-test-cluster-gen5-attempt-1",
 			Namespace: "test-ns",
@@ -786,7 +874,7 @@ func TestHandlePreUpgradeSnapshot_IgnoresFailedJobsFromPreviousGenerations(t *te
 		Status: batchv1.JobStatus{
 			Failed: 1,
 		},
-	}
+	}, cluster)
 
 	scheme := runtime.NewScheme()
 	_ = batchv1.AddToScheme(scheme)
@@ -851,7 +939,7 @@ func TestPreUpgradeSnapshotBlocksUpgradeInitialization(t *testing.T) {
 	}
 
 	// Create a running backup job
-	runningJob := &batchv1.Job{
+	runningJob := managedRollingJob(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			// Name must match the expected format: pre-upgrade-backup-<cluster>-gen<generation>
 			// Cluster generation defaults to 0 in tests unless specified
@@ -870,7 +958,7 @@ func TestPreUpgradeSnapshotBlocksUpgradeInitialization(t *testing.T) {
 			Succeeded: 0,
 			Failed:    0,
 		},
-	}
+	}, cluster)
 
 	scheme := runtime.NewScheme()
 	_ = batchv1.AddToScheme(scheme)

--- a/internal/service/upgrade/rolling/snapshot_results.go
+++ b/internal/service/upgrade/rolling/snapshot_results.go
@@ -68,7 +68,7 @@ func (m *Manager) handleFailedPreUpgradeBackupJob(
 		"job", jobName,
 		"attempt", failedCount+1,
 		"maxRetries", maxRetries)
-	if err := m.deletePreUpgradeBackupJob(ctx, jobName, cluster.Namespace); err != nil {
+	if err := m.deletePreUpgradeBackupJob(ctx, cluster, jobName); err != nil {
 		return false, fmt.Errorf("failed to delete failed backup job %s: %w", jobName, err)
 	}
 

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -621,6 +621,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 		It("performs rolling upgrade", Label(
 			"e2e-anchor",
 			"case:upgrade-rolling-happy-path",
+			"covers:lifecycle-job-owner-proof",
 			"read-replicas",
 			"read-replicas-rolling",
 		), func() {
@@ -872,6 +873,7 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				if job.Annotations[upgradeActionAnnotationKey] != string(upgrade.ExecutorActionRollingStepDownLeader) {
 					continue
 				}
+				Expect(validateManagedLifecycleJobOwnerProof(job, upgradeCluster)).To(Succeed())
 
 				Expect(job.Status.Failed).To(Equal(int32(0)), "step-down job should not fail: %s", job.Name)
 

--- a/test/e2e/backup_restore_test.go
+++ b/test/e2e/backup_restore_test.go
@@ -159,6 +159,9 @@ func triggerManualBackup(ctx context.Context, c client.Client, namespace, cluste
 
 func waitForBackupJobCreated(ctx context.Context, c client.Client, namespace, clusterName string) {
 	Eventually(func(g Gomega) {
+		cluster := &openbaov1alpha1.OpenBaoCluster{}
+		g.Expect(c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, cluster)).To(Succeed())
+
 		var jobs batchv1.JobList
 		err := c.List(ctx, &jobs, client.InNamespace(namespace), client.MatchingLabels{
 			constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
@@ -167,7 +170,44 @@ func waitForBackupJobCreated(ctx context.Context, c client.Client, namespace, cl
 		})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(jobs.Items).ToNot(BeEmpty())
+		for i := range jobs.Items {
+			g.Expect(validateManagedLifecycleJobOwnerProof(&jobs.Items[i], cluster)).To(Succeed())
+		}
 	}, framework.DefaultLongWaitTimeout, framework.DefaultPollInterval).Should(Succeed())
+}
+
+func validateManagedLifecycleJobOwnerProof(
+	job *batchv1.Job,
+	owner *openbaov1alpha1.OpenBaoCluster,
+) error {
+	if job == nil || owner == nil || owner.UID == "" {
+		return fmt.Errorf("job and owner with UID are required")
+	}
+	if got := job.Annotations[constants.AnnotationOpenBaoOwnerUID]; got != string(owner.UID) {
+		return fmt.Errorf("job %s/%s owner UID annotation = %q, want %q", job.Namespace, job.Name, got, owner.UID)
+	}
+	controllerRef := metav1.GetControllerOfNoCopy(job)
+	if controllerRef == nil {
+		return fmt.Errorf("job %s/%s has no controller owner reference", job.Namespace, job.Name)
+	}
+	if controllerRef.APIVersion != openbaov1alpha1.GroupVersion.String() ||
+		controllerRef.Kind != "OpenBaoCluster" ||
+		controllerRef.Name != owner.Name ||
+		controllerRef.UID != owner.UID {
+		return fmt.Errorf(
+			"job %s/%s controller owner = %s %s/%s with UID %q, want OpenBaoCluster %s/%s with UID %q",
+			job.Namespace,
+			job.Name,
+			controllerRef.Kind,
+			owner.Namespace,
+			controllerRef.Name,
+			controllerRef.UID,
+			owner.Namespace,
+			owner.Name,
+			owner.UID,
+		)
+	}
+	return nil
 }
 
 func waitForSuccessfulBackupJob(ctx context.Context, c client.Client, namespace, clusterName string) {
@@ -498,6 +538,7 @@ var _ = Describe("DR: Storage Providers Backup & Restore", Label("dr", "backup",
 		It("creates a restorable S3 backup", Label(
 			"e2e-anchor",
 			"case:dr-s3-restorable-backup",
+			"covers:lifecycle-job-owner-proof",
 			"read-replicas",
 			"read-replicas-restore",
 		), func() {

--- a/test/e2e/catalog/README.md
+++ b/test/e2e/catalog/README.md
@@ -14,7 +14,7 @@ Notes:
 - Files: `20`
 - Specs: `85`
 - Explicit case IDs: `36`
-- Coverage tags: `48`
+- Coverage tags: `49`
 
 ## Suites
 
@@ -49,6 +49,7 @@ Notes:
 | `operation-lock` | 3 |
 | `anti-tamper` | 2 |
 | `backup-owner-first` | 2 |
+| `lifecycle-job-owner-proof` | 2 |
 | `pvc-cleanup` | 2 |
 | `recoverability-secret-cleanup` | 2 |
 | `rolling-upgrade` | 2 |

--- a/test/e2e/catalog/cases.json
+++ b/test/e2e/catalog/cases.json
@@ -2538,6 +2538,9 @@
     "id": "upgrade-rolling-happy-path",
     "generatedId": "upgrade-strategies-performs-rolling-upgrade-2302a23d",
     "caseLabel": "upgrade-rolling-happy-path",
+    "coverage": [
+      "lifecycle-job-owner-proof"
+    ],
     "file": "test/e2e/Upgrade_Strategies_test.go",
     "type": "It",
     "name": "performs rolling upgrade",
@@ -2554,6 +2557,7 @@
       "rolling",
       "e2e-anchor",
       "case:upgrade-rolling-happy-path",
+      "covers:lifecycle-job-owner-proof",
       "read-replicas",
       "read-replicas-rolling"
     ],
@@ -2999,6 +3003,9 @@
     "id": "dr-s3-restorable-backup",
     "generatedId": "backup-restore-creates-a-restorable-s3-backup-44a8d036",
     "caseLabel": "dr-s3-restorable-backup",
+    "coverage": [
+      "lifecycle-job-owner-proof"
+    ],
     "file": "test/e2e/backup_restore_test.go",
     "type": "It",
     "name": "creates a restorable S3 backup",
@@ -3016,6 +3023,7 @@
       "slow",
       "e2e-anchor",
       "case:dr-s3-restorable-backup",
+      "covers:lifecycle-job-owner-proof",
       "read-replicas",
       "read-replicas-restore"
     ],

--- a/test/e2e/catalog/suites/Upgrade_Strategies_test.md
+++ b/test/e2e/catalog/suites/Upgrade_Strategies_test.md
@@ -17,7 +17,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `upgrade-strategies-triggers-late-phase-rollback-after-promotion-c44db935` | triggers late-phase rollback after promotion failures and recovers when auth is restored | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `failure`, `bluegreen`, `rollback` |
 | `upgrade-strategies-recovers-a-failed-rolling-upgrade-after-5a3c4b87` | recovers a failed rolling upgrade after a retry request clears stale state | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `recovery` |
 | `upgrade-strategies-retries-a-failed-rolling-pre-upgrade-fade7ad8` | retries a failed rolling pre-upgrade snapshot before starting rollout | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `snapshot`, `recovery` |
-| `upgrade-rolling-happy-path` | performs rolling upgrade | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `e2e-anchor`, `read-replicas`, `read-replicas-rolling` |
+| `upgrade-rolling-happy-path` | performs rolling upgrade | active | `lifecycle-job-owner-proof` | `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `e2e-anchor`, `read-replicas`, `read-replicas-rolling` |
 | `upgrade-bluegreen-safe-mode-break-glass-recovery` | acknowledges break glass and resumes rollback after the upgrade policy is repaired | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `chaos`, `bluegreen` |
 | `upgrade-bluegreen-safe-mode-consensus-repair-failure` | enters safe mode when rollback consensus repair job fails | active | _none_ | `upgrade`, `upgrades`, `cluster`, `slow`, `chaos`, `bluegreen` |
 
@@ -212,7 +212,7 @@ State: `active`
 
 Generated fallback ID: `upgrade-strategies-performs-rolling-upgrade-2302a23d`
 
-Covers: _none_
+Covers: `lifecycle-job-owner-proof`
 
 Labels: `upgrade`, `upgrades`, `cluster`, `slow`, `rolling`, `e2e-anchor`, `read-replicas`, `read-replicas-rolling`
 

--- a/test/e2e/catalog/suites/backup_restore_test.md
+++ b/test/e2e/catalog/suites/backup_restore_test.md
@@ -12,7 +12,7 @@ Note: recorded checkpoints are best-effort extracts from literal `By(...)` calls
 | `backup-restore-restores-from-azure-backup-using-openbaorestore-b3ea354a` | restores from Azure backup using OpenBaoRestore CR | active | _none_ | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow` |
 | `dr-gcs-provider-backup-smoke` | executes a manual backup to GCS | active | _none_ | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `provider-smoke` |
 | `dr-s3-restore-controller-restart` | completes restore deterministically after controller restart while running | active | _none_ | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `failure-injection` |
-| `dr-s3-restorable-backup` | creates a restorable S3 backup | active | _none_ | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `read-replicas`, `read-replicas-restore` |
+| `dr-s3-restorable-backup` | creates a restorable S3 backup | active | `lifecycle-job-owner-proof` | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `read-replicas`, `read-replicas-restore` |
 | `backup-restore-handles-transient-s3-auth-failure-with-10300347` | handles transient S3 auth failure with backup retry after controller restart | active | _none_ | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `failure-injection` |
 | `dr-s3-restore-cr` | restores from S3 backup using OpenBaoRestore CR | active | _none_ | `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `read-replicas`, `read-replicas-restore` |
 
@@ -97,7 +97,7 @@ State: `active`
 
 Generated fallback ID: `backup-restore-creates-a-restorable-s3-backup-44a8d036`
 
-Covers: _none_
+Covers: `lifecycle-job-owner-proof`
 
 Labels: `dr`, `backup`, `restore`, `storage-providers`, `nightly`, `slow`, `e2e-anchor`, `read-replicas`, `read-replicas-restore`
 

--- a/test/e2e/suites.yaml
+++ b/test/e2e/suites.yaml
@@ -690,7 +690,8 @@ suites:
       - tls-passthrough
       - rollback
       - chaos
-    coverage: []
+    coverage:
+      - lifecycle-job-owner-proof
     runtime:
       observed: 36m39.240s
       budget: 55m
@@ -800,7 +801,8 @@ suites:
       - read-replicas
       - read-replicas-restore
       - failure-injection
-    coverage: []
+    coverage:
+      - lifecycle-job-owner-proof
     runtime:
       observed: 9m32.724s
       budget: 15m

--- a/test/integration/backup_manager_test.go
+++ b/test/integration/backup_manager_test.go
@@ -448,18 +448,30 @@ func createCompletedBackupJobForCluster(
 	succeeded, failed int32,
 ) {
 	t.Helper()
+	cluster := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: clusterName}, cluster); err != nil {
+		t.Fatalf("get OpenBaoCluster %q: %v", clusterName, err)
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(
+					cluster,
+					openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+				),
+			},
 			Labels: map[string]string{
 				constants.LabelAppInstance:      clusterName,
 				constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
 				constants.LabelOpenBaoCluster:   clusterName,
 				constants.LabelOpenBaoComponent: backup.ComponentBackup,
 			},
-			Annotations: map[string]string{},
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: string(cluster.UID),
+			},
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
@@ -480,12 +492,13 @@ func createCompletedBackupJobForCluster(
 		job.Annotations["openbao.org/backup-key"] = backupKey
 	}
 
-	if err := k8sClient.Create(ctx, job); err != nil {
+	controllerClient := newControllerClient(t)
+	if err := controllerClient.Create(ctx, job); err != nil {
 		t.Fatalf("create backup job %q: %v", jobName, err)
 	}
 
 	var latest batchv1.Job
-	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &latest); err != nil {
+	if err := controllerClient.Get(ctx, client.ObjectKeyFromObject(job), &latest); err != nil {
 		t.Fatalf("get backup job %q: %v", jobName, err)
 	}
 
@@ -493,7 +506,7 @@ func createCompletedBackupJobForCluster(
 	latest.Status.Failed = failed
 	now := metav1.Now()
 	latest.Status.StartTime = &now
-	if err := k8sClient.Status().Update(ctx, &latest); err != nil {
+	if err := controllerClient.Status().Update(ctx, &latest); err != nil {
 		t.Fatalf("update backup job status %q: %v", jobName, err)
 	}
 }

--- a/test/integration/restore_manager_test.go
+++ b/test/integration/restore_manager_test.go
@@ -603,7 +603,7 @@ func TestRestoreManager_FailedJob_RemainsTerminalAcrossReconcileRetries(t *testi
 		t.Fatalf("expected restore phase Running before failed job processing, got %s", latest.Status.Phase)
 	}
 
-	createRestoreJobWithStatus(t, namespace, restore.RestoreJobNamePrefix+restoreObj.Name, 0, 1)
+	createRestoreJobWithStatus(t, restoreObj, restore.RestoreJobNamePrefix+restoreObj.Name, 0, 1)
 
 	if _, err := mgr.Reconcile(ctx, logr.Discard(), latest); err != nil {
 		t.Fatalf("reconcile running with failed job: %v", err)
@@ -644,13 +644,35 @@ func TestRestoreManager_FailedJob_RemainsTerminalAcrossReconcileRetries(t *testi
 	}
 }
 
-func createRestoreJobWithStatus(t *testing.T, namespace, name string, succeeded, failed int32) {
+func createRestoreJobWithStatus(
+	t *testing.T,
+	restoreObj *openbaov1alpha1.OpenBaoRestore,
+	name string,
+	succeeded, failed int32,
+) {
 	t.Helper()
+
+	owner := &openbaov1alpha1.OpenBaoRestore{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: restoreObj.Namespace,
+		Name:      restoreObj.Name,
+	}, owner); err != nil {
+		t.Fatalf("get OpenBaoRestore %q: %v", restoreObj.Name, err)
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: owner.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(
+					owner,
+					openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"),
+				),
+			},
+			Annotations: map[string]string{
+				constants.AnnotationOpenBaoOwnerUID: string(owner.UID),
+			},
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
@@ -667,12 +689,13 @@ func createRestoreJobWithStatus(t *testing.T, namespace, name string, succeeded,
 			},
 		},
 	}
-	if err := k8sClient.Create(ctx, job); err != nil {
+	controllerClient := newControllerClient(t)
+	if err := controllerClient.Create(ctx, job); err != nil {
 		t.Fatalf("create restore job %q: %v", name, err)
 	}
 
 	latest := &batchv1.Job{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+	if err := controllerClient.Get(ctx, types.NamespacedName{Namespace: owner.Namespace, Name: name}, latest); err != nil {
 		t.Fatalf("get restore job %q: %v", name, err)
 	}
 
@@ -680,7 +703,7 @@ func createRestoreJobWithStatus(t *testing.T, namespace, name string, succeeded,
 	latest.Status.Failed = failed
 	now := metav1.Now()
 	latest.Status.StartTime = &now
-	if err := k8sClient.Status().Update(ctx, latest); err != nil {
+	if err := controllerClient.Status().Update(ctx, latest); err != nil {
 		t.Fatalf("update restore job status %q: %v", name, err)
 	}
 }

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -229,6 +230,45 @@ func grantServiceAccountWriteAccess(t *testing.T, namespace, username string) {
 	}
 	if err := k8sClient.Create(ctx, binding); err != nil {
 		t.Fatalf("create serviceaccount write binding: %v", err)
+	}
+}
+
+func grantJobCreateAccess(t *testing.T, namespace, username string) {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lifecycle-job-create",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"batch"},
+			Resources: []string{"jobs"},
+			Verbs:     []string{"create"},
+		}},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil {
+		t.Fatalf("create Job writer role: %v", err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lifecycle-job-create-binding",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:     "User",
+			Name:     username,
+			APIGroup: "rbac.authorization.k8s.io",
+		}},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create Job writer binding: %v", err)
 	}
 }
 
@@ -556,6 +596,60 @@ func TestVAP_LockManagedRBAC_DeniesForgedServiceAccountOwnerUID(t *testing.T) {
 	}
 
 	t.Fatalf("expected VAP to deny forged ServiceAccount owner UID provenance")
+}
+
+func TestVAP_LockManagedRBAC_DeniesForgedLifecycleJobOwnerUID(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+
+	namespace := newTestNamespace(t)
+	username := "lifecycle-job-creator"
+	grantJobCreateAccess(t, namespace, username)
+	cluster := createMinimalCluster(t, namespace, "lifecycle-owner-proof")
+	jobCreator := newImpersonatedClient(t, username)
+	ownerRef := *metav1.NewControllerRef(
+		cluster,
+		openbaov1alpha1.GroupVersion.WithKind("OpenBaoCluster"),
+	)
+
+	ownerReferenceOnly := newLifecycleCollisionJob(namespace, "owner-reference-only", ownerRef)
+	if err := jobCreator.Create(ctx, ownerReferenceOnly); err != nil {
+		t.Fatalf("create Job with owner reference only: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, ownerReferenceOnly)
+	})
+
+	forged := newLifecycleCollisionJob(namespace, "forged-owner-proof", ownerRef)
+	forged.Annotations = map[string]string{
+		constants.AnnotationOpenBaoOwnerUID: string(cluster.UID),
+	}
+	err := jobCreator.Create(ctx, forged)
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "openbao.org/owner-uid annotation is reserved") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func newLifecycleCollisionJob(
+	namespace string,
+	name string,
+	ownerRef metav1.OwnerReference,
+) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:    "collision",
+				Image:   "example.invalid/collision:latest",
+				Command: []string{"true"},
+			}},
+		}}},
+	}
 }
 
 func TestVAP_LockManagedRBAC_AllowsStatefulSetControllerManagedPVC(t *testing.T) {


### PR DESCRIPTION
## Summary

- Require an exact `OpenBaoCluster` controller reference and matching `openbao.org/owner-uid` annotation before trusting a lifecycle Job.
- Apply the ownership proof to backup, restore, rolling upgrade, and blue/green upgrade Job creation, adoption, status, and deletion paths.
- Fail closed for foreign or incomplete Jobs and add unit, integration, admission, and Kind E2E coverage.

Lifecycle paths previously did not verify both ownership signals consistently. A Job with the expected name or labels could influence operation state without proving that the current cluster owned it.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, or RBAC contract changes. Foreign or incomplete Jobs that match an expected lifecycle Job name are no longer adopted or deleted. The operation fails closed instead. No user-facing documentation change is required.

## Verification

- Focused ownership, backup, restore, rolling, and blue/green package tests
- Kubernetes 1.35.1 Kind E2E with `covers:lifecycle-job-owner-proof`: 2 passed, 0 failed
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`

## Reviewer Notes

Review the shared ownership contract and the fail-closed handling of existing Jobs across backup, restore, rolling upgrade, and blue/green upgrade paths.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
