### PR TITLE
docs(release): prepare 0.5.0-rc.1 notes

### DIFF
--- a/release-notes/0.5.0-rc.1.md
+++ b/release-notes/0.5.0-rc.1.md
@@ -1,0 +1,67 @@
+`0.5.0-rc.1` is a release candidate for OpenBao Operator 0.5.0. Use it only in
+evaluation and staging environments. Do not use it in production. During the
+candidate period, the project will run manual cluster tests. The project will
+also monitor upgrades, lifecycle operations, security controls, and release
+artifacts.
+
+The candidate serves the `openbao.org/v1alpha1` API. It does not add
+`v1beta1`. The 0.5.0 release notes contain the full release description and
+migration procedure.
+
+### What to Test
+
+* Test the candidate on Kubernetes `1.36.x`. Also exercise Kubernetes `1.34.x`
+  and `1.35.x` when those versions are in your support window.
+* Rehearse the operator upgrade from 0.4.2. Test Development, Transit, and
+  three-replica Hardened clusters. Verify reconciliation and managed resource
+  identity. Verify that stored data remains available.
+* Update stored manifests before you install the candidate custom resource
+  definitions (CRDs). Replace `spec.tls.acme.domain` and
+  `spec.maintenance.restartAt`. Remove the deprecated status aliases. The 0.5.0
+  migration procedure lists the replacement fields.
+* Test backup and restore. Verify stored-data continuity. Test a strategy change
+  between `RollingUpdate` and `BlueGreen` while the cluster is idle.
+* Test plugin-backed key management service (KMS) seal configuration if you use
+  this feature. Also test the OpenBao 2.6 self-init `headers` and `when`
+  controls. OpenBao `2.6.2` is the primary validation version.
+* Verify signatures and attestations for the images, chart, checksums, software
+  bills of materials (SBOMs), manifests, and release provenance. Verify them
+  against the `0.5.0-rc.1` tag.
+
+### Install or Upgrade in an Evaluation Environment
+
+Apply the candidate CRDs before you upgrade the controller or Helm release:
+
+```sh
+kubectl apply -f https://github.com/dc-tec/openbao-operator/releases/download/0.5.0-rc.1/crds.yaml
+```
+
+Upgrade the Helm release with the candidate chart:
+
+```sh
+helm upgrade openbao-operator oci://ghcr.io/dc-tec/charts/openbao-operator \
+  --version 0.5.0-rc.1 \
+  --namespace openbao-operator-system \
+  --reuse-values
+```
+
+First upgrade each 0.4.0 or 0.4.1 installation to 0.4.2. Keep the 0.4.2 CRDs
+and controller installed while you update stored manifests. Kubernetes can
+prune removed fields after you install the candidate CRDs.
+
+### Candidate Limits
+
+* The operator blocks a `BlueGreen` OpenBao upgrade from a version before 2.6
+  to version 2.6.x. Mixed versions cannot complete the request-forwarding
+  health checks. Change an idle cluster to `RollingUpdate` before you request
+  this OpenBao upgrade.
+* Plugin-backed KMS support configures OpenBao. It does not install the plugin
+  binary. It does not supply vendor libraries, devices, or persistent
+  plugin-cache storage.
+* The release process does not create a patch-level documentation snapshot for
+  this candidate. Unreleased changes continue under `/docs/next` until the
+  stable 0.5.0 documentation line is published.
+
+Report each confirmed regression with the candidate version and Kubernetes
+version. Include the OpenBao version, profile, and upgrade strategy. Include
+the relevant operator conditions and sanitized events.

--- a/release-notes/0.5.0.md
+++ b/release-notes/0.5.0.md
@@ -1,102 +1,156 @@
-0.5.0 is a feature-light contract-consolidation release for OpenBao Operator.
-It stabilizes a reviewed subset of the API ahead of a future beta version,
-adds focused OpenBao 2.6 integration, and strengthens upgrade and Hardened
-profile evidence. The served API remains `openbao.org/v1alpha1`; this is not a
-`v1beta1` graduation.
+OpenBao Operator 0.5.0 stabilizes a reviewed subset of the
+`openbao.org/v1alpha1` API. It adds plugin-backed key management service (KMS)
+seal configuration and self-init request controls for OpenBao 2.6. It adds
+operator-upgrade tests and agreement tests for Hardened profile rules. It also
+adds independent voter resource configuration. It fixes Gateway readiness,
+single-tenant Helm configuration, tenant cleanup, and validation-hook image
+verification. This release does not introduce `v1beta1`.
 
 ### Highlights
 
