### PR TITLE
refactor(status): extract storage readiness

### DIFF
--- a/internal/app/openbaocluster/applications.go
+++ b/internal/app/openbaocluster/applications.go
@@ -102,6 +102,22 @@ func (a *Applications) EvaluateTLSReadiness(
 	return statusops.EvaluateTLSReadiness(ctx, a.config.StatusDependencies.Reader, cluster)
 }
 
+// EvaluateACMECacheReadiness evaluates the shared ACME cache readiness contract.
+func (a *Applications) EvaluateACMECacheReadiness(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (StatusConditionResult, bool) {
+	return statusops.EvaluateACMECacheReadiness(ctx, a.config.StatusDependencies.Reader, cluster)
+}
+
+// EvaluateAuditFileStorageReadiness evaluates the audit file storage readiness contract.
+func (a *Applications) EvaluateAuditFileStorageReadiness(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (StatusConditionResult, bool) {
+	return statusops.EvaluateAuditFileStorageReadiness(ctx, a.config.StatusDependencies.Reader, cluster)
+}
+
 // HandleDeletion executes the application-owned deletion workflow.
 func (a *Applications) HandleDeletion(
 	ctx context.Context,

--- a/internal/app/openbaocluster/statusops/storage_readiness.go
+++ b/internal/app/openbaocluster/statusops/storage_readiness.go
@@ -1,0 +1,232 @@
+package statusops
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+// EvaluateACMECacheReadiness evaluates the shared ACME cache when it applies to the cluster.
+// The reader is the reconciler's cached Kubernetes API reader.
+func EvaluateACMECacheReadiness(
+	ctx context.Context,
+	reader client.Reader,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (ConditionResult, bool) {
+	if !portopenbao.UsesACMEMode(cluster) ||
+		(!portopenbao.RequiresSharedACMECache(cluster) && !portopenbao.HasACMESharedCache(cluster)) {
+		return ConditionResult{}, false
+	}
+
+	claimName := portopenbao.ACMESharedCacheClaimName(cluster)
+	if claimName == "" {
+		return ConditionResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonACMECacheNotConfigured,
+			Message: "ACME shared cache is required for this topology; configure spec.tls.acme.sharedCache with a RWX PVC",
+		}, true
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	key := types.NamespacedName{Namespace: cluster.Namespace, Name: claimName}
+	if err := reader.Get(ctx, key, pvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonACMECacheMissing,
+				Message: fmt.Sprintf("ACME shared cache PVC %s/%s was not found", cluster.Namespace, claimName),
+			}, true
+		}
+		return ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonUnknown,
+			Message: fmt.Sprintf("Failed to read ACME shared cache PVC %s/%s: %v", cluster.Namespace, claimName, err),
+		}, true
+	}
+
+	if !containsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteMany) {
+		return ConditionResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonACMECacheInvalidAccessMode,
+			Message: fmt.Sprintf("ACME shared cache PVC %s/%s must support ReadWriteMany", pvc.Namespace, pvc.Name),
+		}, true
+	}
+
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return ConditionResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonACMECachePending,
+			Message: fmt.Sprintf("ACME shared cache PVC %s/%s is not Bound yet (phase=%s)", pvc.Namespace, pvc.Name, pvc.Status.Phase),
+		}, true
+	}
+
+	return ConditionResult{
+		Status:  metav1.ConditionTrue,
+		Reason:  reasonACMECacheReady,
+		Message: fmt.Sprintf("ACME shared cache PVC %s/%s is Bound with ReadWriteMany access", pvc.Namespace, pvc.Name),
+	}, true
+}
+
+// EvaluateAuditFileStorageReadiness evaluates shared audit file storage when it applies to the cluster.
+// The reader is the reconciler's cached Kubernetes API reader.
+func EvaluateAuditFileStorageReadiness(
+	ctx context.Context,
+	reader client.Reader,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (ConditionResult, bool) {
+	if !portopenbao.HasAuditFileStorage(cluster) {
+		return ConditionResult{}, false
+	}
+
+	claimName := portopenbao.AuditFileStorageClaimName(cluster)
+	if claimName == "" {
+		return ConditionResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonAuditFileStorageMissing,
+			Message: "Audit file storage is configured but no PVC claim name could be resolved",
+		}, true
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	key := types.NamespacedName{Namespace: cluster.Namespace, Name: claimName}
+	if err := reader.Get(ctx, key, pvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonAuditFileStorageMissing,
+				Message: fmt.Sprintf("Audit file storage PVC %s/%s was not found", cluster.Namespace, claimName),
+			}, true
+		}
+		return ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonUnknown,
+			Message: fmt.Sprintf("Failed to read audit file storage PVC %s/%s: %v", cluster.Namespace, claimName, err),
+		}, true
+	}
+
+	if !containsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteMany) {
+		return ConditionResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonAuditFileStorageInvalidAccessMode,
+			Message: fmt.Sprintf("Audit file storage PVC %s/%s must support ReadWriteMany", pvc.Namespace, pvc.Name),
+		}, true
+	}
+
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return ConditionResult{
+			Status:  metav1.ConditionFalse,
+			Reason:  reasonAuditFileStoragePending,
+			Message: fmt.Sprintf("Audit file storage PVC %s/%s is not Bound yet (phase=%s)", pvc.Namespace, pvc.Name, pvc.Status.Phase),
+		}, true
+	}
+
+	if stsName, recreateRequired, err := auditFileStorageStatefulSetRecreateRequired(ctx, reader, cluster); err != nil {
+		return ConditionResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  reasonUnknown,
+			Message: fmt.Sprintf("Failed to inspect OpenBao StatefulSets for audit file storage mounts: %v", err),
+		}, true
+	} else if recreateRequired {
+		return ConditionResult{
+			Status: metav1.ConditionFalse,
+			Reason: constants.ReasonAuditFileStorageStatefulSetRecreateRequired,
+			Message: fmt.Sprintf(
+				"StatefulSet %s/%s is missing the requested audit file storage volume or mount; recreate the StatefulSet or create a new workload revision so locked pod-template fields can be applied",
+				cluster.Namespace,
+				stsName,
+			),
+		}, true
+	}
+
+	return ConditionResult{
+		Status:  metav1.ConditionTrue,
+		Reason:  reasonAuditFileStorageReady,
+		Message: fmt.Sprintf("Audit file storage PVC %s/%s is Bound with ReadWriteMany access", pvc.Namespace, pvc.Name),
+	}, true
+}
+
+func containsAccessMode(modes []corev1.PersistentVolumeAccessMode, want corev1.PersistentVolumeAccessMode) bool {
+	for _, mode := range modes {
+		if mode == want {
+			return true
+		}
+	}
+	return false
+}
+
+func auditFileStorageStatefulSetRecreateRequired(
+	ctx context.Context,
+	reader client.Reader,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (string, bool, error) {
+	if reader == nil {
+		return "", false, nil
+	}
+
+	var list appsv1.StatefulSetList
+	if err := reader.List(
+		ctx,
+		&list,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels(resourceidentity.Labels(cluster)),
+	); err != nil {
+		return "", false, err
+	}
+
+	for i := range list.Items {
+		sts := &list.Items[i]
+		if !statefulSetHasAuditFileStorageMount(sts, cluster) {
+			return sts.Name, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func statefulSetHasAuditFileStorageMount(
+	sts *appsv1.StatefulSet,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) bool {
+	if sts == nil {
+		return true
+	}
+
+	claimName := portopenbao.AuditFileStorageClaimName(cluster)
+	hasVolume := false
+	for _, volume := range sts.Spec.Template.Spec.Volumes {
+		if volume.Name == constants.VolumeAuditFileStorage &&
+			volume.PersistentVolumeClaim != nil &&
+			volume.PersistentVolumeClaim.ClaimName == claimName {
+			hasVolume = true
+			break
+		}
+	}
+	if !hasVolume {
+		return false
+	}
+
+	for _, container := range sts.Spec.Template.Spec.Containers {
+		if container.Name != constants.ContainerBao {
+			continue
+		}
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == constants.VolumeAuditFileStorage &&
+				mount.MountPath == portopenbao.AuditFileStorageMountPath(cluster) &&
+				mount.SubPathExpr == portopenbao.AuditFileStoragePodSubPathExpr {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}

--- a/internal/app/openbaocluster/statusops/storage_readiness_test.go
+++ b/internal/app/openbaocluster/statusops/storage_readiness_test.go
@@ -1,0 +1,760 @@
+package statusops
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+)
+
+func TestEvaluateACMECacheReadiness(t *testing.T) {
+	t.Parallel()
+
+	cacheKey := types.NamespacedName{Namespace: "default", Name: "shared-cache"}
+	readFailure := errors.New("injected read failure")
+	tests := []struct {
+		name       string
+		cluster    *openbaov1alpha1.OpenBaoCluster
+		objects    map[types.NamespacedName]*corev1.PersistentVolumeClaim
+		getErrors  map[types.NamespacedName]error
+		want       ConditionResult
+		applicable bool
+		wantGets   []types.NamespacedName
+	}{
+		{
+			name:       "not applicable outside ACME mode",
+			cluster:    newStorageReadinessTestCluster(),
+			applicable: false,
+		},
+		{
+			name: "not applicable to a single replica without a configured cache",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newACMECacheReadinessTestCluster()
+				cluster.Spec.Replicas = 1
+				return cluster
+			}(),
+			applicable: false,
+		},
+		{
+			name:    "required cache claim is unresolved",
+			cluster: newACMECacheReadinessTestCluster(),
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonACMECacheNotConfigured,
+				Message: "ACME shared cache is required for this topology; configure spec.tls.acme.sharedCache with a RWX PVC",
+			},
+			applicable: true,
+		},
+		{
+			name:    "configured cache PVC is missing",
+			cluster: newExistingACMECacheReadinessTestCluster(cacheKey.Name),
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonACMECacheMissing,
+				Message: "ACME shared cache PVC default/shared-cache was not found",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+		{
+			name:      "configured cache PVC read fails",
+			cluster:   newExistingACMECacheReadinessTestCluster(cacheKey.Name),
+			getErrors: map[types.NamespacedName]error{cacheKey: readFailure},
+			want: ConditionResult{
+				Status:  metav1.ConditionUnknown,
+				Reason:  reasonUnknown,
+				Message: "Failed to read ACME shared cache PVC default/shared-cache: injected read failure",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+		{
+			name:    "configured cache PVC does not support ReadWriteMany",
+			cluster: newExistingACMECacheReadinessTestCluster(cacheKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				cacheKey: newStorageReadinessPVC(cacheKey, corev1.ReadWriteOnce, corev1.ClaimPending),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonACMECacheInvalidAccessMode,
+				Message: "ACME shared cache PVC default/shared-cache must support ReadWriteMany",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+		{
+			name: "configured cache applies when the topology does not require it",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newExistingACMECacheReadinessTestCluster(cacheKey.Name)
+				cluster.Spec.Replicas = 1
+				return cluster
+			}(),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				cacheKey: newStorageReadinessPVC(cacheKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonACMECacheReady,
+				Message: "ACME shared cache PVC default/shared-cache is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+		{
+			name:    "configured cache PVC is pending",
+			cluster: newExistingACMECacheReadinessTestCluster(cacheKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				cacheKey: newStorageReadinessPVC(cacheKey, corev1.ReadWriteMany, corev1.ClaimPending),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonACMECachePending,
+				Message: "ACME shared cache PVC default/shared-cache is not Bound yet (phase=Pending)",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+		{
+			name:    "configured cache PVC is ready",
+			cluster: newExistingACMECacheReadinessTestCluster(cacheKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				cacheKey: newStorageReadinessPVC(cacheKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonACMECacheReady,
+				Message: "ACME shared cache PVC default/shared-cache is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+		{
+			name: "managed cache resolves the generated PVC name",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newACMECacheReadinessTestCluster()
+				cluster.Spec.TLS.ACME.SharedCache = &openbaov1alpha1.ACMESharedCacheConfig{
+					Mode: openbaov1alpha1.ACMESharedCacheModeManagedPVC,
+					Size: "1Gi",
+				}
+				return cluster
+			}(),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				{Namespace: "default", Name: "example-acme-cache"}: newStorageReadinessPVC(
+					types.NamespacedName{Namespace: "default", Name: "example-acme-cache"},
+					corev1.ReadWriteMany,
+					corev1.ClaimBound,
+				),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonACMECacheReady,
+				Message: "ACME shared cache PVC default/example-acme-cache is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantGets: []types.NamespacedName{
+				{Namespace: "default", Name: "example-acme-cache"},
+			},
+		},
+		{
+			name:    "existing cache trims the configured PVC name",
+			cluster: newExistingACMECacheReadinessTestCluster("  shared-cache  "),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				cacheKey: newStorageReadinessPVC(cacheKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonACMECacheReady,
+				Message: "ACME shared cache PVC default/shared-cache is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantGets:   []types.NamespacedName{cacheKey},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterBefore := tt.cluster.DeepCopy()
+			reader := &storageReadinessReader{objects: tt.objects, getErrors: tt.getErrors}
+			got, applicable := EvaluateACMECacheReadiness(t.Context(), reader, tt.cluster)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("EvaluateACMECacheReadiness() result = %#v, want %#v", got, tt.want)
+			}
+			if applicable != tt.applicable {
+				t.Fatalf("EvaluateACMECacheReadiness() applicable = %t, want %t", applicable, tt.applicable)
+			}
+			if !reflect.DeepEqual(reader.gets, tt.wantGets) {
+				t.Fatalf("PVC reads = %#v, want %#v", reader.gets, tt.wantGets)
+			}
+			if len(reader.listCalls) != 0 {
+				t.Fatalf("StatefulSet list calls = %#v, want none", reader.listCalls)
+			}
+			if !reflect.DeepEqual(tt.cluster, clusterBefore) {
+				t.Fatalf("EvaluateACMECacheReadiness() mutated cluster: got %#v, want %#v", tt.cluster, clusterBefore)
+			}
+		})
+	}
+}
+
+func TestEvaluateAuditFileStorageReadiness(t *testing.T) {
+	t.Parallel()
+
+	claimKey := types.NamespacedName{Namespace: "default", Name: "audit-claim"}
+	readFailure := errors.New("injected read failure")
+	listFailure := errors.New("injected list failure")
+	tests := []struct {
+		name         string
+		cluster      *openbaov1alpha1.OpenBaoCluster
+		objects      map[types.NamespacedName]*corev1.PersistentVolumeClaim
+		getErrors    map[types.NamespacedName]error
+		statefulSets []appsv1.StatefulSet
+		listError    error
+		want         ConditionResult
+		applicable   bool
+		wantOps      []string
+	}{
+		{
+			name:       "not applicable without audit file storage",
+			cluster:    newStorageReadinessTestCluster(),
+			applicable: false,
+		},
+		{
+			name:    "configured claim is unresolved",
+			cluster: newAuditFileStorageReadinessTestCluster(""),
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonAuditFileStorageMissing,
+				Message: "Audit file storage is configured but no PVC claim name could be resolved",
+			},
+			applicable: true,
+		},
+		{
+			name:    "configured PVC is missing",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonAuditFileStorageMissing,
+				Message: "Audit file storage PVC default/audit-claim was not found",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim"},
+		},
+		{
+			name:      "configured PVC read fails",
+			cluster:   newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			getErrors: map[types.NamespacedName]error{claimKey: readFailure},
+			want: ConditionResult{
+				Status:  metav1.ConditionUnknown,
+				Reason:  reasonUnknown,
+				Message: "Failed to read audit file storage PVC default/audit-claim: injected read failure",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim"},
+		},
+		{
+			name:    "access mode is checked before phase",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteOnce, corev1.ClaimPending),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonAuditFileStorageInvalidAccessMode,
+				Message: "Audit file storage PVC default/audit-claim must support ReadWriteMany",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim"},
+		},
+		{
+			name:    "configured PVC is pending",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimPending),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonAuditFileStoragePending,
+				Message: "Audit file storage PVC default/audit-claim is not Bound yet (phase=Pending)",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim"},
+		},
+		{
+			name:    "StatefulSet list fails after the PVC read",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			listError: listFailure,
+			want: ConditionResult{
+				Status:  metav1.ConditionUnknown,
+				Reason:  reasonUnknown,
+				Message: "Failed to inspect OpenBao StatefulSets for audit file storage mounts: injected list failure",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name:    "ready before a StatefulSet exists",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonAuditFileStorageReady,
+				Message: "Audit file storage PVC default/audit-claim is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name: "managed storage resolves the generated PVC name",
+			cluster: func() *openbaov1alpha1.OpenBaoCluster {
+				cluster := newStorageReadinessTestCluster()
+				cluster.Spec.AuditFileStorage = &openbaov1alpha1.AuditFileStorageConfig{
+					Mode: openbaov1alpha1.AuditFileStorageModeManagedPVC,
+					Size: "5Gi",
+				}
+				return cluster
+			}(),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				{Namespace: "default", Name: "example-audit"}: newStorageReadinessPVC(
+					types.NamespacedName{Namespace: "default", Name: "example-audit"},
+					corev1.ReadWriteMany,
+					corev1.ClaimBound,
+				),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonAuditFileStorageReady,
+				Message: "Audit file storage PVC default/example-audit is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/example-audit", "list statefulsets"},
+		},
+		{
+			name:    "existing storage trims the configured PVC name",
+			cluster: newAuditFileStorageReadinessTestCluster("  audit-claim  "),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonAuditFileStorageReady,
+				Message: "Audit file storage PVC default/audit-claim is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name:    "StatefulSet is missing the requested volume",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			statefulSets: []appsv1.StatefulSet{
+				*newAuditFileStorageReadinessStatefulSet("example", claimKey.Name, auditMountNoVolume),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.ReasonAuditFileStorageStatefulSetRecreateRequired,
+				Message: "StatefulSet default/example is missing the requested audit file storage volume or mount; recreate the StatefulSet or create a new workload revision so locked pod-template fields can be applied",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name:    "StatefulSet is missing the Bao container",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			statefulSets: []appsv1.StatefulSet{
+				*newAuditFileStorageReadinessStatefulSet("example", claimKey.Name, auditMountNoBaoContainer),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.ReasonAuditFileStorageStatefulSetRecreateRequired,
+				Message: "StatefulSet default/example is missing the requested audit file storage volume or mount; recreate the StatefulSet or create a new workload revision so locked pod-template fields can be applied",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name:    "StatefulSet has the wrong Bao mount",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			statefulSets: []appsv1.StatefulSet{
+				*newAuditFileStorageReadinessStatefulSet("example", claimKey.Name, auditMountWrongPath),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.ReasonAuditFileStorageStatefulSetRecreateRequired,
+				Message: "StatefulSet default/example is missing the requested audit file storage volume or mount; recreate the StatefulSet or create a new workload revision so locked pod-template fields can be applied",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name:    "first incompatible StatefulSet is reported",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			statefulSets: []appsv1.StatefulSet{
+				*newAuditFileStorageReadinessStatefulSet("compatible", claimKey.Name, auditMountValid),
+				*newAuditFileStorageReadinessStatefulSet("first-incompatible", claimKey.Name, auditMountWrongSubPath),
+				*newAuditFileStorageReadinessStatefulSet("second-incompatible", claimKey.Name, auditMountWrongPath),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.ReasonAuditFileStorageStatefulSetRecreateRequired,
+				Message: "StatefulSet default/first-incompatible is missing the requested audit file storage volume or mount; recreate the StatefulSet or create a new workload revision so locked pod-template fields can be applied",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+		{
+			name:    "all StatefulSets have the requested mount",
+			cluster: newAuditFileStorageReadinessTestCluster(claimKey.Name),
+			objects: map[types.NamespacedName]*corev1.PersistentVolumeClaim{
+				claimKey: newStorageReadinessPVC(claimKey, corev1.ReadWriteMany, corev1.ClaimBound),
+			},
+			statefulSets: []appsv1.StatefulSet{
+				*newAuditFileStorageReadinessStatefulSet("example", claimKey.Name, auditMountValid),
+				*newAuditFileStorageReadinessStatefulSet("example-read", claimKey.Name, auditMountValid),
+			},
+			want: ConditionResult{
+				Status:  metav1.ConditionTrue,
+				Reason:  reasonAuditFileStorageReady,
+				Message: "Audit file storage PVC default/audit-claim is Bound with ReadWriteMany access",
+			},
+			applicable: true,
+			wantOps:    []string{"get default/audit-claim", "list statefulsets"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterBefore := tt.cluster.DeepCopy()
+			reader := &storageReadinessReader{
+				objects:      tt.objects,
+				getErrors:    tt.getErrors,
+				statefulSets: tt.statefulSets,
+				listError:    tt.listError,
+			}
+			got, applicable := EvaluateAuditFileStorageReadiness(t.Context(), reader, tt.cluster)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("EvaluateAuditFileStorageReadiness() result = %#v, want %#v", got, tt.want)
+			}
+			if applicable != tt.applicable {
+				t.Fatalf("EvaluateAuditFileStorageReadiness() applicable = %t, want %t", applicable, tt.applicable)
+			}
+			if !reflect.DeepEqual(reader.operations, tt.wantOps) {
+				t.Fatalf("reader operations = %#v, want %#v", reader.operations, tt.wantOps)
+			}
+			assertStorageReadinessListOptions(t, reader.listCalls, tt.cluster, len(tt.wantOps) == 2)
+			if !reflect.DeepEqual(tt.cluster, clusterBefore) {
+				t.Fatalf("EvaluateAuditFileStorageReadiness() mutated cluster: got %#v, want %#v", tt.cluster, clusterBefore)
+			}
+		})
+	}
+}
+
+func TestAuditFileStorageStatefulSetHelpers(t *testing.T) {
+	t.Parallel()
+
+	cluster := newAuditFileStorageReadinessTestCluster("audit-claim")
+	valid := newAuditFileStorageReadinessStatefulSet("example", "audit-claim", auditMountValid)
+	tests := []struct {
+		name        string
+		statefulSet *appsv1.StatefulSet
+		mutate      func(*appsv1.StatefulSet)
+		want        bool
+	}{
+		{name: "nil StatefulSet is treated as conforming", want: true},
+		{name: "valid volume and mount", statefulSet: valid, want: true},
+		{
+			name:        "wrong claim",
+			statefulSet: valid,
+			mutate: func(statefulSet *appsv1.StatefulSet) {
+				statefulSet.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = storageReadinessWrongValue
+			},
+		},
+		{
+			name:        "nil PVC source",
+			statefulSet: valid,
+			mutate: func(statefulSet *appsv1.StatefulSet) {
+				statefulSet.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim = nil
+			},
+		},
+		{
+			name:        "wrong volume name",
+			statefulSet: valid,
+			mutate: func(statefulSet *appsv1.StatefulSet) {
+				statefulSet.Spec.Template.Spec.Volumes[0].Name = storageReadinessWrongValue
+			},
+		},
+		{
+			name:        "wrong mount name",
+			statefulSet: valid,
+			mutate: func(statefulSet *appsv1.StatefulSet) {
+				statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name = storageReadinessWrongValue
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			statefulSet := tt.statefulSet
+			if statefulSet != nil {
+				statefulSet = statefulSet.DeepCopy()
+				if tt.mutate != nil {
+					tt.mutate(statefulSet)
+				}
+			}
+			if got := statefulSetHasAuditFileStorageMount(statefulSet, cluster); got != tt.want {
+				t.Fatalf("statefulSetHasAuditFileStorageMount() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+
+	name, recreateRequired, err := auditFileStorageStatefulSetRecreateRequired(t.Context(), nil, cluster)
+	if err != nil || name != "" || recreateRequired {
+		t.Fatalf(
+			"auditFileStorageStatefulSetRecreateRequired(nil reader) = (%q, %t, %v), want (\"\", false, nil)",
+			name,
+			recreateRequired,
+			err,
+		)
+	}
+}
+
+type storageReadinessReader struct {
+	objects      map[types.NamespacedName]*corev1.PersistentVolumeClaim
+	getErrors    map[types.NamespacedName]error
+	statefulSets []appsv1.StatefulSet
+	listError    error
+
+	gets       []types.NamespacedName
+	listCalls  []client.ListOptions
+	operations []string
+}
+
+func (r *storageReadinessReader) Get(
+	_ context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	_ ...client.GetOption,
+) error {
+	r.gets = append(r.gets, key)
+	r.operations = append(r.operations, "get "+key.String())
+	if err := r.getErrors[key]; err != nil {
+		return err
+	}
+	pvc, ok := r.objects[key]
+	if !ok {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "persistentvolumeclaims"}, key.Name)
+	}
+	destination, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return errors.New("storage readiness reader only supports PersistentVolumeClaim reads")
+	}
+	*destination = *pvc.DeepCopy()
+	return nil
+}
+
+func (r *storageReadinessReader) List(
+	_ context.Context,
+	list client.ObjectList,
+	opts ...client.ListOption,
+) error {
+	r.operations = append(r.operations, "list statefulsets")
+	listOptions := *(&client.ListOptions{}).ApplyOptions(opts)
+	r.listCalls = append(r.listCalls, listOptions)
+	if r.listError != nil {
+		return r.listError
+	}
+	destination, ok := list.(*appsv1.StatefulSetList)
+	if !ok {
+		return errors.New("storage readiness reader only supports StatefulSet lists")
+	}
+	destination.Items = make([]appsv1.StatefulSet, len(r.statefulSets))
+	for i := range r.statefulSets {
+		r.statefulSets[i].DeepCopyInto(&destination.Items[i])
+	}
+	return nil
+}
+
+func assertStorageReadinessListOptions(
+	t *testing.T,
+	listCalls []client.ListOptions,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	wantList bool,
+) {
+	t.Helper()
+	if !wantList {
+		if len(listCalls) != 0 {
+			t.Fatalf("StatefulSet list calls = %#v, want none", listCalls)
+		}
+		return
+	}
+	if len(listCalls) != 1 {
+		t.Fatalf("StatefulSet list calls = %#v, want one", listCalls)
+	}
+	if listCalls[0].Namespace != cluster.Namespace {
+		t.Fatalf("StatefulSet list namespace = %q, want %q", listCalls[0].Namespace, cluster.Namespace)
+	}
+	wantSelector := labels.SelectorFromSet(resourceidentity.Labels(cluster)).String()
+	if listCalls[0].LabelSelector == nil || listCalls[0].LabelSelector.String() != wantSelector {
+		t.Fatalf(
+			"StatefulSet label selector = %v, want %q",
+			listCalls[0].LabelSelector,
+			wantSelector,
+		)
+	}
+}
+
+type auditMountState int
+
+const (
+	storageReadinessWrongValue = "wrong"
+
+	auditMountValid auditMountState = iota
+	auditMountNoVolume
+	auditMountNoBaoContainer
+	auditMountWrongPath
+	auditMountWrongSubPath
+)
+
+func newStorageReadinessTestCluster() *openbaov1alpha1.OpenBaoCluster {
+	return &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "example",
+			Namespace:       "default",
+			Generation:      4,
+			ResourceVersion: "3",
+			Labels:          map[string]string{"preserve": "label"},
+		},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 1,
+			Profile:  openbaov1alpha1.ProfileHardened,
+		},
+		Status: openbaov1alpha1.OpenBaoClusterStatus{
+			Phase:              openbaov1alpha1.ClusterPhaseRunning,
+			ObservedGeneration: 3,
+		},
+	}
+}
+
+func newACMECacheReadinessTestCluster() *openbaov1alpha1.OpenBaoCluster {
+	cluster := newStorageReadinessTestCluster()
+	cluster.Spec.Replicas = 3
+	cluster.Spec.TLS = openbaov1alpha1.TLSConfig{
+		Enabled: true,
+		Mode:    openbaov1alpha1.TLSModeACME,
+		ACME:    &openbaov1alpha1.ACMEConfig{DirectoryURL: "https://acme.example/directory"},
+	}
+	return cluster
+}
+
+func newExistingACMECacheReadinessTestCluster(claimName string) *openbaov1alpha1.OpenBaoCluster {
+	cluster := newACMECacheReadinessTestCluster()
+	cluster.Spec.TLS.ACME.SharedCache = &openbaov1alpha1.ACMESharedCacheConfig{
+		Mode:              openbaov1alpha1.ACMESharedCacheModeExistingPVC,
+		ExistingClaimName: claimName,
+	}
+	return cluster
+}
+
+func newAuditFileStorageReadinessTestCluster(claimName string) *openbaov1alpha1.OpenBaoCluster {
+	cluster := newStorageReadinessTestCluster()
+	cluster.Spec.AuditFileStorage = &openbaov1alpha1.AuditFileStorageConfig{
+		Mode:              openbaov1alpha1.AuditFileStorageModeExistingPVC,
+		ExistingClaimName: claimName,
+	}
+	return cluster
+}
+
+func newStorageReadinessPVC(
+	key types.NamespacedName,
+	accessMode corev1.PersistentVolumeAccessMode,
+	phase corev1.PersistentVolumeClaimPhase,
+) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: phase},
+	}
+}
+
+func newAuditFileStorageReadinessStatefulSet(
+	name string,
+	claimName string,
+	mountState auditMountState,
+) *appsv1.StatefulSet {
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: constants.VolumeAuditFileStorage,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: claimName,
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name: constants.ContainerBao,
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:        constants.VolumeAuditFileStorage,
+							MountPath:   portopenbao.AuditFileStorageDefaultMountPath,
+							SubPathExpr: portopenbao.AuditFileStoragePodSubPathExpr,
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	switch mountState {
+	case auditMountValid:
+	case auditMountNoVolume:
+		statefulSet.Spec.Template.Spec.Volumes = nil
+	case auditMountNoBaoContainer:
+		statefulSet.Spec.Template.Spec.Containers[0].Name = "sidecar"
+	case auditMountWrongPath:
+		statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath = "/wrong"
+	case auditMountWrongSubPath:
+		statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].SubPathExpr = storageReadinessWrongValue
+	}
+	return statefulSet
+}

--- a/internal/controller/openbaocluster/constants.go
+++ b/internal/controller/openbaocluster/constants.go
@@ -15,11 +15,6 @@ const (
 	ReasonProfileNotSet                     = "ProfileNotSet"
 	ReasonRootTokenStored                   = "RootTokenStored"
 	ReasonStaticUnsealInUse                 = "StaticUnsealInUse"
-	ReasonACMECacheReady                    = "ACMECacheReady"
-	ReasonACMECacheNotConfigured            = "ACMECacheNotConfigured"
-	ReasonACMECacheMissing                  = "ACMECacheMissing"
-	ReasonACMECachePending                  = "ACMECachePending"
-	ReasonACMECacheInvalidAccessMode        = "ACMECacheInvalidAccessMode"
 
 	ReasonImageVersionMismatch = constants.ReasonImageVersionMismatch
 
@@ -36,13 +31,4 @@ const (
 	annotationLastStaticUnsealWarning    = "openbao.org/last-static-unseal-warning"
 	annotationLastUnsafeAdmissionWarning = "openbao.org/last-unsafe-admission-warning"
 )
-
-const (
-	ReasonAuditFileStorageReady                       = "AuditFileStorageReady"
-	ReasonAuditFileStorageMissing                     = "AuditFileStorageMissing"
-	ReasonAuditFileStoragePending                     = "AuditFileStoragePending"
-	ReasonAuditFileStorageInvalidAccessMode           = "AuditFileStorageInvalidAccessMode"
-	ReasonAuditFileStorageStatefulSetRecreateRequired = constants.ReasonAuditFileStorageStatefulSetRecreateRequired
-)
-
 const securityWarningInterval = time.Hour

--- a/internal/controller/openbaocluster/status_acme_cache.go
+++ b/internal/controller/openbaocluster/status_acme_cache.go
@@ -2,85 +2,19 @@ package openbaocluster
 
 import (
 	"context"
-	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 // setACMECacheReadyCondition evaluates and sets the ACMECacheReady condition when a shared
 // ACME cache is configured or required by the cluster topology.
 func (r *OpenBaoClusterReconciler) setACMECacheReadyCondition(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) {
-	if !portopenbao.UsesACMEMode(cluster) || (!portopenbao.RequiresSharedACMECache(cluster) && !portopenbao.HasACMESharedCache(cluster)) {
+	result, applicable := r.Applications.EvaluateACMECacheReadiness(ctx, cluster)
+	if !applicable {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady))
 		return
 	}
-
-	claimName := portopenbao.ACMESharedCacheClaimName(cluster)
-	if claimName == "" {
-		setACMECacheReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonACMECacheNotConfigured,
-			Message: "ACME shared cache is required for this topology; configure spec.tls.acme.sharedCache with a RWX PVC",
-		})
-		return
-	}
-
-	pvc := &corev1.PersistentVolumeClaim{}
-	key := types.NamespacedName{Namespace: cluster.Namespace, Name: claimName}
-	if err := r.Get(ctx, key, pvc); err != nil {
-		if apierrors.IsNotFound(err) {
-			setACMECacheReadyEvaluatedCondition(cluster, statusConditionResult{
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonACMECacheMissing,
-				Message: fmt.Sprintf("ACME shared cache PVC %s/%s was not found", cluster.Namespace, claimName),
-			})
-			return
-		}
-		setACMECacheReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonUnknown,
-			Message: fmt.Sprintf("Failed to read ACME shared cache PVC %s/%s: %v", cluster.Namespace, claimName, err),
-		})
-		return
-	}
-
-	if !containsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteMany) {
-		setACMECacheReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonACMECacheInvalidAccessMode,
-			Message: fmt.Sprintf("ACME shared cache PVC %s/%s must support ReadWriteMany", pvc.Namespace, pvc.Name),
-		})
-		return
-	}
-
-	if pvc.Status.Phase != corev1.ClaimBound {
-		setACMECacheReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonACMECachePending,
-			Message: fmt.Sprintf("ACME shared cache PVC %s/%s is not Bound yet (phase=%s)", pvc.Namespace, pvc.Name, pvc.Status.Phase),
-		})
-		return
-	}
-
-	setACMECacheReadyEvaluatedCondition(cluster, statusConditionResult{
-		Status:  metav1.ConditionTrue,
-		Reason:  ReasonACMECacheReady,
-		Message: fmt.Sprintf("ACME shared cache PVC %s/%s is Bound with ReadWriteMany access", pvc.Namespace, pvc.Name),
-	})
-}
-
-func containsAccessMode(modes []corev1.PersistentVolumeAccessMode, want corev1.PersistentVolumeAccessMode) bool {
-	for _, mode := range modes {
-		if mode == want {
-			return true
-		}
-	}
-	return false
+	setACMECacheReadyEvaluatedCondition(cluster, result)
 }

