### PR TITLE
fix(retention): authorize reserved secret names

### DIFF
--- a/internal/adapter/cluster/rbac.go
+++ b/internal/adapter/cluster/rbac.go
@@ -53,22 +53,20 @@ func GetRequiredSecretPermissions(c *openbaov1alpha1.OpenBaoCluster) []SecretPer
 		)
 	}
 
-	// Root token: writer if SelfInit is not enabled
-	selfInitEnabled := c.Spec.SelfInit != nil && c.Spec.SelfInit.Enabled
-	if !selfInitEnabled {
-		perms = append(perms, SecretPermission{
+	// Retention secrets use reserved names. Always grant name-scoped writer
+	// access so retained deletion can distinguish an absent Secret from an
+	// authorization failure and can preserve a Secret created by an earlier
+	// cluster configuration.
+	perms = append(perms,
+		SecretPermission{
 			Name:       c.Name + suffixRootToken,
 			Permission: PermissionWrite,
-		})
-	}
-
-	// Unseal key: writer if static unseal
-	if IsStaticUnseal(c) {
-		perms = append(perms, SecretPermission{
+		},
+		SecretPermission{
 			Name:       c.Name + suffixUnsealKey,
 			Permission: PermissionWrite,
-		})
-	}
+		},
+	)
 
 	// Referenced secrets from spec (read-only)
 	if c.Spec.Unseal != nil && c.Spec.Unseal.CredentialsSecretRef != nil {
@@ -112,15 +110,4 @@ func GetRequiredSecretPermissions(c *openbaov1alpha1.OpenBaoCluster) []SecretPer
 	}
 
 	return perms
-}
-
-// IsStaticUnseal returns true if the cluster uses static (Shamir) unsealing.
-func IsStaticUnseal(c *openbaov1alpha1.OpenBaoCluster) bool {
-	if c == nil || c.Spec.Unseal == nil {
-		return true
-	}
-	if c.Spec.Unseal.Type == "" {
-		return true
-	}
-	return c.Spec.Unseal.Type == "static"
 }