-* Stabilized a selected `v1alpha1` API subset and added a deterministic field
-  inventory plus report-only CRD compatibility analysis. The contract covers
-  stable fields, omission behavior, constrained mutability, and condition-type
-  catalogs without freezing every newer feature group.
-* Added plugin-backed KMS seal configuration for OpenBao 2.6 and newer through
-  `spec.unseal.type: kms`, including named plugin selection and plugin-specific
-  string configuration.
-* Added OpenBao 2.6 self-init profile controls. Requests can now render
-  multi-value `headers` and conditional `when` expressions from booleans or
-  profile value objects.
-* Added safe idle switching between `RollingUpdate` and `BlueGreen`. The
-  operator preserves the active StatefulSet and PVC identity, records the
-  accepted strategy in status, and blocks transitions while cluster or
-  administrative work is active.
-* Moved the primary OpenBao validation target to `2.6.2`. Config compatibility
-  checks continue to cover OpenBao `2.4.4`, `2.5.5`, and `2.6.2`.
-* Centralized Hardened-profile rule ownership and added agreement fixtures
-  across admission and runtime readiness. Shared rules now carry stable IDs
-  and must reach the same verdict in both enforcement layers.
-* Added a release-gated operator upgrade path from `0.4.2` to the candidate
-  release. It exercises Development, Transit, and three-replica Hardened
-  clusters and verifies reconciliation, resource identity, and stored data
-  continuity.
+* Stabilizes a selected `v1alpha1` API subset. A deterministic field inventory
+  records the selected fields. A CustomResourceDefinition (CRD) comparison
+  reports compatibility changes but does not block the release. The contract
+  specifies stable fields, omission behavior, mutability constraints, and
+  condition types. It does not freeze newer feature groups.
+* Adds plugin-backed KMS seal configuration for OpenBao 2.6 and newer through
+  `spec.unseal.type: kms`. The configuration selects a named plugin and
+  supplies plugin-specific string values.
+* Adds OpenBao 2.6 self-init profile controls. Requests can render multi-value
+  `headers`. Requests can also render conditional `when` expressions from
+  Boolean values or profile value objects.
+* Allows an upgrade-strategy change between `RollingUpdate` and `BlueGreen`.
+  The operator allows the change only when the cluster has no active
+  administrative operation or workload change. It preserves the active
+  StatefulSet and persistent volume claim (PVC) identity. It records the
+  accepted strategy in status.
+* Adds `spec.resources` for voter OpenBao containers. Read replicas continue to
+  use `spec.readReplicas.template.resources`. You can size the two pools
+  independently.
+* Uses the managed Route `Accepted` and `ResolvedRefs` conditions for Gateway
+  readiness. The operator aligns backend Transport Layer Security (TLS)
+  hostnames with the certificate identity that its clients use. It validates
+  each configured subject alternative name in `extraSANs` for external
+  certificates.
+* Applies `spec.operatorImageVerification` to custom BlueGreen validation-hook
+  images. The operator pins verified hook images to their digests. The
+  validation Job disables service-account token automount. It also uses a
+  read-only root filesystem and fixed resource bounds.
+* Adds a generation-aware `Provisioned` condition to `OpenBaoTenant`. The
+  operator preserves shared namespace resources while another tenant claim
+  exists. It removes operator-managed role-based access control (RBAC),
+  `ResourceQuota`, and `LimitRange` resources when the last claim ends.
+* Uses OpenBao `2.6.2` as the primary validation target. Configuration
+  compatibility checks also cover OpenBao `2.4.4` and `2.5.5`.
+* Uses Kubernetes `1.36.1` as the primary validation target. Release gates also
+  cover the Kubernetes `1.34.x` and `1.35.x` compatibility lines.
+* Places all Hardened profile rules in one source. Agreement fixtures compare
+  admission and runtime-readiness results. Each shared rule has a stable ID and
+  must give the same result in both enforcement layers.
+* Adds an operator upgrade test from `0.4.2` to 0.5.0. The test covers
+  Development, Transit, and three-replica Hardened clusters. It checks
+  reconciliation, resource identity, and stored-data continuity.
 