--- a/internal/controller/openbaocluster/status_acme_cache_test.go
+++ b/internal/controller/openbaocluster/status_acme_cache_test.go
@@ -1,148 +1,82 @@
 package openbaocluster
 
 import (
-	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
 
-func TestSetACMECacheReadyCondition(t *testing.T) {
-	t.Parallel()
-
+func TestSetACMECacheReadyConditionAppliesApplicationResult(t *testing.T) {
 	scheme := newOpenBaoClusterTestScheme(t)
-
-	newCluster := func() *openbaov1alpha1.OpenBaoCluster {
-		return &openbaov1alpha1.OpenBaoCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
-			Spec: openbaov1alpha1.OpenBaoClusterSpec{
-				Replicas: 3,
-				TLS: openbaov1alpha1.TLSConfig{
-					Enabled: true,
-					Mode:    openbaov1alpha1.TLSModeACME,
-					ACME:    &openbaov1alpha1.ACMEConfig{DirectoryURL: "https://acme.example/directory"},
-				},
-			},
-		}
-	}
-
-	tests := []struct {
-		name       string
-		cluster    *openbaov1alpha1.OpenBaoCluster
-		objects    []any
-		wantStatus metav1.ConditionStatus
-		wantReason string
-	}{
-		{
-			name:       "required cache not configured",
-			cluster:    newCluster(),
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonACMECacheNotConfigured,
-		},
-		{
-			name: "configured cache missing pvc",
-			cluster: func() *openbaov1alpha1.OpenBaoCluster {
-				cluster := newCluster()
-				cluster.Spec.TLS.ACME.SharedCache = &openbaov1alpha1.ACMESharedCacheConfig{
-					Mode: openbaov1alpha1.ACMESharedCacheModeManagedPVC,
-					Size: "1Gi",
-				}
-				return cluster
-			}(),
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonACMECacheMissing,
-		},
-		{
-			name: "configured cache pending pvc",
-			cluster: func() *openbaov1alpha1.OpenBaoCluster {
-				cluster := newCluster()
-				cluster.Spec.TLS.ACME.SharedCache = &openbaov1alpha1.ACMESharedCacheConfig{
-					Mode: openbaov1alpha1.ACMESharedCacheModeManagedPVC,
-					Size: "1Gi",
-				}
-				return cluster
-			}(),
-			objects: []any{
-				&corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{Name: "example-acme-cache", Namespace: "default"},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default", Generation: 2},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			Replicas: 3,
+			TLS: openbaov1alpha1.TLSConfig{
+				Enabled: true,
+				Mode:    openbaov1alpha1.TLSModeACME,
+				ACME: &openbaov1alpha1.ACMEConfig{
+					DirectoryURL: "https://acme.example/directory",
+					SharedCache: &openbaov1alpha1.ACMESharedCacheConfig{
+						Mode:              openbaov1alpha1.ACMESharedCacheModeExistingPVC,
+						ExistingClaimName: "shared-cache",
 					},
-					Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
 				},
 			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonACMECachePending,
-		},
-		{
-			name: "configured cache invalid access mode",
-			cluster: func() *openbaov1alpha1.OpenBaoCluster {
-				cluster := newCluster()
-				cluster.Spec.TLS.ACME.SharedCache = &openbaov1alpha1.ACMESharedCacheConfig{
-					Mode:              openbaov1alpha1.ACMESharedCacheModeExistingPVC,
-					ExistingClaimName: "shared-cache",
-				}
-				return cluster
-			}(),
-			objects: []any{
-				&corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{Name: "shared-cache", Namespace: "default"},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-					},
-					Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
-				},
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonACMECacheInvalidAccessMode,
-		},
-		{
-			name: "configured cache ready",
-			cluster: func() *openbaov1alpha1.OpenBaoCluster {
-				cluster := newCluster()
-				cluster.Spec.TLS.ACME.SharedCache = &openbaov1alpha1.ACMESharedCacheConfig{
-					Mode:              openbaov1alpha1.ACMESharedCacheModeExistingPVC,
-					ExistingClaimName: "shared-cache",
-				}
-				return cluster
-			}(),
-			objects: []any{
-				&corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{Name: "shared-cache", Namespace: "default"},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
-					},
-					Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
-				},
-			},
-			wantStatus: metav1.ConditionTrue,
-			wantReason: ReasonACMECacheReady,
 		},
 	}
+	statusReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-cache", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}).Build()
+	reconciler := &OpenBaoClusterReconciler{
+		Applications: newStatusTestApplications(statusReader, scheme),
+	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			builder := fake.NewClientBuilder().WithScheme(scheme)
-			for _, obj := range tt.objects {
-				builder = builder.WithObjects(obj.(client.Object))
-			}
-			reconciler := &OpenBaoClusterReconciler{Client: builder.Build()}
+	reconciler.setACMECacheReadyCondition(t.Context(), cluster)
 
-			reconciler.setACMECacheReadyCondition(context.Background(), tt.cluster)
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady))
+	if condition == nil {
+		t.Fatal("expected ACMECacheReady condition")
+	}
+	if condition.Status != metav1.ConditionTrue || condition.Reason != "ACMECacheReady" {
+		t.Fatalf("ACMECacheReady condition = %#v, want status=True reason=ACMECacheReady", condition)
+	}
+	if condition.Message != "ACME shared cache PVC default/shared-cache is Bound with ReadWriteMany access" {
+		t.Fatalf("message = %q", condition.Message)
+	}
+	if condition.ObservedGeneration != cluster.Generation {
+		t.Fatalf("observed generation = %d, want %d", condition.ObservedGeneration, cluster.Generation)
+	}
+	if condition.LastTransitionTime.IsZero() {
+		t.Fatal("expected nonzero last transition time")
+	}
+}
 
