### PR TITLE
fix(release): isolate pending label cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -796,8 +796,6 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-      issues: write
-      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1082,6 +1080,20 @@ jobs:
             gh release edit "${version}" --title "${version}" --draft=false --latest
           fi
 
+  cleanup-release-state:
+    name: Clear Release Pending State
+    runs-on: *runner
+    needs: [prepare, promote]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
       - name: Clear release-please pending label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1093,7 +1105,7 @@ jobs:
   deploy-docs:
     name: Deploy Docs Site
     runs-on: *runner
-    needs: [prepare, promote]
+    needs: [prepare, promote, cleanup-release-state]
     concurrency:
       group: gh-pages
       cancel-in-progress: false

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -132,6 +132,12 @@ assert_contains "${RELEASE_PLEASE_WORKFLOW}" 'release-as: ${{ steps.release-as.o
 assert_contains "${RELEASE_WORKFLOW}" "Setup Helm 3 compatibility client"
 assert_contains "${RELEASE_WORKFLOW}" 'HELM: ${{ steps.helm4.outputs.helm-path }}'
 assert_contains "${RELEASE_WORKFLOW}" 'HELM_INSTALL: ${{ steps.helm3.outputs.helm-path }}'
+assert_contains "${RELEASE_WORKFLOW}" "  cleanup-release-state:"
+assert_contains "${RELEASE_WORKFLOW}" "    name: Clear Release Pending State"
+assert_contains "${RELEASE_WORKFLOW}" "    needs: [prepare, promote]"
+assert_contains "${RELEASE_WORKFLOW}" "      pull-requests: write"
+assert_contains "${RELEASE_WORKFLOW}" "bash hack/ci/clear-release-please-pending-label.sh"
+assert_contains "${RELEASE_WORKFLOW}" "    needs: [prepare, promote, cleanup-release-state]"
 preserve_change_metadata_count="$(grep -Fc 'PRESERVE_CHANGE_METADATA=true' "${RELEASE_WORKFLOW}")"
 [[ "${preserve_change_metadata_count}" == "2" ]] || {
   fail "release packaging must preserve reviewed chart change metadata in both builds"


### PR DESCRIPTION
## Summary

Move release-please pending-label cleanup out of the registry promotion job. The cleanup job has the narrow PR and issue write permissions that the operation requires. Docs wait for cleanup to pass.

The `0.5.0-rc.3` release published successfully, but cleanup failed with `403 Resource not accessible by integration`. Retrying the combined job replayed keyless signing and Helm publication. The immutable publisher rejected the new byte-different signature bundle, and Helm generated a new chart manifest timestamp. Separating cleanup makes a failed-jobs retry rerun only cleanup and then docs.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, or operator runtime behavior changes. The release workflow adds one job and removes PR and issue write permissions from the registry promotion job.

## Verification

- `bash hack/ci/test-release-automation.sh`
- `make verify-workflows`
- repository pre-push checks
- `git diff --check`

## Reviewer Notes

Review the job dependency: `deploy-docs` now waits for `cleanup-release-state`. A failed cleanup retry cannot rerun registry publication or signing.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.