### PR TITLE
test: make HTTP handler assertions goroutine-safe

### DIFF
--- a/.ast-grep/rules/runtime-safety/no-fail-now-in-httptest-handler.yml
+++ b/.ast-grep/rules/runtime-safety/no-fail-now-in-httptest-handler.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-fail-now-in-httptest-handler
+message: Return handler failures to the test goroutine; terminating test assertions are unsafe in httptest server handlers.
+severity: warning
+language: Go
+files:
+  - '**/*_test.go'
+ignores:
+  - vendor/**/*.go
+rule:
+  all:
+    - kind: call_expression
+    - regex: '^httptest\.New(TLS|Unstarted)?Server\('
+    - has:
+        all:
+          - pattern: func($W http.ResponseWriter, $R *http.Request) { $$$BODY }
+          - has:
+              all:
+                - kind: call_expression
+                - regex: '(\.(Fatal|Fatalf|FailNow|Skip|Skipf|SkipNow)\(|\brequire\.[A-Za-z0-9_]+\(|\bassert\.FailNow\()'
+              stopBy: end
+        stopBy: end
+note: >-
+  httptest servers run handlers in separate goroutines. Fatal, FailNow, Skip, and require assertions terminate only
+  the handler goroutine and can leave the test in an invalid state. This rule checks direct calls in inline handlers
+  that use the standard httptest and assertion package names. It does not resolve assigned or named handlers, aliased
+  imports, or transitive helpers. Code review must reject helpers that receive a test handle and terminate the handler
+  transitively.

--- a/.ast-grep/tests/__snapshots__/no-fail-now-in-httptest-handler-snapshot.yml
+++ b/.ast-grep/tests/__snapshots__/no-fail-now-in-httptest-handler-snapshot.yml
@@ -1,0 +1,260 @@
+id: no-fail-now-in-httptest-handler
+snapshots:
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+      "github.com/stretchr/testify/assert"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        assert.FailNow(t, "unexpected request")
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            assert.FailNow(t, "unexpected request")
+          }))
+      style: primary
+      start: 152
+      end: 284
+    - source: assert.FailNow(t, "unexpected request")
+      style: secondary
+      start: 239
+      end: 278
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            assert.FailNow(t, "unexpected request")
+          }
+      style: secondary
+      start: 188
+      end: 282
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+      "github.com/stretchr/testify/require"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        require.NoError(t, r.Body.Close())
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            require.NoError(t, r.Body.Close())
+          }))
+      style: primary
+      start: 153
+      end: 283
+    - source: require.NoError(t, r.Body.Close())
+      style: secondary
+      start: 243
+      end: 277
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            require.NoError(t, r.Body.Close())
+          }
+      style: secondary
+      start: 192
+      end: 281
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.FailNow()
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            t.FailNow()
+          }))
+      style: primary
+      start: 113
+      end: 217
+    - source: t.FailNow()
+      style: secondary
+      start: 200
+      end: 211
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            t.FailNow()
+          }
+      style: secondary
+      start: 149
+      end: 215
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Fatal("unexpected request")
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            t.Fatal("unexpected request")
+          }))
+      style: primary
+      start: 113
+      end: 235
+    - source: t.Fatal("unexpected request")
+      style: secondary
+      start: 200
+      end: 229
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            t.Fatal("unexpected request")
+          }
+      style: secondary
+      start: 149
+      end: 233
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Fatalf("unexpected path: %s", r.URL.Path)
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            t.Fatalf("unexpected path: %s", r.URL.Path)
+          }))
+      style: primary
+      start: 113
+      end: 249
+    - source: 't.Fatalf("unexpected path: %s", r.URL.Path)'
+      style: secondary
+      start: 200
+      end: 243
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            t.Fatalf("unexpected path: %s", r.URL.Path)
+          }
+      style: secondary
+      start: 149
+      end: 247
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Skip("unsupported environment")
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            t.Skip("unsupported environment")
+          }))
+      style: primary
+      start: 113
+      end: 239
+    - source: t.Skip("unsupported environment")
+      style: secondary
+      start: 200
+      end: 233
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            t.Skip("unsupported environment")
+          }
+      style: secondary
+      start: 149
+      end: 237
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Skipf("unsupported path: %s", r.URL.Path)
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            t.Skipf("unsupported path: %s", r.URL.Path)
+          }))
+      style: primary
+      start: 113
+      end: 249
+    - source: 't.Skipf("unsupported path: %s", r.URL.Path)'
+      style: secondary
+      start: 200
+      end: 243
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            t.Skipf("unsupported path: %s", r.URL.Path)
+          }
+      style: secondary
+      start: 149
+      end: 247
+  ? |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.SkipNow()
+      }))
+      defer server.Close()
+    }
+  : labels:
+    - source: |-
+        httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            t.SkipNow()
+          }))
+      style: primary
+      start: 113
+      end: 226
+    - source: t.SkipNow()
+      style: secondary
+      start: 209
+      end: 220
+    - source: |-
+        func(w http.ResponseWriter, r *http.Request) {
+            t.SkipNow()
+          }
+      style: secondary
+      start: 158
+      end: 224