-			cond := meta.FindStatusCondition(tt.cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady))
-			if cond == nil {
-				t.Fatal("expected ACMECacheReady condition")
-			}
-			if cond.Status != tt.wantStatus || cond.Reason != tt.wantReason {
-				t.Fatalf("ACMECacheReady = %#v, want status=%s reason=%s", cond, tt.wantStatus, tt.wantReason)
-			}
-		})
+func TestSetACMECacheReadyConditionRemovesStaleConditionWhenNotApplicable(t *testing.T) {
+	scheme := newOpenBaoClusterTestScheme(t)
+	cluster := newOpenBaoClusterStatusTestObject()
+	cluster.Status.Conditions = []metav1.Condition{{
+		Type:   string(openbaov1alpha1.ConditionACMECacheReady),
+		Status: metav1.ConditionTrue,
+		Reason: "ACMECacheReady",
+	}}
+	statusReader := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &OpenBaoClusterReconciler{
+		Applications: newStatusTestApplications(statusReader, scheme),
+	}
+
+	reconciler.setACMECacheReadyCondition(t.Context(), cluster)
+
+	if condition := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionACMECacheReady)); condition != nil {
+		t.Fatalf("ACMECacheReady condition = %#v, want removed", condition)
 	}
 }

--- a/internal/controller/openbaocluster/status_audit_file_storage.go
+++ b/internal/controller/openbaocluster/status_audit_file_storage.go
@@ -2,163 +2,19 @@ package openbaocluster
 
 import (
 	"context"
-	"fmt"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/platform/constants"
-	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 // setAuditFileStorageReadyCondition evaluates and sets AuditFileStorageReady when shared
 // audit file storage is configured.
 func (r *OpenBaoClusterReconciler) setAuditFileStorageReadyCondition(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) {
-	if !portopenbao.HasAuditFileStorage(cluster) {
+	result, applicable := r.Applications.EvaluateAuditFileStorageReadiness(ctx, cluster)
+	if !applicable {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
 		return
 	}
-
-	claimName := portopenbao.AuditFileStorageClaimName(cluster)
-	if claimName == "" {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonAuditFileStorageMissing,
-			Message: "Audit file storage is configured but no PVC claim name could be resolved",
-		})
-		return
-	}
-
-	pvc := &corev1.PersistentVolumeClaim{}
-	key := types.NamespacedName{Namespace: cluster.Namespace, Name: claimName}
-	if err := r.Get(ctx, key, pvc); err != nil {
-		if apierrors.IsNotFound(err) {
-			setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonAuditFileStorageMissing,
-				Message: fmt.Sprintf("Audit file storage PVC %s/%s was not found", cluster.Namespace, claimName),
-			})
-			return
-		}
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonUnknown,
-			Message: fmt.Sprintf("Failed to read audit file storage PVC %s/%s: %v", cluster.Namespace, claimName, err),
-		})
-		return
-	}
-
-	if !containsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteMany) {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonAuditFileStorageInvalidAccessMode,
-			Message: fmt.Sprintf("Audit file storage PVC %s/%s must support ReadWriteMany", pvc.Namespace, pvc.Name),
-		})
-		return
-	}
-
-	if pvc.Status.Phase != corev1.ClaimBound {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonAuditFileStoragePending,
-			Message: fmt.Sprintf("Audit file storage PVC %s/%s is not Bound yet (phase=%s)", pvc.Namespace, pvc.Name, pvc.Status.Phase),
-		})
-		return
-	}
-
-	if stsName, ok, err := auditFileStorageStatefulSetRecreateRequired(ctx, r.Client, cluster); err != nil {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status:  metav1.ConditionUnknown,
-			Reason:  reasonUnknown,
-			Message: fmt.Sprintf("Failed to inspect OpenBao StatefulSets for audit file storage mounts: %v", err),
-		})
-		return
-	} else if ok {
-		setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-			Status: metav1.ConditionFalse,
-			Reason: ReasonAuditFileStorageStatefulSetRecreateRequired,
-			Message: fmt.Sprintf(
-				"StatefulSet %s/%s is missing the requested audit file storage volume or mount; recreate the StatefulSet or create a new workload revision so locked pod-template fields can be applied",
-				cluster.Namespace,
-				stsName,
-			),
-		})
-		return
-	}
-
-	setAuditFileStorageReadyEvaluatedCondition(cluster, statusConditionResult{
-		Status:  metav1.ConditionTrue,
-		Reason:  ReasonAuditFileStorageReady,
-		Message: fmt.Sprintf("Audit file storage PVC %s/%s is Bound with ReadWriteMany access", pvc.Namespace, pvc.Name),
-	})
-}
-
-func auditFileStorageStatefulSetRecreateRequired(
-	ctx context.Context,
-	reader client.Reader,
-	cluster *openbaov1alpha1.OpenBaoCluster,
-) (string, bool, error) {
-	if reader == nil {
-		return "", false, nil
-	}
-
-	var list appsv1.StatefulSetList
-	if err := reader.List(
-		ctx,
-		&list,
-		client.InNamespace(cluster.Namespace),
-		client.MatchingLabels(resourceidentity.Labels(cluster)),
-	); err != nil {
-		return "", false, err
-	}
-
-	for i := range list.Items {
-		sts := &list.Items[i]
-		if !statefulSetHasAuditFileStorageMount(sts, cluster) {
-			return sts.Name, true, nil
-		}
-	}
-	return "", false, nil
-}
-
-func statefulSetHasAuditFileStorageMount(sts *appsv1.StatefulSet, cluster *openbaov1alpha1.OpenBaoCluster) bool {
-	if sts == nil {
-		return true
-	}
-
-	claimName := portopenbao.AuditFileStorageClaimName(cluster)
-	hasVolume := false
-	for _, volume := range sts.Spec.Template.Spec.Volumes {
-		if volume.Name == constants.VolumeAuditFileStorage &&
-			volume.PersistentVolumeClaim != nil &&
-			volume.PersistentVolumeClaim.ClaimName == claimName {
-			hasVolume = true
-			break
-		}
-	}
-	if !hasVolume {
-		return false
-	}
-
-	for _, container := range sts.Spec.Template.Spec.Containers {
-		if container.Name != constants.ContainerBao {
-			continue
-		}
-		for _, mount := range container.VolumeMounts {
-			if mount.Name == constants.VolumeAuditFileStorage &&
-				mount.MountPath == portopenbao.AuditFileStorageMountPath(cluster) &&
-				mount.SubPathExpr == portopenbao.AuditFileStoragePodSubPathExpr {
-				return true
-			}
-		}
-		return false
-	}
-	return false
+	setAuditFileStorageReadyEvaluatedCondition(cluster, result)
 }