-### Breaking and Migration Notes
+### Breaking Changes and Migration
 
-The 0.5.0 CRD comparison against 0.4.2 records intentional pre-GA removals and
-validation tightening. Review stored manifests before installing the new CRDs.
+The 0.5.0 CRD comparison with 0.4.2 identifies intentional removals and
+stricter validation. These changes can reject old manifests or remove obsolete
+fields. Update stored manifests before you install the 0.5.0 CRDs.
 
-* `spec.version` now accepts semantic OpenBao versions only. A lowercase `v`
-  prefix, prerelease identifiers, and build metadata remain supported.
-* Non-static `spec.unseal.type` values now require their matching provider
-  block and reject blocks for every unselected provider. Static unseal may
-  still omit `spec.unseal.static`.
-* Backup and restore targets reject provider-specific options that do not match
-  `provider`. S3 targets require `endpoint`; `roleArn` is S3-only.
-* `spec.tls.acme.domain` and `spec.maintenance.restartAt` have been removed in
-  favor of `spec.tls.acme.domains` and `spec.runtime.restartAt`.
-* The unusable `spec.upgrade.tokenSecretRef` placeholder has been removed;
-  built-in upgrade orchestration continues to use `spec.upgrade.jwtAuthRole`.
-* The deprecated top-level `status.lastBackupTime` alias and the deprecated
-  `status.upgrade.lastErrorReason`, `lastErrorMessage`, and `lastErrorAt`
-  aliases have been removed. Their structured replacements are
-  `status.backup.lastBackupTime` and `status.upgrade.failure`.
+* `spec.version` now accepts semantic OpenBao versions only. It accepts a
+  lowercase `v` prefix, prerelease identifiers, and build metadata.
+* Each non-static `spec.unseal.type` value requires its matching provider
+  block. The configuration must not contain blocks for unselected providers.
+  Static unseal can omit `spec.unseal.static`.
+* Backup and restore targets reject options that do not match `provider`. Each
+  S3 target requires `endpoint`. Only S3 targets can use `roleArn`.
+* A scheduled backup without an effective JSON Web Token (JWT) role requires
+  `spec.backup.schedule.tokenSecretRef`. The operator does not infer or use a
+  `<cluster>-root-token` Secret as a fallback.
+* `spec.tls.acme.domains` replaces `spec.tls.acme.domain`.
+  `spec.runtime.restartAt` replaces `spec.maintenance.restartAt`.
+* Remove the obsolete `spec.upgrade.tokenSecretRef` placeholder. Built-in
+  upgrade orchestration uses `spec.upgrade.jwtAuthRole`.
+* `status.backup.lastBackupTime` replaces the deprecated top-level
+  `status.lastBackupTime` alias. `status.upgrade.failure` replaces the
+  deprecated `status.upgrade.lastErrorReason`, `lastErrorMessage`, and
+  `lastErrorAt` aliases.
+* Custom BlueGreen validation-hook images now use
+  `spec.operatorImageVerification`. Hardened clusters require a blocking
+  policy. Configure issuer, subject, or public-key trust when the default policy
+  does not trust the hook publisher.
+* Each external TLS certificate must contain all configured `extraSANs` values.
+  The operator does not set `GatewayIntegrationReady=True` until the managed
+  Route reports `Accepted=True` and `ResolvedRefs=True`.
 
-The new KMS seal and self-init request controls are additive. Existing clusters
-are unchanged when those fields are omitted.
+The new KMS seal, self-init request, and voter-resource controls are optional.
+Omitting these fields does not change an existing cluster.
 
 ### Operational Notes
 
