### PR TITLE
refactor(controllers): require injected runtime collaborators

### DIFF
--- a/.ast-grep/rules/reconcile-shape/no-runtime-collaborator-construction-in-controller-setup.yml
+++ b/.ast-grep/rules/reconcile-shape/no-runtime-collaborator-construction-in-controller-setup.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-runtime-collaborator-construction-in-controller-setup
+message: Inject app and service runtime collaborators before controller setup.
+severity: warning
+language: Go
+files:
+  - internal/controller/**/*.go
+ignores:
+  - '**/*_test.go'
+rule:
+  all:
+    - kind: call_expression
+    - regex: '\.New[A-Za-z0-9]*(Applications?|Manager|Provisioner|Reconciler|Runtime)(With[A-Za-z0-9]+)?\('
+    - inside:
+        all:
+          - kind: method_declaration
+          - regex: 'SetupWithManager\('
+        stopBy: end
+note: Controller setup registers watches and options. Entrypoints must construct and inject app or service runtime collaborators.

--- a/.ast-grep/tests/__snapshots__/no-runtime-collaborator-construction-in-controller-setup-snapshot.yml
+++ b/.ast-grep/tests/__snapshots__/no-runtime-collaborator-construction-in-controller-setup-snapshot.yml
@@ -1,0 +1,107 @@
+id: no-runtime-collaborator-construction-in-controller-setup
+snapshots:
+  ? |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      provisioner, err := appprovisioner.NewProvisioner(dependencies)
+      return err
+    }
+  : labels:
+    - source: appprovisioner.NewProvisioner(dependencies)
+      style: primary
+      start: 141
+      end: 184
+    - source: |-
+        func (r *Reconciler) SetupWithManager(mgr Manager) error {
+          provisioner, err := appprovisioner.NewProvisioner(dependencies)
+          return err
+        }
+      style: secondary
+      start: 60
+      end: 199
+  ? |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.applications = app.NewRuntimeApplications(dependencies)
+      return nil
+    }
+  : labels:
+    - source: app.NewRuntimeApplications(dependencies)
+      style: primary
+      start: 138
+      end: 178
+    - source: |-
+        func (r *Reconciler) SetupWithManager(mgr Manager) error {
+          r.applications = app.NewRuntimeApplications(dependencies)
+          return nil
+        }
+      style: secondary
+      start: 60
+      end: 193
+  ? |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.manager = service.NewManager(client, logger)
+      return nil
+    }
+  : labels:
+    - source: service.NewManager(client, logger)
+      style: primary
+      start: 133
+      end: 167
+    - source: |-
+        func (r *Reconciler) SetupWithManager(mgr Manager) error {
+          r.manager = service.NewManager(client, logger)
+          return nil
+        }
+      style: secondary
+      start: 60
+      end: 182
+  ? |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.manager = service.NewManagerWithReader(client, reader, logger)
+      return nil
+    }
+  : labels:
+    - source: service.NewManagerWithReader(client, reader, logger)
+      style: primary
+      start: 133
+      end: 185
+    - source: |-
+        func (r *Reconciler) SetupWithManager(mgr Manager) error {
+          r.manager = service.NewManagerWithReader(client, reader, logger)
+          return nil
+        }
+      style: secondary
+      start: 60
+      end: 200
+  ? |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.restore = apprestore.NewRestoreReconciler(dependencies)
+      return nil
+    }
+  : labels:
+    - source: apprestore.NewRestoreReconciler(dependencies)
+      style: primary
+      start: 133
+      end: 178
+    - source: |-
+        func (r *Reconciler) SetupWithManager(mgr Manager) error {
+          r.restore = apprestore.NewRestoreReconciler(dependencies)
+          return nil
+        }
+      style: secondary
+      start: 60
+      end: 193

--- a/.ast-grep/tests/reconcile-shape/no-runtime-collaborator-construction-in-controller-setup-test.yml
+++ b/.ast-grep/tests/reconcile-shape/no-runtime-collaborator-construction-in-controller-setup-test.yml
@@ -1,0 +1,59 @@
+id: no-runtime-collaborator-construction-in-controller-setup
+valid:
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      return ctrl.NewControllerManagedBy(mgr).Complete(r)
+    }
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      _ = workqueue.NewTypedItemExponentialFailureRateLimiter[Request](1, 60)
+      _ = metav1.NewTime(now())
+      return nil
+    }
+invalid:
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      provisioner, err := appprovisioner.NewProvisioner(dependencies)
+      return err
+    }
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.restore = apprestore.NewRestoreReconciler(dependencies)
+      return nil
+    }
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.manager = service.NewManager(client, logger)
+      return nil
+    }
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.manager = service.NewManagerWithReader(client, reader, logger)
+      return nil
+    }
+  - |
+    package p
+    type Reconciler struct{}
+    type Manager interface{}
+    func (r *Reconciler) SetupWithManager(mgr Manager) error {
+      r.applications = app.NewRuntimeApplications(dependencies)
+      return nil
+    }

