### PR TITLE
fix(release): allow unchanged RC promotion

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -125,8 +125,9 @@ jobs:
           skip-github-release: true
 
       # release-please-action v5 silently ignores release-as in manifest mode.
-      # Use the matching pinned CLI until googleapis/release-please-action#1220 is fixed.
-      - name: Run release-please CLI (exact-version manifest PR)
+      # The pinned wrapper also permits an exact stable promotion when the latest
+      # release candidate contains all user-facing commits.
+      - name: Run release-please wrapper (exact-version manifest PR)
         if: ${{ steps.release-artifact-guard.outputs.skip_release_please != 'true' && steps.release-as.outputs.release_as != '' }}
         env:
           RELEASE_AS: ${{ steps.release-as.outputs.release_as }}
@@ -140,13 +141,8 @@ jobs:
           umask 077
           printf '%s' "${RELEASE_PLEASE_TOKEN}" > "${token_file}"
 
-          hack/ci/release-please/node_modules/.bin/release-please release-pr \
-            --repo-url="${REPOSITORY}" \
-            --target-branch="${TARGET_BRANCH}" \
-            --token="${token_file}" \
-            --config-file=release-please-config.json \
-            --manifest-file=.release-please-manifest.json \
-            --release-as="${RELEASE_AS}"
+          RELEASE_PLEASE_TOKEN_FILE="${token_file}" \
+            node hack/ci/run-release-please-exact.js
 
       - name: Locate open release PR
         id: release-pr

--- a/hack/ci/run-release-please-exact.js
+++ b/hack/ci/run-release-please-exact.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PINNED_RELEASE_PLEASE_VERSION = '17.6.0';
+const releasePleaseRoot = path.join(
+  __dirname,
+  'release-please',
+  'node_modules',
+  'release-please'
+);
+
+function requireEnvironment(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function permitExactEmptyChangelog(manifest, releaseAs) {
+  if (typeof manifest.getStrategiesByPath !== 'function') {
+    throw new Error('release-please strategy access is unavailable');
+  }
+
+  const strategiesByPath = await manifest.getStrategiesByPath();
+  const paths = Object.keys(strategiesByPath);
+  if (paths.length !== 1 || paths[0] !== '.') {
+    throw new Error(
+      `exact empty-changelog promotion requires one root package, found: ${paths.join(', ')}`
+    );
+  }
+
+  const strategy = strategiesByPath['.'];
+  if (typeof strategy.changelogEmpty !== 'function') {
+    throw new Error('release-please changelog emptiness check is unavailable');
+  }
+
+  const changelogEmpty = strategy.changelogEmpty.bind(strategy);
+  strategy.changelogEmpty = changelogEntry => {
+    if (!changelogEmpty(changelogEntry)) {
+      return false;
+    }
+
+    const nonEmptyLines = changelogEntry
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+    if (
+      nonEmptyLines.length !== 1 ||
+      !nonEmptyLines[0].startsWith('## ') ||
+      !nonEmptyLines[0].includes(releaseAs)
+    ) {
+      throw new Error(
+        `refusing unexpected empty changelog output for ${releaseAs}: ${JSON.stringify(changelogEntry)}`
+      );
+    }
+
+    console.log(
+      `Allowing exact ${releaseAs} promotion with a one-line changelog section; ` +
+        'the stable release rollup must be reviewed before merge.'
+    );
+    return false;
+  };
+}
+
+async function selfTest() {
+  const strategy = {
+    changelogEmpty: entry => entry.split('\n').length <= 1,
+  };
+  const manifest = {
+    getStrategiesByPath: async () => ({'.': strategy}),
+  };
+
+  await permitExactEmptyChangelog(manifest, '0.5.0');
+  if (strategy.changelogEmpty('## [0.5.0](https://example.test/0.5.0)') !== false) {
+    throw new Error('exact empty changelog was not permitted');
+  }
+  if (strategy.changelogEmpty('## 0.5.0\n\n### Bug Fixes\n\n* fixed') !== false) {
+    throw new Error('non-empty changelog behavior changed');
+  }
+
+  let rejected = false;
+  try {
+    strategy.changelogEmpty('');
+  } catch (_error) {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error('unexpected empty changelog output was accepted');
+  }
+
+  console.log('exact release-please promotion self-test passed');
+}
+
+async function main() {
+  if (process.argv.includes('--self-test')) {
+    await selfTest();
+    return;
+  }
+
+  const releasePleasePackage = require(path.join(releasePleaseRoot, 'package.json'));
+  if (releasePleasePackage.version !== PINNED_RELEASE_PLEASE_VERSION) {
+    throw new Error(
+      `release-please version ${releasePleasePackage.version} does not match ` +
+        `pinned compatibility version ${PINNED_RELEASE_PLEASE_VERSION}`
+    );
+  }
+
+  const releaseAs = requireEnvironment('RELEASE_AS');
+  const repository = requireEnvironment('REPOSITORY');
+  const targetBranch = requireEnvironment('TARGET_BRANCH');
+  const tokenFile = requireEnvironment('RELEASE_PLEASE_TOKEN_FILE');
+  const repositoryParts = repository.split('/');
+  if (repositoryParts.length !== 2 || repositoryParts.some(part => !part)) {
+    throw new Error(`REPOSITORY must be owner/name, got ${repository}`);
+  }
+
+  const token = fs.readFileSync(tokenFile, 'utf8').trim();
+  if (!token) {
+    throw new Error('release-please token file is empty');
+  }
+
+  const {GitHub, Manifest} = require(releasePleaseRoot);
+  const github = await GitHub.create({
+    owner: repositoryParts[0],
+    repo: repositoryParts[1],
+    defaultBranch: targetBranch,
+    token,
+  });
+  const manifest = await Manifest.fromManifest(
+    github,
+    targetBranch,
+    'release-please-config.json',
+    '.release-please-manifest.json',
+    {},
+    undefined,
+    releaseAs
+  );
+
+  await permitExactEmptyChangelog(manifest, releaseAs);
+  const pullRequests = await manifest.createPullRequests();
+  if (pullRequests.length !== 1 || !pullRequests[0]) {
+    throw new Error(
+      `expected one exact-version release PR for ${releaseAs}, created ${pullRequests.length}`
+    );
+  }
+
+  console.log(
+    `Created or updated exact-version release PR #${pullRequests[0].number} for ${releaseAs}.`
+  );
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exit(1);
+});

