### PR TITLE
fix(backup): recover after ignoring pre-upgrade jobs

### DIFF
--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -134,6 +134,10 @@ func Reconcile(
 		}
 
 		if result.RequeueAfter > 0 {
+			// A requeue without an error is a successful observation. Clear any
+			// error from an earlier pass before persisting the next poll time.
+			ensureAdminOpsStatus(cluster)
+			cluster.Status.AdminOps.LastError = nil
 			if patchStatus != nil {
 				if statusErr := patchStatus(ctx, deps.Client, logger, original, cluster, "adminops-requeue"); statusErr != nil {
 					return recon.Result{}, statusErr

--- a/internal/app/openbaocluster/adminops/reconcile_test.go
+++ b/internal/app/openbaocluster/adminops/reconcile_test.go
@@ -243,7 +243,7 @@ func TestReconcile_AdminOpsErrorPaths(t *testing.T) {
 }
 
 func TestReconcile_AdminOpsRequeueAndSuccess(t *testing.T) {
-	t.Run("subreconciler requeue is propagated", func(t *testing.T) {
+	t.Run("successful subreconciler requeue clears last error and is propagated", func(t *testing.T) {
 		withAdminOpsReconcilers(t, fakeSubReconciler{result: recon.Result{RequeueAfter: 7 * time.Second}})
 
 		var patchReasons []string
@@ -275,8 +275,8 @@ func TestReconcile_AdminOpsRequeueAndSuccess(t *testing.T) {
 		if len(patchReasons) != 1 || patchReasons[0] != "adminops-requeue" {
 			t.Fatalf("patch reasons=%v, want [adminops-requeue]", patchReasons)
 		}
-		if cluster.Status.AdminOps.LastError == nil || cluster.Status.AdminOps.LastError.Reason != "old" {
-			t.Fatalf("expected existing LastError to remain unchanged on requeue path")
+		if cluster.Status.AdminOps.LastError != nil {
+			t.Fatalf("expected LastError to be cleared after an error-free requeue")
 		}
 	})
 

--- a/internal/service/backup/manager_metrics.go
+++ b/internal/service/backup/manager_metrics.go
@@ -72,10 +72,11 @@ func (m *Manager) syncBackupStatusMetrics(cluster *openbaov1alpha1.OpenBaoCluste
 func (m *Manager) collectBackupJobMetricsSnapshot(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, metrics *Metrics) (backupJobMetricsSnapshot, error) {
 	jobList := &batchv1.JobList{}
 	labelSelector := labels.SelectorFromSet(map[string]string{
-		constants.LabelAppInstance:      cluster.Name,
-		constants.LabelAppManagedBy:     constants.LabelValueAppManagedByOpenBaoOperator,
-		constants.LabelOpenBaoCluster:   cluster.Name,
-		constants.LabelOpenBaoComponent: ComponentBackup,
+		constants.LabelAppInstance:       cluster.Name,
+		constants.LabelAppManagedBy:      constants.LabelValueAppManagedByOpenBaoOperator,
+		constants.LabelOpenBaoCluster:    cluster.Name,
+		constants.LabelOpenBaoComponent:  ComponentBackup,
+		constants.LabelOpenBaoBackupType: constants.BackupTypeScheduled,
 	})
 
 	if err := m.reader.List(ctx, jobList,

--- a/internal/service/backup/manager_metrics_test.go
+++ b/internal/service/backup/manager_metrics_test.go
@@ -164,6 +164,55 @@ func TestCollectBackupJobMetricsSnapshotUpdatesMetricsAndDeduplicates(t *testing
 	}
 }
 
+func TestCollectBackupJobMetricsSnapshotFiltersByBackupType(t *testing.T) {
+	cluster := newTestClusterWithBackup("snapshot-type-filter", "backup-ns")
+	scheduledCompletedAt := time.Unix(1700001000, 0)
+
+	scheduled := newBackupJobForCluster(cluster, "scheduled-success", time.Unix(1700000900, 0))
+	scheduled.Status.Succeeded = 1
+	scheduled.Status.CompletionTime = ptrToTime(scheduledCompletedAt)
+
+	preUpgradeSucceeded := newBackupJobForCluster(cluster, "pre-upgrade-success", time.Unix(1700001900, 0))
+	preUpgradeSucceeded.Labels[constants.LabelOpenBaoBackupType] = constants.BackupTypePreUpgrade
+	preUpgradeSucceeded.Status.Succeeded = 1
+	preUpgradeSucceeded.Status.CompletionTime = ptrToTime(time.Unix(1700002000, 0))
+
+	preUpgradeFailed := newBackupJobForCluster(cluster, "pre-upgrade-failure", time.Unix(1700002900, 0))
+	preUpgradeFailed.Labels[constants.LabelOpenBaoBackupType] = constants.BackupTypePreUpgrade
+	preUpgradeFailed.Status.Failed = 1
+	preUpgradeFailed.Status.CompletionTime = ptrToTime(time.Unix(1700003000, 0))
+
+	preUpgradeRunning := newBackupJobForCluster(cluster, "pre-upgrade-running", time.Unix(1700004000, 0))
+	preUpgradeRunning.Labels[constants.LabelOpenBaoBackupType] = constants.BackupTypePreUpgrade
+	preUpgradeRunning.Status.Active = 1
+
+	manager := newBackupManager(newTestClient(t, scheduled, preUpgradeSucceeded, preUpgradeFailed, preUpgradeRunning))
+	metrics := NewMetrics(cluster.Namespace, cluster.Name)
+	resetBackupTestState(cluster.Namespace, cluster.Name)
+	defer metrics.Clear()
+
+	snapshot, err := manager.collectBackupJobMetricsSnapshot(context.Background(), cluster, metrics)
+	if err != nil {
+		t.Fatalf("collectBackupJobMetricsSnapshot() error = %v", err)
+	}
+
+	if snapshot.inProgress {
+		t.Fatal("snapshot.inProgress = true, want false")
+	}
+	if snapshot.newestSucceeded == nil || snapshot.newestSucceeded.Name != scheduled.Name {
+		t.Fatalf("snapshot.newestSucceeded = %#v, want %q", snapshot.newestSucceeded, scheduled.Name)
+	}
+	if snapshot.newestFailed != nil {
+		t.Fatalf("snapshot.newestFailed = %#v, want nil", snapshot.newestFailed)
+	}
+	if got := testutil.ToFloat64(backupSuccessTotal.WithLabelValues(cluster.Namespace, cluster.Name)); got != 1 {
+		t.Fatalf("backupSuccessTotal = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(backupFailureTotal.WithLabelValues(cluster.Namespace, cluster.Name)); got != 0 {
+		t.Fatalf("backupFailureTotal = %v, want 0", got)
+	}
+}
+
 func TestApplyBackupJobSnapshotToMetrics(t *testing.T) {
 	successJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Unix(1700000000, 0))},


### PR DESCRIPTION
## Summary

- Clear a stale `status.adminOps.lastError` when an admin operations subreconciler successfully requests another observation.
- Restrict scheduled-backup metrics to Jobs labeled `openbao.org/backup-type=scheduled`.
- Add regression coverage for successful requeues and retained pre-upgrade Jobs in succeeded, failed, and active states.

## Related Issues

Follow-up to #661.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, or stored-data changes. The metrics selector now requires the existing `openbao.org/backup-type=scheduled` label. Operator-created scheduled backup Jobs already carry this label. The change does not mutate or delete retained Jobs.

## Verification

- `go test -mod=vendor ./internal/app/openbaocluster/adminops ./internal/service/backup -count=1`
- `go test -mod=vendor -race ./internal/app/openbaocluster/adminops ./internal/service/backup -count=1`
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`
- Deployed the branch image to the forge Kubernetes 1.36.1 qualification cluster.
- Confirmed that the retained pre-upgrade Job kept the same UID and completed state.
- Confirmed that `status.adminOps.lastError` cleared and `Degraded=False` after reconciliation.
- Confirmed zero new missing-backup-key log entries.
- Confirmed scheduled-backup metrics remained neutral and both burn-in workloads continued successful ACKs.

## Reviewer Notes

Review the successful-requeue semantics and the scheduled-backup label selector. PR #661 is merged and is the prerequisite for this follow-up.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed. No documentation changes are required for this internal correction.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.