### PR TITLE
test: enforce helper and suppression hygiene

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,13 +15,18 @@ linters:
     - lll
     - misspell
     - nakedret
+    - nolintlint
     - prealloc
     - revive
     - staticcheck
+    - thelper
     - unconvert
     - unparam
     - unused
   settings:
+    nolintlint:
+      require-explanation: true
+      require-specific: true
     revive:
       rules:
         - name: comment-spacings

--- a/cmd/bao-wrapper/main_test.go
+++ b/cmd/bao-wrapper/main_test.go
@@ -76,6 +76,8 @@ func Test_getFileHash(t *testing.T) {
 		{
 			name: "valid file with content",
 			setupFile: func(t *testing.T) string {
+				t.Helper()
+
 				tmpFile, err := os.CreateTemp("", "test-*.txt")
 				if err != nil {
 					t.Fatalf("failed to create temp file: %v", err)
@@ -91,6 +93,8 @@ func Test_getFileHash(t *testing.T) {
 			},
 			wantErr: false,
 			verify: func(t *testing.T, hash []byte, filePath string) {
+				t.Helper()
+
 				// Verify hash matches expected SHA256
 				f, err := os.Open(filePath)
 				if err != nil {
@@ -117,6 +121,8 @@ func Test_getFileHash(t *testing.T) {
 		{
 			name: "non-existent file",
 			setupFile: func(t *testing.T) string {
+				t.Helper()
+
 				return "/nonexistent/file/path"
 			},
 			wantErr: true,
@@ -124,6 +130,8 @@ func Test_getFileHash(t *testing.T) {
 		{
 			name: "empty file",
 			setupFile: func(t *testing.T) string {
+				t.Helper()
+
 				tmpFile, err := os.CreateTemp("", "test-empty-*.txt")
 				if err != nil {
 					t.Fatalf("failed to create temp file: %v", err)
@@ -135,6 +143,8 @@ func Test_getFileHash(t *testing.T) {
 			},
 			wantErr: false,
 			verify: func(t *testing.T, hash []byte, filePath string) {
+				t.Helper()
+
 				// Empty file should have a known SHA256 hash
 				expected := sha256.Sum256([]byte{})
 				if !bytes.Equal(hash, expected[:]) {
@@ -145,6 +155,8 @@ func Test_getFileHash(t *testing.T) {
 		{
 			name: "file with binary content",
 			setupFile: func(t *testing.T) string {
+				t.Helper()
+
 				tmpFile, err := os.CreateTemp("", "test-binary-*.bin")
 				if err != nil {
 					t.Fatalf("failed to create temp file: %v", err)
@@ -160,6 +172,8 @@ func Test_getFileHash(t *testing.T) {
 			},
 			wantErr: false,
 			verify: func(t *testing.T, hash []byte, filePath string) {
+				t.Helper()
+
 				// Verify hash is correct
 				f, err := os.Open(filePath)
 				if err != nil {

--- a/internal/adapter/config/selfinit_render.go
+++ b/internal/adapter/config/selfinit_render.go
@@ -226,9 +226,7 @@ func renderSelfInitStanzas(body *hclwrite.Body, requests []openbaov1alpha1.SelfI
 		}
 
 		if dataVal != cty.NilVal {
-			if err := setSelfInitRequestData(requestBody, dataVal); err != nil {
-				return fmt.Errorf("failed to render self-init request data for request %q: %w", req.Name, err)
-			}
+			setSelfInitRequestData(requestBody, dataVal)
 		}
 
 		initBody.AppendBlock(requestBlock)
@@ -269,10 +267,9 @@ func selfInitHeadersToCty(headers map[string][]string) (cty.Value, error) {
 	return cty.ObjectVal(rendered), nil
 }
 
-//nolint:unparam // Error return maintained for API consistency and future extensibility
-func setSelfInitRequestData(requestBody *hclwrite.Body, dataVal cty.Value) error {
+func setSelfInitRequestData(requestBody *hclwrite.Body, dataVal cty.Value) {
 	if dataVal == cty.NilVal {
-		return nil
+		return
 	}
 
 	// Prefer "data { ... }" blocks which match OpenBao self-init docs and the
@@ -290,9 +287,8 @@ func setSelfInitRequestData(requestBody *hclwrite.Body, dataVal cty.Value) error
 		for _, k := range keys {
 			dataBody.SetAttributeValue(k, dataMap[k])
 		}
-		return nil
+		return
 	}
 
 	requestBody.SetAttributeValue("data", dataVal)
-	return nil
 }

--- a/internal/service/backup/job_test.go
+++ b/internal/service/backup/job_test.go
@@ -53,7 +53,6 @@ func newTestClient(t *testing.T, objs ...client.Object) client.Client {
 	return builder.Build()
 }
 
-//nolint:unparam // Keeping parameters makes tests easier to expand later.
 func newTestClusterWithBackup(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 	return &openbaov1alpha1.OpenBaoCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/service/networking/helpers_test.go
+++ b/internal/service/networking/helpers_test.go
@@ -18,7 +18,6 @@ var testScheme = func() *runtime.Scheme {
 	return scheme
 }()
 
-//nolint:unparam // namespace is used by tests across the package
 func newMinimalCluster(name, namespace string) *openbaov1alpha1.OpenBaoCluster {
 	return &openbaov1alpha1.OpenBaoCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(name + "-uid")},

--- a/internal/service/restore/manager_status.go
+++ b/internal/service/restore/manager_status.go
@@ -25,8 +25,6 @@ func (m *Manager) patchStatus(ctx context.Context, restore *openbaov1alpha1.Open
 }
 
 // failRestore transitions the restore to Failed phase.
-//
-//nolint:unparam // ctrl.Result is always zero value but required by controller-runtime interface
 func (m *Manager) failRestore(ctx context.Context, logger logr.Logger, restore *openbaov1alpha1.OpenBaoRestore, message string) (ctrl.Result, error) {
 	original := restore.DeepCopy()
 	now := metav1.Now()

--- a/test/e2e/helpers/bao_helpers.go
+++ b/test/e2e/helpers/bao_helpers.go
@@ -381,7 +381,6 @@ func RunCommandViaJWT(
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
-//nolint:unparam
 func randString(n int) string {
 	b := make([]rune, n)
 	for i := range b {

--- a/test/e2e/helpers/bao_infra.go
+++ b/test/e2e/helpers/bao_infra.go
@@ -38,8 +38,6 @@ const infraBaoCAMountPath = "/etc/bao/infra-ca"
 // EnsureInfraBao creates (or reuses) a production-mode OpenBao pod + service with TLS.
 // The service is reachable at https://<name>.<namespace>.svc:8200.
 // Infra-bao always runs in production mode with TLS (never dev mode).
-//
-//nolint:gocyclo // End-to-end provisioning must be explicit to simplify troubleshooting in CI.
 func EnsureInfraBao(ctx context.Context, restCfg *rest.Config, c client.Client, cfg InfraBaoConfig) error {
 	if c == nil {
 		return fmt.Errorf("kubernetes client is required")

--- a/test/e2e/helpers/json.go
+++ b/test/e2e/helpers/json.go
@@ -12,8 +12,6 @@ import (
 // It accepts an interface because json.Marshal's signature requires it for values
 // that are not known at compile time (e.g., structs, maps) and E2E tests often
 // build small request payloads inline.
-//
-//nolint:revive // json.Marshal requires an interface for generic encoding.
 func JSONFrom(v interface{}) (*apiextensionsv1.JSON, error) {
 	raw, err := json.Marshal(v)
 	if err != nil {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 
 	gcrname "github.com/google/go-containerregistry/pkg/name"
-	. "github.com/onsi/ginkgo/v2" // nolint:revive,staticcheck
+	"github.com/onsi/ginkgo/v2"
 )
 
 const (
@@ -43,7 +43,7 @@ const (
 )
 
 func warnError(err error) {
-	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "warning: %v\n", err)
 }
 
 // lookPathNoDot behaves like exec.LookPath, but ignores empty/ "." PATH entries.
@@ -137,7 +137,7 @@ func Run(cmd *exec.Cmd) (string, error) {
 	cmd.Dir = dir
 
 	if err := os.Chdir(cmd.Dir); err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "chdir dir: %q\n", err)
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "chdir dir: %q\n", err)
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
@@ -145,7 +145,7 @@ func Run(cmd *exec.Cmd) (string, error) {
 		return "", err
 	}
 	command := strings.Join(cmd.Args, " ")
-	_, _ = fmt.Fprintf(GinkgoWriter, "running: %q\n", command)
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "running: %q\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("%q failed with error %q: %w", command, string(output), err)
@@ -398,7 +398,7 @@ func LoadImageToKindClusterWithName(imageName string) error {
 				imageName, errors.Join(originalErr, retryErr))
 		}
 
-		_, _ = fmt.Fprintf(GinkgoWriter,
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter,
 			"kind load fallback succeeded for %q using %s/%s digest %q\n",
 			imageName, kindFallbackPlatformOS, fallbackArch, fallbackRef,
 		)


### PR DESCRIPTION
## Summary

- enable `thelper` and strict `nolintlint` checks to preserve helper attribution and suppression quality
- add the seven missing `t.Helper()` calls, remove six stale suppressions, and replace an unnecessary Ginkgo dot import
- remove an impossible error return from the self-init data renderer and simplify its only caller

This resolves all 14 findings from enabling the two linters without adding exclusions.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [x] Other maintenance

## Risk and Compatibility

Low. This adds lint ratchets and cleans up test helpers and suppressions. The only production-code change removes an error result that was always `nil`; rendered self-init output and runtime behavior are unchanged. There are no API, CRD, Helm, RBAC, security-policy, or upgrade compatibility changes.

## Verification

- `make lint-ci` — zero lint issues; all 62 AST rules passed
- `go test -count=1 ./cmd/bao-wrapper ./internal/adapter/config ./internal/service/backup ./internal/service/networking ./internal/service/restore ./test/utils`
- `go test -count=1 -tags=e2e ./test/e2e/helpers ./test/utils`
- `make test-ci` — 3,582 tests passed, four skipped; internal coverage 69.67% against the 68% minimum
- `git diff --check`

## Reviewer Notes

The retained `nolint` directives are linter-specific, explained, and active under the current configuration. No path exclusions were added.

Tagged-source vet coverage and the existing E2E package-selection gap are intentionally excluded. They will be handled in a separate CI-focused change and are not dependencies of this PR.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

No documentation or generated-artifact changes are required. There are no dependent changes.
