### PR TITLE
fix(admission): allow namespace controller cleanup

### DIFF
--- a/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
+++ b/charts/openbao-operator/templates/admission/lock-managed-resources.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "openbao-operator.labels" . | nindent 4 }}
   annotations:
-    openbao.org/admission-policy-fingerprint: sha256:da94c35652f641eb4a7767be72ecaeeb0c1cfbf8f82bb17e0ed394a0e1124109
+    openbao.org/admission-policy-fingerprint: sha256:4fe62c598a00d07ae0569c52123bf927ab9e81745655f17f79ee539e3a267031
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -129,6 +129,10 @@ spec:
       expression: >-
         request.userInfo.username == "system:controller:statefulset-controller" ||
         request.userInfo.username == "system:serviceaccount:kube-system:statefulset-controller"
+    # Some controller managers use dedicated ServiceAccount credentials for the namespace controller.
+    - name: is_namespace_controller_serviceaccount
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:namespace-controller"
     # K3s/K3d and some distributions use service accounts for GC instead of system:controller:*
     - name: is_garbage_collector_sa
       expression: >-
@@ -463,6 +467,7 @@ spec:
         variables.is_operator_provisioner ||
         (variables.is_kube_controller_manager && (request.operation == "DELETE" || request.resource.resource == "pods")) ||
         (variables.is_system_controller && request.operation == "DELETE") ||
+        (variables.is_namespace_controller_serviceaccount && request.operation == "DELETE") ||
         (variables.is_garbage_collector_sa && (request.operation == "DELETE" || request.operation == "UPDATE")) ||
         (variables.is_system_controller && request.resource.resource == "pods") ||
         (variables.is_system_controller && variables.is_endpoints_controller_request) ||

--- a/config/policy/openbao-lock-managed-resource-mutations.yaml
+++ b/config/policy/openbao-lock-managed-resource-mutations.yaml
@@ -3,7 +3,7 @@ kind: ValidatingAdmissionPolicy
 metadata:
   name: openbao-lock-managed-resource-mutations
   annotations:
-    openbao.org/admission-policy-fingerprint: sha256:da94c35652f641eb4a7767be72ecaeeb0c1cfbf8f82bb17e0ed394a0e1124109
+    openbao.org/admission-policy-fingerprint: sha256:4fe62c598a00d07ae0569c52123bf927ab9e81745655f17f79ee539e3a267031
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -126,6 +126,10 @@ spec:
       expression: >-
         request.userInfo.username == "system:controller:statefulset-controller" ||
         request.userInfo.username == "system:serviceaccount:kube-system:statefulset-controller"
+    # Some controller managers use dedicated ServiceAccount credentials for the namespace controller.
+    - name: is_namespace_controller_serviceaccount
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:namespace-controller"
     # K3s/K3d and some distributions use service accounts for GC instead of system:controller:*
     - name: is_garbage_collector_sa
       expression: >-
@@ -460,6 +464,7 @@ spec:
         variables.is_operator_provisioner ||
         (variables.is_kube_controller_manager && (request.operation == "DELETE" || request.resource.resource == "pods")) ||
         (variables.is_system_controller && request.operation == "DELETE") ||
+        (variables.is_namespace_controller_serviceaccount && request.operation == "DELETE") ||
         (variables.is_garbage_collector_sa && (request.operation == "DELETE" || request.operation == "UPDATE")) ||
         (variables.is_system_controller && request.resource.resource == "pods") ||
         (variables.is_system_controller && variables.is_endpoints_controller_request) ||

