### PR TITLE
fix(release): unblock RC publication checks

### DIFF
--- a/.github/workflows/post-release-verification.yml
+++ b/.github/workflows/post-release-verification.yml
@@ -30,6 +30,7 @@ jobs:
          !github.event.workflow_run.repository.fork)
       }}
     permissions:
+      attestations: read
       contents: write
       actions: read
       issues: write
@@ -38,8 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 1
 
       - name: Resolve release context
         id: context
@@ -113,12 +112,20 @@ jobs:
         with:
           version: v0.31.1
 
+      - name: Setup Helm
+        uses: ./.github/actions/setup-helm
+
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to GHCR (Helm)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: printf '%s' "${GH_TOKEN}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -129,13 +136,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.context.outputs.tag }}
+          TAG_HEAD_SHA: ${{ steps.context.outputs.tag_head_sha }}
           REPO: ${{ github.repository }}
           RELEASE_RUN_ID: ${{ steps.context.outputs.release_run_id }}
           EVIDENCE_OUT: dist/post-release-verification.json
         run: |
           set -euo pipefail
           mkdir -p dist
-          bash hack/ci/verify-post-release.sh
+          if ! [[ "${TAG_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Release tag commit is not a full Git SHA: ${TAG_HEAD_SHA}" >&2
+            exit 1
+          fi
+          git fetch --no-tags --depth=1 origin "refs/tags/${VERSION}:refs/tags/${VERSION}"
+          fetched_tag_head="$(git rev-parse "refs/tags/${VERSION}^{commit}")"
+          if [[ "${fetched_tag_head}" != "${TAG_HEAD_SHA}" ]]; then
+            echo "Fetched release tag resolves to ${fetched_tag_head}, expected ${TAG_HEAD_SHA}" >&2
+            exit 1
+          fi
+          git show "${TAG_HEAD_SHA}:charts/openbao-operator/Chart.yaml" > dist/reviewed-Chart.yaml
+          EXPECTED_CHART_FILE=dist/reviewed-Chart.yaml bash hack/ci/verify-post-release.sh
 
       - name: Mint GitHub App token for release PR comment
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,7 +504,7 @@ jobs:
           set -euo pipefail
           work_dir="$(mktemp -d)"
           cp -a charts/openbao-operator "${work_dir}/openbao-operator"
-          CHART_DIR="${work_dir}/openbao-operator" CHART_VERSION="${CHART_VERSION}" OWNER="${OWNER}" bash hack/ci/prepare-release-chart.sh
+          CHART_DIR="${work_dir}/openbao-operator" CHART_VERSION="${CHART_VERSION}" OWNER="${OWNER}" PRESERVE_CHANGE_METADATA=true bash hack/ci/prepare-release-chart.sh
           find "${work_dir}/openbao-operator" -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
           helm lint "${work_dir}/openbao-operator"
           helm package "${work_dir}/openbao-operator" -d dist/primary
@@ -519,7 +519,7 @@ jobs:
           set -euo pipefail
           work_dir="$(mktemp -d)"
           cp -a charts/openbao-operator "${work_dir}/openbao-operator"
-          CHART_DIR="${work_dir}/openbao-operator" CHART_VERSION="${CHART_VERSION}" OWNER="${OWNER}" bash hack/ci/prepare-release-chart.sh
+          CHART_DIR="${work_dir}/openbao-operator" CHART_VERSION="${CHART_VERSION}" OWNER="${OWNER}" PRESERVE_CHANGE_METADATA=true bash hack/ci/prepare-release-chart.sh
           find "${work_dir}/openbao-operator" -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
           helm package "${work_dir}/openbao-operator" -d dist/rebuild
           test -f "dist/rebuild/openbao-operator-${CHART_VERSION}.tgz"

--- a/hack/ci/operator-upgrade-e2e.sh
+++ b/hack/ci/operator-upgrade-e2e.sh
@@ -32,6 +32,8 @@ if [[ -z "${KUBERNETES_VERSION}" ]]; then
 fi
 KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v${KUBERNETES_VERSION}}"
 KEEP_CLUSTER="${OPERATOR_UPGRADE_E2E_KEEP_CLUSTER:-false}"
+REGISTRY_NAME="${OPERATOR_UPGRADE_E2E_REGISTRY_NAME:-${CLUSTER_NAME}-registry}"
+REGISTRY_IMAGE="${OPERATOR_UPGRADE_E2E_REGISTRY_IMAGE:-registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373}"
 
 MANAGER_SOURCE="${OPERATOR_UPGRADE_E2E_MANAGER_SOURCE:-}"
 INIT_SOURCE="${OPERATOR_UPGRADE_E2E_INIT_SOURCE:-}"
@@ -368,6 +370,7 @@ WORK_DIR="$(mktemp -d)"
 KUBECONFIG_PATH="${WORK_DIR}/kubeconfig"
 CANDIDATE_CHART="${WORK_DIR}/openbao-operator"
 CLUSTER_CREATED=false
+REGISTRY_CREATED=false
 
 collect_diagnostics() {
   echo "Collecting operator upgrade diagnostics..." >&2
@@ -401,6 +404,13 @@ cleanup() {
       "${KIND_BIN}" delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
     fi
   fi
+  if [[ "${REGISTRY_CREATED}" == "true" ]]; then
+    if [[ "${KEEP_CLUSTER}" == "true" ]]; then
+      echo "Keeping candidate image registry ${REGISTRY_NAME}" >&2
+    else
+      "${DOCKER_BIN}" rm --force "${REGISTRY_NAME}" >/dev/null 2>&1 || true
+    fi
+  fi
   if [[ "${KEEP_CLUSTER}" != "true" ]]; then
     rm -rf -- "${WORK_DIR}"
   fi
@@ -412,6 +422,10 @@ if "${KIND_BIN}" get clusters | grep -qx "${CLUSTER_NAME}"; then
   echo "Kind cluster ${CLUSTER_NAME} already exists; choose another OPERATOR_UPGRADE_E2E_KIND_CLUSTER" >&2
   exit 1
 fi
+if "${DOCKER_BIN}" container inspect "${REGISTRY_NAME}" >/dev/null 2>&1; then
+  echo "Docker container ${REGISTRY_NAME} already exists; choose another OPERATOR_UPGRADE_E2E_REGISTRY_NAME" >&2
+  exit 1
+fi
 
 echo "Creating Kind ${KUBERNETES_VERSION} cluster ${CLUSTER_NAME}..." >&2
 "${KIND_BIN}" create cluster \
@@ -421,6 +435,35 @@ echo "Creating Kind ${KUBERNETES_VERSION} cluster ${CLUSTER_NAME}..." >&2
 CLUSTER_CREATED=true
 export KUBECONFIG="${KUBECONFIG_PATH}"
 
+echo "Starting candidate image registry ${REGISTRY_NAME}..." >&2
+"${DOCKER_BIN}" run \
+  --detach \
+  --name "${REGISTRY_NAME}" \
+  --publish 127.0.0.1::5000 \
+  "${REGISTRY_IMAGE}" >/dev/null
+REGISTRY_CREATED=true
+"${DOCKER_BIN}" network connect kind "${REGISTRY_NAME}"
+registry_endpoint="$("${DOCKER_BIN}" port "${REGISTRY_NAME}" 5000/tcp | head -n1)"
+registry_port="${registry_endpoint##*:}"
+if ! [[ "${registry_port}" =~ ^[0-9]+$ ]]; then
+  echo "failed to resolve the candidate registry port: ${registry_endpoint}" >&2
+  exit 1
+fi
+
+while IFS= read -r node_name; do
+  if [[ -z "${node_name}" ]]; then
+    continue
+  fi
+  "${DOCKER_BIN}" exec "${node_name}" mkdir -p /etc/containerd/certs.d/operator-upgrade.local
+  "${DOCKER_BIN}" exec --interactive "${node_name}" \
+    tee /etc/containerd/certs.d/operator-upgrade.local/hosts.toml >/dev/null <<EOF
+server = "https://operator-upgrade.local"
+
+[host."http://${REGISTRY_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+done < <("${KIND_BIN}" get nodes --name "${CLUSTER_NAME}")
+
 api_server_endpoint_ips="$(discover_api_server_endpoint_ips)"
 echo "Kubernetes API server endpoint IPs: ${api_server_endpoint_ips}" >&2
 
@@ -428,6 +471,7 @@ prepare_candidate_image() {
   local source_image="$1"
   local local_image="$2"
   local build_target="$3"
+  local registry_image="127.0.0.1:${registry_port}/${local_image#*/}"
 
   if [[ -n "${source_image}" ]]; then
     "${DOCKER_BIN}" pull "${source_image}"
@@ -435,7 +479,8 @@ prepare_candidate_image() {
   else
     make "${build_target}" IMG="${local_image}"
   fi
-  "${KIND_BIN}" load docker-image --name "${CLUSTER_NAME}" "${local_image}"
+  "${DOCKER_BIN}" tag "${local_image}" "${registry_image}"
+  "${DOCKER_BIN}" push "${registry_image}"
 }
 
 cd "${ROOT_DIR}"

--- a/hack/ci/prepare-release-chart.sh
+++ b/hack/ci/prepare-release-chart.sh
@@ -8,6 +8,12 @@ set -euo pipefail
 CHART_DIR="${CHART_DIR:-charts/openbao-operator}"
 CHART_FILE="${CHART_DIR}/Chart.yaml"
 CHANGELOG_FILE="${CHANGELOG_FILE:-CHANGELOG.md}"
+PRESERVE_CHANGE_METADATA="${PRESERVE_CHANGE_METADATA:-false}"
+
+if [[ "${PRESERVE_CHANGE_METADATA}" != "true" && "${PRESERVE_CHANGE_METADATA}" != "false" ]]; then
+  echo "PRESERVE_CHANGE_METADATA must be true or false" >&2
+  exit 1
+fi
 
 if [[ ! -f "${CHART_FILE}" ]]; then
   echo "chart file not found: ${CHART_FILE}" >&2
@@ -35,7 +41,7 @@ sed -E -i.bak \
   "${CHART_FILE}"
 rm -f "${CHART_FILE}.bak"
 
-python3 - "${CHART_FILE}" "${CHANGELOG_FILE}" "${CHART_VERSION}" <<'PY'
+python3 - "${CHART_FILE}" "${CHANGELOG_FILE}" "${CHART_VERSION}" "${PRESERVE_CHANGE_METADATA}" <<'PY'
 import json
 import re
 import sys
@@ -44,6 +50,7 @@ from pathlib import Path
 chart_path = Path(sys.argv[1])
 changelog_path = Path(sys.argv[2])
 version = sys.argv[3]
+preserve_change_metadata = sys.argv[4] == "true"
 
 
 def heading_version(line):
@@ -199,17 +206,18 @@ def replace_contains_security_updates(lines, enabled):
     raise SystemExit("artifacthub.io/containsSecurityUpdates annotation not found")
 
 
-changes = release_changes(changelog_path.read_text())
-has_security_changes = any(change["kind"] == "security" for change in changes)
-
-changes_block = ["  artifacthub.io/changes: |"]
-for change in changes:
-    changes_block.append(f"    - kind: {change['kind']}")
-    changes_block.append(f"      description: {json.dumps(change['description'])}")
-
 chart_lines = chart_path.read_text().splitlines()
-chart_lines = replace_contains_security_updates(chart_lines, has_security_changes)
-chart_lines = replace_annotation_block(chart_lines, "artifacthub.io/changes", changes_block)
+if not preserve_change_metadata:
+    changes = release_changes(changelog_path.read_text())
+    has_security_changes = any(change["kind"] == "security" for change in changes)
+
+    changes_block = ["  artifacthub.io/changes: |"]
+    for change in changes:
+        changes_block.append(f"    - kind: {change['kind']}")
+        changes_block.append(f"      description: {json.dumps(change['description'])}")
+
+    chart_lines = replace_contains_security_updates(chart_lines, has_security_changes)
+    chart_lines = replace_annotation_block(chart_lines, "artifacthub.io/changes", changes_block)
 chart_path.write_text("\n".join(chart_lines) + "\n")
 PY
 
@@ -265,6 +273,11 @@ fi
 
 if ! grep -Eq '^[[:space:]]*artifacthub\.io/changes:[[:space:]]*\|[[:space:]]*$' "${CHART_FILE}"; then
   echo "artifacthub.io/changes annotation not found in ${CHART_FILE}" >&2
+  exit 1
+fi
+
+if ! grep -Eq "^[[:space:]]*artifacthub\.io/containsSecurityUpdates:[[:space:]]*['\"]?(true|false)['\"]?[[:space:]]*$" "${CHART_FILE}"; then
+  echo "artifacthub.io/containsSecurityUpdates annotation missing or invalid in ${CHART_FILE}" >&2
   exit 1
 fi
 

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -132,6 +132,10 @@ assert_contains "${RELEASE_PLEASE_WORKFLOW}" 'release-as: ${{ steps.release-as.o
 assert_contains "${RELEASE_WORKFLOW}" "Setup Helm 3 compatibility client"
 assert_contains "${RELEASE_WORKFLOW}" 'HELM: ${{ steps.helm4.outputs.helm-path }}'
 assert_contains "${RELEASE_WORKFLOW}" 'HELM_INSTALL: ${{ steps.helm3.outputs.helm-path }}'
+preserve_change_metadata_count="$(grep -Fc 'PRESERVE_CHANGE_METADATA=true' "${RELEASE_WORKFLOW}")"
+[[ "${preserve_change_metadata_count}" == "2" ]] || {
+  fail "release packaging must preserve reviewed chart change metadata in both builds"
+}
 
 release_security_images_job="${tmp_dir}/release-security-images.yml"
 awk '
@@ -154,6 +158,15 @@ assert_not_contains "${RELEASE_PR_GATE_WORKFLOW}" "    paths:"
 assert_contains "${POST_RELEASE_VERIFIER}" 'if [[ "${VERSION}" == *-* ]]; then'
 assert_contains "${POST_RELEASE_VERIFIER}" 'if [[ "${is_prerelease}" != "${expected_prerelease}" ]]; then'
 assert_contains "${POST_RELEASE_VERIFIER}" "github_release_prerelease_flag_verified: true"
+assert_contains "${POST_RELEASE_VERIFIER}" "verifying published release-asset checksums"
+assert_contains "${POST_RELEASE_VERIFIER}" "verifying published image tags and release signatures"
+assert_contains "${POST_RELEASE_VERIFIER}" "hack/ci/verify-image-attestations.sh"
+assert_contains "${POST_RELEASE_VERIFIER}" "published_chart_metadata_matches_tag: true"
+assert_contains "${POST_RELEASE_VERIFIER}" "helm_chart_attestation_verified: true"
+assert_not_contains "${ROOT_DIR}/.github/workflows/post-release-verification.yml" 'ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.tag }}'
+assert_contains "${ROOT_DIR}/.github/workflows/post-release-verification.yml" 'git show "${TAG_HEAD_SHA}:charts/openbao-operator/Chart.yaml"'
+assert_contains "${ROOT_DIR}/.github/workflows/post-release-verification.yml" "EXPECTED_CHART_FILE=dist/reviewed-Chart.yaml"
+assert_contains "${ROOT_DIR}/.github/workflows/post-release-verification.yml" "Setup Helm"
 
 spdx_fixture="${tmp_dir}/normalizer.spdx.json"
 cat > "${spdx_fixture}" <<'EOF'
@@ -341,5 +354,36 @@ assert_not_contains "${stable_chart}" "legacy: older release entry"
 
 backup_change_count="$(grep -Fc "backup: add immutable backup evidence" "${stable_chart}")"
 [[ "${backup_change_count}" == "1" ]] || fail "expected rolled-up changes to be deduplicated"
+
+preserved_chart_dir="${tmp_dir}/preserved-chart"
+mkdir -p "${preserved_chart_dir}"
+write_chart_fixture "${preserved_chart_dir}/Chart.yaml"
+sed -E -i.bak \
+  -e "s/artifacthub\.io\/containsSecurityUpdates: 'false'/artifacthub.io\/containsSecurityUpdates: 'true'/" \
+  -e 's/description: "stale"/description: "reviewed security metadata"/' \
+  "${preserved_chart_dir}/Chart.yaml"
+rm -f "${preserved_chart_dir}/Chart.yaml.bak"
+PRESERVE_CHANGE_METADATA=true \
+  CHART_DIR="${preserved_chart_dir}" \
+  CHANGELOG_FILE="${changelog_file}" \
+  CHART_VERSION="0.5.0-rc.2" \
+  OWNER="dc-tec" \
+  bash "${CHART_PREPARER}"
+
+preserved_chart="${preserved_chart_dir}/Chart.yaml"
+assert_contains "${preserved_chart}" 'artifacthub.io/prerelease: "true"'
+assert_contains "${preserved_chart}" "artifacthub.io/containsSecurityUpdates: 'true'"
+assert_contains "${preserved_chart}" 'description: "reviewed security metadata"'
+assert_contains "${preserved_chart}" "image: ghcr.io/dc-tec/openbao-operator:0.5.0-rc.2"
+assert_not_contains "${preserved_chart}" "controller: add rc2-only reconciliation guard"
+
+if PRESERVE_CHANGE_METADATA=invalid \
+  CHART_DIR="${preserved_chart_dir}" \
+  CHANGELOG_FILE="${changelog_file}" \
+  CHART_VERSION="0.5.0-rc.2" \
+  OWNER="dc-tec" \
+  bash "${CHART_PREPARER}" >/dev/null 2>&1; then
+  fail "invalid PRESERVE_CHANGE_METADATA value was accepted"
+fi
 
 echo "release automation tests passed"

--- a/hack/ci/verify-post-release.sh
+++ b/hack/ci/verify-post-release.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 usage() {
   cat >&2 <<'USAGE'
 usage: VERSION=X.Y.Z [REPO=dc-tec/openbao-operator] hack/ci/verify-post-release.sh
@@ -38,6 +40,7 @@ OWNER="${REPO%%/*}"
 GIT_REMOTE="${GIT_REMOTE:-https://github.com/${REPO}.git}"
 ALLOW_DRAFT="${ALLOW_DRAFT:-0}"
 EVIDENCE_OUT="${EVIDENCE_OUT:-}"
+EXPECTED_CHART_FILE="${EXPECTED_CHART_FILE:-${ROOT_DIR}/charts/openbao-operator/Chart.yaml}"
 VERIFIED_AT="${VERIFIED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 RELEASE_RUN_ID="${RELEASE_RUN_ID:-}"
 VERIFICATION_RUN_ID="${GITHUB_RUN_ID:-}"
@@ -57,9 +60,12 @@ if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
   fail "VERSION must be SemVer, got '${VERSION}'"
 fi
 
-for cmd in gh jq git docker cosign; do
+for cmd in gh jq git docker cosign helm sha256sum cmp; do
   require_cmd "${cmd}"
 done
+if [[ ! -f "${EXPECTED_CHART_FILE}" ]]; then
+  fail "reviewed Chart.yaml not found: ${EXPECTED_CHART_FILE}"
+fi
 
 required_assets=(
   install.yaml
@@ -131,14 +137,17 @@ info "release assets present: ${release_url}"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
-info "downloading signature evidence"
+info "downloading published release assets"
 gh release download "${VERSION}" \
   --repo "${REPO}" \
   --dir "${tmpdir}" \
-  --clobber \
-  --pattern checksums.txt \
-  --pattern checksums.txt.bundle \
-  --pattern provenance-index.json
+  --clobber
+
+info "verifying published release-asset checksums"
+(
+  cd "${tmpdir}"
+  sha256sum -c checksums.txt
+)
 
 identity="https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/${VERSION}"
 
@@ -155,6 +164,96 @@ if [[ "${provenance_tag}" != "${VERSION}" ]]; then
   fail "provenance-index.json release tag is '${provenance_tag}', expected '${VERSION}'"
 fi
 
+source_ref="refs/tags/${VERSION}"
+provenance_source_ref="$(jq -r '.release.source_ref' "${tmpdir}/provenance-index.json")"
+if [[ "${provenance_source_ref}" != "${source_ref}" ]]; then
+  fail "provenance-index.json source ref is '${provenance_source_ref}', expected '${source_ref}'"
+fi
+
+checksums_digest="sha256:$(sha256sum "${tmpdir}/checksums.txt" | awk '{print $1}')"
+provenance_checksums_digest="$(jq -r '.release_artifacts.checksums_txt.digest' "${tmpdir}/provenance-index.json")"
+if [[ "${provenance_checksums_digest}" != "${checksums_digest}" ]]; then
+  fail "provenance-index.json checksums digest does not match the published checksums.txt"
+fi
+
+image_count="$(jq '.images | length' "${tmpdir}/provenance-index.json")"
+if [[ "${image_count}" != "4" ]]; then
+  fail "provenance-index.json must contain exactly four release images, found ${image_count}"
+fi
+
+image_value() {
+  local name="$1"
+  local field="$2"
+  jq -er --arg name "${name}" --arg field "${field}" \
+    '[.images[] | select(.name == $name)]
+     | if length == 1 then .[0][$field] else error("expected one image entry for " + $name) end' \
+    "${tmpdir}/provenance-index.json"
+}
+
+manager_image="$(image_value openbao-operator ref)"
+manager_digest="$(image_value openbao-operator digest)"
+config_init_image="$(image_value openbao-init ref)"
+config_init_digest="$(image_value openbao-init digest)"
+backup_executor_image="$(image_value openbao-backup ref)"
+backup_executor_digest="$(image_value openbao-backup digest)"
+upgrade_executor_image="$(image_value openbao-upgrade ref)"
+upgrade_executor_digest="$(image_value openbao-upgrade digest)"
+
+expected_image_refs=(
+  "openbao-operator=ghcr.io/${OWNER}/openbao-operator"
+  "openbao-init=ghcr.io/${OWNER}/openbao-init"
+  "openbao-backup=ghcr.io/${OWNER}/openbao-backup"
+  "openbao-upgrade=ghcr.io/${OWNER}/openbao-upgrade"
+)
+for expected in "${expected_image_refs[@]}"; do
+  image_name="${expected%%=*}"
+  expected_ref="${expected#*=}"
+  actual_ref="$(image_value "${image_name}" ref)"
+  if [[ "${actual_ref}" != "${expected_ref}" ]]; then
+    fail "provenance image ${image_name} ref is '${actual_ref}', expected '${expected_ref}'"
+  fi
+done
+
+attestation_signer_workflow="$(jq -er '.identity_constraints.reusable_build_signer_workflow' "${tmpdir}/provenance-index.json")"
+info "verifying published image attestations"
+REPO="${REPO}" \
+  VERSION="${VERSION}" \
+  SOURCE_REF="${source_ref}" \
+  SIGNER_WORKFLOW="${attestation_signer_workflow}" \
+  MANAGER_IMAGE="${manager_image}" \
+  MANAGER_DIGEST="${manager_digest}" \
+  CONFIG_INIT_IMAGE="${config_init_image}" \
+  CONFIG_INIT_DIGEST="${config_init_digest}" \
+  BACKUP_EXECUTOR_IMAGE="${backup_executor_image}" \
+  BACKUP_EXECUTOR_DIGEST="${backup_executor_digest}" \
+  UPGRADE_EXECUTOR_IMAGE="${upgrade_executor_image}" \
+  UPGRADE_EXECUTOR_DIGEST="${upgrade_executor_digest}" \
+  bash "${ROOT_DIR}/hack/ci/verify-image-attestations.sh"
+
+info "verifying published image tags and release signatures"
+while IFS= read -r image_entry; do
+  image_name="$(jq -r '.name' <<<"${image_entry}")"
+  image_ref="$(jq -r '.ref' <<<"${image_entry}")"
+  image_digest="$(jq -r '.digest' <<<"${image_entry}")"
+  if ! [[ "${image_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    fail "provenance image ${image_name} has invalid digest '${image_digest}'"
+  fi
+
+  published_digest="$(
+    docker buildx imagetools inspect "${image_ref}:${VERSION}" \
+      --format '{{json .Manifest.Digest}}' | tr -d '"'
+  )"
+  if [[ "${published_digest}" != "${image_digest}" ]]; then
+    fail "published image tag ${image_ref}:${VERSION} resolves to ${published_digest}, expected ${image_digest}"
+  fi
+
+  cosign verify \
+    --new-bundle-format=true \
+    --certificate-identity "${identity}" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "${image_ref}@${image_digest}" >/dev/null
+done < <(jq -c '.images[]' "${tmpdir}/provenance-index.json")
+
 chart_ref="ghcr.io/${OWNER}/charts/openbao-operator:${VERSION}"
 info "checking Helm chart publication: ${chart_ref}"
 chart_digest="$(
@@ -164,12 +263,40 @@ if [[ -z "${chart_digest}" || "${chart_digest}" == "null" ]]; then
   fail "could not resolve chart digest for ${chart_ref}"
 fi
 
+provenance_chart_digest="$(jq -r '.chart.digest' "${tmpdir}/provenance-index.json")"
+if [[ "${provenance_chart_digest}" != "${chart_digest}" ]]; then
+  fail "provenance chart digest is ${provenance_chart_digest}, published chart digest is ${chart_digest}"
+fi
+
+info "checking published Helm chart metadata"
+chart_dir="${tmpdir}/chart"
+mkdir -p "${chart_dir}"
+helm pull "oci://ghcr.io/${OWNER}/charts/openbao-operator" \
+  --version "${VERSION}" \
+  --untar \
+  --untardir "${chart_dir}" >/dev/null
+if ! cmp -s \
+  "${EXPECTED_CHART_FILE}" \
+  "${chart_dir}/openbao-operator/Chart.yaml"; then
+  fail "published Helm chart metadata differs from the reviewed ${VERSION} Chart.yaml"
+fi
+
 info "verifying Helm chart signature"
 cosign verify \
   --new-bundle-format=true \
   --certificate-identity "${identity}" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   "ghcr.io/${OWNER}/charts/openbao-operator@${chart_digest}" >/dev/null
+
+info "verifying chart and checksums attestations"
+REPO="${REPO}" \
+  OWNER="${OWNER}" \
+  VERSION="${VERSION}" \
+  SOURCE_REF="${source_ref}" \
+  CHECKSUMS_PATH="${tmpdir}/checksums.txt" \
+  CHART_DIGEST="${chart_digest}" \
+  VERIFY_CHART=true \
+  bash "${ROOT_DIR}/hack/ci/verify-release-artifact-attestations.sh"
 
 info "checking for open release-please PRs"
 open_release_prs="$(
@@ -293,9 +420,16 @@ if [[ -n "${EVIDENCE_OUT}" ]]; then
         github_release_published: true,
         github_release_prerelease_flag_verified: true,
         required_assets_present: true,
+        release_asset_checksums_verified: true,
         checksums_signature_verified: true,
+        checksums_attestation_verified: true,
+        image_tags_match_provenance: true,
+        image_signatures_verified: true,
+        image_attestations_verified: true,
         helm_chart_published: true,
+        published_chart_metadata_matches_tag: true,
         helm_chart_signature_verified: true,
+        helm_chart_attestation_verified: true,
         no_open_release_please_prs: true,
         no_stale_release_please_branches: true,
         release_please_pending_label_cleared: true


### PR DESCRIPTION
## Summary

- Serve candidate operator and init images from a pinned ephemeral registry on the Kind network. This gives kubelet a real pull path for the `operator-upgrade.local` aliases.
- Preserve the reviewed Artifact Hub change list and security flag when the release workflow packages the chart.
- Extend post-release verification to check all asset checksums, image and chart digests, signatures, attestations, and the packaged chart metadata.
- Execute trusted default-branch verification code in the `workflow_run` job. Read only the reviewed `Chart.yaml` bytes from the resolved release commit.

RC2 failed because kubelet could inspect but could not start the imported `openbao-init` alias after the Hardened fixture pulled the same content by digest. It then attempted an external HTTPS pull for the synthetic host. A real registry removes that image-store alias dependency.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No operator runtime API, CRD, RBAC, or Helm values change. The upgrade E2E now starts one pinned Docker Registry container and connects it to the test cluster network. The release workflow packages the metadata already reviewed in the release commit instead of regenerating a narrower list from the latest changelog section.

## Verification

- Exact RC2-input rehearsal on Kind and Kubernetes 1.36.1: `make test-e2e-operator-upgrade`
  - Passed Normal, Transit, and Hardened upgrades from 0.4.2.
  - Preserved data, object identities, PVCs, and migrated API fields.
  - Exercised a new tenant after the handoff.
- `bash hack/ci/test-release-automation.sh`
- `make verify-workflows`
- `make verify-helm`
- `make semgrep-ci` (0 findings)
- `devenv tasks run operator:ci-core` (passed in 486 seconds)
- `git diff --check`

## Reviewer Notes

Review the registry mirror configuration and cleanup path in `operator-upgrade-e2e.sh`. Also review the trust boundary in `post-release-verification.yml`: it does not check out or execute code from the triggering revision.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