-* The supported minor-upgrade baseline is `0.4.2`. Upgrade `0.4.0` or `0.4.1`
-  installations to `0.4.2` first so the old controller can complete the stored
-  object migration before the 0.5.0 CRDs are applied.
-* Pre-2.6 to 2.6.x `BlueGreen` workload upgrades remain blocked because the
-  OpenBao request-forwarding gRPC service-name change prevents mixed-version
-  Autopilot health checks. Return the cluster to an idle state, switch to
-  `RollingUpdate`, wait for `status.acceptedUpgradeStrategy=RollingUpdate`, and
-  then request the 2.6.x upgrade.
-* Strategy changes are accepted only when the initialized cluster, voter and
-  read-replica workloads, versions, and administrative operations are idle.
-  Treat `status.acceptedUpgradeStrategy` as the confirmation that the new
-  strategy owns subsequent upgrades.
-* Plugin-backed KMS support configures OpenBao but does not install the plugin
-  binary, provide vendor libraries or devices, or add persistent plugin-cache
-  storage. Supply the plugin through `spec.plugins` and pass sensitive runtime
-  material by file through `spec.unseal.credentialsSecretRef` rather than
-  embedding secrets in `spec.unseal.kms.config`.
-* Self-init `headers` and `when` controls require OpenBao 2.6 or newer. They do
-  not add operator-owned OpenBao workflow CRDs.
-* Claims and Service Offerings remain a future optional module and are not part
-  of the 0.5.0 release surface.
+* Version `0.4.2` is the supported minor-upgrade baseline. Upgrade a 0.4.0 or
+  0.4.1 installation to 0.4.2 first. Let the 0.4.2 controller complete the
+  stored-object migration before you apply the 0.5.0 CRDs.
+* The operator blocks a `BlueGreen` OpenBao upgrade from a version before 2.6
+  to version 2.6.x. The OpenBao request-forwarding gRPC service-name change
+  prevents mixed-version Autopilot health checks. Return the cluster to an idle
+  state. Change the strategy to `RollingUpdate`. Wait for
+  `status.acceptedUpgradeStrategy=RollingUpdate`. Then request the 2.6.x
+  upgrade.
+* The operator accepts a strategy change only when the cluster is initialized
+  and idle. Voter workloads, read-replica workloads, versions, and
+  administrative operations must also be idle. Check
+  `status.acceptedUpgradeStrategy` before you start the next upgrade.
+* A single-tenant Helm installation sets the controller watch namespace from
+  `tenancy.targetNamespace`. It uses the release namespace when
+  `tenancy.targetNamespace` is empty. A multi-tenant installation with a
+  supported metrics scraper renders ingress policies for controller and
+  provisioner metrics.
+* The Helm provisioner defaults request `64Mi` of memory and set a `128Mi`
+  memory limit. Preserve higher overrides when you upgrade. These defaults
+  prevent startup out-of-memory failures observed during Kubernetes 1.36
+  validation.
+* Plugin-backed KMS support configures OpenBao. It does not install the plugin
+  binary. It does not supply vendor libraries, devices, or persistent
+  plugin-cache storage. Supply the plugin through `spec.plugins`. Supply
+  sensitive runtime data as files through `spec.unseal.credentialsSecretRef`.
+  Do not put secrets in `spec.unseal.kms.config`.
+* Self-init `headers` and `when` controls require OpenBao 2.6 or newer. These
+  controls do not add operator-owned OpenBao workflow CRDs.
+* OpenBao Operator 0.5.0 does not include Claims or Service Offerings.
 
 ### Upgrade from 0.4.2
 
-Update existing custom resources while the 0.4.2 CRDs and controller are still
-installed. Do this before applying the 0.5.0 CRDs, because Kubernetes may prune
-fields that are no longer present in the structural schema.
+Keep the 0.4.2 CRDs and controller installed while you update the OpenBao
+custom resources. Apply the 0.5.0 CRDs only after you complete these updates.
+Kubernetes can prune fields that do not exist in the new structural schema.
 
