### PR TITLE
docs: validate onboarding and production examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ For full details, see the [Compatibility Matrix](https://dc-tec.github.io/openba
 
 ## Quick Start
 
-Once the operator is running, the next move depends on the tenancy mode you chose:
+Install and verify the operator before continuing. If it is not running, complete [Installation](#installation) first.
+The next move depends on the tenancy mode you chose:
 
 - **Multi-tenant (default)**: Create the target namespace, onboard it through `OpenBaoTenant`, then apply the first `OpenBaoCluster`.
 - **Single-tenant**: Skip `OpenBaoTenant` and create the first `OpenBaoCluster` directly in the controller's watched namespace.
@@ -117,13 +118,19 @@ spec:
   targetNamespace: openbao-demo
 EOF
 
-kubectl -n openbao-demo get openbaotenant openbao-demo -w
+kubectl -n openbao-demo wait \
+  --for=condition=Provisioned \
+  openbaotenant/openbao-demo \
+  --timeout=2m
 
 kubectl apply -f cluster.yaml
 
-# Watch status and pods
-kubectl -n openbao-demo get openbaoclusters my-cluster -w
-kubectl -n openbao-demo get pods -l openbao.org/cluster=my-cluster -w
+# Wait for the cluster, then inspect its Pods.
+kubectl -n openbao-demo wait \
+  --for=condition=Available \
+  openbaocluster/my-cluster \
+  --timeout=10m
+kubectl -n openbao-demo get pods -l openbao.org/cluster=my-cluster
 ```
 
 If `spec.selfInit.enabled` is `false` (default), the operator stores a root token in `Secret/openbao-demo/my-cluster-root-token` (key: `token`).

--- a/config/samples/basics/openbao_v1alpha1_openbaocluster_selfinit.yaml
+++ b/config/samples/basics/openbao_v1alpha1_openbaocluster_selfinit.yaml
@@ -37,23 +37,31 @@ spec:
     oidc:
       enabled: true
     requests:
-      # Enable stdout audit logging (useful for debugging)
-      - name: enable-stdout-audit
+      # Create a narrow policy for the sample client.
+      - name: create-sample-read-policy
         operation: update
-        path: sys/audit/stdout
-        auditDevice:
-          type: file
-          fileOptions:
-            filePath: stdout
-      # Enable Kubernetes authentication
-      - name: enable-kubernetes-auth
+        path: sys/policies/acl/sample-read
+        policy:
+          policy: |
+            path "sys/health" {
+              capabilities = ["read"]
+            }
+      # Bind a dedicated ServiceAccount to the JWT mount created by selfInit.oidc.
+      # Change bound_subject if you apply this sample in another namespace.
+      - name: bind-sample-client-role
         operation: update
-        path: sys/auth/kubernetes
-        authMethod:
-          type: kubernetes
-      # Configure Kubernetes auth to use in-cluster service account
-      - name: configure-kubernetes-auth
-        operation: update
-        path: auth/kubernetes/config
+        path: auth/jwt-operator/role/openbao-sample-client
         data:
-          kubernetes_host: "https://kubernetes.default.svc"
+          role_type: jwt
+          bound_audiences:
+            - openbao-internal
+          bound_subject: system:serviceaccount:default:openbao-sample-client
+          user_claim: sub
+          token_policies:
+            - sample-read
+          token_no_default_policy: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-sample-client

--- a/config/samples/integrations/openbao_v1alpha1_openbaocluster_ingress.yaml
+++ b/config/samples/integrations/openbao_v1alpha1_openbaocluster_ingress.yaml
@@ -33,6 +33,12 @@ spec:
     annotations:
       # Use the websecure entrypoint (HTTPS) for TLS termination at Traefik
       traefik.ingress.kubernetes.io/router.entrypoints: websecure
+  network:
+    trustedIngressPeers:
+      # Change this selector when Traefik runs in another namespace.
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: traefik
   deletionPolicy: Retain
   # Structured configuration
   configuration:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_acme.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_acme.yaml
@@ -7,6 +7,7 @@
 # - No TLS Secrets created or mounted (certificates managed entirely by OpenBao)
 # - No TLS reload wrapper needed (ShareProcessNamespace disabled)
 # - Automatic certificate acquisition and rotation via ACME protocol
+# - HA replicas share ACME state through a ReadWriteMany cache PVC
 # - Zero trust: operator never possesses private keys
 # - Compatible with Hardened security profile
 #
@@ -39,6 +40,10 @@ spec:
       # Domain names for which to obtain the certificate (multi-SAN).
       domains:
         - "openbao.example.com"
+      # Select a StorageClass that supports ReadWriteMany when the default does not.
+      sharedCache:
+        mode: ManagedPVC
+        size: "1Gi"
       # Optional: Email address for CA notifications about certificate expiration
       email: "admin@example.com"
       # Note: For internal networks, you may need to use DNS challenges.
@@ -47,12 +52,13 @@ spec:
     size: "10Gi"
   deletionPolicy: Retain
   # Hardened profile note: external dependencies (ACME directory, KMS, object storage, etc.)
-  # require explicit egress rules. Replace 0.0.0.0/0 with CIDR(s) for your endpoints.
+  # require explicit egress rules. Replace this documentation-only CIDR with the ranges
+  # for your endpoints, or use in-cluster selectors.
   network:
     egressRules:
       - to:
           - ipBlock:
-              cidr: 0.0.0.0/0
+              cidr: 203.0.113.0/24
         ports:
           - protocol: TCP
             port: 443
@@ -87,7 +93,6 @@ spec:
     # Optional: If not using IRSA (IAM Roles for Service Accounts)
     # credentialsSecretRef:
     #   name: aws-kms-credentials
-    #   namespace: openbaocluster-acme
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
@@ -114,6 +119,30 @@ spec:
             path "*" {
               capabilities = ["create", "read", "update", "delete", "list", "sudo"]
             }
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: bind-human-jwt-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - admin
   # Image verification for supply chain security
   # Custom Hardened trust roots require `useimagetrustroots` on this OpenBaoCluster.
   imageVerification:
@@ -138,7 +167,6 @@ spec:
       pathPrefix: "clusters/openbaocluster-acme"
       credentialsSecretRef:
         name: s3-backup-credentials
-        namespace: openbaocluster-acme
     jwtAuthRole: backup
     retention:
       maxCount: 7

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_awskms.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_awskms.yaml
@@ -52,9 +52,41 @@ spec:
     # Optional: If not using IRSA (IAM Roles for Service Accounts)
     # credentialsSecretRef:
     #   name: aws-kms-credentials
-    #   namespace: openbaocluster-awskms
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create AWS KMS credentials Secret (only if not using IRSA)
 # apiVersion: v1

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_azure.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_azure.yaml
@@ -62,10 +62,42 @@ spec:
     # Optional: If not using Managed Service Identity (MSI)
     # credentialsSecretRef:
     #   name: azure-keyvault-credentials
-    #   namespace: openbaocluster-azure
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create Azure Key Vault credentials Secret (only if not using MSI)
 # apiVersion: v1

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_external_tls.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_external_tls.yaml
@@ -46,10 +46,42 @@ spec:
     # Recommended: provide credentials via a Secret, workload identity, or another platform mechanism.
     # credentialsSecretRef:
     #   name: transit-credentials
-    #   namespace: default
   # Hardened profile requires self-init (no root token Secret).
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
   storage:
     size: "10Gi"
   deletionPolicy: Retain

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_gcp.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_gcp.yaml
@@ -55,10 +55,42 @@ spec:
     # Optional: If not using Workload Identity (GKE Workload Identity)
     # credentialsSecretRef:
     #   name: gcp-kms-credentials
-    #   namespace: openbaocluster-gcp
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create GCP KMS credentials Secret (only if not using Workload Identity)
 # The Secret should contain the GCP service account JSON key file

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_hardened.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_hardened.yaml
@@ -1,7 +1,8 @@
 # OpenBaoCluster with Hardened Security Profile
 #
-# This example demonstrates a production-ready OpenBao cluster using the Hardened
-# security profile. The Hardened profile enforces strict security requirements:
+# This example demonstrates the fields enforced by the Hardened security profile.
+# It is a starting point, not evidence that the external dependencies or access
+# paths are production-ready. The Hardened profile enforces strict requirements:
 # - External TLS management (cert-manager or CSI)
 # - External KMS for auto-unseal (no static keys in Kubernetes Secrets)
 # - Self-initialization enabled (no root token stored)
@@ -41,12 +42,13 @@ spec:
     size: "10Gi"
   deletionPolicy: Retain
   # Hardened profile note: external dependencies (KMS, object storage, etc.) require explicit
-  # egress rules. Replace 0.0.0.0/0 with CIDR(s) for your endpoints, or use in-cluster selectors.
+  # egress rules. Replace this documentation-only CIDR with the ranges for your endpoints,
+  # or use in-cluster selectors.
   network:
     egressRules:
       - to:
           - ipBlock:
-              cidr: 0.0.0.0/0
+              cidr: 203.0.113.0/24
         ports:
           - protocol: TCP
             port: 443
@@ -74,7 +76,6 @@ spec:
     # Optional: If not using IRSA (IAM Roles for Service Accounts)
     # credentialsSecretRef:
     #   name: aws-kms-credentials
-    #   namespace: openbaocluster-hardened
   # Self-initialization (required for Hardened profile)
   # Root token is automatically revoked after initialization - no root token Secret is created
   selfInit:
@@ -103,6 +104,30 @@ spec:
             path "*" {
               capabilities = ["create", "read", "update", "delete", "list", "sudo"]
             }
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: bind-human-jwt-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - admin
   # Image verification for supply chain security
   # Custom Hardened trust roots require `useimagetrustroots` on this OpenBaoCluster.
   imageVerification:
@@ -128,7 +153,6 @@ spec:
       pathPrefix: "clusters/openbaocluster-hardened"
       credentialsSecretRef:
         name: s3-backup-credentials
-        namespace: openbaocluster-hardened
     # JWT Auth (automatically rotated tokens, better security)
     jwtAuthRole: backup
     retention:

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_kmip.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_kmip.yaml
@@ -36,25 +36,56 @@ spec:
   unseal:
     type: kmip
     kmip:
-      # Address of the KMIP server
-      address: "kmip.example.com:5696"
+      # Endpoint and wrapping-key identifier in the KMIP server
+      endpoint: "kmip.example.com:5696"
+      kmsKeyID: "1"
       # Path to client certificate for KMIP communication
-      certificate: "/etc/kmip/cert.pem"
+      clientCert: "/etc/bao/seal-creds/client.crt"
       # Path to private key for KMIP communication
-      key: "/etc/kmip/key.pem"
+      clientKey: "/etc/bao/seal-creds/client.key"
       # Path to CA certificate for KMIP communication
-      caCert: "/etc/kmip/ca.pem"
+      caCert: "/etc/bao/seal-creds/ca.crt"
       # Optional: SNI server name for TLS
-      # tlsServerName: "kmip.example.com"
-      # Optional: Skip TLS verification (NOT RECOMMENDED for production)
-      # tlsSkipVerify: false
+      serverName: "kmip.example.com"
     # Optional: Reference to Secret containing KMIP certificates
     # credentialsSecretRef:
     #   name: kmip-certificates
-    #   namespace: openbaocluster-kmip
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create KMIP certificates Secret
 # The Secret should contain the client certificate, key, and CA certificate
@@ -66,11 +97,11 @@ spec:
 #   namespace: openbaocluster-kmip
 # type: Opaque
 # stringData:
-#   cert.pem: |
+#   client.crt: |
 #     -----BEGIN CERTIFICATE-----
 #     ...
 #     -----END CERTIFICATE-----
-#   key.pem: |
+#   client.key: |
 #     -----BEGIN PRIVATE KEY-----
 #     ...
 #     -----END PRIVATE KEY-----
@@ -78,4 +109,3 @@ spec:
 #     -----BEGIN CERTIFICATE-----
 #     ...
 #     -----END CERTIFICATE-----
-

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_oci.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_oci.yaml
@@ -55,6 +55,39 @@ spec:
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create OCI KMS credentials Secret (only if using authTypeAPIKey: true)
 # apiVersion: v1

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_pkcs11.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_pkcs11.yaml
@@ -40,27 +40,55 @@ spec:
     pkcs11:
       # Path to the PKCS#11 library provided by the HSM vendor
       lib: "/usr/lib/libpkcs11.so"
-      # Optional: Slot number where the HSM token is located
-      # slot: "0"
+      # Select one HSM slot by number or tokenLabel.
+      slot: "0"
       # Optional: PIN for accessing the HSM token (STRONGLY recommended to use CredentialsSecretRef)
       # pin: "your-hsm-pin"
       # Label for the encryption key used by OpenBao
       keyLabel: "vault-key"
-      # Optional: Label for the HMAC key used by OpenBao
-      # hmacKeyLabel: "vault-hmac-key"
-      # Optional: Generate key if it doesn't exist (default: false)
-      # generateKey: false
-      # Optional: Perform RSA encryption locally (for HSMs that don't support encryption for RSA keys)
-      # rsaEncryptLocal: false
+      # Optional: Disable the software encryption fallback.
+      # disableSoftwareEncryption: true
       # Optional: Hash algorithm for RSA with OAEP padding (sha1, sha224, sha256, sha384, sha512)
       # rsaOAEPHash: "sha256"
     # Optional: Reference to Secret containing HSM PIN
     # credentialsSecretRef:
     #   name: pkcs11-pin
-    #   namespace: openbaocluster-pkcs11
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create PKCS#11 PIN Secret
 # apiVersion: v1
@@ -71,4 +99,3 @@ spec:
 # type: Opaque
 # stringData:
 #   VAULT_HSM_PIN: "your-hsm-pin"
-

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_structured_config.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_structured_config.yaml
@@ -38,8 +38,8 @@ spec:
       pidFile: "/var/run/openbao/openbao.pid"
     # Listener configuration
     listener:
-      # Proxy protocol behavior (use_proxy_protocol, allow_authorized, deny_unauthorized)
-      proxyProtocolBehavior: "use_proxy_protocol"
+      # Proxy protocol behavior (use_always, allow_any, deny_unauthorized)
+      proxyProtocolBehavior: "use_always"
       # TLS disable (typically managed by operator based on spec.tls.enabled)
       # tlsDisable: false
     # Raft storage configuration

--- a/config/samples/production/openbao_v1alpha1_openbaocluster_transit.yaml
+++ b/config/samples/production/openbao_v1alpha1_openbaocluster_transit.yaml
@@ -62,10 +62,42 @@ spec:
     # The token should be an orphan token with encrypt/decrypt permissions on the transit key
     credentialsSecretRef:
       name: transit-seal-token
-      namespace: openbaocluster-transit
   # Self-initialization (required for Hardened profile)
   selfInit:
     enabled: true
+    requests:
+      # Replace the example issuer and audience with values tested against your identity provider.
+      - name: enable-human-jwt-auth
+        operation: update
+        path: sys/auth/jwt
+        authMethod:
+          type: jwt
+      - name: configure-human-jwt-auth
+        operation: update
+        path: auth/jwt/config
+        data:
+          jwks_url: "https://idp.example.com/.well-known/jwks.json"
+          bound_issuer: "https://idp.example.com/"
+      - name: create-platform-operator-policy
+        operation: update
+        path: sys/policies/acl/platform-operator
+        policy:
+          policy: |
+            path "*" {
+              capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+            }
+      - name: bind-platform-operator-role
+        operation: update
+        path: auth/jwt/role/platform-operator
+        data:
+          role_type: jwt
+          bound_audiences:
+            - openbao
+          bound_claims:
+            groups: platform-operators
+          user_claim: sub
+          token_policies:
+            - platform-operator
 ---
 # Example: Create Transit seal token Secret
 # The token must have the following permissions on the transit key:

--- a/test/integration/samples_contract_test.go
+++ b/test/integration/samples_contract_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSamplesPassCurrentCRDAndAdmissionContracts(t *testing.T) {
+	policyProbeNamespace := newTestNamespace(t)
+	waitForOpenBaoClusterAdmissionPolicies(t, policyProbeNamespace)
+
+	samplesRoot := filepath.Join("..", "..", "config", "samples")
+	var samplePaths []string
+	if err := filepath.WalkDir(samplesRoot, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".yaml") {
+			samplePaths = append(samplePaths, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk samples: %v", err)
+	}
+	sort.Strings(samplePaths)
+
+	validated := 0
+	for _, samplePath := range samplePaths {
+		yamlBytes, err := os.ReadFile(samplePath)
+		if err != nil {
+			t.Fatalf("read sample %s: %v", samplePath, err)
+		}
+
+		objects := parseYAMLToUnstructured(t, yamlBytes, func(obj *unstructured.Unstructured) bool {
+			if obj.GroupVersionKind().Group != "openbao.org" {
+				return false
+			}
+			switch obj.GetKind() {
+			case "OpenBaoCluster", "OpenBaoRestore", "OpenBaoTenant":
+				return true
+			default:
+				return false
+			}
+		})
+		if len(objects) == 0 {
+			continue
+		}
+
+		relativePath, err := filepath.Rel(samplesRoot, samplePath)
+		if err != nil {
+			t.Fatalf("resolve relative sample path %s: %v", samplePath, err)
+		}
+		t.Run(relativePath, func(t *testing.T) {
+			namespace := newTestNamespace(t)
+			for _, object := range objects {
+				candidate := object.DeepCopy()
+				candidate.SetNamespace(namespace)
+				if candidate.GetKind() == "OpenBaoTenant" {
+					candidate.SetName("sample-tenant")
+					if err := unstructured.SetNestedField(
+						candidate.Object,
+						namespace,
+						"spec",
+						"targetNamespace",
+					); err != nil {
+						t.Fatalf("set sample tenant target namespace: %v", err)
+					}
+				}
+				if err := k8sClient.Create(ctx, candidate); err != nil {
+					t.Fatalf(
+						"sample %s does not satisfy the current CRD and admission policies: %v",
+						relativePath,
+						err,
+					)
+				}
+			}
+		})
+		validated += len(objects)
+	}
+
+	if validated == 0 {
+		t.Fatal("no OpenBao custom-resource samples were validated")
+	}
+}

--- a/website/content-versions/0.4.x/docs/get-started/create-cluster.md
+++ b/website/content-versions/0.4.x/docs/get-started/create-cluster.md
@@ -26,6 +26,12 @@ Create a disposable Development cluster for evaluation. Do not create a producti
   production.
 - Decide whether the cluster is disposable or intended for production before the first reconcile.
 
+{{< command label="verify" title="Verify evaluation storage" >}}
+kubectl get storageclass
+{{< /command >}}
+
+For evaluation, the output must identify one default StorageClass. Stop and configure storage when no default exists.
+
 ## Choose the profile
 
 | Profile | Intended use | Security behavior |
@@ -67,12 +73,11 @@ Create a disposable Development cluster for evaluation. Do not create a producti
    kubectl apply -f cluster.yaml
    {{< /command >}}
 
-3. Watch the custom resource and Pods converge.
+3. In a separate terminal, optionally watch the custom resource converge. Stop the watch with `Ctrl-C` after the
+   availability condition becomes true.
 
    {{< command label="inspect" title="Watch cluster creation" >}}
    kubectl -n openbao-demo get openbaocluster dev-cluster -w
-   kubectl -n openbao-demo get pods \
-     -l openbao.org/cluster=dev-cluster -w
    {{< /command >}}
 
 4. Wait for the availability condition.
@@ -99,6 +104,28 @@ Create a disposable Development cluster for evaluation. Do not create a producti
    - `Available=True` and `TLSReady=True`;
    - every voter Pod is Ready and its PVC is Bound;
    - the TLS mode and storage match the declared configuration.
+
+6. Prove that the evaluation credential can authenticate to OpenBao from inside the cluster.
+
+   {{< command label="verify" title="Run an authenticated OpenBao check" >}}
+   (
+     kubectl -n openbao-demo get secret dev-cluster-root-token \
+       -o jsonpath='{.data.token}' | base64 -d
+     printf '\n'
+   ) | kubectl -n openbao-demo exec -i -c openbao dev-cluster-0 -- \
+     sh -ec '
+       IFS= read -r BAO_TOKEN
+       export BAO_ADDR=https://127.0.0.1:8200
+       export BAO_CACERT=/etc/bao/tls/ca.crt
+       export BAO_TLS_SERVER_NAME=openbao-cluster-dev-cluster.local
+       export BAO_TOKEN
+       bao token capabilities sys/health
+     '
+   {{< /command >}}
+
+   The command must print `root`. This check proves authenticated API access through the Pod-local endpoint. It does
+   not place the token in the exec command or expose OpenBao outside the cluster. Use
+   [Expose OpenBao](../../configure/expose/) when the evaluation requires a client entry path.
 
 {{< callout type="warning" title="Development stores sensitive material in Kubernetes Secrets" >}}
 The default static auto-unseal key and root token are stored in Kubernetes Secrets. Protect etcd encryption, RBAC,

--- a/website/content-versions/next/docs/get-started/create-cluster.md
+++ b/website/content-versions/next/docs/get-started/create-cluster.md
@@ -26,6 +26,12 @@ Create a disposable Development cluster for evaluation. Do not create a producti
   production.
 - Decide whether the cluster is disposable or intended for production before the first reconcile.
 
+{{< command label="verify" title="Verify evaluation storage" >}}
+kubectl get storageclass
+{{< /command >}}
+
+For evaluation, the output must identify one default StorageClass. Stop and configure storage when no default exists.
+
 ## Choose the profile
 
 | Profile | Intended use | Security behavior |
@@ -46,7 +52,7 @@ Create a disposable Development cluster for evaluation. Do not create a producti
      name: dev-cluster
      namespace: openbao-demo
    spec:
-    version: "2.6.2"
+     version: "2.6.2"
      replicas: 1
      profile: Development
      tls:
@@ -67,12 +73,11 @@ Create a disposable Development cluster for evaluation. Do not create a producti
    kubectl apply -f cluster.yaml
    {{< /command >}}
 
-3. Watch the custom resource and Pods converge.
+3. In a separate terminal, optionally watch the custom resource converge. Stop the watch with `Ctrl-C` after the
+   availability condition becomes true.
 
    {{< command label="inspect" title="Watch cluster creation" >}}
    kubectl -n openbao-demo get openbaocluster dev-cluster -w
-   kubectl -n openbao-demo get pods \
-     -l openbao.org/cluster=dev-cluster -w
    {{< /command >}}
 
 4. Wait for the availability condition.
@@ -99,6 +104,28 @@ Create a disposable Development cluster for evaluation. Do not create a producti
    - `Available=True` and `TLSReady=True`;
    - every voter Pod is Ready and its PVC is Bound;
    - the TLS mode and storage match the declared configuration.
+
+6. Prove that the evaluation credential can authenticate to OpenBao from inside the cluster.
+
+   {{< command label="verify" title="Run an authenticated OpenBao check" >}}
+   (
+     kubectl -n openbao-demo get secret dev-cluster-root-token \
+       -o jsonpath='{.data.token}' | base64 -d
+     printf '\n'
+   ) | kubectl -n openbao-demo exec -i -c openbao dev-cluster-0 -- \
+     sh -ec '
+       IFS= read -r BAO_TOKEN
+       export BAO_ADDR=https://127.0.0.1:8200
+       export BAO_CACERT=/etc/bao/tls/ca.crt
+       export BAO_TLS_SERVER_NAME=openbao-cluster-dev-cluster.local
+       export BAO_TOKEN
+       bao token capabilities sys/health
+     '
+   {{< /command >}}
+
+   The command must print `root`. This check proves authenticated API access through the Pod-local endpoint. It does
+   not place the token in the exec command or expose OpenBao outside the cluster. Use
+   [Expose OpenBao](../../configure/expose/) when the evaluation requires a client entry path.
 
 {{< callout type="warning" title="Development stores sensitive material in Kubernetes Secrets" >}}
 The default static auto-unseal key and root token are stored in Kubernetes Secrets. Protect etcd encryption, RBAC,

--- a/website/content-versions/next/docs/get-started/onboard-namespace.md
+++ b/website/content-versions/next/docs/get-started/onboard-namespace.md
@@ -58,14 +58,19 @@ The target namespace must already exist. `spec.targetNamespace` is required and 
 4. Verify that provisioning completed.
 
    {{< command label="verify" title="Verify the tenant handoff" >}}
+   kubectl -n openbao-demo wait \
+     --for=condition=Provisioned \
+     openbaotenant/openbao-demo \
+     --timeout=2m
    kubectl -n openbao-demo get openbaotenant openbao-demo \
      -o jsonpath='{.status.provisioned}{"\t"}{.status.conditions[?(@.type=="Provisioned")].status}{"\n"}'
    kubectl -n openbao-demo get rolebinding \
      openbao-operator-tenant-rolebinding
    {{< /command >}}
 
-   The first command must print `true` and `True`. The condition carries the current generation, reason, and message;
-   the RoleBinding is the concrete handoff that allows cluster reconciliation to continue.
+   The wait command must report `condition met`. The status command must print `true` and `True`. The condition carries
+   the current generation, reason, and message; the RoleBinding is the concrete handoff that allows cluster
+   reconciliation to continue.
 
 ## Onboard centrally
 

--- a/website/content-versions/next/docs/get-started/single-tenant.md
+++ b/website/content-versions/next/docs/get-started/single-tenant.md
@@ -31,25 +31,46 @@ in the target namespace, so the platform must own that RoleBinding explicitly.
 
 ## Install with Helm
 
-Use the chart from the same source checkout as the Next behavior you are evaluating:
+Use the chart from the same source checkout as the Next behavior you are evaluating.
 
-{{< command label="apply" title="Install a single-tenant operator" >}}
-helm upgrade --install openbao-operator \
-  charts/openbao-operator \
-  --namespace openbao-operator-system \
-  --create-namespace \
-  --set image.tag=edge \
-  --set operatorVersion=edge \
-  --set tenancy.mode=single \
-  --set tenancy.targetNamespace=openbao
-{{< /command >}}
+1. Create the target namespace through the platform's normal workflow. The chart must create a RoleBinding in this
+   namespace during installation.
 
-Create the target namespace through the platform's normal workflow before applying the first `OpenBaoCluster`. When
-`tenancy.targetNamespace` is omitted, the chart watches its release namespace.
+   {{< command label="apply" title="Create the target namespace" >}}
+   kubectl create namespace openbao
+   {{< /command >}}
 
-Verify that the rendered Deployment contains `WATCH_NAMESPACE=openbao`, the target RoleBinding is in `openbao`, and no
-Provisioner resources exist. Custom release names or `fullnameOverride` values change the controller identity; keep
-manually managed JWT roles aligned with the rendered ServiceAccount.
+2. Install the operator.
+
+   {{< command label="apply" title="Install a single-tenant operator" >}}
+   helm upgrade --install openbao-operator \
+     charts/openbao-operator \
+     --namespace openbao-operator-system \
+     --create-namespace \
+     --set image.tag=edge \
+     --set operatorVersion=edge \
+     --set tenancy.mode=single \
+     --set tenancy.targetNamespace=openbao
+   {{< /command >}}
+
+When `tenancy.targetNamespace` is omitted, the chart watches its release namespace and `--create-namespace` creates
+that namespace.
+
+3. Verify that the rendered Deployment contains `WATCH_NAMESPACE=openbao`, the target RoleBinding is in `openbao`, and
+   no Provisioner resources exist. Custom release names or `fullnameOverride` values change the controller identity;
+   keep manually managed JWT roles aligned with the rendered ServiceAccount.
+
+   {{< command label="verify" title="Verify single-tenant scope" >}}
+   kubectl -n openbao-operator-system rollout status \
+     deployment/openbao-operator-controller --timeout=2m
+   kubectl -n openbao-operator-system get deployment \
+     openbao-operator-controller \
+     -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="WATCH_NAMESPACE")].value}{"\n"}'
+   kubectl -n openbao get rolebinding openbao-operator-single-tenant
+   kubectl -n openbao-operator-system get deployment
+   {{< /command >}}
+
+   The JSONPath command must print `openbao`. The Deployment list must contain the controller and no Provisioner.
 
 ## Install with Kustomize
 

--- a/website/content/docs/get-started/create-cluster.md
+++ b/website/content/docs/get-started/create-cluster.md
@@ -26,6 +26,12 @@ Create a disposable Development cluster for evaluation. Do not create a producti
   production.
 - Decide whether the cluster is disposable or intended for production before the first reconcile.
 
+{{< command label="verify" title="Verify evaluation storage" >}}
+kubectl get storageclass
+{{< /command >}}
+
+For evaluation, the output must identify one default StorageClass. Stop and configure storage when no default exists.
+
 ## Choose the profile
 
 | Profile | Intended use | Security behavior |
@@ -46,7 +52,7 @@ Create a disposable Development cluster for evaluation. Do not create a producti
      name: dev-cluster
      namespace: openbao-demo
    spec:
-    version: "2.6.2"
+     version: "2.6.2"
      replicas: 1
      profile: Development
      tls:
@@ -67,12 +73,11 @@ Create a disposable Development cluster for evaluation. Do not create a producti
    kubectl apply -f cluster.yaml
    {{< /command >}}
 
-3. Watch the custom resource and Pods converge.
+3. In a separate terminal, optionally watch the custom resource converge. Stop the watch with `Ctrl-C` after the
+   availability condition becomes true.
 
    {{< command label="inspect" title="Watch cluster creation" >}}
    kubectl -n openbao-demo get openbaocluster dev-cluster -w
-   kubectl -n openbao-demo get pods \
-     -l openbao.org/cluster=dev-cluster -w
    {{< /command >}}
 
 4. Wait for the availability condition.
@@ -99,6 +104,28 @@ Create a disposable Development cluster for evaluation. Do not create a producti
    - `Available=True` and `TLSReady=True`;
    - every voter Pod is Ready and its PVC is Bound;
    - the TLS mode and storage match the declared configuration.
+
+6. Prove that the evaluation credential can authenticate to OpenBao from inside the cluster.
+
+   {{< command label="verify" title="Run an authenticated OpenBao check" >}}
+   (
+     kubectl -n openbao-demo get secret dev-cluster-root-token \
+       -o jsonpath='{.data.token}' | base64 -d
+     printf '\n'
+   ) | kubectl -n openbao-demo exec -i -c openbao dev-cluster-0 -- \
+     sh -ec '
+       IFS= read -r BAO_TOKEN
+       export BAO_ADDR=https://127.0.0.1:8200
+       export BAO_CACERT=/etc/bao/tls/ca.crt
+       export BAO_TLS_SERVER_NAME=openbao-cluster-dev-cluster.local
+       export BAO_TOKEN
+       bao token capabilities sys/health
+     '
+   {{< /command >}}
+
+   The command must print `root`. This check proves authenticated API access through the Pod-local endpoint. It does
+   not place the token in the exec command or expose OpenBao outside the cluster. Use
+   [Expose OpenBao](../../configure/expose/) when the evaluation requires a client entry path.
 
 {{< callout type="warning" title="Development stores sensitive material in Kubernetes Secrets" >}}
 The default static auto-unseal key and root token are stored in Kubernetes Secrets. Protect etcd encryption, RBAC,

--- a/website/content/docs/get-started/onboard-namespace.md
+++ b/website/content/docs/get-started/onboard-namespace.md
@@ -58,14 +58,19 @@ The target namespace must already exist. `spec.targetNamespace` is required and 
 4. Verify that provisioning completed.
 
    {{< command label="verify" title="Verify the tenant handoff" >}}
+   kubectl -n openbao-demo wait \
+     --for=condition=Provisioned \
+     openbaotenant/openbao-demo \
+     --timeout=2m
    kubectl -n openbao-demo get openbaotenant openbao-demo \
      -o jsonpath='{.status.provisioned}{"\t"}{.status.conditions[?(@.type=="Provisioned")].status}{"\n"}'
    kubectl -n openbao-demo get rolebinding \
      openbao-operator-tenant-rolebinding
    {{< /command >}}
 
-   The first command must print `true` and `True`. The condition carries the current generation, reason, and message;
-   the RoleBinding is the concrete handoff that allows cluster reconciliation to continue.
+   The wait command must report `condition met`. The status command must print `true` and `True`. The condition carries
+   the current generation, reason, and message; the RoleBinding is the concrete handoff that allows cluster
+   reconciliation to continue.
 
 ## Onboard centrally
 

--- a/website/content/docs/get-started/single-tenant.md
+++ b/website/content/docs/get-started/single-tenant.md
@@ -31,24 +31,45 @@ in the target namespace, so the platform must own that RoleBinding explicitly.
 
 ## Install with Helm
 
-Use Helm for a released 0.5.x installation:
+Use Helm for a released 0.5.x installation.
 
-{{< command label="apply" title="Install a single-tenant operator" >}}
-helm upgrade --install openbao-operator \
-  oci://ghcr.io/dc-tec/charts/openbao-operator \
-  --version 0.5.0 \
-  --namespace openbao-operator-system \
-  --create-namespace \
-  --set tenancy.mode=single \
-  --set tenancy.targetNamespace=openbao
-{{< /command >}}
+1. Create the target namespace through the platform's normal workflow. The chart must create a RoleBinding in this
+   namespace during installation.
 
-Create the target namespace through the platform's normal workflow before applying the first `OpenBaoCluster`. When
-`tenancy.targetNamespace` is omitted, the chart watches its release namespace.
+   {{< command label="apply" title="Create the target namespace" >}}
+   kubectl create namespace openbao
+   {{< /command >}}
 
-Verify that the rendered Deployment contains `WATCH_NAMESPACE=openbao`, the target RoleBinding is in `openbao`, and no
-Provisioner resources exist. Custom release names or `fullnameOverride` values change the controller identity; keep
-manually managed JWT roles aligned with the rendered ServiceAccount.
+2. Install the operator.
+
+   {{< command label="apply" title="Install a single-tenant operator" >}}
+   helm upgrade --install openbao-operator \
+     oci://ghcr.io/dc-tec/charts/openbao-operator \
+     --version 0.5.0 \
+     --namespace openbao-operator-system \
+     --create-namespace \
+     --set tenancy.mode=single \
+     --set tenancy.targetNamespace=openbao
+   {{< /command >}}
+
+When `tenancy.targetNamespace` is omitted, the chart watches its release namespace and `--create-namespace` creates
+that namespace.
+
+3. Verify that the rendered Deployment contains `WATCH_NAMESPACE=openbao`, the target RoleBinding is in `openbao`, and
+   no Provisioner resources exist. Custom release names or `fullnameOverride` values change the controller identity;
+   keep manually managed JWT roles aligned with the rendered ServiceAccount.
+
+   {{< command label="verify" title="Verify single-tenant scope" >}}
+   kubectl -n openbao-operator-system rollout status \
+     deployment/openbao-operator-controller --timeout=2m
+   kubectl -n openbao-operator-system get deployment \
+     openbao-operator-controller \
+     -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="WATCH_NAMESPACE")].value}{"\n"}'
+   kubectl -n openbao get rolebinding openbao-operator-single-tenant
+   kubectl -n openbao-operator-system get deployment
+   {{< /command >}}
+
+   The JSONPath command must print `openbao`. The Deployment list must contain the controller and no Provisioner.
 
 ## Install with Kustomize
 

--- a/website/layouts/shortcodes/command.html
+++ b/website/layouts/shortcodes/command.html
@@ -1,3 +1,22 @@
+{{- $content := .Inner -}}
+{{- $indent := "" -}}
+{{- $foundContent := false -}}
+{{- range split $content "\n" -}}
+  {{- if and (not $foundContent) (ne (strings.TrimSpace .) "") -}}
+    {{- $foundContent = true -}}
+    {{- $matches := findRE `^[ \t]*` . 1 -}}
+    {{- if gt (len $matches) 0 -}}
+      {{- $indent = index $matches 0 -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if ne $indent "" -}}
+  {{- $content = replaceRE (printf `(?m)^%s` $indent) "" $content -}}
+{{- end -}}
+{{- $content = strings.TrimSpace $content -}}
+{{- if or (hasPrefix $content "apiVersion:") (hasPrefix $content "spec:") (hasPrefix $content "image:") (hasPrefix $content "metrics:") (hasPrefix $content "- name:") -}}
+  {{- $validatedManifest := transform.Unmarshal $content -}}
+{{- end -}}
 <div class="command-block">
   <div class="command-head">
     <div>
@@ -6,5 +25,5 @@
     </div>
     <button type="button" data-copy-button>Copy</button>
   </div>
-  <pre><code>{{ .Inner | strings.TrimSpace | htmlEscape | safeHTML }}</code></pre>
+  <pre><code>{{ $content | htmlEscape | safeHTML }}</code></pre>
 </div>

--- a/website/scripts/check-rendered-site.py
+++ b/website/scripts/check-rendered-site.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from collections import Counter
 from html.parser import HTMLParser
@@ -21,16 +22,75 @@ class Document(HTMLParser):
         self.ids: list[str] = []
         self.hrefs: list[str] = []
         self.text: list[str] = []
+        self.command_blocks: list[str] = []
+        self._command_div_depth = 0
+        self._command_code: list[str] | None = None
 
-    def handle_starttag(self, _tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = dict(attrs)
         if values.get("id"):
             self.ids.append(values["id"] or "")
         if values.get("href"):
             self.hrefs.append(values["href"] or "")
 
+        classes = (values.get("class") or "").split()
+        if tag == "div":
+            if self._command_div_depth > 0:
+                self._command_div_depth += 1
+            elif "command-block" in classes:
+                self._command_div_depth = 1
+        elif tag == "code" and self._command_div_depth > 0:
+            self._command_code = []
+
     def handle_data(self, data: str) -> None:
         self.text.append(data)
+        if self._command_code is not None:
+            self._command_code.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "code" and self._command_code is not None:
+            self.command_blocks.append("".join(self._command_code))
+            self._command_code = None
+        elif tag == "div" and self._command_div_depth > 0:
+            self._command_div_depth -= 1
+
+
+def yaml_line_opens_block(stripped: str) -> bool:
+    if stripped.startswith("- "):
+        return True
+    without_comment = stripped.split(" #", 1)[0].rstrip()
+    return re.search(r":\s*(?:[|>][-+0-9]*)?$", without_comment) is not None
+
+
+def validate_kubernetes_yaml(code: str) -> str | None:
+    """Return a rendering or indentation error for a Kubernetes YAML block."""
+    documents: list[list[str]] = [[]]
+    for line in code.splitlines():
+        if line.strip() == "---":
+            documents.append([])
+        else:
+            documents[-1].append(line.rstrip())
+
+    for document in documents:
+        significant = [line for line in document if line.strip() and not line.lstrip().startswith("#")]
+        if not significant or not significant[0].startswith("apiVersion:"):
+            continue
+
+        top_level = {line.split(":", 1)[0] for line in significant if line == line.lstrip() and ":" in line}
+        missing = {"apiVersion", "kind", "metadata"} - top_level
+        if missing:
+            return f"top-level fields are indented or missing: {', '.join(sorted(missing))}"
+
+        previous_indent = 0
+        previous_stripped = significant[0].strip()
+        for line_number, line in enumerate(significant[1:], start=2):
+            indent = len(line) - len(line.lstrip(" "))
+            if indent > previous_indent and not yaml_line_opens_block(previous_stripped):
+                return f"line {line_number} is nested below a scalar value: {line.strip()!r}"
+            previous_indent = indent
+            previous_stripped = line.strip()
+
+    return None
 
 
 def route_for(root: Path, html_file: Path) -> str:
@@ -111,6 +171,11 @@ def main() -> int:
             if marker in text:
                 errors.append(f"encoding marker {marker!r}: {route}")
 
+        for index, code in enumerate(document.command_blocks, start=1):
+            yaml_error = validate_kubernetes_yaml(code)
+            if yaml_error:
+                errors.append(f"invalid rendered Kubernetes YAML: {route}: block {index}: {yaml_error}")
+
         for href in document.hrefs:
             try:
                 target = normalize_internal_path(route, href)
@@ -136,7 +201,7 @@ def main() -> int:
     print(
         f"Rendered HTML: {len(html_files)}; "
         f"duplicate IDs: {sum(error.startswith('duplicate id:') for error in errors)}; "
-        f"target, fragment, and encoding errors: "
+        f"content, target, fragment, and encoding errors: "
         f"{sum(not error.startswith('duplicate id:') for error in errors)}"
     )
     if errors:


### PR DESCRIPTION
## Summary

- Validate the installation-to-running-cluster journey and add deterministic readiness checks to the README and versioned documentation.
- Correct the basic, integration, and production samples so that current CRD and admission contracts accept them.
- Add an envtest contract test for all OpenBao custom resources under `config/samples`.
- Validate rendered command-block YAML so that malformed indentation fails the documentation build.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This change does not modify APIs, CRDs, RBAC, Helm behavior, or operator runtime code. It changes documentation, sample manifests, documentation validation, and integration-test coverage.

The production samples remain reference configurations. External KMS, HSM, KMIP, transit, ACME, and object-storage dependencies require environment-specific credentials and endpoints.

## Verification

- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`
- Installed the `0.5.0-rc.4` Helm chart on Kind 1.34.3 and completed the documented development, namespace onboarding, and single-tenant journeys.
- Applied all 19 OpenBao custom-resource samples with server-side validation against the installed CRDs and 12 validating admission policies.
- Verified self-initialization with three ready replicas, no root-token Secret, projected JWT login, authorized health access, and denied Raft configuration access.
- Ran the Hardened, ACME, and RustFS backup/restore E2E profiles: 7 of 7 specifications passed.
- Ran the PKCS11 and KMIP E2E profiles: 2 of 2 specifications passed.
- `git diff --check`

## Reviewer Notes

The documentation follows the repository version split:

- `website/content` documents planned 0.5.x behavior.
- `website/content-versions/next` documents unreleased behavior.
- `website/content-versions/0.4.x` keeps 0.4-specific constraints and versions.

Review the revised production samples as executable references, not production deployment claims. Placeholder identities, endpoints, and trust material must be replaced for a target environment.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