--- a/internal/platform/admission/check.go
+++ b/internal/platform/admission/check.go
@@ -45,7 +45,7 @@ const (
 	PolicyFingerprintAnnotation = "openbao.org/admission-policy-fingerprint"
 
 	fingerprintOpenBaoValidateOpenBaoCluster       = "sha256:828902329ac47bb74fa1ef8ab7f92d80e1f16b3e2d088b8e585d2dd77b9fd6c1"
-	fingerprintOpenBaoLockManagedResourceMutations = "sha256:da94c35652f641eb4a7767be72ecaeeb0c1cfbf8f82bb17e0ed394a0e1124109"
+	fingerprintOpenBaoLockManagedResourceMutations = "sha256:4fe62c598a00d07ae0569c52123bf927ab9e81745655f17f79ee539e3a267031"
 
 	dependencyOpenBaoValidateOpenBaoCluster             = "openbao-validate-openbaocluster"
 	dependencyOpenBaoValidateOpenBaoTenant              = "openbao-validate-openbao-tenant"

--- a/test/integration/kustomize_contract_test.go
+++ b/test/integration/kustomize_contract_test.go
@@ -205,6 +205,7 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	var isPersistentVolumeBinderExpression string
 	var isPVCProtectionControllerExpression string
 	var isStatefulSetControllerExpression string
+	var isNamespaceControllerServiceAccountExpression string
 	var isStoragePVCBindingUpdateExpression string
 	var currentServiceMonitorOwnedExpression string
 	var oldServiceMonitorOwnedExpression string
@@ -242,6 +243,8 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			isPVCProtectionControllerExpression = expression
 		case "is_statefulset_controller":
 			isStatefulSetControllerExpression = expression
+		case "is_namespace_controller_serviceaccount":
+			isNamespaceControllerServiceAccountExpression = expression
 		case "is_storage_pvc_binding_update":
 			isStoragePVCBindingUpdateExpression = expression
 		case "current_service_monitor_is_operator_owned":
@@ -310,6 +313,12 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 		!strings.Contains(isStatefulSetControllerExpression, "system:serviceaccount:kube-system:statefulset-controller") {
 		t.Fatalf("is_statefulset_controller expression does not recognize StatefulSet controller identities: %q", isStatefulSetControllerExpression)
 	}
+	if !strings.Contains(isNamespaceControllerServiceAccountExpression, "system:serviceaccount:kube-system:namespace-controller") {
+		t.Fatalf(
+			"is_namespace_controller_serviceaccount expression does not recognize the namespace controller identity: %q",
+			isNamespaceControllerServiceAccountExpression,
+		)
+	}
 	if !strings.Contains(isKubeSchedulerExpression, "system:kube-scheduler") ||
 		!strings.Contains(isKubeSchedulerExpression, "system:serviceaccount:kube-system:kube-scheduler") {
 		t.Fatalf("is_kube_scheduler expression does not recognize scheduler identities: %q", isKubeSchedulerExpression)
@@ -360,6 +369,7 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	var foundOwnerUIDAnnotationGuard bool
 	var foundStatefulSetPVCGuard bool
 	var foundStoragePVCBindingGuard bool
+	var foundNamespaceControllerDeleteGuard bool
 	for _, validation := range validations {
 		validationMap, ok := validation.(map[string]any)
 		if !ok {
@@ -389,6 +399,11 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 			strings.Contains(expression, "variables.is_storage_pvc_binding_update") {
 			foundStoragePVCBindingGuard = true
 		}
+		if strings.Contains(message, "Direct modification of OpenBao-managed resources is prohibited") &&
+			strings.Contains(expression, "variables.is_namespace_controller_serviceaccount") &&
+			strings.Contains(expression, `request.operation == "DELETE"`) {
+			foundNamespaceControllerDeleteGuard = true
+		}
 	}
 	if !foundServiceMonitorOwnershipGuard {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy missing ServiceMonitor ownership guard")
@@ -401,6 +416,9 @@ func TestKustomizeDefault_LockManagedPolicyRequiresOpenBaoLabels(t *testing.T) {
 	}
 	if !foundStoragePVCBindingGuard {
 		t.Fatalf("openbao-lock-managed-resource-mutations policy missing storage PVC binding update guard")
+	}
+	if !foundNamespaceControllerDeleteGuard {
+		t.Fatalf("openbao-lock-managed-resource-mutations policy missing namespace controller delete guard")
 	}
 }
 

--- a/test/integration/vap_lock_managed_rbac_test.go
+++ b/test/integration/vap_lock_managed_rbac_test.go
@@ -963,6 +963,83 @@ func TestVAP_LockManagedRBAC_DeniesDirectMutationOfProvisionerManagedRoleBinding
 	t.Fatalf("expected VAP to deny direct mutation of provisioner-managed RoleBinding after retries")
 }
 
+func TestVAP_LockManagedRBAC_AllowsNamespaceControllerServiceAccountDeleteOnly(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+	ensureProvisionerRBACApplied(t)
+
+	namespace := newTestNamespace(t)
+	provisionerClient := newPrivilegedImpersonatedClient(t, provisionerUsername)
+	namespaceControllerClient := newPrivilegedImpersonatedClient(
+		t,
+		"system:serviceaccount:kube-system:namespace-controller",
+	)
+	tenantNamespaceControllerClient := newPrivilegedImpersonatedClient(
+		t,
+		"system:serviceaccount:"+namespace+":namespace-controller",
+	)
+
+	tenantRole := provisionerpkg.GenerateTenantRole(namespace)
+	if err := provisionerClient.Create(ctx, tenantRole); err != nil {
+		t.Fatalf("create tenant Role: %v", err)
+	}
+
+	roleBinding := provisionerpkg.GenerateTenantRoleBinding(namespace, provisionerpkg.OperatorServiceAccount{
+		Name:      "openbao-operator-controller",
+		Namespace: "openbao-operator-system",
+	})
+	if err := provisionerClient.Create(ctx, roleBinding); err != nil {
+		t.Fatalf("create managed RoleBinding: %v", err)
+	}
+
+	roleKey := types.NamespacedName{Namespace: namespace, Name: tenantRole.Name}
+	var updateDenied bool
+	for attempt := 0; attempt < 25; attempt++ {
+		var latestRole rbacv1.Role
+		if err := namespaceControllerClient.Get(ctx, roleKey, &latestRole); err != nil {
+			t.Fatalf("get managed Role before namespace controller update: %v", err)
+		}
+		latestRole.Rules = append(latestRole.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		})
+		err := namespaceControllerClient.Update(ctx, &latestRole)
+		if err == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		requireAdmissionDenied(t, err)
+		if !strings.Contains(err.Error(), "Direct modification of OpenBao-managed resources is prohibited") {
+			t.Fatalf("unexpected namespace controller update error: %v", err)
+		}
+		updateDenied = true
+		break
+	}
+	if !updateDenied {
+		t.Fatal("expected namespace controller ServiceAccount update to be denied")
+	}
+
+	err := tenantNamespaceControllerClient.Delete(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: roleBinding.Name, Namespace: namespace},
+	})
+	requireAdmissionDenied(t, err)
+	if !strings.Contains(err.Error(), "Direct modification of OpenBao-managed resources is prohibited") {
+		t.Fatalf("unexpected tenant namespace controller delete error: %v", err)
+	}
+
+	if err := namespaceControllerClient.Delete(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: roleBinding.Name, Namespace: namespace},
+	}); err != nil {
+		t.Fatalf("expected namespace controller ServiceAccount to delete managed RoleBinding, got: %v", err)
+	}
+	if err := namespaceControllerClient.Delete(ctx, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: tenantRole.Name, Namespace: namespace},
+	}); err != nil {
+		t.Fatalf("expected namespace controller ServiceAccount to delete managed Role, got: %v", err)
+	}
+}
+
 func TestVAP_LockManagedRBAC_DoesNotTrustCertManagerNamespace(t *testing.T) {
 	ensureDefaultAdmissionPoliciesApplied(t)
 


### PR DESCRIPTION
## Summary

Allow the dedicated Kubernetes namespace-controller ServiceAccount to delete OpenBao-managed resources during namespace finalization.

K3s authenticates this controller as `system:serviceaccount:kube-system:namespace-controller`. The existing policy only recognized the shared kube-controller-manager identities and `system:controller:*` identities, which left namespaces stuck when provisioner-managed RBAC remained.

The exception is limited to the exact `kube-system/namespace-controller` ServiceAccount and `DELETE` operations. A same-named ServiceAccount in a tenant namespace remains blocked, and the identity cannot update managed resources.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This changes the ValidatingAdmissionPolicy authorization boundary. It grants only `DELETE` to the exact upstream namespace-controller ServiceAccount identity. It does not grant create or update access, trust arbitrary `kube-system` ServiceAccounts, or trust same-named ServiceAccounts in tenant namespaces.

The change supports Kubernetes distributions that run built-in controllers with dedicated ServiceAccount credentials. No API, CRD, Helm value, or user RBAC changes are required.

The admission-policy fingerprint and generated Helm policy are updated together.

## Verification

- `go test ./internal/platform/admission -run 'TestExpectedPolicyFingerprintsMatchSourcePolicyContent|TestDefaultDependencies' -count=1`
- Kubernetes 1.36 envtest for the Kustomize contract and namespace-controller VAP regression
- `make helm-sync helm-test`
- `make test-integration`
- `git diff --check`
- Live Kubernetes v1.36.1+k3s1 validation:
  - the previously stuck qualification namespaces completed deletion after the policy update
  - two fresh namespaces containing provisioner-managed Roles and RoleBindings completed deletion
  - the exact `kube-system/namespace-controller` ServiceAccount could delete managed RBAC
  - a same-named ServiceAccount in a tenant namespace remained denied
  - both operator deployments remained healthy without warnings, errors, or restarts

## Reviewer Notes

Review the principal and operation boundary in `openbao-lock-managed-resource-mutations.yaml`. The regression test separately covers allowed deletion, denied update, and namespace-scoped identity spoofing.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed. No user-facing configuration or procedure changes.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