-1. Move each ACME `domain` value into the `domains` list.
+1. Move each Automatic Certificate Management Environment (ACME) `domain`
+   value into the `domains` list.
 2. Move `maintenance.restartAt` to `runtime.restartAt`. Keep
-   `maintenance.enabled` under `maintenance` if maintenance mode is still
-   required.
-3. Normalize every non-static unseal configuration so it contains the block
-   selected by `type` and no other provider block.
-4. Normalize backup and restore targets. Remove `gcs` and `azure` blocks from
-   S3 targets, remove S3-only `roleArn` from other providers, and make every S3
-   `endpoint` explicit.
-5. Remove any explicit `upgrade.tokenSecretRef: null` placeholder and configure
-   `upgrade.jwtAuthRole` when the self-init OIDC bootstrap role is unavailable.
-6. Replace image-tag aliases or partial versions with a complete semantic
+   `maintenance.enabled` under `maintenance` if you still use maintenance mode.
+3. Add the provider block selected by each non-static unseal `type`. Remove all
+   unselected provider blocks.
+4. Remove `gcs` and `azure` blocks from S3 backup and restore targets.
+5. Remove `roleArn` from backup and restore targets that do not use S3.
+6. Set an explicit `endpoint` for each S3 backup and restore target.
+7. Remove each `upgrade.tokenSecretRef: null` placeholder. Configure
+   `upgrade.jwtAuthRole` when the self-init OpenID Connect (OIDC) bootstrap role
+   is not available.
+8. Replace each image-tag alias or partial version with a complete semantic
    version such as `2.6.2`.
+
+After the controller upgrade, complete these steps before you resume affected
+operations:
+
+1. Configure `spec.backup.schedule.tokenSecretRef` when neither an explicit
+   `jwtAuthRole` nor the self-init OIDC default provides backup authentication.
+2. Configure issuer, subject, or public-key trust for each custom BlueGreen
+   validation-hook publisher that the default policy does not trust.
+3. Make sure that each external TLS certificate contains all configured
+   `extraSANs` values.
+4. For Gateway exposure, wait until the managed Route reports `Accepted=True`
+   and `ResolvedRefs=True`. Then check for `GatewayIntegrationReady=True`.
 
 For example, migrate these 0.4.2 fields:
 
@@ -114,7 +168,7 @@ spec:
     awskms: {region: eu-west-1, kmsKeyID: alias/unused}
 ```
 
-to the 0.5.0 shape:
+Use this 0.5.0 configuration:
 
 ```yaml
 spec:
@@ -131,18 +185,17 @@ spec:
     transit: {address: https://transit.example.com, keyName: autounseal, mountPath: transit}
 ```
 
-The status aliases are operator-owned and require no user patch. The 0.4.2
-controller already writes the structured replacement fields, so upgrading from
-that supported baseline preserves the current backup and upgrade-failure state.
+The operator owns the status aliases, so users do not patch them. The 0.4.2
+controller writes the replacement fields. Therefore, an upgrade from 0.4.2
+preserves the backup state and upgrade-failure state.
 
-After all stored manifests are updated, apply the 0.5.0 CRDs before upgrading
-the controller or Helm release:
+After you update all stored manifests, apply the 0.5.0 CRDs:
 
 ```sh
 kubectl apply -f https://github.com/dc-tec/openbao-operator/releases/download/0.5.0/crds.yaml
 ```
 
-Upgrade the Helm release:
+Then upgrade the Helm release:
 
 ```sh
 helm upgrade openbao-operator oci://ghcr.io/dc-tec/charts/openbao-operator \
@@ -151,19 +204,27 @@ helm upgrade openbao-operator oci://ghcr.io/dc-tec/charts/openbao-operator \
   --reuse-values
 ```
 
-Verify the operator rollout, admission-policy health, CRD version, managed
-cluster conditions, `status.acceptedUpgradeStrategy`, recent lifecycle events,
-and backup and restore readiness before continuing production changes.
+Before you continue production changes, complete these checks:
+
+1. Check that the operator rollout completed.
+2. Check the admission-policy health and CRD version.
+3. Check the managed cluster conditions and
+   `status.acceptedUpgradeStrategy`.
+4. Check lifecycle events from the upgrade period for errors.
+5. Check backup and restore readiness.
 
 ### Compatibility
 
-OpenBao Operator requires Kubernetes `v1.33+`. Kubernetes `v1.34` and `v1.35`
-are release-gated for 0.5.0, with `v1.35` as the primary validation baseline.
-OpenBao `2.6.2` is the primary validated target; config compatibility checks
-also cover OpenBao `2.4.4` and `2.5.5`.
+OpenBao Operator requires Kubernetes `v1.33+`. The release gates test
+Kubernetes `v1.34`, `v1.35`, and `v1.36`. Kubernetes `v1.36` is the primary
+validation version. Kubernetes `v1.34` and `v1.35` are compatibility lines.
 
-The served and storage API remains `openbao.org/v1alpha1`. The selected
-beta-stable subset is tracked as a compatibility contract, while read replicas,
-recovery-key bootstrap, Gateway, observability, plugins, telemetry, workload
-hardening, raw audit options, audit file storage, and plugin-specific KMS
-payloads remain supported but additive and unfrozen.
+OpenBao `2.6.2` is the primary validation version. Configuration compatibility
+checks also cover OpenBao `2.4.4` and `2.5.5`.
+
+The served and storage API remains `openbao.org/v1alpha1`. The compatibility
+contract covers only the fields that the project selected as stable. It does
+not cover read replicas, recovery-key bootstrap, Gateway, observability,
+plugins, telemetry, workload hardening, raw audit options, audit file storage,
+or plugin-specific KMS data. The operator supports these fields in `v1alpha1`,
+but the project can change them before a beta API release.

--- a/website/content-versions/next/docs/reference/compatibility.md
+++ b/website/content-versions/next/docs/reference/compatibility.md
@@ -15,9 +15,10 @@ The operator requires Kubernetes 1.33 or newer. The rows below describe the curr
 
 | Version | Validation | Support posture |
 | --- | --- | --- |
-| 1.35.x | Pull request, nightly, release, Helm, and upgrade coverage | Primary validated line |
-| 1.34.x | Nightly and release-gate lifecycle coverage | Validated compatibility line |
-| 1.33.x | Not validated for the current release line | May work; validate in staging before adoption |
+| 1.36.x | Pull request, nightly, release, Helm, and upgrade coverage | Primary validated line |
+| 1.35.x | Daily smoke, alternating weekly full coverage, and release coverage | Validated compatibility line |
+| 1.34.x | Daily smoke, alternating weekly full coverage, and release coverage | Validated compatibility line |
+| 1.33.x | Not validated for the current release line | Upstream end of life; validate in staging before adoption |
 | OpenShift | Manifest, Helm, admission, and focused platform coverage | Validate on the target cluster |
 
 ## OpenBao versions


### PR DESCRIPTION
## Summary

Prepare the human release notes and compatibility guidance for the 0.5.0-rc.1 release candidate.

- Add the exact 0.5.0-rc.1 release notes.
- Reconcile the detailed 0.5.0 notes for the later stable release.
- Document Kubernetes 1.36 as the primary tested version, with 1.34 and 1.35 compatibility coverage.

## Related Issues

None.

## Type of Change

- [x] Documentation
- [x] CI, release, or build tooling

## Risk and Compatibility

This change affects release documentation only. It does not change runtime behavior, APIs, CRDs, Helm templates, or RBAC.

## Verification

- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`
- `OPERATOR_UPGRADE_E2E_VERIFY_ONLY=true bash hack/ci/operator-upgrade-e2e.sh`
- `bash hack/ci/test-release-automation.sh`
- `TARGET_BRANCH=main VERSION=0.5.0-rc.1 bash hack/ci/validate-release-as-request.sh`

## Reviewer Notes

Merge this preparation PR before requesting the audited Release-As marker for 0.5.0-rc.1. Release-please remains responsible for release metadata and the generated changelog.

## Checklist

- [x] The release notes use the exact prerelease version.
- [x] The compatibility matrix matches the tested Kubernetes and OpenBao versions.
- [x] The commit has a DCO sign-off and a valid GPG signature.