### PR TITLE
ci: verify tagged Go sources

### DIFF
--- a/.agents/rules/testing-standards.md
+++ b/.agents/rules/testing-standards.md
@@ -35,7 +35,7 @@ make test               # Unit tests (fast, no envtest)
 make test-sum           # Unit tests with gotestsum output + JUnit/coverage artifacts in dist/test/
 make test-integration   # Envtest-based integration tests (-tags=integration)
 make test-integration-sum # Envtest tests with gotestsum output + JUnit/coverage artifacts in dist/test/
-make test-ci            # Unit + integration tests (CI-equivalent)
+make test-ci            # Unit, integration, and cluster-independent E2E support tests (CI-equivalent)
 make ci-core            # Main pre-PR local gate (everything except E2E)
 make test-update-golden # Update HCL golden files
 make test-e2e           # E2E tests (requires Kind)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
       - name: Setup repo tools
         uses: ./.github/actions/setup-repo-tools
 
-      - name: Run unit and integration tests with coverage gate
+      - name: Run unit, integration, and cluster-independent E2E support tests with coverage gate
         run: make test-ci
 
   fuzz:

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -60,18 +60,25 @@ verify-fmt: ## Verify all Go code is gofmt'd (does not modify files).
 		exit 1; \
 	fi
 
+E2E_SUITE_PACKAGE := $(shell GOFLAGS="$(GOFLAGS_VENDOR)" go list -m)/test/e2e
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	GOFLAGS="$(GOFLAGS_VENDOR)" go vet ./...
 
+.PHONY: vet-tagged
+vet-tagged: ## Run go vet against integration and E2E tagged code without a cluster.
+	GOFLAGS="$(GOFLAGS_VENDOR)" go vet -tags=integration ./...
+	GOFLAGS="$(GOFLAGS_VENDOR)" go vet -tags=e2e ./test/e2e/...
+
 .PHONY: test
 test: manifests generate fmt vet ## Run unit tests (fast, no envtest).
-	GOFLAGS="$(GOFLAGS_VENDOR)" go test $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e) -coverprofile cover.out
+	GOFLAGS="$(GOFLAGS_VENDOR)" go test $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -vx '$(E2E_SUITE_PACKAGE)') -coverprofile cover.out
 
 .PHONY: test-sum
 test-sum: manifests generate fmt vet gotestsum ## Run unit tests with gotestsum output and JUnit XML.
 	@mkdir -p "$(TEST_ARTIFACT_DIR)"
-	GOFLAGS="$(GOFLAGS_VENDOR)" "$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" --junitfile "$(TEST_ARTIFACT_DIR)/unit.xml" -- -coverprofile "$(TEST_ARTIFACT_DIR)/unit.cover.out" $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e)
+	GOFLAGS="$(GOFLAGS_VENDOR)" "$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" --junitfile "$(TEST_ARTIFACT_DIR)/unit.xml" -- -coverprofile "$(TEST_ARTIFACT_DIR)/unit.cover.out" $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -vx '$(E2E_SUITE_PACKAGE)')
 
 COVERAGE_PROFILE ?= cover.out
 COVERAGE_MIN_INTERNAL ?= 68.0
@@ -83,24 +90,24 @@ verify-coverage: ## Verify production code under internal/ meets the coverage re
 		--minimum "$(COVERAGE_MIN_INTERNAL)"
 
 .PHONY: test-ci
-test-ci: manifests generate vet setup-envtest gotestsum ## Run unit + integration tests and enforce the coverage floor.
+test-ci: manifests generate vet setup-envtest gotestsum test-e2e-support ## Run unit, integration, and E2E support tests and enforce the coverage floor.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
 		GOFLAGS="$(GOFLAGS_VENDOR)" \
 		"$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" -- \
 		-tags=integration \
 		-count=1 \
 		-coverprofile "$(COVERAGE_PROFILE)" \
