### PR TITLE
refactor(status): extract blocked policies

### DIFF
--- a/internal/app/openbaocluster/status_facade.go
+++ b/internal/app/openbaocluster/status_facade.go
@@ -115,10 +115,24 @@ func ApplyCloudUnsealIdentityReadyCondition(cluster *openbaov1alpha1.OpenBaoClus
 	statusops.ApplyCloudUnsealIdentityReadyCondition(cluster, result)
 }
 
-// ApplyUserAccessBootstrapCondition updates the user-access condition for the
-// current cluster generation.
-func ApplyUserAccessBootstrapCondition(cluster *openbaov1alpha1.OpenBaoCluster, now metav1.Time) {
-	statusops.ApplyUserAccessBootstrapCondition(cluster, now)
+// ApplyPausedStatusPolicy updates status for a cluster whose reconciliation is paused.
+func ApplyPausedStatusPolicy(cluster *openbaov1alpha1.OpenBaoCluster, now metav1.Time) {
+	_, cloudUnsealIdentityApplicable := DescribeCloudUnsealIdentity(cluster)
+	statusops.ApplyPausedPolicy(statusops.BlockedPolicyInput{
+		Cluster:                       cluster,
+		CloudUnsealIdentityApplicable: cloudUnsealIdentityApplicable,
+		Now:                           now,
+	})
+}
+
+// ApplyProfileNotSetStatusPolicy updates status for a cluster whose profile is not set.
+func ApplyProfileNotSetStatusPolicy(cluster *openbaov1alpha1.OpenBaoCluster, now metav1.Time) {
+	_, cloudUnsealIdentityApplicable := DescribeCloudUnsealIdentity(cluster)
+	statusops.ApplyProfileNotSetPolicy(statusops.BlockedPolicyInput{
+		Cluster:                       cluster,
+		CloudUnsealIdentityApplicable: cloudUnsealIdentityApplicable,
+		Now:                           now,
+	})
 }
 
 // GatherStatusState reads current cluster state needed for status reconciliation.

--- a/internal/app/openbaocluster/statusops/blocked_policy.go
+++ b/internal/app/openbaocluster/statusops/blocked_policy.go
@@ -1,0 +1,200 @@
+package statusops
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+// BlockedPolicyInput contains the state used to project a blocked
+// reconciliation decision into cluster status.
+type BlockedPolicyInput struct {
+	Cluster                       *openbaov1alpha1.OpenBaoCluster
+	CloudUnsealIdentityApplicable bool
+	Now                           metav1.Time
+}
+
+// ApplyPausedPolicy marks status evaluations that cannot run while
+// reconciliation is paused.
+func ApplyPausedPolicy(input BlockedPolicyInput) {
+	cluster := input.Cluster
+	if cluster.Status.Phase == "" {
+		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseInitializing
+	}
+
+	setBlockedCondition(cluster, openbaov1alpha1.ConditionAvailable, metav1.ConditionUnknown, reasonPaused, "Reconciliation is paused; availability is not being evaluated")
+	setBlockedCondition(cluster, openbaov1alpha1.ConditionDegraded, metav1.ConditionFalse, reasonPaused, "Cluster is paused; no new degradation has been evaluated")
+	ApplyTLSReadyCondition(cluster, ConditionResult{
+		Status:  metav1.ConditionUnknown,
+		Reason:  reasonPaused,
+		Message: "TLS readiness is not being evaluated while reconciliation is paused",
+	})
+	ApplyAPIServerNetworkReadyCondition(cluster, ConditionResult{
+		Status:  metav1.ConditionUnknown,
+		Reason:  reasonPaused,
+		Message: "Kubernetes API egress readiness is not being evaluated while reconciliation is paused",
+	})
+
+	if portopenbao.UsesACMEMode(cluster) {
+		ApplyACMEIntegrationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "ACME integration prerequisites are not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMEIntegrationReady))
+	}
+
+	if portopenbao.HasAuditFileStorage(cluster) {
+		ApplyAuditFileStorageReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "Audit file storage readiness is not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
+	}
+
+	if cluster.Spec.Gateway != nil && cluster.Spec.Gateway.Enabled {
+		ApplyGatewayIntegrationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "Gateway integration prerequisites are not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
+	}
+
+	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
+		ApplyIngressIntegrationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "Ingress integration prerequisites are not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
+	}
+
+	if cluster.Spec.Backup != nil {
+		ApplyBackupConfigurationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "Backup Job prerequisites are not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionBackupConfigurationReady))
+	}
+
+	if input.CloudUnsealIdentityApplicable {
+		ApplyCloudUnsealIdentityReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonPaused,
+			Message: "Cloud KMS unseal identity prerequisites are not being evaluated while reconciliation is paused",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionCloudUnsealIdentityReady))
+	}
+
+	ApplyUserAccessBootstrapCondition(cluster, input.Now)
+}
+
+// ApplyProfileNotSetPolicy marks status evaluations that cannot run until the
+// cluster profile is set.
+func ApplyProfileNotSetPolicy(input BlockedPolicyInput) {
+	cluster := input.Cluster
+	if cluster.Status.Phase == "" {
+		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseInitializing
+	}
+
+	setBlockedCondition(cluster, openbaov1alpha1.ConditionAvailable, metav1.ConditionFalse, ReasonProfileNotSet, "spec.profile must be explicitly set to Hardened or Development; reconciliation is blocked until set")
+	setBlockedCondition(cluster, openbaov1alpha1.ConditionDegraded, metav1.ConditionTrue, ReasonProfileNotSet, "spec.profile is not set; defaults may be inappropriate for production and could lead to insecure deployment")
+	ApplyTLSReadyCondition(cluster, ConditionResult{
+		Status:  metav1.ConditionUnknown,
+		Reason:  ReasonProfileNotSet,
+		Message: "TLS readiness is not being evaluated until spec.profile is set",
+	})
+	ApplyAPIServerNetworkReadyCondition(cluster, ConditionResult{
+		Status:  metav1.ConditionUnknown,
+		Reason:  ReasonProfileNotSet,
+		Message: "Kubernetes API egress readiness is not being evaluated until spec.profile is set",
+	})
+
+	if portopenbao.UsesACMEMode(cluster) {
+		ApplyACMEIntegrationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "ACME integration prerequisites are not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMEIntegrationReady))
+	}
+
+	if portopenbao.HasAuditFileStorage(cluster) {
+		ApplyAuditFileStorageReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "Audit file storage readiness is not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
+	}
+
+	if cluster.Spec.Gateway != nil && cluster.Spec.Gateway.Enabled {
+		ApplyGatewayIntegrationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "Gateway integration prerequisites are not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
+	}
+
+	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
+		ApplyIngressIntegrationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "Ingress integration prerequisites are not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
+	}
+
+	if cluster.Spec.Backup != nil {
+		ApplyBackupConfigurationReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "Backup Job prerequisites are not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionBackupConfigurationReady))
+	}
+
+	if input.CloudUnsealIdentityApplicable {
+		ApplyCloudUnsealIdentityReadyCondition(cluster, ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonProfileNotSet,
+			Message: "Cloud KMS unseal identity prerequisites are not being evaluated until spec.profile is set",
+		})
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionCloudUnsealIdentityReady))
+	}
+
+	setBlockedCondition(cluster, openbaov1alpha1.ConditionProductionReady, metav1.ConditionFalse, ReasonProfileNotSet, "Cluster cannot be considered production-ready until spec.profile is explicitly set")
+	ApplyUserAccessBootstrapCondition(cluster, input.Now)
+}
+
+func setBlockedCondition(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	conditionType openbaov1alpha1.ConditionType,
+	status metav1.ConditionStatus,
+	reason string,
+	message string,
+) {
+	setClusterConditionResult(cluster, conditionType, ConditionResult{
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}

--- a/internal/app/openbaocluster/statusops/blocked_policy_test.go
+++ b/internal/app/openbaocluster/statusops/blocked_policy_test.go
@@ -1,0 +1,355 @@
+package statusops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestApplyPausedPolicy(t *testing.T) {
+	now := metav1.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC)
+	cluster := fullyConfiguredBlockedPolicyCluster()
+
+	ApplyPausedPolicy(BlockedPolicyInput{
+		Cluster:                       cluster,
+		CloudUnsealIdentityApplicable: true,
+		Now:                           now,
+	})
+
+	assert.Equal(t, openbaov1alpha1.ClusterPhaseInitializing, cluster.Status.Phase)
+	assert.Zero(t, cluster.Status.ObservedGeneration)
+	assertConditionOrder(t, cluster,
+		openbaov1alpha1.ConditionAvailable,
+		openbaov1alpha1.ConditionDegraded,
+		openbaov1alpha1.ConditionTLSReady,
+		openbaov1alpha1.ConditionAPIServerNetworkReady,
+		openbaov1alpha1.ConditionACMEIntegrationReady,
+		openbaov1alpha1.ConditionAuditFileStorageReady,
+		openbaov1alpha1.ConditionGatewayIntegrationReady,
+		openbaov1alpha1.ConditionIngressIntegrationReady,
+		openbaov1alpha1.ConditionBackupConfigurationReady,
+		openbaov1alpha1.ConditionCloudUnsealIdentityReady,
+		openbaov1alpha1.ConditionUserAccessBootstrap,
+	)
+
+	want := []conditionExpectation{
+		{openbaov1alpha1.ConditionAvailable, metav1.ConditionUnknown, reasonPaused, "Reconciliation is paused; availability is not being evaluated"},
+		{openbaov1alpha1.ConditionDegraded, metav1.ConditionFalse, reasonPaused, "Cluster is paused; no new degradation has been evaluated"},
+		{openbaov1alpha1.ConditionTLSReady, metav1.ConditionUnknown, reasonPaused, "TLS readiness is not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionAPIServerNetworkReady, metav1.ConditionUnknown, reasonPaused, "Kubernetes API egress readiness is not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionACMEIntegrationReady, metav1.ConditionUnknown, reasonPaused, "ACME integration prerequisites are not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionAuditFileStorageReady, metav1.ConditionUnknown, reasonPaused, "Audit file storage readiness is not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionGatewayIntegrationReady, metav1.ConditionUnknown, reasonPaused, "Gateway integration prerequisites are not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionIngressIntegrationReady, metav1.ConditionUnknown, reasonPaused, "Ingress integration prerequisites are not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionBackupConfigurationReady, metav1.ConditionUnknown, reasonPaused, "Backup Job prerequisites are not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionCloudUnsealIdentityReady, metav1.ConditionUnknown, reasonPaused, "Cloud KMS unseal identity prerequisites are not being evaluated while reconciliation is paused"},
+		{openbaov1alpha1.ConditionUserAccessBootstrap, metav1.ConditionFalse, ReasonDisabled, "Self-init is disabled; user access bootstrap heuristics are not evaluated"},
+	}
+	assertConditionExpectations(t, cluster, now, want)
+	assert.Nil(t, meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionProductionReady)))
+	assert.Nil(t, meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady)))
+}
+
+func TestApplyProfileNotSetPolicy(t *testing.T) {
+	now := metav1.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC)
+	cluster := fullyConfiguredBlockedPolicyCluster()
+
+	ApplyProfileNotSetPolicy(BlockedPolicyInput{
+		Cluster:                       cluster,
+		CloudUnsealIdentityApplicable: true,
+		Now:                           now,
+	})
+
+	assert.Equal(t, openbaov1alpha1.ClusterPhaseInitializing, cluster.Status.Phase)
+	assert.Zero(t, cluster.Status.ObservedGeneration)
+	assertConditionOrder(t, cluster,
+		openbaov1alpha1.ConditionAvailable,
+		openbaov1alpha1.ConditionDegraded,
+		openbaov1alpha1.ConditionTLSReady,
+		openbaov1alpha1.ConditionAPIServerNetworkReady,
+		openbaov1alpha1.ConditionACMEIntegrationReady,
+		openbaov1alpha1.ConditionAuditFileStorageReady,
+		openbaov1alpha1.ConditionGatewayIntegrationReady,
+		openbaov1alpha1.ConditionIngressIntegrationReady,
+		openbaov1alpha1.ConditionBackupConfigurationReady,
+		openbaov1alpha1.ConditionCloudUnsealIdentityReady,
+		openbaov1alpha1.ConditionProductionReady,
+		openbaov1alpha1.ConditionUserAccessBootstrap,
+	)
+
+	want := []conditionExpectation{
+		{openbaov1alpha1.ConditionAvailable, metav1.ConditionFalse, ReasonProfileNotSet, "spec.profile must be explicitly set to Hardened or Development; reconciliation is blocked until set"},
+		{openbaov1alpha1.ConditionDegraded, metav1.ConditionTrue, ReasonProfileNotSet, "spec.profile is not set; defaults may be inappropriate for production and could lead to insecure deployment"},
+		{openbaov1alpha1.ConditionTLSReady, metav1.ConditionUnknown, ReasonProfileNotSet, "TLS readiness is not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionAPIServerNetworkReady, metav1.ConditionUnknown, ReasonProfileNotSet, "Kubernetes API egress readiness is not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionACMEIntegrationReady, metav1.ConditionUnknown, ReasonProfileNotSet, "ACME integration prerequisites are not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionAuditFileStorageReady, metav1.ConditionUnknown, ReasonProfileNotSet, "Audit file storage readiness is not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionGatewayIntegrationReady, metav1.ConditionUnknown, ReasonProfileNotSet, "Gateway integration prerequisites are not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionIngressIntegrationReady, metav1.ConditionUnknown, ReasonProfileNotSet, "Ingress integration prerequisites are not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionBackupConfigurationReady, metav1.ConditionUnknown, ReasonProfileNotSet, "Backup Job prerequisites are not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionCloudUnsealIdentityReady, metav1.ConditionUnknown, ReasonProfileNotSet, "Cloud KMS unseal identity prerequisites are not being evaluated until spec.profile is set"},
+		{openbaov1alpha1.ConditionProductionReady, metav1.ConditionFalse, ReasonProfileNotSet, "Cluster cannot be considered production-ready until spec.profile is explicitly set"},
+		{openbaov1alpha1.ConditionUserAccessBootstrap, metav1.ConditionFalse, ReasonDisabled, "Self-init is disabled; user access bootstrap heuristics are not evaluated"},
+	}
+	assertConditionExpectations(t, cluster, now, want)
+	assert.Nil(t, meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady)))
+}
+
+func TestApplyPausedPolicyPreservesProductionReady(t *testing.T) {
+	productionReady := metav1.Condition{
+		Type:               string(openbaov1alpha1.ConditionProductionReady),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 2,
+		LastTransitionTime: metav1.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC),
+		Reason:             "ProductionReady",
+		Message:            "existing production readiness result",
+	}
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Generation: 7},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Conditions: []metav1.Condition{productionReady},
+		},
+	}
+
+	ApplyPausedPolicy(BlockedPolicyInput{
+		Cluster: cluster,
+		Now:     metav1.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC),
+	})
+
+	assert.Equal(t, &productionReady, meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionProductionReady)))
+}
+
+func TestBlockedPoliciesRemoveInapplicableConditions(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(BlockedPolicyInput)
+	}{
+		{name: "paused", apply: ApplyPausedPolicy},
+		{name: "profile not set", apply: ApplyProfileNotSetPolicy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			untouched := metav1.Condition{
+				Type:               string(openbaov1alpha1.ConditionACMECacheReady),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 2,
+				LastTransitionTime: metav1.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC),
+				Reason:             "ACMECacheReady",
+				Message:            "existing ACME cache result",
+			}
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 7},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Conditions: append([]metav1.Condition{untouched}, optionalBlockedConditions()...),
+				},
+			}
+
+			tt.apply(BlockedPolicyInput{
+				Cluster: cluster,
+				Now:     metav1.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC),
+			})
+
+			for _, conditionType := range []openbaov1alpha1.ConditionType{
+				openbaov1alpha1.ConditionACMEIntegrationReady,
+				openbaov1alpha1.ConditionAuditFileStorageReady,
+				openbaov1alpha1.ConditionGatewayIntegrationReady,
+				openbaov1alpha1.ConditionIngressIntegrationReady,
+				openbaov1alpha1.ConditionBackupConfigurationReady,
+				openbaov1alpha1.ConditionCloudUnsealIdentityReady,
+			} {
+				assert.Nil(t, meta.FindStatusCondition(cluster.Status.Conditions, string(conditionType)), "condition %s", conditionType)
+			}
+			assert.Equal(t, &untouched, meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady)))
+		})
+	}
+}
+
+func TestBlockedPoliciesPreserveExistingPhaseAndOtherFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(BlockedPolicyInput)
+	}{
+		{name: "paused", apply: ApplyPausedPolicy},
+		{name: "profile not set", apply: ApplyProfileNotSetPolicy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := fullyConfiguredBlockedPolicyCluster()
+			cluster.Status.Phase = openbaov1alpha1.ClusterPhaseRunning
+			cluster.Status.ActiveLeader = "example-0"
+			cluster.Status.ReadyReplicas = 3
+			cluster.Status.CurrentVersion = "2.4.1"
+			cluster.Status.Initialized = true
+			before := cluster.DeepCopy()
+
+			tt.apply(BlockedPolicyInput{
+				Cluster:                       cluster,
+				CloudUnsealIdentityApplicable: true,
+				Now:                           metav1.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC),
+			})
+
+			assert.Equal(t, openbaov1alpha1.ClusterPhaseRunning, cluster.Status.Phase)
+			afterWithoutOwnedFields := cluster.DeepCopy()
+			afterWithoutOwnedFields.Status.Conditions = before.Status.Conditions
+			assert.Equal(t, before, afterWithoutOwnedFields)
+		})
+	}
+}
+
+func TestBlockedPoliciesPreserveOrAdvanceTransitionTimes(t *testing.T) {
+	oldTime := metav1.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	now := metav1.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		apply           func(BlockedPolicyInput)
+		availableStatus metav1.ConditionStatus
+	}{
+		{name: "paused", apply: ApplyPausedPolicy, availableStatus: metav1.ConditionUnknown},
+		{name: "profile not set", apply: ApplyProfileNotSetPolicy, availableStatus: metav1.ConditionFalse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 7},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(openbaov1alpha1.ConditionAvailable),
+							Status:             tt.availableStatus,
+							ObservedGeneration: 3,
+							LastTransitionTime: oldTime,
+							Reason:             "OldReason",
+							Message:            "old message",
+						},
+						{
+							Type:               string(openbaov1alpha1.ConditionTLSReady),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 3,
+							LastTransitionTime: oldTime,
+							Reason:             "TLSSecretMissing",
+							Message:            "old message",
+						},
+						{
+							Type:               string(openbaov1alpha1.ConditionUserAccessBootstrap),
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 3,
+							LastTransitionTime: oldTime,
+							Reason:             ReasonUserAccessConfigured,
+							Message:            "old message",
+						},
+					},
+				},
+			}
+
+			tt.apply(BlockedPolicyInput{Cluster: cluster, Now: now})
+
+			available := requireCondition(t, cluster, openbaov1alpha1.ConditionAvailable)
+			assert.Equal(t, oldTime, available.LastTransitionTime)
+			assert.Equal(t, int64(7), available.ObservedGeneration)
+			tlsReady := requireCondition(t, cluster, openbaov1alpha1.ConditionTLSReady)
+			assert.NotEqual(t, oldTime, tlsReady.LastTransitionTime)
+			userAccess := requireCondition(t, cluster, openbaov1alpha1.ConditionUserAccessBootstrap)
+			assert.Equal(t, now, userAccess.LastTransitionTime)
+		})
+	}
+}
+
+type conditionExpectation struct {
+	conditionType openbaov1alpha1.ConditionType
+	status        metav1.ConditionStatus
+	reason        string
+	message       string
+}
+
+func fullyConfiguredBlockedPolicyCluster() *openbaov1alpha1.OpenBaoCluster {
+	return &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Generation: 7},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			TLS: openbaov1alpha1.TLSConfig{
+				Enabled: true,
+				Mode:    openbaov1alpha1.TLSModeACME,
+			},
+			AuditFileStorage: &openbaov1alpha1.AuditFileStorageConfig{},
+			Gateway:          &openbaov1alpha1.GatewayConfig{Enabled: true},
+			Ingress:          &openbaov1alpha1.IngressConfig{Enabled: true},
+			Backup:           &openbaov1alpha1.BackupSchedule{},
+		},
+	}
+}
+
+func optionalBlockedConditions() []metav1.Condition {
+	conditionTypes := []openbaov1alpha1.ConditionType{
+		openbaov1alpha1.ConditionACMEIntegrationReady,
+		openbaov1alpha1.ConditionAuditFileStorageReady,
+		openbaov1alpha1.ConditionGatewayIntegrationReady,
+		openbaov1alpha1.ConditionIngressIntegrationReady,
+		openbaov1alpha1.ConditionBackupConfigurationReady,
+		openbaov1alpha1.ConditionCloudUnsealIdentityReady,
+	}
+	conditions := make([]metav1.Condition, 0, len(conditionTypes))
+	for _, conditionType := range conditionTypes {
+		conditions = append(conditions, metav1.Condition{
+			Type:               string(conditionType),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 2,
+			LastTransitionTime: metav1.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC),
+			Reason:             "OldReason",
+			Message:            "old message",
+		})
+	}
+	return conditions
+}
+
+func assertConditionOrder(t *testing.T, cluster *openbaov1alpha1.OpenBaoCluster, want ...openbaov1alpha1.ConditionType) {
+	t.Helper()
+	got := make([]string, 0, len(cluster.Status.Conditions))
+	for _, condition := range cluster.Status.Conditions {
+		got = append(got, condition.Type)
+	}
+	wantStrings := make([]string, 0, len(want))
+	for _, conditionType := range want {
+		wantStrings = append(wantStrings, string(conditionType))
+	}
+	assert.Equal(t, wantStrings, got)
+}
+
+func assertConditionExpectations(
+	t *testing.T,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	userAccessTime metav1.Time,
+	want []conditionExpectation,
+) {
+	t.Helper()
+	for _, expectation := range want {
+		condition := requireCondition(t, cluster, expectation.conditionType)
+		assert.Equal(t, expectation.status, condition.Status, "condition %s status", expectation.conditionType)
+		assert.Equal(t, expectation.reason, condition.Reason, "condition %s reason", expectation.conditionType)
+		assert.Equal(t, expectation.message, condition.Message, "condition %s message", expectation.conditionType)
+		assert.Equal(t, cluster.Generation, condition.ObservedGeneration, "condition %s observed generation", expectation.conditionType)
+		if expectation.conditionType == openbaov1alpha1.ConditionUserAccessBootstrap {
+			assert.Equal(t, userAccessTime, condition.LastTransitionTime)
+		} else {
+			assert.False(t, condition.LastTransitionTime.IsZero(), "condition %s transition time", expectation.conditionType)
+		}
+	}
+}
+
+func requireCondition(
+	t *testing.T,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	conditionType openbaov1alpha1.ConditionType,
+) *metav1.Condition {
+	t.Helper()
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, string(conditionType))
+	require.NotNil(t, condition, "condition %s", conditionType)
+	return condition
+}

