### PR TITLE
fix(backup): ignore pre-upgrade jobs in scheduled observation

### DIFF
--- a/internal/service/backup/manager_jobs.go
+++ b/internal/service/backup/manager_jobs.go
@@ -63,10 +63,11 @@ type backupJobObservation struct {
 func (m *Manager) observeBackupJobs(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) (backupJobObservation, error) {
 	jobList := &batchv1.JobList{}
 	labelSelector := labels.SelectorFromSet(map[string]string{
-		constants.LabelAppInstance:      cluster.Name,
-		constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
-		constants.LabelOpenBaoCluster:   cluster.Name,
-		constants.LabelOpenBaoComponent: ComponentBackup,
+		constants.LabelAppInstance:       cluster.Name,
+		constants.LabelAppManagedBy:      constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelOpenBaoCluster:    cluster.Name,
+		constants.LabelOpenBaoComponent:  ComponentBackup,
+		constants.LabelOpenBaoBackupType: constants.BackupTypeScheduled,
 	})
 
 	if err := m.reader.List(ctx, jobList,

--- a/internal/service/backup/manager_jobs_test.go
+++ b/internal/service/backup/manager_jobs_test.go
@@ -1,0 +1,120 @@
+package backup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+)
+
+func TestObserveBackupJobs_FiltersByBackupType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		backupType   string
+		status       batchv1.JobStatus
+		wantActive   bool
+		wantTerminal bool
+	}{
+		{
+			name:       "observes active scheduled job",
+			backupType: constants.BackupTypeScheduled,
+			wantActive: true,
+		},
+		{
+			name:         "observes successful scheduled job",
+			backupType:   constants.BackupTypeScheduled,
+			status:       batchv1.JobStatus{Succeeded: 1},
+			wantTerminal: true,
+		},
+		{
+			name:         "observes failed scheduled job",
+			backupType:   constants.BackupTypeScheduled,
+			status:       batchv1.JobStatus{Failed: 1},
+			wantTerminal: true,
+		},
+		{
+			name:       "ignores active pre-upgrade job",
+			backupType: constants.BackupTypePreUpgrade,
+		},
+		{
+			name:       "ignores successful pre-upgrade job",
+			backupType: constants.BackupTypePreUpgrade,
+			status:     batchv1.JobStatus{Succeeded: 1},
+		},
+		{
+			name:       "ignores failed pre-upgrade job",
+			backupType: constants.BackupTypePreUpgrade,
+			status:     batchv1.JobStatus{Failed: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := newTestClusterWithBackup("job-observation", "default")
+			job := newBackupJobForCluster(cluster, "observed-job", time.Now().UTC())
+			job.Labels[constants.LabelOpenBaoBackupType] = tt.backupType
+			job.Status = tt.status
+			manager := newBackupManager(newTestClient(t, cluster, job))
+
+			observation, err := manager.observeBackupJobs(context.Background(), cluster)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantActive, observation.hasActive)
+			if tt.wantTerminal {
+				require.NotNil(t, observation.mostRecentTerminal)
+				assert.Equal(t, job.Name, observation.mostRecentTerminal.Name)
+				return
+			}
+			assert.Nil(t, observation.mostRecentTerminal)
+		})
+	}
+}
+
+func TestCheckForCompletedJobs_RequiresBackupKeyOnlyForScheduledJobs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		backupType string
+		wantErr    string
+	}{
+		{
+			name:       "rejects scheduled job without backup key",
+			backupType: constants.BackupTypeScheduled,
+			wantErr:    "without openbao.org/backup-key",
+		},
+		{
+			name:       "ignores pre-upgrade job without backup key",
+			backupType: constants.BackupTypePreUpgrade,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := newTestClusterWithBackup("completed-job", "default")
+			job := newBackupJobForCluster(cluster, "completed-job", time.Now().UTC())
+			job.Labels[constants.LabelOpenBaoBackupType] = tt.backupType
+			job.Status = batchv1.JobStatus{Succeeded: 1}
+			manager := newBackupManager(newTestClient(t, cluster, job))
+
+			result, err := manager.checkForCompletedJobs(context.Background(), logr.Discard(), cluster)
+			assert.Equal(t, backupJobProcessResult{}, result)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/test/e2e/Upgrade_Strategies_test.go
+++ b/test/e2e/Upgrade_Strategies_test.go
@@ -1223,6 +1223,8 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				g.Expect(admin.Get(ctx, types.NamespacedName{Name: expectedJobName, Namespace: tenantNamespace}, job)).To(Succeed())
 				g.Expect(job.UID).NotTo(Equal(failedJobUID), "snapshot retry should recreate the deterministic job after deleting the failed attempt")
 				g.Expect(jobSucceeded(job)).To(BeTrue(), "recreated snapshot job should succeed")
+				g.Expect(job.Labels).To(HaveKeyWithValue(constants.LabelOpenBaoBackupType, constants.BackupTypePreUpgrade))
+				g.Expect(job.Annotations).NotTo(HaveKey("openbao.org/backup-key"))
 				successfulJobUID = job.UID
 			}, 20*time.Minute, framework.DefaultPollInterval).Should(Succeed())
 			Expect(successfulJobUID).NotTo(BeZero())
