### PR TITLE
fix(logging): reduce steady-state bootstrap noise

### DIFF
--- a/internal/service/bootstrap/config.go
+++ b/internal/service/bootstrap/config.go
@@ -79,7 +79,7 @@ func (m *Manager) ensureUnsealSecret(ctx context.Context, logger logr.Logger, cl
 			if proofErr := m.requireExistingSecretOwnerProof(ctx, cluster, secretName, "use existing unseal Secret"); proofErr != nil {
 				return proofErr
 			}
-			logger.Info("Unseal Secret already exists; skipping creation", "secret", secretName)
+			logger.V(1).Info("Unseal Secret already exists; skipping creation", "secret", secretName)
 			return nil
 		}
 		return fmt.Errorf("failed to create unseal Secret %s/%s: %w", cluster.Namespace, secretName, err)

--- a/website/content-versions/next/docs/configure/monitor.md
+++ b/website/content-versions/next/docs/configure/monitor.md
@@ -11,6 +11,8 @@ verifiedBy:
   - config/policy/openbao-validate-openbaocluster.yaml
   - internal/adapter/config/builder.go
   - internal/adapter/config/render_listener.go
+  - internal/controller/openbaocluster/split_reconcilers.go
+  - internal/platform/constants/timing.go
   - internal/platform/observability/metrics.go
   - internal/service/networking/metrics.go
   - internal/service/networking/services.go
@@ -60,6 +62,31 @@ VictoriaMetrics users can set `metrics.victoriaMetrics.enabled: true` instead. A
 scrape a reachable operator metrics Service on HTTPS port 8443 with a bearer token authorized for `GET /metrics`.
 
 The selector defaults to `metrics: enabled`.
+
+## Estimate multi-tenant API request load
+
+Multi-tenant mode avoids cluster-wide watches for namespaced child resources. The workload reconciler instead uses a
+periodic refresh to detect drift. Kubernetes API request volume therefore increases approximately linearly with the
+number of `OpenBaoCluster` resources. See [tenancy watch boundaries](../../architecture/invariants-and-boundaries/#account-for-tenancy-watch-boundaries)
+for the underlying controller design.
+
+The 0.5.0 pre-release qualification run on Kubernetes 1.36.1 measured the following steady-state controller traffic:
+
+| Test shape | Controller requests |
+| --- | ---: |
+| 25 clusters | 2,328 per minute, or 38.8 per second |
+| Increment for 19 one-replica `Development` clusters | 1,691 per minute |
+| Observed incremental slope | 89 per cluster per minute |
+
+Each added cluster contributed 63 successful `GET` requests, 14 expected `GET` requests that returned `404`, 11
+no-op `PATCH` requests, and one expected `POST` request that returned `409` per minute. A representative
+`resourceVersion` sample did not change during the measurement, so the no-op patches did not persist object updates
+in that sample.
+
+Use this result as an initial capacity estimate, not as a supported-cluster limit or a capacity guarantee. Cluster
+profiles, enabled features, object state, API server latency, and reconciliation activity change the request rate.
+Measure `rest_client_requests_total` and API server throttling, latency, and errors under a representative workload
+before you consolidate many clusters under one operator installation.
 
 ## Scrape the active OpenBao node
 

--- a/website/content/docs/configure/monitor.md
+++ b/website/content/docs/configure/monitor.md
@@ -11,6 +11,8 @@ verifiedBy:
   - config/policy/openbao-validate-openbaocluster.yaml
   - internal/adapter/config/builder.go
   - internal/adapter/config/render_listener.go
+  - internal/controller/openbaocluster/split_reconcilers.go
+  - internal/platform/constants/timing.go
   - internal/platform/observability/metrics.go
   - internal/service/networking/metrics.go
   - internal/service/networking/services.go
@@ -60,6 +62,31 @@ VictoriaMetrics users can set `metrics.victoriaMetrics.enabled: true` instead. A
 scrape a reachable operator metrics Service on HTTPS port 8443 with a bearer token authorized for `GET /metrics`.
 
 The selector defaults to `metrics: enabled`.
+
+## Estimate multi-tenant API request load
+
+Multi-tenant mode avoids cluster-wide watches for namespaced child resources. The workload reconciler instead uses a
+periodic refresh to detect drift. Kubernetes API request volume therefore increases approximately linearly with the
+number of `OpenBaoCluster` resources. See [tenancy watch boundaries](../../architecture/invariants-and-boundaries/#account-for-tenancy-watch-boundaries)
+for the underlying controller design.
+
+The 0.5.0 pre-release qualification run on Kubernetes 1.36.1 measured the following steady-state controller traffic:
+
+| Test shape | Controller requests |
+| --- | ---: |
+| 25 clusters | 2,328 per minute, or 38.8 per second |
+| Increment for 19 one-replica `Development` clusters | 1,691 per minute |
+| Observed incremental slope | 89 per cluster per minute |
+
+Each added cluster contributed 63 successful `GET` requests, 14 expected `GET` requests that returned `404`, 11
+no-op `PATCH` requests, and one expected `POST` request that returned `409` per minute. A representative
+`resourceVersion` sample did not change during the measurement, so the no-op patches did not persist object updates
+in that sample.
+
+Use this result as an initial capacity estimate, not as a supported-cluster limit or a capacity guarantee. Cluster
+profiles, enabled features, object state, API server latency, and reconciliation activity change the request rate.
+Measure `rest_client_requests_total` and API server throttling, latency, and errors under a representative workload
+before you consolidate many clusters under one operator installation.
 
 ## Scrape the active OpenBao node
 


### PR DESCRIPTION
## Summary

- Move the repeated existing unseal Secret message to debug verbosity.
- Document the measured multi-tenant Kubernetes API request slope from the 0.5.0 qualification run.
- Clarify that the measurement is a capacity-planning reference, not a supported-cluster limit.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Low. The controller keeps the existing ownership check and reconciliation behavior. The change only reduces the default log verbosity for a successful steady-state path. There are no API, CRD, Helm, RBAC, security, or upgrade compatibility changes.

## Verification

- `go test -tags=integration ./internal/service/bootstrap`
- `PATH="$PWD/.devenv/profile/bin:$PATH" make docs-build`
- `git diff --check`
- Repository pre-commit and pre-push hooks

## Reviewer Notes

The documented request slope comes from the Kubernetes 1.36.1 0.5.0 qualification run with 25 clusters. The section records the workload shape, request composition, and no-op patch observation so readers do not interpret it as a universal capacity guarantee.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