--- a/internal/controller/openbaocluster/constants.go
+++ b/internal/controller/openbaocluster/constants.go
@@ -27,7 +27,6 @@ const (
 	ReasonImageVersionMismatch = constants.ReasonImageVersionMismatch
 
 	reasonReady   = "Ready"
-	reasonPaused  = "Paused"
 	reasonUnknown = constants.ReasonUnknown
 
 	controllerNameWorkload = "openbaocluster-workload"

--- a/internal/controller/openbaocluster/status_condition_contract.go
+++ b/internal/controller/openbaocluster/status_condition_contract.go
@@ -1,9 +1,6 @@
 package openbaocluster
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 )
@@ -65,45 +62,4 @@ func setCloudUnsealIdentityReadyEvaluatedCondition(
 	result statusConditionResult,
 ) {
 	appopenbaocluster.ApplyCloudUnsealIdentityReadyCondition(cluster, result)
-}
-
-func setClusterConditionResult(
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	conditionType openbaov1alpha1.ConditionType,
-	result statusConditionResult,
-) {
-	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:               string(conditionType),
-		Status:             result.Status,
-		ObservedGeneration: cluster.Generation,
-		LastTransitionTime: metav1.Now(),
-		Reason:             result.Reason,
-		Message:            result.Message,
-	})
-}
-
-func setPausedCondition(
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	conditionType openbaov1alpha1.ConditionType,
-	status metav1.ConditionStatus,
-	message string,
-) {
-	setClusterConditionResult(cluster, conditionType, statusConditionResult{
-		Status:  status,
-		Reason:  reasonPaused,
-		Message: message,
-	})
-}
-
-func setProfileNotSetCondition(
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	conditionType openbaov1alpha1.ConditionType,
-	status metav1.ConditionStatus,
-	message string,
-) {
-	setClusterConditionResult(cluster, conditionType, statusConditionResult{
-		Status:  status,
-		Reason:  ReasonProfileNotSet,
-		Message: message,
-	})
 }

