### PR TITLE
test(integration): wait for RBAC authorization

### DIFF
--- a/test/integration/crd_contract_test.go
+++ b/test/integration/crd_contract_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -57,6 +58,44 @@ func requireInvalidRequest(t *testing.T, err error) {
 	}
 
 	t.Fatalf("expected invalid request error, got %T: %v", err, err)
+}
+
+func waitForResourceAuthorization(t *testing.T, username, namespace, apiGroup, resourceName, objectName, verb string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		review := &authorizationv1.SubjectAccessReview{
+			Spec: authorizationv1.SubjectAccessReviewSpec{
+				User: username,
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace: namespace,
+					Verb:      verb,
+					Group:     apiGroup,
+					Resource:  resourceName,
+					Name:      objectName,
+				},
+			},
+		}
+		if err := k8sClient.Create(ctx, review); err != nil {
+			t.Fatalf("create SubjectAccessReview for %s %s/%s: %v", verb, resourceName, objectName, err)
+		}
+		if review.Status.Allowed {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf(
+				"wait for %s authorization to %s %s/%s: reason=%q evaluationError=%q",
+				username,
+				verb,
+				resourceName,
+				objectName,
+				review.Status.Reason,
+				review.Status.EvaluationError,
+			)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func grantTenantOpenBaoWriteAccess(t *testing.T, namespace, username string) {
@@ -108,6 +147,7 @@ func grantTenantOpenBaoWriteAccess(t *testing.T, namespace, username string) {
 	if err := k8sClient.Create(ctx, binding); err != nil {
 		t.Fatalf("create tenant writer rolebinding: %v", err)
 	}
+	waitForResourceAuthorization(t, username, namespace, "openbao.org", "openbaoclusters", "", "create")
 }
 
 func grantClusterOpenBaoVerbs(t *testing.T, namespace, clusterName, username, roleName string, verbs ...string) {
@@ -159,6 +199,9 @@ func grantClusterOpenBaoVerbs(t *testing.T, namespace, clusterName, username, ro
 	}
 	if err := k8sClient.Create(ctx, binding); err != nil {
 		t.Fatalf("create delegated OpenBao rolebinding: %v", err)
+	}
+	for _, verb := range verbs {
+		waitForResourceAuthorization(t, username, namespace, "openbao.org", "openbaoclusters", clusterName, verb)
 	}
 }
 
@@ -242,6 +285,11 @@ func grantNamespacedResourceVerbs(t *testing.T, namespace, username, roleName, a
 	if err := k8sClient.Create(ctx, binding); err != nil {
 		t.Fatalf("create delegated reference rolebinding: %v", err)
 	}
+	for _, verb := range verbs {
+		for _, objectName := range resourceNames {
+			waitForResourceAuthorization(t, username, namespace, apiGroup, resourceName, objectName, verb)
+		}
+	}
 }
 
 func grantClusterScopedResourceVerbs(t *testing.T, username, roleName, apiGroup, resourceName string, resourceNames []string, verbs ...string) {
@@ -291,6 +339,11 @@ func grantClusterScopedResourceVerbs(t *testing.T, username, roleName, apiGroup,
 	}
 	if err := k8sClient.Create(ctx, binding); err != nil {
 		t.Fatalf("create delegated cluster reference rolebinding: %v", err)
+	}
+	for _, verb := range verbs {
+		for _, objectName := range resourceNames {
+			waitForResourceAuthorization(t, username, "", apiGroup, resourceName, objectName, verb)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Poll `SubjectAccessReview` after integration-test RBAC bindings are created.
- Wait for the exact user, namespace, API group, resource, object name, and verb before running admission assertions.
- Prevent allowed admission cases from racing the API server authorizer cache.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Test-only change. It does not change operator APIs, CRDs, Helm resources, production RBAC, security behavior, upgrades, or runtime behavior.

The wait is bounded to five seconds and queries the same API-server authorization path used by the validating admission policy.

## Verification

- Five independent Kubernetes 1.36.2 envtest runs of `TestVAP_OpenBaoCluster_RequiresReferenceUseAuthorization`
- `make test-ci` — 3,510 tests, 4 skipped, 69.89% internal coverage
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core` — passed in 553 seconds
- Pre-commit and pre-push hooks

## Reviewer Notes

The race failed `Envtest Integration` on PR #633 for image-pull-secret and ingress authorization cases, then on PR #632 for existing-PVC and ServiceMonitor TLS authorization cases. The production admission policy was unchanged, and independent fresh local API servers passed.

Review the `SubjectAccessReview` attributes and the placement of the wait after each RoleBinding or ClusterRoleBinding creation.

Documentation is not needed because this changes only integration-test synchronization. Generated artifacts are unaffected.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.