@@ -1234,6 +1236,11 @@ var _ = Describe("Upgrade Strategies", Label("upgrade", "upgrades", "cluster", "
 				g.Expect(updated.Status.CurrentVersion).To(Equal(targetVersion))
 				g.Expect(updated.Status.Upgrade).To(BeNil())
 				g.Expect(updated.Status.Phase).To(Equal(openbaov1alpha1.ClusterPhaseRunning))
+				degraded := meta.FindStatusCondition(updated.Status.Conditions, string(openbaov1alpha1.ConditionDegraded))
+				if degraded != nil {
+					g.Expect(degraded.Message).NotTo(ContainSubstring("without openbao.org/backup-key"),
+						"scheduled backup manager must ignore successful pre-upgrade snapshot Jobs")
+				}
 			}, 30*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})

--- a/test/integration/backup_manager_test.go
+++ b/test/integration/backup_manager_test.go
@@ -464,10 +464,11 @@ func createCompletedBackupJobForCluster(
 				),
 			},
 			Labels: map[string]string{
-				constants.LabelAppInstance:      clusterName,
-				constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
-				constants.LabelOpenBaoCluster:   clusterName,
-				constants.LabelOpenBaoComponent: backup.ComponentBackup,
+				constants.LabelAppInstance:       clusterName,
+				constants.LabelAppManagedBy:      constants.LabelValueAppManagedByOpenBaoOperator,
+				constants.LabelOpenBaoCluster:    clusterName,
+				constants.LabelOpenBaoComponent:  backup.ComponentBackup,
+				constants.LabelOpenBaoBackupType: constants.BackupTypeScheduled,
 			},
 			Annotations: map[string]string{
 				constants.AnnotationOpenBaoOwnerUID: string(cluster.UID),


### PR DESCRIPTION
## Summary

- restrict scheduled backup observation to Jobs labeled `openbao.org/backup-type=scheduled`
- preserve strict ownership and `openbao.org/backup-key` validation for scheduled Jobs
- add unit and Kubernetes 1.36 rolling-upgrade regression coverage for keyless pre-upgrade snapshots

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. This change only restricts which operator-managed Jobs the scheduled backup manager observes. Scheduled and manual backups continue to use the scheduled Job type and retain strict ownership and backup-key checks. The upgrade manager continues to own and process pre-upgrade snapshot Jobs. This change does not affect APIs, CRDs, Helm values, RBAC, or user configuration.

## Verification

- `make test`
- `make lint-ci`
- `make verify-e2e-manifest`
- focused Kind E2E on Kubernetes 1.36.1: rolling snapshot recovery from OpenBao 2.5.5 to 2.6.2 (1 passed)

## Reviewer Notes

Review the backup Job label selector and the regression boundary between the scheduled backup manager and rolling upgrade snapshot manager. The E2E assertion targets the missing-backup-key degradation because the recovery scenario can retain an unrelated transient `LeaderUnknown` condition.

Documentation is not required because the change corrects internal Job classification without changing user-facing behavior. No generated artifacts are affected, and the change has no dependent changes.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
