### PR TITLE
fix(upgrade): preserve rolling leader ordering

### DIFF
--- a/internal/service/upgrade/rolling/rollout.go
+++ b/internal/service/upgrade/rolling/rollout.go
@@ -74,7 +74,7 @@ func (m *Manager) targetPodAlreadyRolledOut(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	target rolloutTargetPod,
 ) (bool, error) {
-	revisionUpdated, err := m.waitForPodRevisionUpdated(ctx, logger, cluster, target.Name)
+	revisionUpdated, err := m.podRevisionAlreadyUpdated(ctx, logger, cluster, target.Name)
 	if err != nil || !revisionUpdated {
 		return false, err
 	}

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -746,6 +746,82 @@ func TestWaitForPodRevisionUpdated_DeletesStalePodWhenImageMismatchesTemplate(t 
 	}
 }
 
+func TestTargetPodAlreadyRolledOut_DoesNotDeletePodBeforePartitionAdvance(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = openbaov1alpha1.AddToScheme(scheme)
+
+	ns := testNamespace
+	name := "c1"
+	podName := name + "-0"
+	startedAt := metav1.Now()
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				StartedAt:        &startedAt,
+				CurrentPartition: 1,
+			},
+		},
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  constants.ContainerBao,
+						Image: "openbao/openbao:2.6.2",
+					}},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{UpdateRevision: "rev-new"},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			Labels: map[string]string{
+				appsv1.StatefulSetRevisionLabel: "rev-old",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  constants.ContainerBao,
+				Image: "openbao/openbao:2.5.5",
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts, pod).Build()
+	mgr := newManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
+		return &openbaoapi.MockClusterActions{}, nil
+	}, nil)
+
+	rolledOut, err := mgr.targetPodAlreadyRolledOut(
+		context.Background(),
+		testr.New(t),
+		cluster,
+		rolloutTargetPod{CurrentPartition: 1, NextPartition: 0, Ordinal: 0, Name: podName},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if rolledOut {
+		t.Fatal("expected the pre-partition resume check to report the old pod as pending")
+	}
+
+	remainingPod := &corev1.Pod{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: podName}, remainingPod); err != nil {
+		t.Fatalf("expected the pre-partition resume check to preserve the pod, got %v", err)
+	}
+}
+
 func TestRollingWaitStages_TimeoutsMarkUpgradeFailed(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/service/upgrade/rolling/rollout_wait.go
+++ b/internal/service/upgrade/rolling/rollout_wait.go
@@ -44,9 +44,37 @@ func (m *Manager) setStatefulSetPartition(ctx context.Context, cluster *openbaov
 	return nil
 }
 
+// podRevisionAlreadyUpdated checks whether a target pod is already at the
+// StatefulSet update revision without changing the pod. The rolling manager
+// calls this before leader transfer and the partition update.
+func (m *Manager) podRevisionAlreadyUpdated(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	podName string,
+) (bool, error) {
+	return m.checkPodRevisionUpdated(ctx, logger, cluster, podName, false)
+}
+
 // waitForPodRevisionUpdated checks whether a pod has rolled to the StatefulSet
-// update revision.
-func (m *Manager) waitForPodRevisionUpdated(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, podName string) (bool, error) {
+// update revision. It repairs a stale pod only after the caller has completed
+// leader transfer and advanced the partition for that pod.
+func (m *Manager) waitForPodRevisionUpdated(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	podName string,
+) (bool, error) {
+	return m.checkPodRevisionUpdated(ctx, logger, cluster, podName, true)
+}
+
+func (m *Manager) checkPodRevisionUpdated(
+	ctx context.Context,
+	logger logr.Logger,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	podName string,
+	repairStalePod bool,
+) (bool, error) {
 	if err := failUpgradeIfStartedTimeout(cluster, podRevisionTimeout(podName)); err != nil {
 		return false, err
 	}
@@ -85,7 +113,7 @@ func (m *Manager) waitForPodRevisionUpdated(ctx context.Context, logger logr.Log
 		// If the pod no longer matches the StatefulSet template, waiting alone can stall
 		// forever after a failed retry because the StatefulSet controller does not replace
 		// an already-existing stale pod on its own. Force a fresh recreate instead.
-		if desiredImage != "" && podImage != desiredImage {
+		if repairStalePod && desiredImage != "" && podImage != desiredImage {
 			if err := m.client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
 				return false, fmt.Errorf("failed to delete stale pod %s while waiting for revision update: %w", podName, err)
 			}


### PR DESCRIPTION
## Summary

Preserve rolling-upgrade leader ordering when reconciliation resumes after a partial rollout.

The controller now transfers leadership and advances the StatefulSet partition before it deletes a stale leader pod. This prevents the resume check from disrupting the active leader before the replacement path is ready.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This change affects only rolling-upgrade resume ordering. It does not change the CRDs, Helm values, RBAC, or public API. Tests cover an already-updated target, leader ordering, and partition advancement.

## Verification

- `go test ./internal/... -count=1`
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core` non-fuzz stages, including integration and coverage
- `make fuzz` after clearing the stale local Go fuzz cache

## Reviewer Notes

Review the ordering between stale pod remediation, leadership transfer, and StatefulSet partition advancement.

This is the foundational PR in stack #669. Merge the stack from the top PR, #668.

Documentation is not required because this change restores the existing rolling-upgrade contract without changing its user-facing configuration or API.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