--- a/internal/controller/openbaocluster/status_pause_profile.go
+++ b/internal/controller/openbaocluster/status_pause_profile.go
@@ -5,95 +5,15 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 func (r *OpenBaoClusterReconciler) updateStatusForPaused(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
-	if cluster.Status.Phase == "" {
-		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseInitializing
-	}
-
 	now := metav1.Now()
-
-	setPausedCondition(cluster, openbaov1alpha1.ConditionAvailable, metav1.ConditionUnknown, "Reconciliation is paused; availability is not being evaluated")
-	setPausedCondition(cluster, openbaov1alpha1.ConditionDegraded, metav1.ConditionFalse, "Cluster is paused; no new degradation has been evaluated")
-	setTLSReadyEvaluatedCondition(cluster, statusConditionResult{
-		Status:  metav1.ConditionUnknown,
-		Reason:  reasonPaused,
-		Message: "TLS readiness is not being evaluated while reconciliation is paused",
-	})
-	setAPIServerNetworkReadyEvaluatedCondition(cluster, appopenbaocluster.APIServerNetworkResult{
-		Status:  metav1.ConditionUnknown,
-		Reason:  reasonPaused,
-		Message: "Kubernetes API egress readiness is not being evaluated while reconciliation is paused",
-	})
-
-	if portopenbao.UsesACMEMode(cluster) {
-		setACMEIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.ACMEIntegrationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonPaused,
-			Message: "ACME integration prerequisites are not being evaluated while reconciliation is paused",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMEIntegrationReady))
-	}
-
-	if portopenbao.HasAuditFileStorage(cluster) {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonPaused,
-			Message: "Audit file storage readiness is not being evaluated while reconciliation is paused",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
-	}
-
-	if cluster.Spec.Gateway != nil && cluster.Spec.Gateway.Enabled {
-		setGatewayIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.GatewayIntegrationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonPaused,
-			Message: "Gateway integration prerequisites are not being evaluated while reconciliation is paused",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
-	}
-
-	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
-		setIngressIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.IngressIntegrationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonPaused,
-			Message: "Ingress integration prerequisites are not being evaluated while reconciliation is paused",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
-	}
-
-	if cluster.Spec.Backup != nil {
-		setBackupConfigurationReadyEvaluatedCondition(cluster, appopenbaocluster.BackupConfigurationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonPaused,
-			Message: "Backup Job prerequisites are not being evaluated while reconciliation is paused",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionBackupConfigurationReady))
-	}
-
-	if _, applicable := appopenbaocluster.DescribeCloudUnsealIdentity(cluster); applicable {
-		setCloudUnsealIdentityReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonPaused,
-			Message: "Cloud KMS unseal identity prerequisites are not being evaluated while reconciliation is paused",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionCloudUnsealIdentityReady))
-	}
-
-	appopenbaocluster.ApplyUserAccessBootstrapCondition(cluster, now)
+	appopenbaocluster.ApplyPausedStatusPolicy(cluster, now)
 
 	if err := r.patchStatusSSA(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to update status for paused OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
@@ -105,86 +25,7 @@ func (r *OpenBaoClusterReconciler) updateStatusForPaused(ctx context.Context, lo
 
 func (r *OpenBaoClusterReconciler) updateStatusForProfileNotSet(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	now := metav1.Now()
-	if cluster.Status.Phase == "" {
-		cluster.Status.Phase = openbaov1alpha1.ClusterPhaseInitializing
-	}
-
-	setProfileNotSetCondition(cluster, openbaov1alpha1.ConditionAvailable, metav1.ConditionFalse, "spec.profile must be explicitly set to Hardened or Development; reconciliation is blocked until set")
-	setProfileNotSetCondition(cluster, openbaov1alpha1.ConditionDegraded, metav1.ConditionTrue, "spec.profile is not set; defaults may be inappropriate for production and could lead to insecure deployment")
-	setTLSReadyEvaluatedCondition(cluster, statusConditionResult{
-		Status:  metav1.ConditionUnknown,
-		Reason:  ReasonProfileNotSet,
-		Message: "TLS readiness is not being evaluated until spec.profile is set",
-	})
-	setAPIServerNetworkReadyEvaluatedCondition(cluster, appopenbaocluster.APIServerNetworkResult{
-		Status:  metav1.ConditionUnknown,
-		Reason:  ReasonProfileNotSet,
-		Message: "Kubernetes API egress readiness is not being evaluated until spec.profile is set",
-	})
-
-	if portopenbao.UsesACMEMode(cluster) {
-		setACMEIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.ACMEIntegrationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  ReasonProfileNotSet,
-			Message: "ACME integration prerequisites are not being evaluated until spec.profile is set",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMEIntegrationReady))
-	}
-
-	if portopenbao.HasAuditFileStorage(cluster) {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  ReasonProfileNotSet,
-			Message: "Audit file storage readiness is not being evaluated until spec.profile is set",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
-	}
-
-	if cluster.Spec.Gateway != nil && cluster.Spec.Gateway.Enabled {
-		setGatewayIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.GatewayIntegrationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  ReasonProfileNotSet,
-			Message: "Gateway integration prerequisites are not being evaluated until spec.profile is set",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
-	}
-
-	if cluster.Spec.Ingress != nil && cluster.Spec.Ingress.Enabled {
-		setIngressIntegrationReadyEvaluatedCondition(cluster, appopenbaocluster.IngressIntegrationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  ReasonProfileNotSet,
-			Message: "Ingress integration prerequisites are not being evaluated until spec.profile is set",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionIngressIntegrationReady))
-	}
-
-	if cluster.Spec.Backup != nil {
-		setBackupConfigurationReadyEvaluatedCondition(cluster, appopenbaocluster.BackupConfigurationResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  ReasonProfileNotSet,
-			Message: "Backup Job prerequisites are not being evaluated until spec.profile is set",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionBackupConfigurationReady))
-	}
-
-	if _, applicable := appopenbaocluster.DescribeCloudUnsealIdentity(cluster); applicable {
-		setCloudUnsealIdentityReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  ReasonProfileNotSet,
-			Message: "Cloud KMS unseal identity prerequisites are not being evaluated until spec.profile is set",
-		})
-	} else {
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionCloudUnsealIdentityReady))
-	}
-
-	setProfileNotSetCondition(cluster, openbaov1alpha1.ConditionProductionReady, metav1.ConditionFalse, "Cluster cannot be considered production-ready until spec.profile is explicitly set")
-
-	appopenbaocluster.ApplyUserAccessBootstrapCondition(cluster, now)
+	appopenbaocluster.ApplyProfileNotSetStatusPolicy(cluster, now)
 
 	if err := r.patchStatusSSA(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to update status for missing profile on OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)