--- a/internal/controller/openbaocluster/status_audit_file_storage_test.go
+++ b/internal/controller/openbaocluster/status_audit_file_storage_test.go
@@ -1,164 +1,74 @@
 package openbaocluster
 
 import (
-	"context"
 	"testing"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
-	"github.com/dc-tec/openbao-operator/internal/platform/constants"
-	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
-func TestSetAuditFileStorageReadyCondition(t *testing.T) {
-	t.Parallel()
-
+func TestSetAuditFileStorageReadyConditionAppliesApplicationResult(t *testing.T) {
 	scheme := newOpenBaoClusterTestScheme(t)
-
-	newCluster := func() *openbaov1alpha1.OpenBaoCluster {
-		return &openbaov1alpha1.OpenBaoCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
-			Spec: openbaov1alpha1.OpenBaoClusterSpec{
-				AuditFileStorage: &openbaov1alpha1.AuditFileStorageConfig{
-					Mode: openbaov1alpha1.AuditFileStorageModeManagedPVC,
-					Size: "5Gi",
-				},
+	cluster := &openbaov1alpha1.OpenBaoCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default", Generation: 2},
+		Spec: openbaov1alpha1.OpenBaoClusterSpec{
+			AuditFileStorage: &openbaov1alpha1.AuditFileStorageConfig{
+				Mode: openbaov1alpha1.AuditFileStorageModeManagedPVC,
+				Size: "5Gi",
 			},
-		}
-	}
-
-	tests := []struct {
-		name       string
-		cluster    *openbaov1alpha1.OpenBaoCluster
-		objects    []client.Object
-		wantStatus metav1.ConditionStatus
-		wantReason string
-	}{
-		{
-			name:       "configured storage missing pvc",
-			cluster:    newCluster(),
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonAuditFileStorageMissing,
-		},
-		{
-			name:    "configured storage pending pvc",
-			cluster: newCluster(),
-			objects: []client.Object{
-				auditFileStoragePVC(corev1.ReadWriteMany, corev1.ClaimPending),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonAuditFileStoragePending,
-		},
-		{
-			name:    "configured storage invalid access mode",
-			cluster: newCluster(),
-			objects: []client.Object{
-				auditFileStoragePVC(corev1.ReadWriteOnce, corev1.ClaimBound),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonAuditFileStorageInvalidAccessMode,
-		},
-		{
-			name:    "configured storage ready before statefulset exists",
-			cluster: newCluster(),
-			objects: []client.Object{
-				auditFileStoragePVC(corev1.ReadWriteMany, corev1.ClaimBound),
-			},
-			wantStatus: metav1.ConditionTrue,
-			wantReason: ReasonAuditFileStorageReady,
-		},
-		{
-			name:    "existing statefulset requires recreate",
-			cluster: newCluster(),
-			objects: []client.Object{
-				auditFileStoragePVC(corev1.ReadWriteMany, corev1.ClaimBound),
-				openBaoStatefulSetWithoutAuditStorage(newCluster()),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: ReasonAuditFileStorageStatefulSetRecreateRequired,
-		},
-		{
-			name:    "existing statefulset already mounted",
-			cluster: newCluster(),
-			objects: []client.Object{
-				auditFileStoragePVC(corev1.ReadWriteMany, corev1.ClaimBound),
-				openBaoStatefulSetWithAuditStorage(newCluster()),
-			},
-			wantStatus: metav1.ConditionTrue,
-			wantReason: ReasonAuditFileStorageReady,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			reconciler := &OpenBaoClusterReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(tt.objects...).
-					Build(),
-			}
-
-			reconciler.setAuditFileStorageReadyCondition(context.Background(), tt.cluster)
-
-			cond := meta.FindStatusCondition(tt.cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
-			if cond == nil {
-				t.Fatal("expected AuditFileStorageReady condition")
-			}
-			if cond.Status != tt.wantStatus || cond.Reason != tt.wantReason {
-				t.Fatalf("AuditFileStorageReady = %#v, want status=%s reason=%s", cond, tt.wantStatus, tt.wantReason)
-			}
-		})
-	}
-}
-
-func auditFileStoragePVC(mode corev1.PersistentVolumeAccessMode, phase corev1.PersistentVolumeClaimPhase) *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
+	statusReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "example-audit", Namespace: "default"},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{mode},
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
 		},
-		Status: corev1.PersistentVolumeClaimStatus{Phase: phase},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}).Build()
+	reconciler := &OpenBaoClusterReconciler{
+		Applications: newStatusTestApplications(statusReader, scheme),
+	}
+
+	reconciler.setAuditFileStorageReadyCondition(t.Context(), cluster)
+
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady))
+	if condition == nil {
+		t.Fatal("expected AuditFileStorageReady condition")
+	}
+	if condition.Status != metav1.ConditionTrue || condition.Reason != "AuditFileStorageReady" {
+		t.Fatalf("AuditFileStorageReady condition = %#v, want status=True reason=AuditFileStorageReady", condition)
+	}
+	if condition.Message != "Audit file storage PVC default/example-audit is Bound with ReadWriteMany access" {
+		t.Fatalf("message = %q", condition.Message)
+	}
+	if condition.ObservedGeneration != cluster.Generation {
+		t.Fatalf("observed generation = %d, want %d", condition.ObservedGeneration, cluster.Generation)
+	}
+	if condition.LastTransitionTime.IsZero() {
+		t.Fatal("expected nonzero last transition time")
 	}
 }
 