--- a/cmd/controller/runtime_setup.go
+++ b/cmd/controller/runtime_setup.go
@@ -123,9 +123,7 @@ func setupControllers(mgr ctrl.Manager, runtime controllerProcessRuntime) error 
 
 	if err := (&openbaorestorecontroller.OpenBaoRestoreReconciler{
 		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
 		AdmissionTracker: runtime.admissionTracker,
-		Recorder:         mgr.GetEventRecorder(controllerNameOpenBaoRestore),
 		RestoreReconciler: appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{
 			Client:                mgr.GetClient(),
 			APIReader:             mgr.GetAPIReader(),
@@ -135,8 +133,6 @@ func setupControllers(mgr ctrl.Manager, runtime controllerProcessRuntime) error 
 			Platform:              runtime.platform,
 			ClientConfig:          runtime.openBaoRuntime.SmartClientConfig,
 		}),
-		OperatorImageVerifier: runtime.imageVerificationRuntime.OperatorImageVerifier,
-		Platform:              runtime.platform,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %w", controllerNameOpenBaoRestore, err)
 	}

--- a/cmd/provisioner/runtime_setup.go
+++ b/cmd/provisioner/runtime_setup.go
@@ -37,7 +37,6 @@ func setupControllers(mgr ctrl.Manager, runtime provisionerProcessRuntime) error
 	if err := (&provisionercontroller.NamespaceProvisionerReconciler{
 		Client:            mgr.GetClient(),
 		APIReader:         mgr.GetAPIReader(),
-		Scheme:            mgr.GetScheme(),
 		Recorder:          mgr.GetEventRecorder("namespace-provisioner"),
 		Provisioner:       runtime.provisioner,
 		OperatorNamespace: runtime.operatorNamespace,
@@ -50,7 +49,6 @@ func setupControllers(mgr ctrl.Manager, runtime provisionerProcessRuntime) error
 		Client:           mgr.GetClient(),
 		AdmissionTracker: runtime.admissionTracker,
 		APIReader:        mgr.GetAPIReader(),
-		Scheme:           mgr.GetScheme(),
 		Recorder:         mgr.GetEventRecorder("namespace-provisioner-tenant-secrets"),
 		Provisioner:      runtime.provisioner,
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/app/openbaorestore/reconcile.go
+++ b/internal/app/openbaorestore/reconcile.go
@@ -5,39 +5,28 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 )
 
-// ReconcileOpenBaoRestore loads the restore resource and delegates lifecycle
-// orchestration to the restore manager.
+// ReconcileOpenBaoRestore delegates lifecycle orchestration to the restore manager.
 func ReconcileOpenBaoRestore(
 	ctx context.Context,
-	c client.Client,
-	key types.NamespacedName,
+	restoreResource *openbaov1alpha1.OpenBaoRestore,
 	logger logr.Logger,
 	restoreManager RestoreReconciler,
 ) (recon.Result, error) {
 	if restoreManager == nil {
 		return recon.Result{}, fmt.Errorf("restore manager is required")
 	}
-
-	restoreResource := &openbaov1alpha1.OpenBaoRestore{}
-	if err := c.Get(ctx, key, restoreResource); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Resource deleted - nothing to do.
-			return recon.Result{}, nil
-		}
-		return recon.Result{}, fmt.Errorf("failed to get OpenBaoRestore: %w", err)
+	if restoreResource == nil {
+		return recon.Result{}, fmt.Errorf("restore resource is required")
 	}
 
 	logger = logger.WithValues(
-		"restore", key.Name,
-		"namespace", key.Namespace,
+		"restore", restoreResource.Name,
+		"namespace", restoreResource.Namespace,
 		"cluster", restoreResource.Spec.Cluster,
 		"phase", restoreResource.Status.Phase,
 	)

--- a/internal/app/openbaorestore/reconcile_test.go
+++ b/internal/app/openbaorestore/reconcile_test.go
@@ -8,144 +8,73 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 )
 
 type fakeRestoreManager struct {
-	result       recon.Result
-	err          error
-	called       bool
-	observedName string
+	result   recon.Result
+	err      error
+	called   bool
+	observed *openbaov1alpha1.OpenBaoRestore
 }
 
 func (f *fakeRestoreManager) Reconcile(_ context.Context, _ logr.Logger, restore *openbaov1alpha1.OpenBaoRestore) (recon.Result, error) {
 	f.called = true
-	if restore != nil {
-		f.observedName = restore.Name
-	}
+	f.observed = restore
 	return f.result, f.err
-}
-
-func newRestoreScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	s := runtime.NewScheme()
-	if err := openbaov1alpha1.AddToScheme(s); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
-	return s
-}
-
-func newRestoreClient(t *testing.T, objs ...client.Object) client.Client {
-	t.Helper()
-	builder := fake.NewClientBuilder().WithScheme(newRestoreScheme(t))
-	if len(objs) > 0 {
-		builder = builder.WithObjects(objs...)
-	}
-	return builder.Build()
-}
-
-func newRestoreClientWithGetError(t *testing.T, matchName string, err error, objs ...client.Object) client.Client {
-	t.Helper()
-	builder := fake.NewClientBuilder().WithScheme(newRestoreScheme(t)).WithInterceptorFuncs(interceptor.Funcs{
-		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-			if key.Name == matchName {
-				return err
-			}
-			return c.Get(ctx, key, obj, opts...)
-		},
-	})
-	if len(objs) > 0 {
-		builder = builder.WithObjects(objs...)
-	}
-	return builder.Build()
 }
 
 func TestReconcileOpenBaoRestore(t *testing.T) {
 	t.Parallel()
 
-	req := types.NamespacedName{Namespace: "ns", Name: "restore"}
 	restoreObj := &openbaov1alpha1.OpenBaoRestore{
 		ObjectMeta: metav1.ObjectMeta{Name: "restore", Namespace: "ns"},
 		Spec:       openbaov1alpha1.OpenBaoRestoreSpec{Cluster: "cluster-a"},
 	}
 
 	t.Run("nil manager", func(t *testing.T) {
-		_, err := ReconcileOpenBaoRestore(context.Background(), newRestoreClient(t), req, logr.Discard(), nil)
+		_, err := ReconcileOpenBaoRestore(context.Background(), restoreObj, logr.Discard(), nil)
 		if err == nil || !strings.Contains(err.Error(), "restore manager is required") {
 			t.Fatalf("expected manager required error, got %v", err)
 		}
 	})
 
-	t.Run("resource not found", func(t *testing.T) {
+	t.Run("nil restore resource", func(t *testing.T) {
 		mgr := &fakeRestoreManager{}
-		result, err := ReconcileOpenBaoRestore(context.Background(), newRestoreClient(t), req, logr.Discard(), mgr)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if result != (recon.Result{}) {
-			t.Fatalf("result=%v, want zero", result)
+		_, err := ReconcileOpenBaoRestore(context.Background(), nil, logr.Discard(), mgr)
+		if err == nil || !strings.Contains(err.Error(), "restore resource is required") {
+			t.Fatalf("expected restore resource required error, got %v", err)
 		}
 		if mgr.called {
-			t.Fatalf("manager should not be called for not-found resource")
-		}
-	})
-
-	t.Run("get failure", func(t *testing.T) {
-		mgr := &fakeRestoreManager{}
-		reader := newRestoreClientWithGetError(t, "restore", errors.New("boom"), restoreObj)
-		_, err := ReconcileOpenBaoRestore(context.Background(), reader, req, logr.Discard(), mgr)
-		if err == nil || !strings.Contains(err.Error(), "failed to get OpenBaoRestore") {
-			t.Fatalf("expected get error, got %v", err)
-		}
-		if mgr.called {
-			t.Fatalf("manager should not be called when get fails")
+			t.Fatalf("manager should not be called without a restore resource")
 		}
 	})
 
 	t.Run("manager error is propagated", func(t *testing.T) {
 		mgr := &fakeRestoreManager{err: errors.New("reconcile failed")}
-		_, err := ReconcileOpenBaoRestore(context.Background(), newRestoreClient(t, restoreObj.DeepCopy()), req, logr.Discard(), mgr)
+		_, err := ReconcileOpenBaoRestore(context.Background(), restoreObj, logr.Discard(), mgr)
 		if err == nil || !strings.Contains(err.Error(), "reconcile failed") {
 			t.Fatalf("expected manager error, got %v", err)
 		}
-		if !mgr.called || mgr.observedName != "restore" {
-			t.Fatalf("expected manager to be called with restore object")
+		if !mgr.called || mgr.observed != restoreObj {
+			t.Fatalf("expected manager to receive the supplied restore object")
 		}
 	})
 
 	t.Run("manager result is passed through", func(t *testing.T) {
 		mgr := &fakeRestoreManager{result: recon.Result{RequeueAfter: 9 * time.Second}}
-		result, err := ReconcileOpenBaoRestore(context.Background(), newRestoreClient(t, restoreObj.DeepCopy()), req, logr.Discard(), mgr)
+		result, err := ReconcileOpenBaoRestore(context.Background(), restoreObj, logr.Discard(), mgr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if result.RequeueAfter != 9*time.Second {
 			t.Fatalf("RequeueAfter=%v, want 9s", result.RequeueAfter)
 		}
-	})
-
-	t.Run("explicit not found error path", func(t *testing.T) {
-		mgr := &fakeRestoreManager{}
-		reader := newRestoreClientWithGetError(t, "restore", apierrors.NewNotFound(schema.GroupResource{Group: "openbao.org", Resource: "openbaorestores"}, "restore"))
-		result, err := ReconcileOpenBaoRestore(context.Background(), reader, req, logr.Discard(), mgr)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if result != (recon.Result{}) {
-			t.Fatalf("result=%v, want zero", result)
-		}
-		if mgr.called {
-			t.Fatalf("manager should not be called for not found")
+		if mgr.observed != restoreObj {
+			t.Fatalf("expected manager to receive the supplied restore object")
 		}
 	})
 }

--- a/internal/controller/openbaorestore/controller.go
+++ b/internal/controller/openbaorestore/controller.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -35,18 +33,13 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
 	observability "github.com/dc-tec/openbao-operator/internal/platform/observability"
-	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 )
 
 // OpenBaoRestoreReconciler reconciles a OpenBaoRestore object.
 type OpenBaoRestoreReconciler struct {
 	client.Client
-	Scheme                *runtime.Scheme
-	AdmissionTracker      *admission.Tracker
-	RestoreReconciler     appopenbaorestore.RestoreReconciler
-	Recorder              events.EventRecorder
-	OperatorImageVerifier imageverify.Verifier
-	Platform              string
+	AdmissionTracker  *admission.Tracker
+	RestoreReconciler appopenbaorestore.RestoreReconciler
 }
 
 const controllerNameOpenBaoRestore = "openbaorestore"
@@ -104,8 +97,7 @@ func (r *OpenBaoRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	appResult, appErr := appopenbaorestore.ReconcileOpenBaoRestore(
 		ctx,
-		r.Client,
-		req.NamespacedName,
+		restoreResource,
 		logger,
 		r.RestoreReconciler,
 	)
@@ -143,19 +135,8 @@ func (r *OpenBaoRestoreReconciler) pauseForAdmissionDependencyLoss(ctx context.C
 // list/watch permissions on Jobs, which we don't have. Instead, the restore manager
 // uses direct API calls (GET) and RequeueAfter polling to monitor job status.
 func (r *OpenBaoRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Initialize the restore manager
-	if r.Recorder == nil {
-		r.Recorder = mgr.GetEventRecorder("openbaorestore")
-	}
 	if r.RestoreReconciler == nil {
-		r.RestoreReconciler = appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{
-			Client:                r.Client,
-			APIReader:             mgr.GetAPIReader(),
-			Scheme:                r.Scheme,
-			Recorder:              r.Recorder,
-			OperatorImageVerifier: r.OperatorImageVerifier,
-			Platform:              r.Platform,
-		})
+		return fmt.Errorf("restore reconciler is not configured")
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/openbaorestore/controller_integration_test.go
+++ b/internal/controller/openbaorestore/controller_integration_test.go
@@ -24,6 +24,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	appopenbaorestore "github.com/dc-tec/openbao-operator/internal/app/openbaorestore"
 	openbaorestorecontroller "github.com/dc-tec/openbao-operator/internal/controller/openbaorestore"
 	"github.com/dc-tec/openbao-operator/internal/platform/admission"
 )
@@ -115,7 +116,12 @@ func startOpenBaoRestoreManager(t *testing.T) client.Client {
 
 	reconciler := &openbaorestorecontroller.OpenBaoRestoreReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		RestoreReconciler: appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{
+			Client:    mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
+			Scheme:    mgr.GetScheme(),
+			Recorder:  mgr.GetEventRecorder("openbaorestore"),
+		}),
 	}
 	require.NoError(t, reconciler.SetupWithManager(mgr))
 

--- a/internal/controller/openbaorestore/controller_test.go
+++ b/internal/controller/openbaorestore/controller_test.go
@@ -17,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appopenbaorestore "github.com/dc-tec/openbao-operator/internal/app/openbaorestore"
@@ -26,16 +27,18 @@ import (
 )
 
 type recordingRestoreReconciler struct {
-	calls  int
-	result recon.Result
+	calls    int
+	result   recon.Result
+	observed *openbaov1alpha1.OpenBaoRestore
 }
 
 func (r *recordingRestoreReconciler) Reconcile(
 	_ context.Context,
 	_ logr.Logger,
-	_ *openbaov1alpha1.OpenBaoRestore,
+	restoreResource *openbaov1alpha1.OpenBaoRestore,
 ) (recon.Result, error) {
 	r.calls++
+	r.observed = restoreResource
 	return r.result, nil
 }
 
@@ -58,8 +61,7 @@ func TestOpenBaoRestoreReconciler_Reconcile_NotFound(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &OpenBaoRestoreReconciler{
 		Client:            c,
-		Scheme:            scheme,
-		RestoreReconciler: appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{Client: c, Scheme: scheme}),
+		RestoreReconciler: &recordingRestoreReconciler{},
 	}
 
 	req := ctrl.Request{
@@ -98,7 +100,6 @@ func TestOpenBaoRestoreReconciler_AdmissionDependencyLoss(t *testing.T) {
 		tracker.Set(admission.Status{CheckedAt: time.Now(), OverallReady: false})
 		r := &OpenBaoRestoreReconciler{
 			Client:            c,
-			Scheme:            scheme,
 			AdmissionTracker:  tracker,
 			RestoreReconciler: appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{Client: c, APIReader: c, Scheme: scheme}),
 		}
@@ -131,7 +132,6 @@ func TestOpenBaoRestoreReconciler_AdmissionDependencyLoss(t *testing.T) {
 		tracker.Set(admission.Status{CheckedAt: time.Now(), OverallReady: false})
 		r := &OpenBaoRestoreReconciler{
 			Client:            c,
-			Scheme:            scheme,
 			AdmissionTracker:  tracker,
 			RestoreReconciler: appopenbaorestore.NewRestoreReconciler(appopenbaorestore.RestoreDependencies{Client: c, APIReader: c, Scheme: scheme}),
 		}
@@ -167,13 +167,30 @@ func TestOpenBaoRestoreReconciler_AdmissionDependencyLoss(t *testing.T) {
 				},
 			},
 		}
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(restore).Build()
+		restoreGetCalls := 0
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(restore).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					c client.WithWatch,
+					key client.ObjectKey,
+					obj client.Object,
+					opts ...client.GetOption,
+				) error {
+					if _, ok := obj.(*openbaov1alpha1.OpenBaoRestore); ok {
+						restoreGetCalls++
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			}).
+			Build()
 		tracker := admission.NewTracker(c, admission.DefaultDependencies(), admission.DefaultNamePrefixes(), time.Hour)
 		tracker.Set(admission.Status{CheckedAt: time.Now(), OverallReady: false})
 		recorder := &recordingRestoreReconciler{result: recon.Result{RequeueAfter: 7 * time.Second}}
 		r := &OpenBaoRestoreReconciler{
 			Client:            c,
-			Scheme:            scheme,
 			AdmissionTracker:  tracker,
 			RestoreReconciler: recorder,
 		}
@@ -182,5 +199,15 @@ func TestOpenBaoRestoreReconciler_AdmissionDependencyLoss(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 7*time.Second, result.RequeueAfter)
 		assert.Equal(t, 1, recorder.calls)
+		assert.Equal(t, 1, restoreGetCalls)
+		require.NotNil(t, recorder.observed)
+		assert.Equal(t, restore.Name, recorder.observed.Name)
+		assert.Equal(t, restore.Status.Execution.OperationID, recorder.observed.Status.Execution.OperationID)
 	})
+}
+
+func TestOpenBaoRestoreReconciler_SetupWithManager_RequiresRestoreReconciler(t *testing.T) {
+	err := (&OpenBaoRestoreReconciler{}).SetupWithManager(nil)
+
+	require.EqualError(t, err, "restore reconciler is not configured")
 }

--- a/internal/controller/provisioner/controller.go
+++ b/internal/controller/provisioner/controller.go
@@ -18,9 +18,9 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,7 +52,6 @@ import (
 type NamespaceProvisionerReconciler struct {
 	client.Client
 	APIReader         client.Reader
-	Scheme            *runtime.Scheme
 	Recorder          events.EventRecorder
 	Provisioner       appprovisioner.Provisioner
 	OperatorNamespace string
@@ -106,14 +105,7 @@ func controllerResult(result recon.Result) ctrl.Result {
 // SetupWithManager sets up the controller with the Manager.
 func (r *NamespaceProvisionerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Provisioner == nil {
-		provisionerRuntime, err := appprovisioner.NewProvisioner(appprovisioner.ProvisionerDependencies{
-			Client: r.Client,
-			Logger: log.Log.WithName(controllerNameNamespaceProvisioner),
-		})
-		if err != nil {
-			return err
-		}
-		r.Provisioner = provisionerRuntime
+		return errors.New("provisioner application is not configured")
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/provisioner/integration_test_helpers_test.go
+++ b/internal/controller/provisioner/integration_test_helpers_test.go
@@ -59,7 +59,6 @@ func startNamespaceProvisionerController(t *testing.T) client.Client {
 		reconciler := &provisionercontroller.NamespaceProvisionerReconciler{
 			Client:            mgr.GetClient(),
 			APIReader:         mgr.GetAPIReader(),
-			Scheme:            mgr.GetScheme(),
 			Recorder:          mgr.GetEventRecorder("namespace-provisioner-test"),
 			Provisioner:       provisionerManager,
 			OperatorNamespace: operatorNamespace,
@@ -83,7 +82,6 @@ func startProvisionerControllers(t *testing.T) client.Client {
 		namespaceReconciler := &provisionercontroller.NamespaceProvisionerReconciler{
 			Client:            mgr.GetClient(),
 			APIReader:         mgr.GetAPIReader(),
-			Scheme:            mgr.GetScheme(),
 			Recorder:          mgr.GetEventRecorder("namespace-provisioner-test"),
 			Provisioner:       provisionerManager,
 			OperatorNamespace: operatorNamespace,
@@ -95,7 +93,6 @@ func startProvisionerControllers(t *testing.T) client.Client {
 		tenantSecretsReconciler := &provisionercontroller.TenantSecretsRBACReconciler{
 			Client:      mgr.GetClient(),
 			APIReader:   mgr.GetAPIReader(),
-			Scheme:      mgr.GetScheme(),
 			Recorder:    mgr.GetEventRecorder("tenant-secrets-rbac-test"),
 			Provisioner: provisionerManager,
 		}

--- a/internal/controller/provisioner/setup_test.go
+++ b/internal/controller/provisioner/setup_test.go
@@ -1,0 +1,35 @@
+package provisioner
+
+import (
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestSetupWithManagerRequiresProvisionerApplication(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(ctrl.Manager) error
+	}{
+		{
+			name:  "namespace provisioner",
+			setup: (&NamespaceProvisionerReconciler{}).SetupWithManager,
+		},
+		{
+			name:  "tenant Secrets RBAC",
+			setup: (&TenantSecretsRBACReconciler{}).SetupWithManager,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.setup(nil)
+			if err == nil {
+				t.Fatal("SetupWithManager() error = nil, want missing provisioner error")
+			}
+			if got, want := err.Error(), "provisioner application is not configured"; got != want {
+				t.Fatalf("SetupWithManager() error = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/controller/provisioner/tenant_secrets_rbac_controller.go
+++ b/internal/controller/provisioner/tenant_secrets_rbac_controller.go
@@ -2,11 +2,11 @@ package provisioner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,7 +32,6 @@ type TenantSecretsRBACReconciler struct {
 	client.Client
 	AdmissionTracker *admission.Tracker
 	APIReader        client.Reader
-	Scheme           *runtime.Scheme
 	Recorder         events.EventRecorder
 	Provisioner      appprovisioner.Provisioner
 }
@@ -123,14 +122,7 @@ func (r *TenantSecretsRBACReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 func (r *TenantSecretsRBACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Provisioner == nil {
-		provisionerRuntime, err := appprovisioner.NewProvisioner(appprovisioner.ProvisionerDependencies{
-			Client: r.Client,
-			Logger: log.Log.WithName(controllerNameTenantSecretsRBAC),
-		})
-		if err != nil {
-			return err
-		}
-		r.Provisioner = provisionerRuntime
+		return errors.New("provisioner application is not configured")
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/provisioner/tenant_secrets_rbac_controller_test.go
+++ b/internal/controller/provisioner/tenant_secrets_rbac_controller_test.go
@@ -78,7 +78,6 @@ func TestTenantSecretsRBACReconcile_AdmissionDependenciesNotReady(t *testing.T) 
 	reconciler := &TenantSecretsRBACReconciler{
 		Client:      k8sClient,
 		APIReader:   k8sClient,
-		Scheme:      testScheme,
 		Provisioner: newProvisionerManager(t, k8sClient),
 	}
 
@@ -104,7 +103,6 @@ func TestTenantSecretsRBACReconcile_UnprovisionedNamespace(t *testing.T) {
 	reconciler := &TenantSecretsRBACReconciler{
 		Client:      k8sClient,
 		APIReader:   k8sClient,
-		Scheme:      testScheme,
 		Provisioner: newProvisionerManager(t, k8sClient),
 	}
 
@@ -191,7 +189,6 @@ func TestTenantSecretsRBACReconcile_ProvisionedNamespaceSyncsAllowlists(t *testi
 	reconciler := &TenantSecretsRBACReconciler{
 		Client:      k8sClient,
 		APIReader:   k8sClient,
-		Scheme:      testScheme,
 		Recorder:    recorder,
 		Provisioner: newProvisionerManager(t, k8sClient),
 	}
@@ -277,7 +274,6 @@ func TestTenantSecretsRBACReconcile_RemovesStaleSecretRBAC(t *testing.T) {
 	reconciler := &TenantSecretsRBACReconciler{
 		Client:      k8sClient,
 		APIReader:   k8sClient,
-		Scheme:      testScheme,
 		Provisioner: newProvisionerManager(t, k8sClient),
 	}
 
@@ -332,7 +328,6 @@ func TestTenantSecretsRBACReconcile_UnsafeAdmissionDisabledBypassesDependencyChe
 	reconciler := &TenantSecretsRBACReconciler{
 		Client:      k8sClient,
 		APIReader:   k8sClient,
-		Scheme:      testScheme,
 		Provisioner: newProvisionerManager(t, k8sClient),
 	}
 


### PR DESCRIPTION
## Summary

- Read each `OpenBaoRestore` input once at the controller boundary and pass the same snapshot to app orchestration.
- Require restore and provisioner runtime collaborators to be constructed by the process entrypoints instead of controller setup fallbacks.
- Remove construction-only controller fields and add a reconcile-shape rule that prevents the current runtime collaborator constructor families from returning to `SetupWithManager`.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or operational behavior changes are intended.

Restore admission gating and lifecycle orchestration now use one fetched snapshot. Committed restore draining and uncached reads for operation locks, status mutation, admission checks, and provisioner RBAC snapshots remain unchanged.

Missing runtime collaborators now fail during controller setup. Production and manager-driven integration wiring already inject them.

## Verification

- `make lint-ci`
  - zero findings
  - tagged integration and E2E vet passed
  - all 63 AST rules passed
- `make test-ci`
  - 3,659 tests passed
  - 4 expected skips
  - 69.72% internal coverage against the 68% requirement
- Focused race tests for the affected restore and provisioner packages
- Manager-driven restore and provisioner integration tests
- `make generate-ast-rules verify-arch-policy report-internal-deps`
  - no architecture policy warnings
- `make verify-fmt`
- `git diff --check`
- Pre-commit and pre-push hooks passed

## Reviewer Notes

The restore service result adapter remains intentionally unchanged. Converting the restore lifecycle from `ctrl.Result` to the neutral result type would touch approximately 100 lifecycle-result references and belongs in a separate change.

The new AST rule targets the repository current constructor naming families. It is a focused regression ratchet, not a universal application-constructor detector.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

Documentation is not affected. Generated architecture reports remain clean and no generated artifacts changed. This PR has no dependent changes.