### PR TITLE
fix(retention): preserve unrelated secret owners

### DIFF
--- a/internal/app/openbaocluster/deletionops/retention.go
+++ b/internal/app/openbaocluster/deletionops/retention.go
@@ -2,13 +2,13 @@ package deletionops
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -29,27 +29,17 @@ func OrphanRetentionSecrets(
 	}
 
 	for _, secretName := range retentionSecretNames {
-		secret := &corev1.Secret{}
-		key := types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      secretName,
+		removed, found, err := RemoveClusterOwnerReference(ctx, logger, kubeClient, cluster, secretName)
+		if err != nil {
+			return fmt.Errorf("failed to orphan secret %s: %w", secretName, err)
 		}
-
-		if err := kubeClient.Get(ctx, key, secret); err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("failed to get secret %s: %w", secretName, err)
-			}
+		if !found {
 			logger.V(1).Info("Retention secret not found, skipping orphan", "secret", secretName)
 			continue
 		}
-
-		if !HasOwnerReference(secret, cluster.UID) {
+		if !removed {
 			logger.V(1).Info("Retention secret already orphaned", "secret", secretName)
 			continue
-		}
-
-		if err := RemoveOwnerReferences(ctx, logger, kubeClient, secret); err != nil {
-			return fmt.Errorf("failed to orphan secret %s: %w", secretName, err)
 		}
 
 		logger.Info("Orphaned retention secret to preserve data recoverability",
@@ -67,34 +57,76 @@ func OrphanRetentionSecrets(
 	return nil
 }
 
-// HasOwnerReference checks whether object has an owner reference with the provided UID.
-func HasOwnerReference(obj metav1.Object, uid types.UID) bool {
+// HasClusterOwnerReference checks whether obj has the exact OpenBaoCluster owner reference.
+func HasClusterOwnerReference(obj metav1.Object, cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	if obj == nil || cluster == nil {
+		return false
+	}
 	for _, ref := range obj.GetOwnerReferences() {
-		if ref.UID == uid {
+		if isClusterOwnerReference(ref, cluster) {
 			return true
 		}
 	}
 	return false
 }
 
-// RemoveOwnerReferences patches the secret to remove all owner references.
-func RemoveOwnerReferences(ctx context.Context, logger logr.Logger, kubeClient client.Client, secret *corev1.Secret) error {
-	patch := []map[string]interface{}{
-		{
-			"op":   "remove",
-			"path": "/metadata/ownerReferences",
-		},
-	}
+func isClusterOwnerReference(ref metav1.OwnerReference, cluster *openbaov1alpha1.OpenBaoCluster) bool {
+	return ref.APIVersion == openbaov1alpha1.GroupVersion.String() &&
+		ref.Kind == "OpenBaoCluster" &&
+		ref.Name == cluster.Name &&
+		ref.UID == cluster.UID
+}
 
-	patchBytes, err := json.Marshal(patch)
+// RemoveClusterOwnerReference removes only the matching OpenBaoCluster owner
+// reference. It re-reads and retries on resource-version conflicts so concurrent
+// metadata updates and unrelated owner references are preserved.
+func RemoveClusterOwnerReference(
+	ctx context.Context,
+	logger logr.Logger,
+	kubeClient client.Client,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	secretName string,
+) (removed bool, found bool, err error) {
+	if cluster == nil {
+		return false, false, fmt.Errorf("cluster is required")
+	}
+	key := client.ObjectKey{Namespace: cluster.Namespace, Name: secretName}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret := &corev1.Secret{}
+		if getErr := kubeClient.Get(ctx, key, secret); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				found = false
+				return nil
+			}
+			return getErr
+		}
+		found = true
+
+		ownerReferences := secret.GetOwnerReferences()
+		if !HasClusterOwnerReference(secret, cluster) {
+			return nil
+		}
+
+		preserved := make([]metav1.OwnerReference, 0, len(ownerReferences)-1)
+		for _, ref := range ownerReferences {
+			if !isClusterOwnerReference(ref, cluster) {
+				preserved = append(preserved, ref)
+			}
+		}
+		secret.SetOwnerReferences(preserved)
+		if updateErr := kubeClient.Update(ctx, secret); updateErr != nil {
+			return updateErr
+		}
+		removed = true
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal patch: %w", err)
+		return false, found, fmt.Errorf("failed to update secret owner references: %w", err)
 	}
 
-	if err := kubeClient.Patch(ctx, secret, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
-		return fmt.Errorf("failed to patch secret: %w", err)
+	if removed {
+		logger.V(1).Info("Removed OpenBaoCluster ownerReference from secret", "secret", secretName, "cluster", cluster.Name)
 	}
-
-	logger.V(1).Info("Removed ownerReferences from secret", "secret", secret.Name)
-	return nil
+	return removed, found, nil
 }

--- a/internal/app/openbaocluster/deletionops/retention_test.go
+++ b/internal/app/openbaocluster/deletionops/retention_test.go
@@ -2,15 +2,21 @@ package deletionops
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -153,31 +159,105 @@ func TestOrphanRetentionSecrets(t *testing.T) {
 	}
 }
 
-func TestHasOwnerReference(t *testing.T) {
-	uid := types.UID("test-uid")
+func TestOrphanRetentionSecrets_PreservesUnrelatedOwners(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-cluster", Namespace: "default", UID: types.UID("test-cluster-uid"),
+	}}
+	clusterOwner := metav1.OwnerReference{
+		APIVersion: openbaov1alpha1.GroupVersion.String(), Kind: "OpenBaoCluster", Name: cluster.Name, UID: cluster.UID,
+	}
+	unrelatedOwner := metav1.OwnerReference{
+		APIVersion: "example.org/v1", Kind: "RetentionPolicy", Name: "policy-a", UID: types.UID("policy-uid"),
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "retained-secret", Namespace: cluster.Namespace, OwnerReferences: []metav1.OwnerReference{unrelatedOwner, clusterOwner},
+	}}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, secret).Build()
+
+	require.NoError(t, OrphanRetentionSecrets(context.Background(), logr.Discard(), kubeClient, cluster, []string{secret.Name}))
+	updated := &corev1.Secret{}
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(secret), updated))
+	require.Equal(t, []metav1.OwnerReference{unrelatedOwner}, updated.OwnerReferences)
+}
+
+func TestRemoveClusterOwnerReference_RetriesConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-cluster", Namespace: "default", UID: types.UID("test-cluster-uid"),
+	}}
+	unrelatedOwner := metav1.OwnerReference{
+		APIVersion: "example.org/v1", Kind: "RetentionPolicy", Name: "policy-a", UID: types.UID("policy-uid"),
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      "retained-secret",
+		Namespace: cluster.Namespace,
+		OwnerReferences: []metav1.OwnerReference{
+			unrelatedOwner,
+			{APIVersion: openbaov1alpha1.GroupVersion.String(), Kind: "OpenBaoCluster", Name: cluster.Name, UID: cluster.UID},
+		},
+	}}
+	updateAttempts := 0
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					updateAttempts++
+					if updateAttempts == 1 {
+						return apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, obj.GetName(), errors.New("concurrent metadata update"))
+					}
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	removed, found, err := RemoveClusterOwnerReference(context.Background(), logr.Discard(), kubeClient, cluster, secret.Name)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.True(t, removed)
+	assert.Equal(t, 2, updateAttempts)
+
+	updated := &corev1.Secret{}
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(secret), updated))
+	require.Equal(t, []metav1.OwnerReference{unrelatedOwner}, updated.OwnerReferences)
+}
+
+func TestHasClusterOwnerReference(t *testing.T) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-cluster", UID: types.UID("test-uid"),
+	}}
 
 	tests := []struct {
 		name     string
 		refs     []metav1.OwnerReference
-		uid      types.UID
 		expected bool
 	}{
 		{
-			name:     "returns true when UID matches",
-			refs:     []metav1.OwnerReference{{UID: uid}},
-			uid:      uid,
+			name: "returns true when exact cluster identity matches",
+			refs: []metav1.OwnerReference{{
+				APIVersion: openbaov1alpha1.GroupVersion.String(), Kind: "OpenBaoCluster", Name: cluster.Name, UID: cluster.UID,
+			}},
 			expected: true,
 		},
 		{
-			name:     "returns false when UID does not match",
-			refs:     []metav1.OwnerReference{{UID: "other-uid"}},
-			uid:      uid,
+			name: "returns false when only UID matches",
+			refs: []metav1.OwnerReference{{
+				APIVersion: "example.org/v1", Kind: "Other", Name: cluster.Name, UID: cluster.UID,
+			}},
 			expected: false,
 		},
 		{
 			name:     "returns false when empty",
 			refs:     nil,
-			uid:      uid,
 			expected: false,
 		},
 	}
