### PR TITLE
refactor(errors): enforce wrapped error checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - copyloopvar
     - dupl
     - errcheck
+    - errorlint
     - ginkgolinter
     - goconst
     - gocyclo
@@ -25,6 +26,11 @@ linters:
     - unparam
     - unused
   settings:
+    errorlint:
+      asserts: true
+      comparison: true
+      # Audit error-chain composition and multi-error precedence separately.
+      errorf: false
     nolintlint:
       require-explanation: true
       require-specific: true

--- a/cmd/bao-wrapper/process_runner.go
+++ b/cmd/bao-wrapper/process_runner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -48,7 +49,8 @@ func run(ctx context.Context) error {
 	startFileWatcher(ctx, cmd, watchFile, interval)
 
 	if err := cmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			return fmt.Errorf("child process exited with code %d: %w", exitErr.ExitCode(), err)
 		}
 		return fmt.Errorf("child process exited with error: %w", err)

--- a/hack/tools/crd_compatibility/main.go
+++ b/hack/tools/crd_compatibility/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -229,7 +230,7 @@ func loadSchemaNodes(paths []string) ([]schemaNode, error) {
 		for {
 			var raw map[string]any
 			err := decoder.Decode(&raw)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/internal/adapter/auth/oidc_discovery.go
+++ b/internal/adapter/auth/oidc_discovery.go
@@ -31,9 +31,6 @@ func DiscoverConfig(ctx context.Context, cfg *rest.Config, baseURL string) (*por
 	httpClient := &http.Client{Transport: transport, Timeout: defaultOIDCHTTPTimeout}
 	oidcConfig, err := fetchOIDCWellKnown(ctx, httpClient, wellKnownURL)
 	if err != nil {
-		if statusErr, ok := err.(*HTTPStatusError); ok {
-			return nil, statusErr
-		}
 		return nil, err
 	}
 	if oidcConfig.Issuer == "" {

--- a/internal/adapter/storage/s3.go
+++ b/internal/adapter/storage/s3.go
@@ -98,7 +98,7 @@ func (b *Bucket) List(ctx context.Context, prefix string) ([]blobstore.ObjectInf
 	iter := b.bucket.List(&blob.ListOptions{Prefix: prefix})
 	for {
 		obj, err := iter.Next(ctx)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/app/openbaocluster/infra_test.go
+++ b/internal/app/openbaocluster/infra_test.go
@@ -893,7 +893,7 @@ func TestInfraReconciler_MapManagerReconcileError(t *testing.T) {
 
 	t.Run("unmapped error passes through", func(t *testing.T) {
 		original := errors.New("boom")
-		if got := r.mapManagerReconcileError(original); got != original {
+		if got := r.mapManagerReconcileError(original); got != original { //nolint:errorlint // Exact identity is the behavior under test.
 			t.Fatalf("got %v, want original %v", got, original)
 		}
 	})

--- a/internal/platform/errors/errors_test.go
+++ b/internal/platform/errors/errors_test.go
@@ -532,8 +532,10 @@ func TestWrapTransientRemoteOverloaded(t *testing.T) {
 				t.Errorf("expected transient=%v, got %v", tt.wantIsTransient, IsTransientRemoteOverloaded(got))
 			}
 
-			isWrapped := errors.Is(got, ErrTransientRemoteOverloaded) && got != ErrTransientRemoteOverloaded
-			if isWrapped != tt.wantWrapped && tt.err != ErrTransientRemoteOverloaded {
+			isSentinel := got == ErrTransientRemoteOverloaded //nolint:errorlint // Exact identity distinguishes the unwrapped sentinel.
+			isWrapped := errors.Is(got, ErrTransientRemoteOverloaded) && !isSentinel
+			isSentinelInput := tt.err == ErrTransientRemoteOverloaded //nolint:errorlint // Exact identity selects the sentinel input case.
+			if isWrapped != tt.wantWrapped && !isSentinelInput {
 				t.Errorf("expected wrapped=%v, got %v (err=%v)", tt.wantWrapped, isWrapped, got)
 			}
 		})


### PR DESCRIPTION
## Summary

- Enable `errorlint` checks for wrapped-error comparisons and type assertions.
- Replace direct error assertions and `io.EOF` comparisons with `errors.As` and `errors.Is`.
- Remove a redundant OIDC error branch whose paths returned the same error.
- Preserve intentional exact-identity test assertions with narrow, explained suppressions.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No public API, CRD, Helm, RBAC, security, upgrade, or operational behavior changes. The `errorlint` formatting check remains disabled, so this PR does not change `%v`/`%w` composition, error-chain precedence, retry classification, or recovery behavior.

## Verification

- `bin/golangci-lint config verify`
- `bin/golangci-lint run --enable-only=errorlint --max-same-issues=0 --max-issues-per-linter=0 ./...` (0 issues)
- Focused race tests for all six affected Go packages
- `make lint-ci` (including 62 architecture and safety checks)
- `make test-ci` (3,657 passed, 4 skipped, 69.70% internal coverage)
- `git diff --check`
- Independent read-only error-semantics audit

## Reviewer Notes

Focus on the staged linter boundary: assertions and comparisons are enforced, while error formatting remains disabled for a separate subsystem-level audit. Existing focused tests cover the changed paths, so this PR adds no new tests.

Documentation is not needed because this changes internal error inspection and lint policy only. Generated artifacts are not affected. This PR has no dependent changes.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.