--- a/.ast-grep/tests/runtime-safety/no-fail-now-in-httptest-handler-test.yml
+++ b/.ast-grep/tests/runtime-safety/no-fail-now-in-httptest-handler-test.yml
@@ -1,0 +1,155 @@
+id: no-fail-now-in-httptest-handler
+valid:
+  - |
+    package p
+    import (
+      "errors"
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      handlerErrs := make(chan error, 1)
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        handlerErrs <- errors.New("unexpected request")
+        http.Error(w, "unexpected request", http.StatusBadRequest)
+      }))
+      defer server.Close()
+      _, _ = server.Client().Get(server.URL)
+      if err := <-handlerErrs; err != nil {
+        t.Fatal(err)
+      }
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Fatal("safe because ServeHTTP is called synchronously")
+      })
+      handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Errorf("nonfatal assertion: %s", r.URL.Path)
+      }))
+      defer server.Close()
+    }
+invalid:
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Fatal("unexpected request")
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Fatalf("unexpected path: %s", r.URL.Path)
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.FailNow()
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+      "github.com/stretchr/testify/require"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        require.NoError(t, r.Body.Close())
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Skip("unsupported environment")
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.Skipf("unsupported path: %s", r.URL.Path)
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        t.SkipNow()
+      }))
+      defer server.Close()
+    }
+  - |
+    package p
+    import (
+      "net/http"
+      "net/http/httptest"
+      "testing"
+      "github.com/stretchr/testify/assert"
+    )
+    func TestHandler(t *testing.T) {
+      server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        assert.FailNow(t, "unexpected request")
+      }))
+      defer server.Close()
+    }

--- a/cmd/bao-backup/http_handler_test.go
+++ b/cmd/bao-backup/http_handler_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type httpHandlerErrors struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func newHTTPHandlerErrors(t *testing.T) *httpHandlerErrors {
+	t.Helper()
+
+	errors := &httpHandlerErrors{}
+	t.Cleanup(func() {
+		errors.mu.Lock()
+		defer errors.mu.Unlock()
+
+		for _, message := range errors.messages {
+			t.Errorf("HTTP handler: %s", message)
+		}
+	})
+	return errors
+}
+
+func (e *httpHandlerErrors) Errorf(format string, args ...any) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.messages = append(e.messages, fmt.Sprintf(format, args...))
+}

