### PR TITLE
refactor(openbao): clarify response body ownership

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   default: none
   enable:
+    - bodyclose
     - copyloopvar
     - dupl
     - errcheck

--- a/internal/adapter/openbao/client_bootstrap.go
+++ b/internal/adapter/openbao/client_bootstrap.go
@@ -116,12 +116,12 @@ func (c *Client) Restore(ctx context.Context, reader io.Reader, options portopen
 		Timeout:   portopenbao.DefaultSnapshotTimeout,
 	}
 
-	resp, body, err := c.doAndReadAll(req, restoreClient, "failed to execute restore request")
+	statusCode, body, err := c.doAndReadAll(req, restoreClient, "failed to execute restore request")
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return portopenbao.NewAPIError("restore request failed", resp.StatusCode, body)
+	if statusCode != http.StatusOK && statusCode != http.StatusNoContent {
+		return portopenbao.NewAPIError("restore request failed", statusCode, body)
 	}
 
 	return nil
@@ -140,13 +140,13 @@ func (c *Client) Init(ctx context.Context, req InitRequest) (*InitResponse, erro
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, respBody, err := c.doAndReadAll(httpReq, c.clientForContextDeadline(ctx), "failed to execute init request")
+	statusCode, respBody, err := c.doAndReadAll(httpReq, c.clientForContextDeadline(ctx), "failed to execute init request")
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != http.StatusOK {
-		apiErr := portopenbao.NewAPIError("init request failed", resp.StatusCode, respBody)
-		if resp.StatusCode == http.StatusBadRequest && initResponseAlreadyInitialized(respBody) {
+	if statusCode != http.StatusOK {
+		apiErr := portopenbao.NewAPIError("init request failed", statusCode, respBody)
+		if statusCode == http.StatusBadRequest && initResponseAlreadyInitialized(respBody) {
 			return nil, fmt.Errorf("%w: %w", portopenbao.ErrAlreadyInitialized, apiErr)
 		}
 		return nil, apiErr
@@ -190,14 +190,14 @@ func (c *Client) LoginJWT(ctx context.Context, role, jwtToken string) (string, i
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, respBody, err := c.doAndReadAll(req, nil, "failed to execute JWT auth request")
+	statusCode, respBody, err := c.doAndReadAll(req, nil, "failed to execute JWT auth request")
 	if err != nil {
 		recordAuthLoginError("request_error")
 		return "", 0, err
 	}
-	if resp.StatusCode != http.StatusOK {
-		recordAuthLoginError(fmt.Sprintf("status_%d", resp.StatusCode))
-		return "", 0, portopenbao.NewAPIError("JWT auth request failed", resp.StatusCode, respBody)
+	if statusCode != http.StatusOK {
+		recordAuthLoginError(fmt.Sprintf("status_%d", statusCode))
+		return "", 0, portopenbao.NewAPIError("JWT auth request failed", statusCode, respBody)
 	}
 
 	var authResp JWTAuthLoginResponse

--- a/internal/adapter/openbao/client_health.go
+++ b/internal/adapter/openbao/client_health.go
@@ -30,13 +30,13 @@ func (c *Client) Health(ctx context.Context) (*portopenbao.HealthStatus, error) 
 		}
 	}
 
-	resp, body, err := c.doAndReadAll(req, nil, "failed to query health endpoint")
+	statusCode, body, err := c.doAndReadAll(req, nil, "failed to query health endpoint")
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode == http.StatusForbidden {
+	if statusCode == http.StatusForbidden {
 		return nil, fmt.Errorf("health check forbidden: check operator permissions: %w",
-			portopenbao.NewAPIError("health check request failed", resp.StatusCode, body),
+			portopenbao.NewAPIError("health check request failed", statusCode, body),
 		)
 	}
 
@@ -71,12 +71,12 @@ func (c *Client) StepDown(ctx context.Context) error {
 		return fmt.Errorf("failed to authorize step-down request: %w", err)
 	}
 
-	resp, body, err := c.doAndReadAll(req, nil, "failed to execute step-down request")
+	statusCode, body, err := c.doAndReadAll(req, nil, "failed to execute step-down request")
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		return portopenbao.NewAPIError("step-down request failed", resp.StatusCode, body)
+	if statusCode != http.StatusNoContent && statusCode != http.StatusOK {
+		return portopenbao.NewAPIError("step-down request failed", statusCode, body)
 	}
 
 	return nil

--- a/internal/adapter/openbao/client_raft.go
+++ b/internal/adapter/openbao/client_raft.go
@@ -61,15 +61,15 @@ func (c *Client) JoinRaftCluster(ctx context.Context, leaderAPIAddr string, retr
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, body, err := c.doAndReadAll(httpReq, nil, "failed to execute raft join request")
+	statusCode, body, err := c.doAndReadAll(httpReq, nil, "failed to execute raft join request")
 	if err != nil {
 		if translatedErr := translateRaftAPIErrorFromChain(err, portopenbao.ErrAlreadyJoined, "already joined"); translatedErr != nil {
 			return translatedErr
 		}
 		return err
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		apiErr := portopenbao.NewAPIError("raft join request failed", resp.StatusCode, body)
+	if statusCode != http.StatusOK && statusCode != http.StatusNoContent {
+		apiErr := portopenbao.NewAPIError("raft join request failed", statusCode, body)
 		if translatedErr := translateRaftAPIErrorFromChain(apiErr, portopenbao.ErrAlreadyJoined, "already joined"); translatedErr != nil {
 			return translatedErr
 		}
@@ -101,12 +101,12 @@ func (c *Client) ReadRaftConfiguration(ctx context.Context) (*portopenbao.RaftCo
 		return nil, fmt.Errorf("failed to authorize raft configuration request: %w", err)
 	}
 
-	resp, body, err := c.doAndReadAll(req, nil, "failed to execute raft configuration request")
+	statusCode, body, err := c.doAndReadAll(req, nil, "failed to execute raft configuration request")
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, portopenbao.NewAPIError("raft configuration request failed", resp.StatusCode, body)
+	if statusCode != http.StatusOK {
+		return nil, portopenbao.NewAPIError("raft configuration request failed", statusCode, body)
 	}
 
 	type raftConfigEnvelope struct {
@@ -138,15 +138,15 @@ func (c *Client) ReadRaftAutopilotState(ctx context.Context) (*portopenbao.RaftA
 		return nil, fmt.Errorf("failed to authorize raft autopilot state request: %w", err)
 	}
 
-	resp, body, err := c.doAndReadAll(req, nil, "failed to execute raft autopilot state request")
+	statusCode, body, err := c.doAndReadAll(req, nil, "failed to execute raft autopilot state request")
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("%w: %w", ErrAutopilotNotAvailable, portopenbao.NewAPIError("raft autopilot state request failed", resp.StatusCode, body))
+	if statusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: %w", ErrAutopilotNotAvailable, portopenbao.NewAPIError("raft autopilot state request failed", statusCode, body))
 	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, portopenbao.NewAPIError("raft autopilot state request failed", resp.StatusCode, body)
+	if statusCode != http.StatusOK {
+		return nil, portopenbao.NewAPIError("raft autopilot state request failed", statusCode, body)
 	}
 
 	type raftAutopilotEnvelope struct {
@@ -184,12 +184,12 @@ func (c *Client) ConfigureRaftAutopilot(ctx context.Context, config portopenbao.
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, body, err := c.doAndReadAll(httpReq, nil, "failed to execute autopilot config request")
+	statusCode, body, err := c.doAndReadAll(httpReq, nil, "failed to execute autopilot config request")
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return portopenbao.NewAPIError("autopilot config request failed", resp.StatusCode, body)
+	if statusCode != http.StatusOK && statusCode != http.StatusNoContent {
+		return portopenbao.NewAPIError("autopilot config request failed", statusCode, body)
 	}
 
 	return nil
@@ -217,15 +217,15 @@ func (c *Client) executeRaftPeerAction(ctx context.Context, serverID string, pat
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, body, err := c.doAndReadAll(httpReq, nil, fmt.Sprintf("failed to execute raft %s request", action))
+	statusCode, body, err := c.doAndReadAll(httpReq, nil, fmt.Sprintf("failed to execute raft %s request", action))
 	if err != nil {
 		if translatedErr := translateRaftPeerActionAPIError(err, action); translatedErr != nil {
 			return translatedErr
 		}
 		return err
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		apiErr := portopenbao.NewAPIError(fmt.Sprintf("raft %s request failed", action), resp.StatusCode, body)
+	if statusCode != http.StatusOK && statusCode != http.StatusNoContent {
+		apiErr := portopenbao.NewAPIError(fmt.Sprintf("raft %s request failed", action), statusCode, body)
 		if translatedErr := translateRaftPeerActionAPIError(apiErr, action); translatedErr != nil {
 			return translatedErr
 		}
@@ -274,12 +274,12 @@ func (c *Client) UpdateRaftConfiguration(ctx context.Context, servers []portopen
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, body, err := c.doAndReadAll(httpReq, nil, "failed to execute raft configuration update request")
+	statusCode, body, err := c.doAndReadAll(httpReq, nil, "failed to execute raft configuration update request")
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return portopenbao.NewAPIError("raft configuration update request failed", resp.StatusCode, body)
+	if statusCode != http.StatusOK && statusCode != http.StatusNoContent {
+		return portopenbao.NewAPIError("raft configuration update request failed", statusCode, body)
 	}
 
 	return nil

--- a/internal/adapter/openbao/transport.go
+++ b/internal/adapter/openbao/transport.go
@@ -266,10 +266,10 @@ func drainAndClose(resp *http.Response) {
 	_ = resp.Body.Close()
 }
 
-func (c *Client) doAndReadAll(req *http.Request, httpClient *http.Client, op string) (*http.Response, []byte, error) {
+func (c *Client) doAndReadAll(req *http.Request, httpClient *http.Client, op string) (int, []byte, error) {
 	resp, err := c.doRequest(req, httpClient, op)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 
 	defer drainAndClose(resp)
@@ -281,9 +281,9 @@ func (c *Client) doAndReadAll(req *http.Request, httpClient *http.Client, op str
 		}
 		wrapped := fmt.Errorf("%s: failed to read response body: %w", op, err)
 		if operatorerrors.IsTransientConnection(err) {
-			return nil, nil, operatorerrors.WrapTransientConnection(wrapped)
+			return 0, nil, operatorerrors.WrapTransientConnection(wrapped)
 		}
-		return nil, nil, wrapped
+		return 0, nil, wrapped
 	}
 
 	// The health endpoint encodes state in HTTP status codes (sealed, standby, etc.),
@@ -293,14 +293,14 @@ func (c *Client) doAndReadAll(req *http.Request, httpClient *http.Client, op str
 			if c.state != nil {
 				c.state.after(req, false)
 			}
-			return nil, nil, operatorerrors.WrapTransientRemoteOverloaded(portopenbao.NewAPIError(op, resp.StatusCode, body))
+			return 0, nil, operatorerrors.WrapTransientRemoteOverloaded(portopenbao.NewAPIError(op, resp.StatusCode, body))
 		}
 	}
 
 	if c.state != nil {
 		c.state.after(req, true)
 	}
-	return resp, body, nil
+	return resp.StatusCode, body, nil
 }
 
 // clientForContextDeadline returns a clone of the default HTTP client with a timeout

--- a/internal/adapter/openbao/transport_test.go
+++ b/internal/adapter/openbao/transport_test.go
@@ -2,8 +2,11 @@ package openbao
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,6 +14,45 @@ import (
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingResponseBody struct {
+	reader     io.Reader
+	closed     bool
+	reachedEOF bool
+}
+
+func (b *trackingResponseBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		b.reachedEOF = true
+	}
+	return n, err
+}
+
+func (b *trackingResponseBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type errorThenReader struct {
+	err           error
+	reader        io.Reader
+	returnedError bool
+}
+
+func (r *errorThenReader) Read(p []byte) (int, error) {
+	if !r.returnedError {
+		r.returnedError = true
+		return 0, r.err
+	}
+	return r.reader.Read(p)
+}
 
 func TestSmartClient_CircuitBreaker_SharedAcrossClients(t *testing.T) {
 	var requests int32
@@ -96,6 +138,99 @@ func TestClient_DoRequestRecordsRequestMetric(t *testing.T) {
 	after := testutil.ToFloat64(counter)
 	if after != before+1 {
 		t.Fatalf("request counter delta = %v, want 1", after-before)
+	}
+}
+
+func TestClient_DoAndReadAllOwnsResponseBody(t *testing.T) {
+	readErr := errors.New("response body read failed")
+	tests := []struct {
+		name           string
+		path           string
+		statusCode     int
+		reader         io.Reader
+		wantStatusCode int
+		wantBody       string
+		wantErr        bool
+		wantReadErr    bool
+		wantOverloaded bool
+		wantDrained    bool
+	}{
+		{
+			name:           "successful response",
+			path:           apiPathSysLeader,
+			statusCode:     http.StatusOK,
+			reader:         strings.NewReader("leader"),
+			wantStatusCode: http.StatusOK,
+			wantBody:       "leader",
+		},
+		{
+			name:           "overload response",
+			path:           apiPathSysLeader,
+			statusCode:     http.StatusServiceUnavailable,
+			reader:         strings.NewReader("unavailable"),
+			wantErr:        true,
+			wantOverloaded: true,
+		},
+		{
+			name:       "response body read failure",
+			path:       apiPathSysLeader,
+			statusCode: http.StatusOK,
+			reader: &errorThenReader{
+				err:    readErr,
+				reader: strings.NewReader("remaining"),
+			},
+			wantErr:     true,
+			wantReadErr: true,
+			wantDrained: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responseBody := &trackingResponseBody{reader: tt.reader}
+			client := &Client{
+				httpClient: &http.Client{
+					Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: tt.statusCode,
+							Header:     make(http.Header),
+							Body:       responseBody,
+							Request:    req,
+						}, nil
+					}),
+				},
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://openbao.example"+tt.path, nil)
+			if err != nil {
+				t.Fatalf("NewRequestWithContext() error: %v", err)
+			}
+
+			gotStatusCode, gotBody, err := client.doAndReadAll(req, nil, "test request")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("doAndReadAll() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantReadErr && !errors.Is(err, readErr) {
+				t.Errorf("doAndReadAll() error = %v, want wrapped read error", err)
+			}
+			if tt.wantOverloaded && !operatorerrors.IsTransientRemoteOverloaded(err) {
+				t.Errorf("doAndReadAll() error = %v, want transient remote overload", err)
+			}
+			if gotStatusCode != tt.wantStatusCode {
+				t.Errorf("doAndReadAll() status code = %d, want %d", gotStatusCode, tt.wantStatusCode)
+			}
+			if string(gotBody) != tt.wantBody {
+				t.Errorf("doAndReadAll() body = %q, want %q", gotBody, tt.wantBody)
+			}
+			if tt.wantErr && gotBody != nil {
+				t.Errorf("doAndReadAll() body = %q, want nil on error", gotBody)
+			}
+			if tt.wantDrained && !responseBody.reachedEOF {
+				t.Error("doAndReadAll() did not drain response body")
+			}
+			if !responseBody.closed {
+				t.Error("doAndReadAll() did not close response body")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Return the HTTP status code and body from `doAndReadAll` instead of returning a response whose body is already closed.
- Keep response-body draining and closure inside the transport helper.
- Enable `bodyclose` to prevent future response ownership regressions.
- Add focused tests for successful reads, overload responses, and cleanup after body-read failures.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No public API, CRD, Helm, RBAC, security, upgrade, or operational behavior changes. Existing status handling, health semantics, overload classification, client state transitions, and error wrapping are preserved.

## Verification

- `go test ./internal/adapter/openbao`
- `go test -race ./internal/adapter/openbao`
- `bin/golangci-lint run --enable-only=bodyclose ./...` (0 issues)
- `make lint-ci`
- `make test-ci` (3,657 tests, 4 skipped, 69.69% internal coverage)
- `git diff --check`
- Independent read-only audit of all 12 callers and response cleanup paths

## Reviewer Notes

Focus on the ownership boundary: `doAndReadAll` now returns only values that remain valid after it drains and closes the response body.

Documentation is not needed because this changes an internal helper contract only. Generated artifacts are not affected. This PR has no dependent changes.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.