--- a/internal/controller/openbaocluster/status_paused_test.go
+++ b/internal/controller/openbaocluster/status_paused_test.go
@@ -72,7 +72,7 @@ func TestUpdateStatusForPaused(t *testing.T) {
 			t.Fatalf("observedGeneration = %d, want %d", cluster.Status.ObservedGeneration, cluster.Generation)
 		}
 		cond := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMEIntegrationReady))
-		if cond == nil || cond.Reason != reasonPaused {
+		if cond == nil || cond.Reason != "Paused" {
 			t.Fatalf("acme integration condition = %#v, want paused reason", cond)
 		}
 	})
@@ -101,7 +101,7 @@ func TestUpdateStatusForPaused(t *testing.T) {
 			t.Fatalf("observedGeneration = %d, want %d", cluster.Status.ObservedGeneration, cluster.Generation)
 		}
 		cond := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionGatewayIntegrationReady))
-		if cond == nil || cond.Reason != reasonPaused {
+		if cond == nil || cond.Reason != "Paused" {
 			t.Fatalf("gateway integration condition = %#v, want paused reason", cond)
 		}
 	})


### PR DESCRIPTION
## Summary

Move paused and missing-profile status policy into focused application-layer functions.

The extraction preserves optional-condition applicability, exact reasons and messages, condition ordering, and the controller-owned SSA patch.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or operational behavior change is intended. This refactor changes internal ownership and test placement. Generated artifacts are unchanged. User-facing documentation does not require an update.

## Verification

- `go test -race -count=1 ./internal/app/openbaocluster/statusops ./internal/app/openbaocluster ./internal/controller/openbaocluster`
- `make lint-ci`
- `make test-ci`
- `make generate-ast-rules verify-arch-policy test-ast lint-ast report-internal-deps verify-fmt`

The completed stack passes 3,619 tests with 4 expected skips and 70.18% internal coverage against the 68% minimum.

## Reviewer Notes

Stack 3 of 6. Depends on #694. Review this PR against `refactor/status-condition-contracts`. Merge the complete stack through top PR #698 after all checks pass.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.