### PR TITLE
fix(release): checkout before image scans

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,11 @@ jobs:
           - image_name: upgrade-executor
             image_ref: ${{ needs.prepare.outputs.upgrade_executor_image }}:${{ needs.prepare.outputs.build_tag }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
       - name: Login to GHCR (pull)
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -103,6 +103,21 @@ assert_not_contains() {
   fi
 }
 
+assert_ordered() {
+  local file="$1"
+  local first="$2"
+  local second="$3"
+  local first_line
+  local second_line
+
+  first_line="$(grep -nF -- "${first}" "${file}" | head -n 1 | cut -d: -f1)"
+  second_line="$(grep -nF -- "${second}" "${file}" | head -n 1 | cut -d: -f1)"
+
+  [[ -n "${first_line}" ]] || fail "expected '${first}' in ${file}"
+  [[ -n "${second_line}" ]] || fail "expected '${second}' in ${file}"
+  (( first_line < second_line )) || fail "expected '${first}' before '${second}' in ${file}"
+}
+
 bash -n \
   "${VALIDATOR}" \
   "${RELEASE_AS_RESOLVER}" \
@@ -117,6 +132,17 @@ assert_contains "${RELEASE_PLEASE_WORKFLOW}" 'release-as: ${{ steps.release-as.o
 assert_contains "${RELEASE_WORKFLOW}" "Setup Helm 3 compatibility client"
 assert_contains "${RELEASE_WORKFLOW}" 'HELM: ${{ steps.helm4.outputs.helm-path }}'
 assert_contains "${RELEASE_WORKFLOW}" 'HELM_INSTALL: ${{ steps.helm3.outputs.helm-path }}'
+
+release_security_images_job="${tmp_dir}/release-security-images.yml"
+awk '
+  /^  security-images:/ { capture = 1 }
+  /^  e2e-matrix:/ { capture = 0 }
+  capture
+' "${RELEASE_WORKFLOW}" > "${release_security_images_job}"
+assert_ordered \
+  "${release_security_images_job}" \
+  "- name: Checkout" \
+  "- name: Install Trivy (safe pinned release)"
 
 assert_contains "${RELEASE_PR_GATE_WORKFLOW}" "pull_request_review:"
 assert_contains "${RELEASE_PR_GATE_WORKFLOW}" "      - dismissed"


### PR DESCRIPTION
## Summary

Ensure release image-scan jobs check out the tagged repository before invoking the repository-local Trivy setup action.

Add a release automation regression assertion that keeps checkout before Trivy installation in the `security-images` job.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [x] CI, release, or build tooling

## Risk and Compatibility

This change affects only the tag-triggered release workflow. It does not change runtime code, APIs, CRDs, Helm rendering, or RBAC.

The failed 0.5.0-rc.1 publication jobs stopped before Trivy installation because `.github/actions/setup-trivy` was unavailable without checkout. No image vulnerability scan ran in those jobs.

## Verification

- `git diff --check`
- `bash hack/ci/test-release-automation.sh`
- `devenv shell -- make verify-workflows`
- Repository pre-commit and pre-push checks

## Reviewer Notes

After this PR merges, recreate the unpublished 0.5.0-rc.1 tag and draft release at the fixed `main` branch head through the documented `branch-head` retry path.

## Checklist

- [x] The release image-scan job checks out the tag before invoking local actions.
- [x] Regression coverage verifies the required step order.
- [x] The commit has a DCO sign-off and a valid GPG signature.