--- a/internal/adapter/cluster/rbac_test.go
+++ b/internal/adapter/cluster/rbac_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestGetRequiredSecretPermissions(t *testing.T) {
 			},
 		},
 		{
-			name: "SelfInit enabled - no root token written",
+			name: "SelfInit enabled - root token name remains writable for retention",
 			cluster: &openbaov1alpha1.OpenBaoCluster{
 				ObjectMeta: objectMeta("selfinit"),
 				Spec: openbaov1alpha1.OpenBaoClusterSpec{
@@ -124,13 +125,14 @@ func TestGetRequiredSecretPermissions(t *testing.T) {
 				},
 			},
 			wantWriters: []string{
+				"selfinit-root-token",
 				"selfinit-tls-ca",
 				"selfinit-tls-server",
 				"selfinit-unseal-key",
 			},
 		},
 		{
-			name: "Cloud unseal (awskms) - no unseal key written",
+			name: "Cloud unseal (awskms) - unseal key name remains writable for retention",
 			cluster: &openbaov1alpha1.OpenBaoCluster{
 				ObjectMeta: objectMeta("cloud"),
 				Spec: openbaov1alpha1.OpenBaoClusterSpec{
@@ -150,6 +152,7 @@ func TestGetRequiredSecretPermissions(t *testing.T) {
 				"cloud-root-token",
 				"cloud-tls-ca",
 				"cloud-tls-server",
+				"cloud-unseal-key",
 			},
 			wantReaders: []string{
 				"aws-creds",
@@ -337,80 +340,33 @@ func TestGetRequiredSecretPermissions(t *testing.T) {
 	}
 }
 
-func TestIsStaticUnseal(t *testing.T) {
+func TestGetRequiredSecretPermissions_RetentionNamesAreAlwaysWritable(t *testing.T) {
 	tests := []struct {
-		name    string
-		cluster *openbaov1alpha1.OpenBaoCluster
-		want    bool
+		name     string
+		selfInit bool
+		unseal   string
 	}{
-		{
-			name:    "nil cluster is static",
-			cluster: nil,
-			want:    true,
-		},
-		{
-			name: "nil Unseal is static",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				ObjectMeta: objectMeta("test"),
-				Spec:       openbaov1alpha1.OpenBaoClusterSpec{},
-			},
-			want: true,
-		},
-		{
-			name: "empty type is static",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				ObjectMeta: objectMeta("test"),
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Unseal: &openbaov1alpha1.UnsealConfig{
-						Type: "",
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "explicit static type",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				ObjectMeta: objectMeta("test"),
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Unseal: &openbaov1alpha1.UnsealConfig{
-						Type: "static",
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "awskms is not static",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				ObjectMeta: objectMeta("test"),
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Unseal: &openbaov1alpha1.UnsealConfig{
-						Type: "awskms",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "gcpkms is not static",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				ObjectMeta: objectMeta("test"),
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Unseal: &openbaov1alpha1.UnsealConfig{
-						Type: "gcpkms",
-					},
-				},
-			},
-			want: false,
-		},
+		{name: "manual init with static unseal", unseal: "static"},
+		{name: "self init with static unseal", selfInit: true, unseal: "static"},
+		{name: "manual init with external unseal", unseal: "awskms"},
+		{name: "self init with external unseal", selfInit: true, unseal: "awskms"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsStaticUnseal(tt.cluster)
-			if got != tt.want {
-				t.Errorf("IsStaticUnseal() = %v, want %v", got, tt.want)
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: objectMeta("retained"),
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: tt.selfInit},
+					Unseal:   &openbaov1alpha1.UnsealConfig{Type: tt.unseal},
+				},
+			}
+
+			writers := filterByPermission(GetRequiredSecretPermissions(cluster), PermissionWrite)
+			for _, name := range []string{"retained-root-token", "retained-unseal-key"} {
+				if !slices.Contains(writers, name) {
+					t.Errorf("writers = %v, want reserved retention Secret %q", writers, name)
+				}
 			}
 		})
 	}

--- a/internal/service/provisioner/manager_test.go
+++ b/internal/service/provisioner/manager_test.go
@@ -958,6 +958,49 @@ func TestEnsureTenantSecretRBAC_CreatesRolesAndRoleBindings(t *testing.T) {
 	}
 }
 
+func TestEnsureTenantSecretRBAC_IncludesReservedRetentionNames(t *testing.T) {
+	namespace := testNamespace
+	clusterName := "self-init-external"
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			SelfInit: &openbaov1alpha1.SelfInitConfig{Enabled: true},
+			Unseal:   &openbaov1alpha1.UnsealConfig{Type: "awskms"},
+		},
+	}
+
+	k8sClient := newTestClient(t, cluster)
+	manager, err := NewManager(k8sClient, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewManager() failed: %v", err)
+	}
+
+	if err := manager.EnsureTenantSecretRBAC(context.Background(), namespace); err != nil {
+		t.Fatalf("EnsureTenantSecretRBAC() error = %v", err)
+	}
+
+	writerRole := &rbacv1.Role{}
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      TenantSecretsWriterRoleName,
+	}, writerRole); err != nil {
+		t.Fatalf("expected writer Role to exist: %v", err)
+	}
+
+	resourceNames := extractSecretResourceNames(writerRole.Rules)
+	for _, name := range []string{
+		clusterName + constants.SuffixRootToken,
+		clusterName + constants.SuffixUnsealKey,
+	} {
+		if !slices.Contains(resourceNames, name) {
+			t.Errorf("writer Role allowlist = %v, want reserved retention Secret %q", resourceNames, name)
+		}
+	}
+}
+
 func TestAccumulateRestoreTenantSecretNames_SkipsTokenSecretWhenJWTAuthConfigured(t *testing.T) {
 	restore := &openbaov1alpha1.OpenBaoRestore{
 		Spec: openbaov1alpha1.OpenBaoRestoreSpec{


### PR DESCRIPTION
## Summary

- authorize the controller to access both reserved retention Secret names for every cluster configuration
- keep access restricted to the exact `<cluster>-root-token` and `<cluster>-unseal-key` resource names
- allow retained deletion to distinguish an absent Secret from an authorization failure and preserve legacy Secrets

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

The tenant writer Role now includes two additional exact resource names when the current cluster configuration does not generate those Secrets. The Role remains resource-name scoped and does not gain collection-level `get`, `list`, or `watch` access. No API, CRD, Helm, or configuration changes are required.

This fixes retained deletion for self-init and external-unseal configurations. Kubernetes authorization otherwise returns `Forbidden` before the controller can observe that a reserved Secret is absent.

## Verification

- `go test ./internal/adapter/cluster ./internal/service/provisioner ./internal/app/openbaocluster/deletionops`
- `devenv tasks run operator:ci-core`
- forge-dev matrix: manual init and self-init with static and transit unseal
- verified exact-name access, one-to-two-second finalizer completion, and no `Forbidden` errors
- verified a real self-init/static unseal Secret retained its UID while only the OpenBaoCluster owner reference was removed

## Reviewer Notes

Self-init does not create a root-token Secret. The additional permission lets the retention path receive `NotFound` for that reserved name instead of `Forbidden`. It does not create the Secret.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
