### PR TITLE
fix(controller): reduce steady-state log noise

### DIFF
--- a/internal/adapter/raft/autopilot.go
+++ b/internal/adapter/raft/autopilot.go
@@ -138,7 +138,7 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 	}
 
 	// Log the Profile and replicas being used for debugging
-	logger.Info("Reconciling autopilot config",
+	logger.V(1).Info("Reconciling autopilot config",
 		"profile", cluster.Spec.Profile,
 		"replicas", cluster.Spec.Replicas,
 		"cluster", cluster.Name,
@@ -148,7 +148,7 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 	desiredConfig := BuildAutopilotConfig(cluster)
 
 	// Log the calculated min_quorum for debugging
-	logger.Info("Calculated autopilot config",
+	logger.V(1).Info("Calculated autopilot config",
 		"min_quorum", desiredConfig.MinQuorum,
 		"cleanup_dead_servers", desiredConfig.CleanupDeadServers,
 		"profile", cluster.Spec.Profile,
@@ -197,7 +197,7 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 		}
 	}
 
-	logger.Info("Reconciling Raft Autopilot configuration",
+	logger.V(1).Info("Reconciling Raft Autopilot configuration",
 		"cluster", cluster.Name,
 		"cleanup_dead_servers", desiredConfig.CleanupDeadServers,
 		"dead_server_last_contact_threshold", desiredConfig.DeadServerLastContactThreshold,
@@ -448,7 +448,7 @@ func (m *Manager) configureAutopilotWithClient(ctx context.Context, logger logr.
 
 	desiredConfig := BuildAutopilotConfig(cluster)
 
-	logger.Info("Reconciling Raft Autopilot configuration",
+	logger.V(1).Info("Reconciling Raft Autopilot configuration",
 		"cluster", cluster.Name,
 		"cleanup_dead_servers", desiredConfig.CleanupDeadServers,
 		"dead_server_last_contact_threshold", desiredConfig.DeadServerLastContactThreshold,

--- a/internal/app/openbaocluster/infra.go
+++ b/internal/app/openbaocluster/infra.go
@@ -117,7 +117,7 @@ func NewInfraReconciler(deps InfraDependencies) SubReconciler {
 
 // Reconcile implements the controller's sub-reconciler contract for infrastructure reconciliation.
 func (r *infraReconciler) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
-	logger.Info("Reconciling infrastructure for OpenBaoCluster")
+	logger.V(1).Info("Reconciling infrastructure for OpenBaoCluster")
 
 	if err := upgrade.ValidateUpgradeTargetVersion(logger, cluster.Status.CurrentVersion, cluster.Spec.Version); err != nil {
 		return recon.Result{}, err

--- a/internal/app/openbaocluster/infra_images.go
+++ b/internal/app/openbaocluster/infra_images.go
@@ -101,7 +101,7 @@ func (r *infraReconciler) verifyImageDigestWithPolicy(
 
 	digest, err := verify(verifyCtx)
 	if err == nil {
-		logger.Info(opts.successMessage, "digest", digest)
+		logger.V(1).Info(opts.successMessage, "digest", digest)
 		return digest, nil
 	}
 

--- a/internal/app/openbaocluster/statusops/observe.go
+++ b/internal/app/openbaocluster/statusops/observe.go
@@ -251,7 +251,7 @@ func gatherStatefulSetState(
 
 	state.StatusStale = statefulSetStillScaling || statusPotentiallyStale
 
-	logger.Info("StatefulSet status read for ReadyReplicas calculation",
+	logger.V(1).Info("StatefulSet status read for ReadyReplicas calculation",
 		"statefulSetReadyReplicas", statefulSet.Status.ReadyReplicas,
 		"statefulSetReplicas", statefulSet.Status.Replicas,
 		"statefulSetCurrentReplicas", statefulSet.Status.CurrentReplicas,

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -59,7 +59,7 @@ func (r *openBaoClusterWorkloadReconciler) Reconcile(ctx context.Context, req ct
 	}()
 
 	logger := r.parent.loggerFor(ctx, req, controllerNameWorkload)
-	logger.Info("Reconciling OpenBaoCluster workload")
+	logger.V(1).Info("Reconciling OpenBaoCluster workload")
 
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
 	if err := r.parent.Get(ctx, req.NamespacedName, cluster); err != nil {
@@ -141,7 +141,7 @@ func (r *openBaoClusterAdminOpsReconciler) Reconcile(ctx context.Context, req ct
 	}()
 
 	logger := r.parent.loggerFor(ctx, req, controllerNameAdminOps)
-	logger.Info("Reconciling OpenBaoCluster admin operations")
+	logger.V(1).Info("Reconciling OpenBaoCluster admin operations")
 
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
 	reader := r.parent.APIReader
@@ -196,7 +196,7 @@ func (r *openBaoClusterStatusReconciler) Reconcile(ctx context.Context, req ctrl
 	}()
 
 	logger := r.parent.loggerFor(ctx, req, controllerNameStatus)
-	logger.Info("Reconciling OpenBaoCluster status")
+	logger.V(1).Info("Reconciling OpenBaoCluster status")
 
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
 	if err := r.parent.Get(ctx, req.NamespacedName, cluster); err != nil {

--- a/internal/controller/openbaocluster/status.go
+++ b/internal/controller/openbaocluster/status.go
@@ -101,7 +101,7 @@ func (r *OpenBaoClusterReconciler) updateStatus(ctx context.Context, logger logr
 		return ctrl.Result{}, fmt.Errorf("failed to update status for OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 	}
 
-	logger.Info("Updated status for OpenBaoCluster",
+	logger.V(1).Info("Updated status for OpenBaoCluster",
 		"readyReplicas", state.ReadyReplicas,
 		"readReplicaReadyReplicas", state.ReadReplicaReadyReplicas,
 		"phase", cluster.Status.Phase,

--- a/internal/service/bootstrap/config.go
+++ b/internal/service/bootstrap/config.go
@@ -150,7 +150,7 @@ func (m *Manager) ensureSelfInitConfigMap(ctx context.Context, logger logr.Logge
 	cmName := resourceidentity.ConfigInitMapName(cluster)
 
 	if cluster.Status.SelfInitialized {
-		logger.Info("Self-init already completed; reconciling inert self-init ConfigMap", "configmap", cmName)
+		logger.V(1).Info("Self-init already completed; reconciling inert self-init ConfigMap", "configmap", cmName)
 		return m.ensureConfigMapWithName(ctx, cluster, cmName, completedSelfInitConfig)
 	}
 

--- a/internal/service/certs/reload.go
+++ b/internal/service/certs/reload.go
@@ -36,17 +36,19 @@ func NewKubernetesReloadSignaler(clientset kubernetes.Interface) *KubernetesRelo
 	}
 }
 
-// SignalReload annotates all ready OpenBao pods in the cluster with the current
-// TLS certificate hash. Implementations running inside the pod (for example,
-// a sidecar container) may watch this annotation or the underlying volume and
-// send SIGHUP to the OpenBao process when a new hash is observed.
+// SignalReload annotates all ready OpenBao workload pods in the cluster with
+// the current TLS certificate hash. Implementations running inside the pod
+// (for example, a sidecar container) may watch this annotation or the
+// underlying volume and send SIGHUP to the OpenBao process when a new hash is
+// observed.
 func (k *KubernetesReloadSignaler) SignalReload(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, certHash string) error {
 	// List all pods for this cluster using the same labels as the StatefulSet
 	podList, err := k.clientset.CoreV1().Pods(cluster.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{
-			constants.LabelAppInstance:  cluster.Name,
-			constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-			constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+			constants.LabelAppInstance:      cluster.Name,
+			constants.LabelAppName:          constants.LabelValueAppNameOpenBao,
+			constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+			constants.LabelOpenBaoComponent: constants.ComponentOpenBaoCluster,
 		}).String(),
 	})
 	if err != nil {
@@ -58,7 +60,7 @@ func (k *KubernetesReloadSignaler) SignalReload(ctx context.Context, logger logr
 	}
 
 	if len(podList.Items) == 0 {
-		logger.Info("No pods found for OpenBaoCluster; skipping TLS reload signal")
+		logger.V(1).Info("No pods found for OpenBaoCluster; skipping TLS reload signal")
 		return nil
 	}
 
@@ -70,7 +72,7 @@ func (k *KubernetesReloadSignaler) SignalReload(ctx context.Context, logger logr
 
 		// Check if pod is ready
 		if !isPodReady(pod) {
-			logger.Info("Skipping TLS reload for pod that is not ready", "pod", pod.Name)
+			logger.V(1).Info("Skipping TLS reload for pod that is not ready", "pod", pod.Name)
 			continue
 		}
 
@@ -98,7 +100,7 @@ func (k *KubernetesReloadSignaler) SignalReload(ctx context.Context, logger logr
 	}
 
 	if updatedCount == 0 && lastErr == nil {
-		logger.Info("No pods required TLS reload annotation update", "totalPods", len(podList.Items))
+		logger.V(1).Info("No pods required TLS reload annotation update", "totalPods", len(podList.Items))
 		return nil
 	}
 

--- a/internal/service/certs/reload_test.go
+++ b/internal/service/certs/reload_test.go
@@ -73,9 +73,10 @@ func TestSignalReload_AnnotatesReadyPods(t *testing.T) {
 			Name:      "test-cluster-0",
 			Namespace: "default",
 			Labels: map[string]string{
-				constants.LabelAppInstance:  "test-cluster",
-				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelAppInstance:      "test-cluster",
+				constants.LabelAppName:          constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoComponent: constants.ComponentOpenBaoCluster,
 			},
 		},
 		Status: corev1.PodStatus{
@@ -118,9 +119,10 @@ func TestSignalReload_SkipsNonReadyPods(t *testing.T) {
 			Name:      "test-cluster-0",
 			Namespace: "default",
 			Labels: map[string]string{
-				constants.LabelAppInstance:  "test-cluster",
-				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelAppInstance:      "test-cluster",
+				constants.LabelAppName:          constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoComponent: constants.ComponentOpenBaoCluster,
 			},
 		},
 		Status: corev1.PodStatus{
@@ -163,9 +165,10 @@ func TestSignalReload_SkipsPodsWithCurrentHash(t *testing.T) {
 			Name:      "test-cluster-0",
 			Namespace: "default",
 			Labels: map[string]string{
-				constants.LabelAppInstance:  "test-cluster",
-				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelAppInstance:      "test-cluster",
+				constants.LabelAppName:          constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoComponent: constants.ComponentOpenBaoCluster,
 			},
 			Annotations: map[string]string{
 				tlsCertHashAnnotation: testCertHash,
@@ -205,15 +208,17 @@ func TestSignalReload_SkipsPodsWithCurrentHash(t *testing.T) {
 	}
 }
 
-func TestSignalReload_UpdatesMultiplePods(t *testing.T) {
+func TestSignalReload_AnnotatesVoterAndReadReplicaPods(t *testing.T) {
 	pod1 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster-0",
 			Namespace: "default",
 			Labels: map[string]string{
-				constants.LabelAppInstance:  "test-cluster",
-				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelAppInstance:         "test-cluster",
+				constants.LabelAppName:             constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy:        constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoComponent:    constants.ComponentOpenBaoCluster,
+				constants.LabelOpenBaoWorkloadPool: constants.LabelValueOpenBaoWorkloadPoolVoter,
 			},
 		},
 		Status: corev1.PodStatus{
@@ -231,9 +236,11 @@ func TestSignalReload_UpdatesMultiplePods(t *testing.T) {
 			Name:      "test-cluster-1",
 			Namespace: "default",
 			Labels: map[string]string{
-				constants.LabelAppInstance:  "test-cluster",
-				constants.LabelAppName:      constants.LabelValueAppNameOpenBao,
-				constants.LabelAppManagedBy: constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelAppInstance:         "test-cluster",
+				constants.LabelAppName:             constants.LabelValueAppNameOpenBao,
+				constants.LabelAppManagedBy:        constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoComponent:    constants.ComponentOpenBaoCluster,
+				constants.LabelOpenBaoWorkloadPool: constants.LabelValueOpenBaoWorkloadPoolReadReplica,
 			},
 		},
 		Status: corev1.PodStatus{
@@ -269,6 +276,60 @@ func TestSignalReload_UpdatesMultiplePods(t *testing.T) {
 		if updatedPod.Annotations[tlsCertHashAnnotation] != certHash {
 			t.Errorf("Pod %s annotation = %v, want %v", podName, updatedPod.Annotations[tlsCertHashAnnotation], certHash)
 		}
+	}
+}
+
+func TestSignalReload_ExcludesExecutorPods(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+	}{
+		{name: "backup", component: "backup"},
+		{name: "restore", component: "restore"},
+		{name: "upgrade", component: "upgrade"},
+		{name: "upgrade-snapshot", component: "upgrade-snapshot"},
+		{name: "autopilot", component: "autopilot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executorPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster-" + tt.name,
+					Namespace: "default",
+					Labels: map[string]string{
+						constants.LabelAppInstance:      "test-cluster",
+						constants.LabelAppName:          constants.LabelValueAppNameOpenBao,
+						constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
+						constants.LabelOpenBaoComponent: tt.component,
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			clientset := newTestClientset(executorPod)
+			signaler := NewKubernetesReloadSignaler(clientset)
+			ctx := context.Background()
+
+			if err := signaler.SignalReload(ctx, logr.Discard(), newTestCluster("test-cluster", "default"), testCertHash); err != nil {
+				t.Fatalf("SignalReload() error = %v", err)
+			}
+
+			unchangedPod, err := clientset.CoreV1().Pods("default").Get(ctx, executorPod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get executor pod: %v", err)
+			}
+			if got := unchangedPod.Annotations[tlsCertHashAnnotation]; got != "" {
+				t.Errorf("Executor pod annotation = %q, want empty", got)
+			}
+		})
 	}
 }
 

--- a/internal/service/provisioner/manager_secret_rbac.go
+++ b/internal/service/provisioner/manager_secret_rbac.go
@@ -167,7 +167,7 @@ func (m *Manager) ensureSecretsRole(ctx context.Context, namespace string, roleN
 	if role.GetName() != roleName || role.GetNamespace() != namespace {
 		return fmt.Errorf("failed to build Role %s/%s: factory returned %s/%s", namespace, roleName, role.GetNamespace(), role.GetName())
 	}
-	m.logger.Info("Applying tenant secrets Role", "namespace", namespace, "role", roleName)
+	m.logger.V(1).Info("Applying tenant secrets Role", "namespace", namespace, "role", roleName)
 	if err := m.applyResource(ctx, role); err != nil {
 		return fmt.Errorf("failed to apply secrets Role %s/%s: %w", namespace, roleName, err)
 	}
@@ -207,7 +207,7 @@ func (m *Manager) ensureSecretsRoleBinding(ctx context.Context, namespace string
 	if roleBinding.RoleRef.Name != roleName {
 		return fmt.Errorf("failed to build RoleBinding %s/%s: roleRef.name=%q want %q", namespace, roleBindingName, roleBinding.RoleRef.Name, roleName)
 	}
-	m.logger.Info("Applying tenant secrets RoleBinding", "namespace", namespace, "rolebinding", roleBindingName)
+	m.logger.V(1).Info("Applying tenant secrets RoleBinding", "namespace", namespace, "rolebinding", roleBindingName)
 	if err := m.applyResource(ctx, roleBinding); err != nil {
 		return fmt.Errorf("failed to apply secrets RoleBinding %s/%s: %w", namespace, roleBindingName, err)
 	}

--- a/internal/service/upgrade/image_verification.go
+++ b/internal/service/upgrade/image_verification.go
@@ -49,7 +49,7 @@ func VerifyOperatorImageDigest(
 
 	digest, err := security.VerifyOperatorImageForCluster(verifyCtx, logger, verifier, cluster, imageRef)
 	if err == nil {
-		logger.Info("Operator image verified successfully", "digest", digest)
+		logger.V(1).Info("Operator image verified successfully", "digest", digest)
 		return digest, nil
 	}
 

--- a/internal/service/workload/compute.go
+++ b/internal/service/workload/compute.go
@@ -139,7 +139,7 @@ func (m *Manager) EnsureStatefulSet(ctx context.Context, logger logr.Logger, clu
 	if !initialized {
 		logger.Info("Cluster not yet initialized; applying staged replica count", "statefulset", name, "desiredReplicas", desiredReplicas, "pool", spec.Pool)
 	} else {
-		logger.Info("Cluster initialized; ensuring StatefulSet has desired replicas", "statefulset", name, "desiredReplicas", desiredReplicas, "pool", spec.Pool)
+		logger.V(1).Info("Cluster initialized; ensuring StatefulSet has desired replicas", "statefulset", name, "desiredReplicas", desiredReplicas, "pool", spec.Pool)
 	}
 
 	desired, buildErr := buildStatefulSetForSpec(cluster, configContent, initialized, spec, m.platform)


### PR DESCRIPTION
## Summary

- Restrict TLS reload signaling to Pods labeled `openbao.org/component=openbaocluster`. Backup, restore, upgrade, and Autopilot executor Pods share the broader application labels and must not receive workload TLS annotations.
- Move repeated steady-state reconciliation, successful verification, and no-op messages to verbosity level 1. State changes, security warnings, and failures remain visible at the default level.
- Add regression coverage for voter and read-replica workload Pods and for excluded executor Pod components.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

The TLS reload selector becomes narrower and uses the workload component label already applied to voter and read-replica Pods in supported releases. This prevents executor Pod updates and their associated optimistic-concurrency errors.

Default operator logs contain fewer steady-state details. Set the controller log verbosity to level 1 to retain those messages. Errors, security warnings, lifecycle changes, and TLS reload updates remain at the default level.

There are no API, CRD, Helm chart, RBAC, or dependency changes.

## Verification

- `go test ./internal/controller/openbaocluster ./internal/app/openbaocluster/... ./internal/service/bootstrap ./internal/service/certs ./internal/service/provisioner ./internal/service/upgrade ./internal/service/workload ./internal/adapter/raft`
- `make lint-ci`
- `devenv test`
- `devenv tasks run operator:bootstrap operator:doctor operator:ci-core`

## Reviewer Notes

This change does not alter reconciliation cadence, caching, or idempotent apply behavior. Those efficiency questions require separate load measurement. RC5 remains deferred until the current qualification soak and remaining release tests are complete.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed. No user-facing documentation changes are required for this internal correction.
- [x] I have updated generated artifacts, or confirmed none are affected. No generated artifacts are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out. There are no dependent changes.