--- a/hack/ci/test-release-automation.sh
+++ b/hack/ci/test-release-automation.sh
@@ -12,6 +12,7 @@ RELEASE_WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
 RELEASE_PLEASE_WORKFLOW="${ROOT_DIR}/.github/workflows/release-please.yml"
 RELEASE_PLEASE_PACKAGE="${ROOT_DIR}/hack/ci/release-please/package.json"
 RELEASE_PLEASE_LOCK="${ROOT_DIR}/hack/ci/release-please/package-lock.json"
+RELEASE_PLEASE_EXACT_RUNNER="${ROOT_DIR}/hack/ci/run-release-please-exact.js"
 RELEASE_PR_GATE_WORKFLOW="${ROOT_DIR}/.github/workflows/release-pr-gate.yml"
 
 tmp_dir="$(mktemp -d)"
@@ -130,12 +131,14 @@ bash -n \
 assert_contains "${RELEASE_PLEASE_WORKFLOW}" "Resolve Release-As override"
 assert_contains "${RELEASE_PLEASE_WORKFLOW}" "bash hack/ci/resolve-release-as-override.sh"
 assert_contains "${RELEASE_PLEASE_WORKFLOW}" "Run release-please action (normal manifest PR)"
-assert_contains "${RELEASE_PLEASE_WORKFLOW}" "Run release-please CLI (exact-version manifest PR)"
+assert_contains "${RELEASE_PLEASE_WORKFLOW}" "Run release-please wrapper (exact-version manifest PR)"
 assert_contains "${RELEASE_PLEASE_PACKAGE}" '"release-please": "17.6.0"'
-assert_contains "${RELEASE_PLEASE_WORKFLOW}" '--release-as="${RELEASE_AS}"'
+assert_contains "${RELEASE_PLEASE_WORKFLOW}" "node hack/ci/run-release-please-exact.js"
+assert_contains "${RELEASE_PLEASE_EXACT_RUNNER}" "PINNED_RELEASE_PLEASE_VERSION = '17.6.0'"
 assert_contains "${RELEASE_PLEASE_WORKFLOW}" "exact-version release PR does not match requested version"
 assert_contains "${RELEASE_PLEASE_WORKFLOW}" "release-please did not create the requested"
 assert_not_contains "${RELEASE_PLEASE_WORKFLOW}" 'release-as: ${{ steps.release-as.outputs.release_as }}'
+node "${RELEASE_PLEASE_EXACT_RUNNER}" --self-test
 release_please_lock_version="$(jq -er '.packages["node_modules/release-please"].version' "${RELEASE_PLEASE_LOCK}")"
 [[ "${release_please_lock_version}" == "17.6.0" ]] || fail "release-please lockfile version is not pinned to 17.6.0"
 release_please_lock_integrity="$(jq -er '.packages["node_modules/release-please"].integrity' "${RELEASE_PLEASE_LOCK}")"

--- a/website/content/contribute/release.md
+++ b/website/content/contribute/release.md
@@ -47,6 +47,10 @@ with a concise rollup from the previous stable release to `X.Y.0`. Use the previ
 and keep the incremental release-candidate sections below it. Do not add the stable section before release-please
 creates the PR because that can produce duplicate version headings.
 
+If the final release candidate contains all user-facing commits, the pinned exact-version wrapper permits release-please
+to create a stable PR with only the new version heading. Replace that heading-only section with the same reviewed
+previous-stable rollup before you authorize the release.
+
 For a patch, make the conventional commit or squash title describe the user-visible fix. Release-please uses that text
 to generate the changelog.
 


### PR DESCRIPTION
## Summary

Allow an exact stable Release-As request to produce a Release Please PR when the latest release candidate already contains every user-facing commit. Keep normal Release Please generation unchanged and fail closed unless the pinned 17.6.0 strategy returns the expected one-line version section.

This fixes the 0.5.0 stable promotion failure in Release Please run 33426531571. The run resolved `Release-As: 0.5.0` but skipped the PR because no visible commits followed 0.5.0-rc.6.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [x] CI, release, or build tooling
- [x] Documentation

## Risk and Compatibility

The wrapper is used only for exact-version requests. It requires the pinned Release Please version, one root package, an expected version heading, and exactly one created or updated PR. Normal manifest PR generation remains on the upstream action. There is no runtime, API, CRD, RBAC, or Helm behavior change.

## Verification

- `node hack/ci/run-release-please-exact.js --self-test`
- `devenv test`
- `devenv shell -- make lint`
- `devenv shell -- make verify-workflows`
- `devenv shell -- make docs-build`
- `git diff --check`

## Reviewer Notes

After merge, rerun the audited 0.5.0 Release-As marker flow or dispatch the exact Release Please workflow. The generated heading-only stable changelog section must be replaced with the reviewed 0.4.2-to-0.5.0 rollup before the release PR is authorized.

## Checklist

- [x] I reviewed the exact failure before changing the workflow.
- [x] The commit is DCO-signed and GPG-signed.
- [x] Release automation and documentation tests pass locally.