### PR TITLE
fix(upgrade): resolve leaders on revisioned rolling workloads

### DIFF
--- a/internal/service/upgrade/raftops/actions.go
+++ b/internal/service/upgrade/raftops/actions.go
@@ -44,7 +44,7 @@ func runRollingStepDownLeaderWithFuncs(
 	for _, attempt := range AttemptOrdinals(policy.MaxAttempts) {
 		attemptNumber := attempt + 1
 
-		leaderURL, err := findLeader(ctx, cfg, "")
+		leaderURL, err := findLeader(ctx, cfg, cfg.BlueRevision)
 		if err != nil {
 			return fmt.Errorf("failed to find leader: %w", err)
 		}

--- a/internal/service/upgrade/raftops/actions_test.go
+++ b/internal/service/upgrade/raftops/actions_test.go
@@ -35,15 +35,18 @@ func TestRunRollingStepDownLeaderWithFuncs_RetriesUntilLeaderChanges(t *testing.
 	cfg := &ExecutorConfig{
 		ClusterName:     "vault",
 		ClusterReplicas: 3,
+		BlueRevision:    "active-revision",
 	}
 	client := &rollingStepDownStubClient{}
+	var searchedRevisions []string
 
 	err := runRollingStepDownLeaderWithFuncs(
 		context.Background(),
 		logr.Discard(),
 		cfg,
 		RetryPolicy{MaxAttempts: 3},
-		func(context.Context, *ExecutorConfig, string) (string, error) {
+		func(_ context.Context, _ *ExecutorConfig, revision string) (string, error) {
+			searchedRevisions = append(searchedRevisions, revision)
 			return testRollingLeaderURL0, nil
 		},
 		func(context.Context, string) (LeaderTransferClient, error) {
@@ -61,6 +64,14 @@ func TestRunRollingStepDownLeaderWithFuncs_RetriesUntilLeaderChanges(t *testing.
 	}
 	if client.stepDownCalls != 2 {
 		t.Fatalf("stepDownCalls = %d, want 2", client.stepDownCalls)
+	}
+	if len(searchedRevisions) != 2 {
+		t.Fatalf("searched revisions = %v, want two searches", searchedRevisions)
+	}
+	for _, revision := range searchedRevisions {
+		if revision != cfg.BlueRevision {
+			t.Fatalf("searched revision = %q, want active revision %q", revision, cfg.BlueRevision)
+		}
 	}
 }
 

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -106,7 +106,7 @@ func (m *Manager) cleanupStepDownJobForRetry(ctx context.Context, logger logr.Lo
 
 	targetOrdinal := cluster.Status.Upgrade.CurrentPartition - 1
 	targetPod := upgrade.StableVoterPodName(cluster, targetOrdinal)
-	jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, targetPod, "", "")
+	jobName := rollingStepDownJobName(cluster, targetPod)
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
 
 	job, err := opslifecycle.ReadManagedJob(

--- a/internal/service/upgrade/rolling/rollout_leader.go
+++ b/internal/service/upgrade/rolling/rollout_leader.go
@@ -53,7 +53,8 @@ func (m *Manager) stepDownLeader(ctx context.Context, logger logr.Logger, cluste
 		return false, fmt.Errorf("upgrade state is nil")
 	}
 
-	jobName := upgrade.ExecutorJobName(cluster.Name, upgrade.ExecutorActionRollingStepDownLeader, podName, "", "")
+	stableRevision := upgrade.StableVoterRevision(cluster)
+	jobName := rollingStepDownJobName(cluster, podName)
 	jobKey := types.NamespacedName{Namespace: cluster.Namespace, Name: jobName}
 
 	var stepDownJob *batchv1.Job
@@ -106,7 +107,7 @@ func (m *Manager) stepDownLeader(ctx context.Context, logger logr.Logger, cluste
 		cluster,
 		upgrade.ExecutorActionRollingStepDownLeader,
 		podName,
-		"",
+		stableRevision,
 		"",
 		m.clientConfig,
 		m.operatorImageVerifier,
@@ -205,6 +206,19 @@ func (m *Manager) stepDownLeader(ctx context.Context, logger logr.Logger, cluste
 
 	logger.V(1).Info("Waiting for leadership transfer", "pod", podName)
 	return false, nil // Requeue
+}
+
+func rollingStepDownJobName(cluster *openbaov1alpha1.OpenBaoCluster, podName string) string {
+	if cluster == nil {
+		return ""
+	}
+	return upgrade.ExecutorJobName(
+		cluster.Name,
+		upgrade.ExecutorActionRollingStepDownLeader,
+		podName,
+		upgrade.StableVoterRevision(cluster),
+		"",
+	)
 }
 
 func (m *Manager) isTargetPodLeader(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, podName string) (bool, error) {

--- a/internal/service/upgrade/rolling/rollout_test.go
+++ b/internal/service/upgrade/rolling/rollout_test.go
@@ -371,6 +371,69 @@ func TestStepDownLeader_SkipsJobWhenTargetPodIsNotLeader(t *testing.T) {
 	}
 }
 
+func TestStepDownLeader_PassesStableRevisionToExecutorJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
+	_ = openbaov1alpha1.AddToScheme(scheme)
+
+	const (
+		name           = "c1"
+		stableRevision = "active-revision"
+	)
+	podName := name + "-" + stableRevision + "-0"
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: "cluster-uid"},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+			Upgrade: &openbaov1alpha1.UpgradeConfig{
+				Image:       "openbao-upgrade:test",
+				JWTAuthRole: "upgrade-role",
+			},
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			BlueGreen: &openbaov1alpha1.BlueGreenStatus{BlueRevision: stableRevision},
+			Upgrade: &openbaov1alpha1.UpgradeProgress{
+				TargetVersion: "2.6.2",
+				FromVersion:   "2.5.5",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	mgr := newManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
+		return &openbaoapi.MockClusterActions{IsLeaderFunc: func(context.Context) (bool, error) {
+			return true, nil
+		}}, nil
+	}, nil)
+
+	complete, err := mgr.stepDownLeader(context.Background(), testr.New(t), cluster, podName, upgrade.NewMetrics(testNamespace, name))
+	if err != nil {
+		t.Fatalf("stepDownLeader() error = %v", err)
+	}
+	if complete {
+		t.Fatal("stepDownLeader() complete = true, want running executor Job")
+	}
+
+	job := &batchv1.Job{}
+	jobName := rollingStepDownJobName(cluster, podName)
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: jobName}, job); err != nil {
+		t.Fatalf("get step-down Job: %v", err)
+	}
+	foundRevision := false
+	for _, env := range job.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == constants.EnvUpgradeBlueRevision {
+			foundRevision = true
+			if env.Value != stableRevision {
+				t.Fatalf("%s = %q, want %q", constants.EnvUpgradeBlueRevision, env.Value, stableRevision)
+			}
+		}
+	}
+	if !foundRevision {
+		t.Fatalf("step-down Job is missing %s", constants.EnvUpgradeBlueRevision)
+	}
+}
+
 func TestEnsureTargetPodLeadershipTransferred_SkipsSingleReplicaStepDown(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)


### PR DESCRIPTION
## Summary

- Pass the active voter revision to rolling leader step-down Jobs.
- Include that revision in the deterministic Job identity and retry cleanup.
- Verify revision-aware leader discovery and Job configuration with unit tests.

The strategy-switch E2E scenario promotes a revisioned blue-green StatefulSet and then switches back to rolling. The rolling step-down executor previously searched the original unrevisioned pod names, could not find the leader, and left the last voter on the old OpenBao version.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

The change affects rolling upgrades only when the active voter StatefulSet has a persisted revision, such as after a completed blue-green upgrade. Original unrevisioned rolling workloads keep the existing empty revision and Job naming behavior. No API, CRD, Helm, or RBAC changes are required.

The revision becomes part of the deterministic step-down Job name. Retry cleanup uses the same identity.

## Verification

- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`
- `go test ./internal/service/upgrade/... -count=1`
- Kubernetes 1.36.1 focused E2E: `case:idle-upgrade-strategy-switch` passed in 8m21s

Reproduced against the release commit in [main CI run 33170139696](https://github.com/dc-tec/openbao-operator/actions/runs/33170139696), where both upgrade shards timed out at OpenBao 2.5.5 instead of reaching 2.6.2.

## Reviewer Notes

Review the active revision flow from `rolling.stepDownLeader` into the executor environment and from `RunRollingStepDownLeader` into leader discovery. The PR has the `ci:full-e2e` label because the failing strategy-switch scenario is not part of the default PR anchor selection.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed. No documentation change is required for this internal correctness fix.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