--- a/cmd/bao-backup/main_test.go
+++ b/cmd/bao-backup/main_test.go
@@ -34,6 +34,7 @@ func TestAuthenticate_Token(t *testing.T) {
 
 func TestAuthenticate_JWT(t *testing.T) {
 	// Mock OpenBao server
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request
 		assert.Equal(t, "/v1/auth/jwt-operator/login", r.URL.Path)
@@ -41,7 +42,11 @@ func TestAuthenticate_JWT(t *testing.T) {
 
 		var body map[string]string
 		err := json.NewDecoder(r.Body).Decode(&body)
-		require.NoError(t, err)
+		if err != nil {
+			handlerErrors.Errorf("decode request body: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
 		assert.Equal(t, "test-jwt", body["jwt"])
 		assert.Equal(t, "test-role", body["role"])
 
@@ -51,7 +56,9 @@ func TestAuthenticate_JWT(t *testing.T) {
 				"client_token": "login-token",
 			},
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(resp))
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			handlerErrors.Errorf("encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -70,8 +77,10 @@ func TestAuthenticate_JWT(t *testing.T) {
 func TestAuthenticate_JWTInlineDoesNotLogin(t *testing.T) {
 	t.Parallel()
 
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected request for inline auth: %s %s", r.Method, r.URL.Path)
+		handlerErrors.Errorf("unexpected request for inline auth: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 

--- a/cmd/bao-backup/openbao_runtime_test.go
+++ b/cmd/bao-backup/openbao_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -45,6 +46,7 @@ func TestOpenClusterClient_JWTInlineSnapshotUsesInlineAuthHeaders(t *testing.T) 
 
 	var loginRequests int32
 	var snapshotRequests int32
+	handlerErrors := newHTTPHandlerErrors(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -56,7 +58,11 @@ func TestOpenClusterClient_JWTInlineSnapshotUsesInlineAuthHeaders(t *testing.T) 
 			if r.Method != http.MethodGet {
 				t.Errorf("snapshot method=%s, want GET", r.Method)
 			}
-			requireInlineAuthHeaders(t, r, testBackupJWTAuthRole, testBackupJWTToken)
+			if err := validateInlineAuthHeaders(r, testBackupJWTAuthRole, testBackupJWTToken); err != nil {
+				handlerErrors.Errorf("%v", err)
+				http.Error(w, "invalid inline authentication headers", http.StatusBadRequest)
+				return
+			}
 			_, _ = w.Write([]byte(testBackupSnapshotData))
 		default:
 			http.NotFound(w, r)
@@ -113,6 +119,7 @@ func TestOpenClusterClient_JWTInlineRestoreUsesInlineAuthHeaders(t *testing.T) {
 
 			var loginRequests int32
 			var restoreRequests int32
+			handlerErrors := newHTTPHandlerErrors(t)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -131,7 +138,11 @@ func TestOpenClusterClient_JWTInlineRestoreUsesInlineAuthHeaders(t *testing.T) {
 					if string(body) != testBackupRestoreData {
 						t.Errorf("restore body=%q, want %q", string(body), testBackupRestoreData)
 					}
-					requireInlineAuthHeaders(t, r, testBackupJWTAuthRole, testBackupJWTToken)
+					if err := validateInlineAuthHeaders(r, testBackupJWTAuthRole, testBackupJWTToken); err != nil {
+						handlerErrors.Errorf("%v", err)
+						http.Error(w, "invalid inline authentication headers", http.StatusBadRequest)
+						return
+					}
 					w.WriteHeader(http.StatusNoContent)
 				default:
 					http.NotFound(w, r)
@@ -234,35 +245,34 @@ func newInlineJWTBackupConfig() *backupconfig.ExecutorConfig {
 	}
 }
 
-func requireInlineAuthHeaders(t *testing.T, r *http.Request, role, jwtToken string) {
-	t.Helper()
-
+func validateInlineAuthHeaders(r *http.Request, role, jwtToken string) error {
 	if got := r.Header.Get(testVaultTokenHeader); got != "" {
-		t.Fatalf("%s=%q, want empty", testVaultTokenHeader, got)
+		return fmt.Errorf("%s=%q, want empty", testVaultTokenHeader, got)
 	}
 	if got := r.Header.Get(testInlineAuthPathHeader); got != testInlineAuthJWTPath {
-		t.Fatalf("%s=%q, want %q", testInlineAuthPathHeader, got, testInlineAuthJWTPath)
+		return fmt.Errorf("%s=%q, want %q", testInlineAuthPathHeader, got, testInlineAuthJWTPath)
 	}
 	if got := r.Header.Get(testInlineAuthOperationHeader); got != testInlineAuthOperation {
-		t.Fatalf("%s=%q, want %q", testInlineAuthOperationHeader, got, testInlineAuthOperation)
+		return fmt.Errorf("%s=%q, want %q", testInlineAuthOperationHeader, got, testInlineAuthOperation)
 	}
 
-	requireInlineAuthParameter(t, r.Header.Get(testInlineAuthRoleParameterHeader), "role", role)
-	requireInlineAuthParameter(t, r.Header.Get(testInlineAuthJWTParameterHeader), "jwt", jwtToken)
+	if err := validateInlineAuthParameter(r.Header.Get(testInlineAuthRoleParameterHeader), "role", role); err != nil {
+		return err
+	}
+	return validateInlineAuthParameter(r.Header.Get(testInlineAuthJWTParameterHeader), "jwt", jwtToken)
 }
 
-func requireInlineAuthParameter(t *testing.T, encoded, key, value string) {
-	t.Helper()
-
+func validateInlineAuthParameter(encoded, key, value string) error {
 	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {
-		t.Fatalf("failed to decode inline auth parameter %q: %v", key, err)
+		return fmt.Errorf("decode inline auth parameter %q: %w", key, err)
 	}
 	var param testInlineAuthParameter
 	if err := json.Unmarshal(decoded, &param); err != nil {
-		t.Fatalf("failed to unmarshal inline auth parameter %q: %v", key, err)
+		return fmt.Errorf("unmarshal inline auth parameter %q: %w", key, err)
 	}
 	if param.Key != key || param.Value != value {
-		t.Fatalf("inline auth parameter=%#v, want key=%q value=%q", param, key, value)
+		return fmt.Errorf("inline auth parameter=%#v, want key=%q value=%q", param, key, value)
 	}
+	return nil
 }

--- a/hack/tools/ghcr_housekeeping/http_handler_test.go
+++ b/hack/tools/ghcr_housekeeping/http_handler_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type httpHandlerErrors struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func newHTTPHandlerErrors(t *testing.T) *httpHandlerErrors {
+	t.Helper()
+
+	errors := &httpHandlerErrors{}
+	t.Cleanup(func() {
+		errors.mu.Lock()
+		defer errors.mu.Unlock()
+
+		for _, message := range errors.messages {
+			t.Errorf("HTTP handler: %s", message)
+		}
+	})
+	return errors
+}
+
+func (e *httpHandlerErrors) Errorf(format string, args ...any) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.messages = append(e.messages, fmt.Sprintf(format, args...))
+}

--- a/hack/tools/ghcr_housekeeping/main_test.go
+++ b/hack/tools/ghcr_housekeeping/main_test.go
@@ -435,9 +435,12 @@ func TestGitHubClientPaginatesVersions(t *testing.T) {
 		},
 	}
 
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
-			t.Fatalf("missing bearer auth header")
+			handlerErrors.Errorf("missing bearer auth header")
+			http.Error(w, "missing bearer auth header", http.StatusUnauthorized)
+			return
 		}
 		page := r.URL.Query().Get("page")
 		if page == "" {
@@ -448,15 +451,15 @@ func TestGitHubClientPaginatesVersions(t *testing.T) {
 		switch page {
 		case "1":
 			if err := json.NewEncoder(w).Encode(pageOne); err != nil {
-				t.Fatalf("encode page1: %v", err)
+				handlerErrors.Errorf("encode page1: %v", err)
 			}
 		case "2":
 			if err := json.NewEncoder(w).Encode(pageTwo); err != nil {
-				t.Fatalf("encode page2: %v", err)
+				handlerErrors.Errorf("encode page2: %v", err)
 			}
 		default:
 			if err := json.NewEncoder(w).Encode([]apiPackageVersion{}); err != nil {
-				t.Fatalf("encode empty page: %v", err)
+				handlerErrors.Errorf("encode empty page: %v", err)
 			}
 		}
 	}))
@@ -677,14 +680,19 @@ func TestExtractAPIErrorMessageFallback(t *testing.T) {
 }
 
 func TestGitHubClientDeleteHandlesNotFoundAsSuccess(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
-			t.Fatalf("method = %s, want DELETE", r.Method)
+			handlerErrors.Errorf("method = %s, want DELETE", r.Method)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
 		}
 		idText := filepath.Base(r.URL.Path)
 		id, err := strconv.Atoi(idText)
 		if err != nil {
-			t.Fatalf("parse id: %v", err)
+			handlerErrors.Errorf("parse id: %v", err)
+			http.Error(w, "invalid package version", http.StatusBadRequest)
+			return
 		}
 		if id == 404 {
 			w.WriteHeader(http.StatusNotFound)

--- a/hack/tools/ghcr_housekeeping/registry_test.go
+++ b/hack/tools/ghcr_housekeeping/registry_test.go
@@ -15,22 +15,29 @@ func TestContainerRegistryClientListsManifestReferencesAndCachesToken(t *testing
 
 	tokenRequests := 0
 	manifestRequests := 0
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/token":
 			tokenRequests++
 			username, password, ok := r.BasicAuth()
 			if !ok || username != "github-actions[bot]" || password != "github-token" {
-				t.Fatalf("unexpected registry token credentials: username=%q ok=%t", username, ok)
+				handlerErrors.Errorf("unexpected registry token credentials: username=%q ok=%t", username, ok)
+				http.Error(w, "invalid credentials", http.StatusUnauthorized)
+				return
 			}
 			if got := r.URL.Query().Get("scope"); got != "repository:dc-tec/openbao-operator:pull" {
-				t.Fatalf("scope = %q", got)
+				handlerErrors.Errorf("scope = %q", got)
+				http.Error(w, "invalid scope", http.StatusBadRequest)
+				return
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"token": "registry-token"})
 		case strings.HasPrefix(r.URL.Path, "/v2/dc-tec/openbao-operator/manifests/"):
 			manifestRequests++
 			if got := r.Header.Get("Authorization"); got != "Bearer registry-token" {
-				t.Fatalf("authorization = %q", got)
+				handlerErrors.Errorf("authorization = %q", got)
+				http.Error(w, "invalid authorization", http.StatusUnauthorized)
+				return
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"schemaVersion": 2,

--- a/internal/adapter/openbao/client_manager_test.go
+++ b/internal/adapter/openbao/client_manager_test.go
@@ -124,10 +124,11 @@ func TestClientManager_CircuitBreakerIsolation(t *testing.T) {
 	defer mgr2.Close()
 
 	var requests int32
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&requests, 1)
 		if r.URL.Path != apiPathSysStepDown {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("boom"))

--- a/internal/adapter/openbao/client_test.go
+++ b/internal/adapter/openbao/client_test.go
@@ -39,9 +39,10 @@ type healthBoolTestCase struct {
 func newHealthResponseClient(t *testing.T, response HealthResponse) *Client {
 	t.Helper()
 
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			t.Fatal(err)
+			handlerErrors.Errorf("encode health response: %v", err)
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -229,6 +230,7 @@ func TestClient_Health(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			handlerErrors := newHTTPHandlerErrors(t)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != apiPathSysHealth {
 					t.Errorf("unexpected path: %s", r.URL.Path)
@@ -239,7 +241,7 @@ func TestClient_Health(t *testing.T) {
 
 				w.WriteHeader(tt.statusCode)
 				if err := json.NewEncoder(w).Encode(tt.response); err != nil {
-					t.Fatal(err)
+					handlerErrors.Errorf("encode health response: %v", err)
 				}
 			}))
 			defer server.Close()
@@ -415,6 +417,7 @@ func TestClient_StepDown(t *testing.T) {
 func TestClient_StepDownWithInlineJWTUsesStandardJWTFallback(t *testing.T) {
 	var loginRequests int
 	var stepDownRequests int
+	handlerErrors := newHTTPHandlerErrors(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -431,10 +434,10 @@ func TestClient_StepDownWithInlineJWTUsesStandardJWTFallback(t *testing.T) {
 				t.Errorf("step-down method=%s, want PUT", r.Method)
 			}
 			if got := r.Header.Get(headerVaultToken); got != "s.stepdown" {
-				t.Fatalf("%s=%q, want %q", headerVaultToken, got, "s.stepdown")
+				handlerErrors.Errorf("%s=%q, want %q", headerVaultToken, got, "s.stepdown")
 			}
 			if got := r.Header.Get(headerInlineAuthPath); got != "" {
-				t.Fatalf("%s=%q, want empty", headerInlineAuthPath, got)
+				handlerErrors.Errorf("%s=%q, want empty", headerInlineAuthPath, got)
 			}
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -461,12 +464,13 @@ func TestClient_StepDownWithInlineJWTUsesStandardJWTFallback(t *testing.T) {
 }
 
 func TestClient_JoinRaftCluster_AlreadyJoinedStatus(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathRaftJoin {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPut {
-			t.Fatalf("unexpected method: %s", r.Method)
+			handlerErrors.Errorf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"errors":["node already joined to cluster"]}`))
@@ -492,9 +496,10 @@ func TestClient_JoinRaftCluster_AlreadyJoinedStatus(t *testing.T) {
 }
 
 func TestClient_JoinRaftCluster_NotJoinedResponse(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathRaftJoin {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"joined":false}`))
@@ -519,12 +524,13 @@ func TestClient_JoinRaftCluster_NotJoinedResponse(t *testing.T) {
 }
 
 func TestClient_JoinRaftCluster_StandaloneStatusIsNotAlreadyJoined(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathRaftJoin {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPut {
-			t.Fatalf("unexpected method: %s", r.Method)
+			handlerErrors.Errorf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"errors":["node already initialized as standalone"]}`))
@@ -550,12 +556,13 @@ func TestClient_JoinRaftCluster_StandaloneStatusIsNotAlreadyJoined(t *testing.T)
 }
 
 func TestClient_DemoteRaftPeer_AlreadyNonVoterStatus(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathRaftDemotePeer {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
+			handlerErrors.Errorf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"errors":["peer is already a non-voter"]}`))
@@ -612,12 +619,13 @@ type raftPeerActionTranslationTest struct {
 func assertTranslatedRaftPeerActionError(t *testing.T, tc raftPeerActionTranslationTest) {
 	t.Helper()
 
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != tc.path {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
+			handlerErrors.Errorf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(tc.responseBody))
@@ -646,12 +654,13 @@ func assertTranslatedRaftPeerActionError(t *testing.T, tc raftPeerActionTranslat
 }
 
 func TestClient_JoinRaftCluster_AlreadyJoinedWrappedOverload(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathRaftJoin {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPut {
-			t.Fatalf("unexpected method: %s", r.Method)
+			handlerErrors.Errorf("unexpected method: %s", r.Method)
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"errors":["node already joined to cluster"]}`))
@@ -896,6 +905,7 @@ func TestClient_Init(t *testing.T) {
 }
 
 func TestClient_Init_UsesContextDeadlineBeyondDefaultRequestTimeout(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathSysInit {
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -911,7 +921,7 @@ func TestClient_Init_UsesContextDeadlineBeyondDefaultRequestTimeout(t *testing.T
 			UnsealKeysB64: []string{"key1"},
 			RootToken:     "s.root-token",
 		}); err != nil {
-			t.Fatalf("failed to encode response: %v", err)
+			handlerErrors.Errorf("failed to encode response: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -1057,6 +1067,7 @@ func TestClient_LoginJWT(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			handlerErrors := newHTTPHandlerErrors(t)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != apiPathAuthJWTLogin {
 					t.Errorf("unexpected path: %s, want %s", r.URL.Path, apiPathAuthJWTLogin)
@@ -1088,7 +1099,7 @@ func TestClient_LoginJWT(t *testing.T) {
 
 				if tt.responseBody != nil {
 					if err := json.NewEncoder(w).Encode(tt.responseBody); err != nil {
-						t.Fatal(err)
+						handlerErrors.Errorf("encode login response: %v", err)
 					}
 				}
 			}))
@@ -1123,9 +1134,10 @@ func TestClient_LoginJWT(t *testing.T) {
 }
 
 func TestClient_ReadRaftAutopilotState_NotFoundPreservesStatus(t *testing.T) {
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != apiPathRaftAutopilotState {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"errors":["autopilot not enabled"]}`))

--- a/internal/adapter/openbao/factory_test.go
+++ b/internal/adapter/openbao/factory_test.go
@@ -68,23 +68,24 @@ func TestClientFactory_LoginJWT(t *testing.T) {
 		JWT  string `json:"jwt"`
 	}
 
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
+			handlerErrors.Errorf("unexpected method: %s", r.Method)
 		}
 		if r.URL.Path != apiPathAuthJWTLogin {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
-			t.Fatalf("Content-Type=%q, expected application/json", got)
+			handlerErrors.Errorf("Content-Type=%q, expected application/json", got)
 		}
 
 		var body requestBody
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
+			handlerErrors.Errorf("failed to decode request body: %v", err)
 		}
 		if body.Role != "role" || body.JWT != "jwt" {
-			t.Fatalf("unexpected body: %#v", body)
+			handlerErrors.Errorf("unexpected body: %#v", body)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/adapter/openbao/http_handler_test.go
+++ b/internal/adapter/openbao/http_handler_test.go
@@ -1,0 +1,33 @@
+package openbao
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type httpHandlerErrors struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func newHTTPHandlerErrors(t *testing.T) *httpHandlerErrors {
+	t.Helper()
+
+	errors := &httpHandlerErrors{}
+	t.Cleanup(func() {
+		errors.mu.Lock()
+		defer errors.mu.Unlock()
+
+		for _, message := range errors.messages {
+			t.Errorf("HTTP handler: %s", message)
+		}
+	})
+	return errors
+}
+
+func (e *httpHandlerErrors) Errorf(format string, args ...any) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.messages = append(e.messages, fmt.Sprintf(format, args...))
+}

--- a/internal/adapter/openbao/transport_test.go
+++ b/internal/adapter/openbao/transport_test.go
@@ -14,10 +14,11 @@ import (
 
 func TestSmartClient_CircuitBreaker_SharedAcrossClients(t *testing.T) {
 	var requests int32
+	handlerErrors := newHTTPHandlerErrors(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&requests, 1)
 		if r.URL.Path != apiPathSysStepDown {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			handlerErrors.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("boom"))

--- a/internal/adapter/probe/prober_test.go
+++ b/internal/adapter/probe/prober_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -135,9 +136,13 @@ func TestHTTPProber_CheckStartup_StatusCodes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			handlerErrors := make(chan error, 1)
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/v1/sys/health" {
-					t.Fatalf("startup path=%q, want /v1/sys/health", r.URL.Path)
+					select {
+					case handlerErrors <- fmt.Errorf("startup path=%q, want /v1/sys/health", r.URL.Path):
+					default:
+					}
 				}
 				w.WriteHeader(tt.statusCode)
 			}))
@@ -164,6 +169,11 @@ func TestHTTPProber_CheckStartup_StatusCodes(t *testing.T) {
 			}
 
 			err = prober.CheckStartup(context.Background())
+			select {
+			case handlerErr := <-handlerErrors:
+				t.Fatal(handlerErr)
+			default:
+			}
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("CheckStartup() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/service/upgrade/raftops/auth_strategy_test.go
+++ b/internal/service/upgrade/raftops/auth_strategy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -39,6 +40,7 @@ func TestNewAuthenticatedClient_DefaultInlineUsesInlineAuthHeaders(t *testing.T)
 
 	var loginRequests int32
 	var demoteRequests int32
+	handlerErrors := make(chan error, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -50,7 +52,12 @@ func TestNewAuthenticatedClient_DefaultInlineUsesInlineAuthHeaders(t *testing.T)
 			if r.Method != http.MethodPost {
 				t.Errorf("demote method=%s, want POST", r.Method)
 			}
-			requireUpgradeInlineAuthHeaders(t, r, testUpgradeJWTAuthRole, testUpgradeJWTToken)
+			if err := validateUpgradeInlineAuthHeaders(r, testUpgradeJWTAuthRole, testUpgradeJWTToken); err != nil {
+				select {
+				case handlerErrors <- err:
+				default:
+				}
+			}
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			http.NotFound(w, r)
@@ -70,6 +77,11 @@ func TestNewAuthenticatedClient_DefaultInlineUsesInlineAuthHeaders(t *testing.T)
 	}
 	if err := client.DemoteRaftPeer(context.Background(), "node-1"); err != nil {
 		t.Fatalf("DemoteRaftPeer() error: %v", err)
+	}
+	select {
+	case handlerErr := <-handlerErrors:
+		t.Fatal(handlerErr)
+	default:
 	}
 
 	if got := atomic.LoadInt32(&loginRequests); got != 0 {
@@ -143,35 +155,42 @@ func newJWTUpgradeConfig(strategy string) *ExecutorConfig {
 	}
 }
 
-func requireUpgradeInlineAuthHeaders(t *testing.T, r *http.Request, role, jwtToken string) {
-	t.Helper()
-
+func validateUpgradeInlineAuthHeaders(r *http.Request, role, jwtToken string) error {
 	if got := r.Header.Get(testUpgradeVaultTokenHeader); got != "" {
-		t.Fatalf("%s=%q, want empty", testUpgradeVaultTokenHeader, got)
+		return fmt.Errorf("%s=%q, want empty", testUpgradeVaultTokenHeader, got)
 	}
 	if got := r.Header.Get(testUpgradeInlineAuthPathHeader); got != testUpgradeInlineAuthJWTPath {
-		t.Fatalf("%s=%q, want %q", testUpgradeInlineAuthPathHeader, got, testUpgradeInlineAuthJWTPath)
+		return fmt.Errorf("%s=%q, want %q", testUpgradeInlineAuthPathHeader, got, testUpgradeInlineAuthJWTPath)
 	}
 	if got := r.Header.Get(testUpgradeInlineAuthOperationHeader); got != testUpgradeInlineAuthOperation {
-		t.Fatalf("%s=%q, want %q", testUpgradeInlineAuthOperationHeader, got, testUpgradeInlineAuthOperation)
+		return fmt.Errorf("%s=%q, want %q", testUpgradeInlineAuthOperationHeader, got, testUpgradeInlineAuthOperation)
 	}
 
-	requireUpgradeInlineAuthParameter(t, r.Header.Get(testUpgradeInlineAuthRoleParameterHeader), "role", role)
-	requireUpgradeInlineAuthParameter(t, r.Header.Get(testUpgradeInlineAuthJWTParameterHeader), "jwt", jwtToken)
+	if err := validateUpgradeInlineAuthParameter(
+		r.Header.Get(testUpgradeInlineAuthRoleParameterHeader),
+		"role",
+		role,
+	); err != nil {
+		return err
+	}
+	return validateUpgradeInlineAuthParameter(
+		r.Header.Get(testUpgradeInlineAuthJWTParameterHeader),
+		"jwt",
+		jwtToken,
+	)
 }
 
-func requireUpgradeInlineAuthParameter(t *testing.T, encoded, key, value string) {
-	t.Helper()
-
+func validateUpgradeInlineAuthParameter(encoded, key, value string) error {
 	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {
-		t.Fatalf("failed to decode inline auth parameter %q: %v", key, err)
+		return fmt.Errorf("decode inline auth parameter %q: %w", key, err)
 	}
 	var param testUpgradeInlineAuthParameter
 	if err := json.Unmarshal(decoded, &param); err != nil {
-		t.Fatalf("failed to unmarshal inline auth parameter %q: %v", key, err)
+		return fmt.Errorf("unmarshal inline auth parameter %q: %w", key, err)
 	}
 	if param.Key != key || param.Value != value {
-		t.Fatalf("inline auth parameter=%#v, want key=%q value=%q", param, key, value)
+		return fmt.Errorf("inline auth parameter=%#v, want key=%q value=%q", param, key, value)
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- replace fail-now assertions in `httptest` server handlers with race-safe error reporting on the owning test goroutine
- convert transitive inline-auth assertion helpers into validators that return errors
- add an AST guardrail with fixtures to prevent direct terminating assertions in inline `httptest` handlers

This fixes 41 unsafe invocation sites across 24 handlers in 10 test files. No production code changes.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

None. This changes test failure reporting and adds a static test-safety rule. It does not change APIs, CRDs, Helm resources, RBAC, security policy, upgrade behavior, or runtime behavior.

## Verification

- `make lint-ci` — zero lint issues; all 62 AST rules passed
- `go test -race -count=1 -p 2 ./cmd/bao-backup ./hack/tools/ghcr_housekeeping ./internal/adapter/openbao ./internal/adapter/probe ./internal/service/upgrade/raftops`
- `make test-ci` — 3,582 tests passed, four skipped; internal coverage 69.67% against the 68% minimum
- `make generate-ast-rules verify-arch-policy test-ast lint-ast`
- `git diff --check`

## Reviewer Notes

Focus on whether handler failures remain attributable to their original expectations and are reported only after the server request completes.

The AST rule covers direct terminating calls in inline handlers passed to literally named `httptest.NewServer`, `httptest.NewTLSServer`, and `httptest.NewUnstartedServer`. It does not resolve assigned or named handlers, aliased imports, or transitive helper call graphs. The rule documents these limits, and the existing transitive helper cases now return errors instead of accepting `*testing.T`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

Documentation is not needed because the change affects only test implementation and repository-internal static analysis. The generated AST snapshot is included. There are no dependent changes.