@@ -189,7 +269,7 @@ func TestHasOwnerReference(t *testing.T) {
 					OwnerReferences: tt.refs,
 				},
 			}
-			assert.Equal(t, tt.expected, HasOwnerReference(secret, tt.uid))
+			assert.Equal(t, tt.expected, HasClusterOwnerReference(secret, cluster))
 		})
 	}
 }

--- a/website/content/docs/security/secrets.md
+++ b/website/content/docs/security/secrets.md
@@ -56,9 +56,10 @@ operator-owned Secret names and provenance. Ordinary cluster-editor access must 
 
 ## Plan deletion and recovery
 
-`deletionPolicy: Retain` removes owner references from the generated unseal-key and root-token Secrets before cluster
-cleanup. It does not retain every generated or referenced Secret. TLS Secrets and user-managed credential Secrets
-follow their own owners and policies.
+`deletionPolicy: Retain` removes only the deleting `OpenBaoCluster` owner reference from the generated unseal-key and
+root-token Secrets before cluster cleanup. It preserves unrelated owner references and metadata. The policy does not
+retain every generated or referenced Secret. TLS Secrets and user-managed credential Secrets follow their own owners
+and policies.
 
 {{< callout type="warning" title="Retention preserves sensitive bootstrap material" >}}
 Retaining an unseal key or root token improves recoverability but leaves a high-value credential in Kubernetes.


### PR DESCRIPTION
## Summary

Remove only the matching `OpenBaoCluster` owner reference when the retention policy preserves a Secret.

The retention path now matches the cluster owner by API version, kind, name, and UID. It preserves unrelated owner references and performs the update with resource-version-aware conflict retries that re-read the Secret before each attempt.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

This change narrows owner-reference removal to the intended cluster owner. It does not change the CRDs, RBAC, or public API. Tests cover multiple owners, exact identity matching, and update conflicts.

## Verification

- `go test ./internal/... -count=1`
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core` non-fuzz stages, including integration and coverage
- `make fuzz` after clearing the stale local Go fuzz cache

## Reviewer Notes

Review the exact owner-reference match and the conflict retry path, especially whether each retry uses the latest resource version while preserving unrelated owners.

This PR depends on #666. It is the third PR in stack #669. Merge the stack from the top PR, #668.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