-		$$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e)
+		$$(GOFLAGS="$(GOFLAGS_VENDOR)" go list -tags=integration ./... | grep -vx '$(E2E_SUITE_PACKAGE)')
 	$(MAKE) verify-coverage COVERAGE_PROFILE="$(COVERAGE_PROFILE)" COVERAGE_MIN_INTERNAL="$(COVERAGE_MIN_INTERNAL)"
 
 .PHONY: test-integration
 test-integration: manifests generate vet setup-envtest ## Run envtest-based integration tests (envtest; requires -tags=integration).
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" GOFLAGS="$(GOFLAGS_VENDOR)" go test $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e) -tags=integration -count=1 -v
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" GOFLAGS="$(GOFLAGS_VENDOR)" go test $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list -tags=integration ./... | grep -vx '$(E2E_SUITE_PACKAGE)') -tags=integration -count=1 -v
 
 .PHONY: test-integration-sum
 test-integration-sum: manifests generate vet setup-envtest gotestsum ## Run envtest-based integration tests with gotestsum output and JUnit XML.
 	@mkdir -p "$(TEST_ARTIFACT_DIR)"
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" GOFLAGS="$(GOFLAGS_VENDOR)" "$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" --junitfile "$(TEST_ARTIFACT_DIR)/integration.xml" -- -tags=integration -count=1 -coverprofile "$(TEST_ARTIFACT_DIR)/integration.cover.out" $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list ./... | grep -v /e2e)
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" GOFLAGS="$(GOFLAGS_VENDOR)" "$(GOTESTSUM)" --format="$(GOTESTSUM_FORMAT)" --junitfile "$(TEST_ARTIFACT_DIR)/integration.xml" -- -tags=integration -count=1 -coverprofile "$(TEST_ARTIFACT_DIR)/integration.cover.out" $$(GOFLAGS="$(GOFLAGS_VENDOR)" go list -tags=integration ./... | grep -vx '$(E2E_SUITE_PACKAGE)')
 
 .PHONY: fuzz
 fuzz: ## Run the curated fuzz smoke sweep across repo fuzz targets.
@@ -483,6 +490,10 @@ MUTATION_INCREMENTAL ?= false
 MUTATION_TOP_SURVIVORS ?= 20
 MUTATION_GOFLAGS ?= -p=1
 MUTATION_GOMEMLIMIT ?= 8GiB
+
+.PHONY: test-e2e-support
+test-e2e-support: ## Run cluster-independent tests for E2E framework and helper packages.
+	GOFLAGS="$(GOFLAGS_VENDOR)" go test -tags=e2e -count=1 ./test/e2e/framework ./test/e2e/helpers
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
@@ -906,7 +917,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	"$(GOLANGCI_LINT)" config verify
 
 .PHONY: lint-ci
-lint-ci: lint-config lint verify-arch-policy lint-testonly-exports test-ast lint-ast ## Run CI lint gates (golangci-lint + test-only export audit + ast-grep tests/scans).
+lint-ci: lint-config lint vet-tagged verify-arch-policy lint-testonly-exports test-ast lint-ast ## Run CI lint gates (golangci-lint + tagged vet + test-only export audit + ast-grep tests/scans).
 
 .PHONY: vulncheck
 vulncheck: govulncheck govulncheck-ignore ## Run govulncheck to scan for known vulnerabilities (production code only). Findings listed in .govulnignore are ignored. Set VULNCHECK_SHOW_IGNORED=true to print traces even if all findings are ignored.


### PR DESCRIPTION
## Summary

- Vet integration-tagged sources repo-wide and E2E-tagged support sources without starting a cluster.
- Exclude only the root E2E suite from canonical unit and integration package selection.
- Run cluster-independent E2E framework and helper tests as part of `test-ci`.
- Document the expanded `test-ci` contract without changing the required `Envtest Integration` job name.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or runtime behavior changes. CI now runs previously omitted ordinary tests under packages whose paths contain `/e2e`, and it statically verifies tagged Go sources. The additional cluster-independent helper tests complete in milliseconds.

## Verification

- `make vet-tagged`
- `make test-e2e-support`
- `make lint-ci`
- `make test-ci` (3,653 passed, 4 skipped, 69.67% internal coverage)
- `bin/actionlint .github/workflows/ci.yml`
- `git diff --check`
- Independent read-only review found no blocking or functional issues.

## Reviewer Notes

Review the exact root-suite exclusion and the tagged package coverage in `mk/development.mk`. The required GitHub Actions job name remains `Envtest Integration`.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