-func openBaoStatefulSetWithoutAuditStorage(cluster *openbaov1alpha1.OpenBaoCluster) *appsv1.StatefulSet {
-	return &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name,
-			Namespace: cluster.Namespace,
-			Labels:    resourceidentity.Labels(cluster),
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: constants.ContainerBao}},
-				},
-			},
-		},
+func TestSetAuditFileStorageReadyConditionRemovesStaleConditionWhenNotApplicable(t *testing.T) {
+	scheme := newOpenBaoClusterTestScheme(t)
+	cluster := newOpenBaoClusterStatusTestObject()
+	cluster.Status.Conditions = []metav1.Condition{{
+		Type:   string(openbaov1alpha1.ConditionAuditFileStorageReady),
+		Status: metav1.ConditionTrue,
+		Reason: "AuditFileStorageReady",
+	}}
+	statusReader := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &OpenBaoClusterReconciler{
+		Applications: newStatusTestApplications(statusReader, scheme),
 	}
-}
 
-func openBaoStatefulSetWithAuditStorage(cluster *openbaov1alpha1.OpenBaoCluster) *appsv1.StatefulSet {
-	sts := openBaoStatefulSetWithoutAuditStorage(cluster)
-	sts.Spec.Template.Spec.Volumes = []corev1.Volume{{
-		Name: constants.VolumeAuditFileStorage,
-		VolumeSource: corev1.VolumeSource{
-			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: portopenbao.AuditFileStorageClaimName(cluster),
-			},
-		},
-	}}
-	sts.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
-		Name:        constants.VolumeAuditFileStorage,
-		MountPath:   portopenbao.AuditFileStorageMountPath(cluster),
-		SubPathExpr: portopenbao.AuditFileStoragePodSubPathExpr,
-	}}
-	return sts
+	reconciler.setAuditFileStorageReadyCondition(t.Context(), cluster)
+
+	if condition := meta.FindStatusCondition(cluster.Status.Conditions, string(openbaov1alpha1.ConditionAuditFileStorageReady)); condition != nil {
+		t.Fatalf("AuditFileStorageReady condition = %#v, want removed", condition)
+	}
 }


### PR DESCRIPTION
## Summary

Move ACME shared-cache and audit-file storage readiness policy from the controller into `statusops`.

The extraction preserves PVC resolution, read errors, RWX-before-Bound precedence, StatefulSet mount compatibility checks, reader ordering, and stale-condition removal.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or operational behavior change is intended. This refactor changes internal ownership and test placement. Generated artifacts are unchanged. User-facing documentation does not require an update.

## Verification

- `go test -race -count=1 ./internal/app/openbaocluster/statusops ./internal/app/openbaocluster ./internal/controller/openbaocluster`
- `make lint-ci`
- `make test-ci`
- `make generate-ast-rules verify-arch-policy test-ast lint-ast report-internal-deps verify-fmt`

The completed stack passes 3,619 tests with 4 expected skips and 70.18% internal coverage against the 68% minimum.

## Reviewer Notes

Stack 5 of 6. Depends on #696. Review this PR against `refactor/status-tls-readiness`. Merge the complete stack through top PR #698 after all checks pass.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.