### PR TITLE
refactor(raft): make runtime composition explicit

### DIFF
--- a/.ast-grep/policy/architecture-boundaries.yml
+++ b/.ast-grep/policy/architecture-boundaries.yml
@@ -201,7 +201,6 @@ serviceBoundaries:
     allowServiceImports: []
     allowAdapterImports:
       - internal/adapter/openbao
-      - internal/adapter/raft
   - name: networking
     displayName: Networking
     packageRoot: internal/service/networking

--- a/.ast-grep/rules/architecture/no-init-manager-capability-discovery-in-runtime-applications.yml
+++ b/.ast-grep/rules/architecture/no-init-manager-capability-discovery-in-runtime-applications.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-init-manager-capability-discovery-in-runtime-applications
+message: Inject Raft runtime capabilities explicitly instead of discovering them from the initialization manager.
+severity: warning
+language: Go
+files:
+  - internal/app/openbaocluster/runtime_applications.go
+rule:
+  all:
+    - kind: type_assertion_expression
+    - has:
+        kind: selector_expression
+        regex: '^config\.OpenBao\.InitManager$'
+        stopBy: end
+    - inside:
+        all:
+          - kind: function_declaration
+          - regex: 'func NewRuntimeApplications\('
+        stopBy: end
+note: Startup composition provides the Raft runtime directly. Keep the initialization manager focused on initialization.

--- a/.ast-grep/rules/generated/architecture-boundary/no-init-service-unapproved-adapter-imports.yml
+++ b/.ast-grep/rules/generated/architecture-boundary/no-init-service-unapproved-adapter-imports.yml
@@ -12,5 +12,5 @@ ignores:
 rule:
     all:
         - kind: import_spec
-        - regex: '"github\.com/dc-tec/openbao-operator/(internal/adapter/auth(/[^"]*)?|internal/adapter/cluster(/[^"]*)?|internal/adapter/config(/[^"]*)?|internal/adapter/kube(/[^"]*)?|internal/adapter/probe(/[^"]*)?|internal/adapter/revision(/[^"]*)?|internal/adapter/security(/[^"]*)?|internal/adapter/storage(/[^"]*)?|internal/adapter/storageenv(/[^"]*)?)"'
-note: 'Approved adapter imports for this service: internal/adapter/openbao, internal/adapter/raft.'
+        - regex: '"github\.com/dc-tec/openbao-operator/(internal/adapter/auth(/[^"]*)?|internal/adapter/cluster(/[^"]*)?|internal/adapter/config(/[^"]*)?|internal/adapter/kube(/[^"]*)?|internal/adapter/probe(/[^"]*)?|internal/adapter/raft(/[^"]*)?|internal/adapter/revision(/[^"]*)?|internal/adapter/security(/[^"]*)?|internal/adapter/storage(/[^"]*)?|internal/adapter/storageenv(/[^"]*)?)"'
+note: 'Approved adapter imports for this service: internal/adapter/openbao.'

--- a/.ast-grep/tests/__snapshots__/no-init-manager-capability-discovery-in-runtime-applications-snapshot.yml
+++ b/.ast-grep/tests/__snapshots__/no-init-manager-capability-discovery-in-runtime-applications-snapshot.yml
@@ -1,0 +1,27 @@
+id: no-init-manager-capability-discovery-in-runtime-applications
+snapshots:
+  ? |
+    package openbaocluster
+    func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
+      runtime, ok := config.OpenBao.InitManager.(AutopilotRuntime)
+      _, _ = runtime, ok
+      return nil
+    }
+  : labels:
+    - source: config.OpenBao.InitManager.(AutopilotRuntime)
+      style: primary
+      start: 118
+      end: 163
+    - source: config.OpenBao.InitManager
+      style: secondary
+      start: 118
+      end: 144
+    - source: |-
+        func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
+          runtime, ok := config.OpenBao.InitManager.(AutopilotRuntime)
+          _, _ = runtime, ok
+          return nil
+        }
+      style: secondary
+      start: 23
+      end: 199

--- a/.ast-grep/tests/architecture/no-init-manager-capability-discovery-in-runtime-applications-test.yml
+++ b/.ast-grep/tests/architecture/no-init-manager-capability-discovery-in-runtime-applications-test.yml
@@ -1,0 +1,22 @@
+id: no-init-manager-capability-discovery-in-runtime-applications
+valid:
+  - |
+    package openbaocluster
+    func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
+      runtime := config.OpenBao.Raft
+      return NewApplications(runtime)
+    }
+  - |
+    package openbaocluster
+    func other(config RuntimeApplicationsConfig) {
+      runtime, ok := config.OpenBao.InitManager.(AutopilotRuntime)
+      _, _ = runtime, ok
+    }
+invalid:
+  - |
+    package openbaocluster
+    func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
+      runtime, ok := config.OpenBao.InitManager.(AutopilotRuntime)
+      _, _ = runtime, ok
+      return nil
+    }

--- a/cmd/controller/openbaocluster_applications_test.go
+++ b/cmd/controller/openbaocluster_applications_test.go
@@ -7,10 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
+	"github.com/dc-tec/openbao-operator/internal/adapter/raft"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
+
+func TestSetupControllersRequiresRaftRuntime(t *testing.T) {
+	err := setupControllers(nil, controllerProcessRuntime{})
+
+	assert.EqualError(t, err, "OpenBaoCluster Raft runtime is required")
+}
+
+func TestSetupControllersRequiresInitializationManager(t *testing.T) {
+	err := setupControllers(nil, controllerProcessRuntime{
+		openBaoRuntime: appopenbaocluster.RuntimeOpenBaoConfig{
+			Raft: raft.NewManager(kubernetesfake.NewClientset(), nil),
+		},
+	})
+
+	assert.EqualError(t, err, "OpenBaoCluster initialization manager is required")
+}
+
+func TestRaftClientFactoryProviderBuildsAuthenticatedClient(t *testing.T) {
+	provider := raftClientFactoryProvider{
+		clientManager: openbao.NewClientManager(portopenbao.ClientConfig{}),
+	}
+
+	factory := provider.FactoryFor("tenant-a/example", nil, "openbao.example.internal")
+	require.NotNil(t, factory)
+	client, err := factory.NewWithToken("https://openbao.example.internal:8200", "test-token")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
 
 func TestOpenBaoClusterPodClientFactoryConfiguresPodEndpoint(t *testing.T) {
 	baseConfig := portopenbao.ClientConfig{BaseURL: "https://unused.example"}

--- a/cmd/controller/raft_runtime.go
+++ b/cmd/controller/raft_runtime.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
+	"github.com/dc-tec/openbao-operator/internal/adapter/raft"
+)
+
+type raftClientFactoryProvider struct {
+	clientManager *openbao.ClientManager
+}
+
+type raftClientFactoryAdapter struct {
+	factory *openbao.ClientFactory
+}
+
+func (p raftClientFactoryProvider) FactoryFor(
+	clusterKey string,
+	caCert []byte,
+	tlsServerName string,
+) raft.ClientFactory {
+	if p.clientManager == nil {
+		return nil
+	}
+
+	factory := p.clientManager.FactoryFor(clusterKey, caCert, tlsServerName)
+	if factory == nil {
+		return nil
+	}
+
+	return raftClientFactoryAdapter{factory: factory}
+}
+
+func (a raftClientFactoryAdapter) NewWithJWT(
+	ctx context.Context,
+	baseURL string,
+	role string,
+	jwtToken string,
+) (raft.Client, error) {
+	if a.factory == nil {
+		return nil, fmt.Errorf("OpenBao client factory is required")
+	}
+
+	return a.factory.NewWithJWT(ctx, baseURL, role, jwtToken)
+}
+
+func (a raftClientFactoryAdapter) NewWithToken(baseURL, token string) (raft.Client, error) {
+	if a.factory == nil {
+		return nil, fmt.Errorf("OpenBao client factory is required")
+	}
+
+	return a.factory.NewWithToken(baseURL, token)
+}

--- a/cmd/controller/runtime_setup.go
+++ b/cmd/controller/runtime_setup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dc-tec/openbao-operator/internal/adapter/auth"
 	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
+	"github.com/dc-tec/openbao-operator/internal/adapter/raft"
 	"github.com/dc-tec/openbao-operator/internal/adapter/security"
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	appopenbaorestore "github.com/dc-tec/openbao-operator/internal/app/openbaorestore"
@@ -53,7 +54,17 @@ func buildControllerProcessRuntime(
 	}
 
 	clientMgr := openbao.NewClientManager(smartClientConfig)
-	initMgr := initmanager.NewManager(config, clientset, clientMgr, mgr.GetEventRecorder(controllerNameOpenBaoCluster))
+	raftMgr := raft.NewManager(clientset, raftClientFactoryProvider{clientManager: clientMgr})
+	initMgr, err := initmanager.NewManager(
+		config,
+		clientset,
+		clientMgr,
+		raftMgr,
+		mgr.GetEventRecorder(controllerNameOpenBaoCluster),
+	)
+	if err != nil {
+		return controllerProcessRuntime{}, fmt.Errorf("unable to create initialization manager: %w", err)
+	}
 	imageVerifier := security.NewImageVerifier(mgr.GetLogger().WithName("image-verifier"), mgr.GetAPIReader(), nil)
 	operatorImageVerifier := security.NewImageVerifier(
 		mgr.GetLogger().WithName("operator-image-verifier"),
@@ -95,6 +106,7 @@ func buildControllerProcessRuntime(
 		openBaoRuntime: appopenbaocluster.RuntimeOpenBaoConfig{
 			TLSReload:         reloadSignaler,
 			InitManager:       initMgr,
+			Raft:              raftMgr,
 			SmartClientConfig: smartClientConfig,
 			ClientForPod: openBaoClusterPodClientFactory(
 				mgr.GetClient(),
@@ -107,6 +119,13 @@ func buildControllerProcessRuntime(
 }
 
 func setupControllers(mgr ctrl.Manager, runtime controllerProcessRuntime) error {
+	if runtime.openBaoRuntime.Raft == nil {
+		return fmt.Errorf("OpenBaoCluster Raft runtime is required")
+	}
+	if runtime.openBaoRuntime.InitManager == nil {
+		return fmt.Errorf("OpenBaoCluster initialization manager is required")
+	}
+
 	applications := buildOpenBaoClusterApplications(mgr, runtime)
 	if err := (&openbaoclustercontroller.OpenBaoClusterReconciler{
 		Client: mgr.GetClient(),

--- a/internal/app/openbaocluster/applications_test.go
+++ b/internal/app/openbaocluster/applications_test.go
@@ -12,7 +12,67 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
+
+type runtimeInitManagerStub struct{}
+
+func (runtimeInitManagerStub) Reconcile(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+) (recon.Result, error) {
+	return recon.Result{}, nil
+}
+
+type runtimeRaftStub struct{}
+
+func (*runtimeRaftStub) ReconcileAutopilotConfig(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+) error {
+	return nil
+}
+
+func (*runtimeRaftStub) PrepareScaleDown(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+	string,
+	int32,
+	int32,
+) error {
+	return nil
+}
+
+func (*runtimeRaftStub) PrepareReadReplicaScaleDown(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+	string,
+	int32,
+	int32,
+) error {
+	return nil
+}
+
+func (*runtimeRaftStub) ReadRaftConfiguration(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+) (*portopenbao.RaftConfigurationResponse, error) {
+	return nil, nil
+}
+
+func (*runtimeRaftStub) ReadRaftAutopilotState(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+) (*portopenbao.RaftAutopilotStateResponse, error) {
+	return nil, nil
+}
 
 func TestNewRuntimeApplicationsBuildsApplicationBoundary(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -31,6 +91,37 @@ func TestNewRuntimeApplicationsBuildsApplicationBoundary(t *testing.T) {
 	require.NotNil(t, applications)
 	require.NotNil(t, applications.config.AdminOpsApplication)
 	assert.False(t, applications.InitializationConfigured())
+}
+
+func TestNewRuntimeApplicationsWiresExplicitRaftRuntime(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	raftRuntime := &runtimeRaftStub{}
+	applications := NewRuntimeApplications(RuntimeApplicationsConfig{
+		Kubernetes: RuntimeKubernetesConfig{
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    scheme,
+		},
+		OpenBao: RuntimeOpenBaoConfig{
+			InitManager: runtimeInitManagerStub{},
+			Raft:        raftRuntime,
+		},
+	})
+
+	require.Len(t, applications.config.WorkloadReconcilers, 6)
+	infra, ok := applications.config.WorkloadReconcilers[1].(*infraReconciler)
+	require.True(t, ok)
+	assert.Same(t, raftRuntime, infra.deps.ScaleDown.Runtime)
+	assert.Same(t, raftRuntime, infra.deps.ScaleDown.ReadReplicaRuntime)
+	autopilot, ok := applications.config.WorkloadReconcilers[5].(*autopilotConfigReconciler)
+	require.True(t, ok)
+	assert.Same(t, raftRuntime, autopilot.autopilotRuntime)
+	assert.Same(t, raftRuntime, applications.config.StatusDependencies.MembershipRuntime)
+	assert.True(t, applications.InitializationConfigured())
 }
 
 func TestApplicationsRequireConfiguredBoundary(t *testing.T) {

--- a/internal/app/openbaocluster/runtime_applications.go
+++ b/internal/app/openbaocluster/runtime_applications.go
@@ -44,8 +44,18 @@ type RuntimeOIDCConfig struct {
 type RuntimeOpenBaoConfig struct {
 	TLSReload         TLSReloadSignaler
 	InitManager       initmanagerport.Manager
+	Raft              RuntimeRaft
 	SmartClientConfig portopenbao.ClientConfig
 	ClientForPod      func(context.Context, *openbaov1alpha1.OpenBaoCluster, string) (portopenbao.ClusterActions, error)
+}
+
+// RuntimeRaft groups the Raft capabilities used by workload and status
+// orchestration into one explicitly injected runtime.
+type RuntimeRaft interface {
+	initmanagerport.AutopilotRuntime
+	initmanagerport.ScaleDownRuntime
+	initmanagerport.ReadReplicaScaleDownRuntime
+	StatusMembershipRuntime
 }
 
 // RuntimeImageVerificationConfig groups image verification collaborators.
@@ -72,23 +82,6 @@ func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
 		clientForPod = func(context.Context, *openbaov1alpha1.OpenBaoCluster, string) (portopenbao.ClusterActions, error) {
 			return nil, fmt.Errorf("OpenBao pod client factory is not configured")
 		}
-	}
-
-	var scaleDownRuntime initmanagerport.ScaleDownRuntime
-	if provider, ok := config.OpenBao.InitManager.(initmanagerport.ScaleDownProvider); ok {
-		scaleDownRuntime = provider.ScaleDownRuntime()
-	}
-	var readReplicaScaleDownRuntime initmanagerport.ReadReplicaScaleDownRuntime
-	if provider, ok := config.OpenBao.InitManager.(initmanagerport.ReadReplicaScaleDownProvider); ok {
-		readReplicaScaleDownRuntime = provider.ReadReplicaScaleDownRuntime()
-	}
-	var autopilotRuntime initmanagerport.AutopilotRuntime
-	if provider, ok := config.OpenBao.InitManager.(initmanagerport.AutopilotProvider); ok {
-		autopilotRuntime = provider.AutopilotRuntime()
-	}
-	var membershipRuntime StatusMembershipRuntime
-	if provider, ok := config.OpenBao.InitManager.(initmanagerport.MembershipProvider); ok {
-		membershipRuntime = provider.MembershipRuntime()
 	}
 
 	workloadReconcilers := []SubReconciler{
@@ -124,8 +117,8 @@ func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
 				},
 			},
 			ScaleDown: InfraScaleDownRuntime{
-				Runtime:            scaleDownRuntime,
-				ReadReplicaRuntime: readReplicaScaleDownRuntime,
+				Runtime:            config.OpenBao.Raft,
+				ReadReplicaRuntime: config.OpenBao.Raft,
 			},
 		}),
 		NewStorageReconciler(StorageDependencies{
@@ -148,7 +141,7 @@ func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
 	workloadReconcilers = AppendInitAndAutopilotReconcilers(
 		workloadReconcilers,
 		config.OpenBao.InitManager,
-		autopilotRuntime,
+		config.OpenBao.Raft,
 		config.Kubernetes.APIReader,
 		config.Kubernetes.Recorder,
 		constants.RequeueShort,
@@ -171,7 +164,7 @@ func NewRuntimeApplications(config RuntimeApplicationsConfig) *Applications {
 		}),
 		StatusDependencies: StatusDependencies{
 			Reader:            config.Kubernetes.Client,
-			MembershipRuntime: membershipRuntime,
+			MembershipRuntime: config.OpenBao.Raft,
 			PodObserverFactory: func(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, podName string) (StatusPodObserver, error) {
 				actions, err := clientForPod(ctx, cluster, podName)
 				if err != nil {

--- a/internal/port/initmanager/initmanager.go
+++ b/internal/port/initmanager/initmanager.go
@@ -7,7 +7,6 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 // Manager handles OpenBao cluster initialization.
@@ -30,33 +29,4 @@ type ScaleDownRuntime interface {
 // operations used to stage safe steady-state read-replica scale-downs.
 type ReadReplicaScaleDownRuntime interface {
 	PrepareReadReplicaScaleDown(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, statefulSetName string, currentReplicas, desiredReplicas int32) error
-}
-
-// MembershipRuntime exposes authenticated Raft membership reads used by status
-// observation for steady-state read replicas.
-type MembershipRuntime interface {
-	ReadRaftConfiguration(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (*portopenbao.RaftConfigurationResponse, error)
-	ReadRaftAutopilotState(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (*portopenbao.RaftAutopilotStateResponse, error)
-}
-
-// AutopilotProvider allows init managers to optionally expose an autopilot runtime.
-type AutopilotProvider interface {
-	AutopilotRuntime() AutopilotRuntime
-}
-
-// ScaleDownProvider allows init managers to optionally expose a safe scale-down runtime.
-type ScaleDownProvider interface {
-	ScaleDownRuntime() ScaleDownRuntime
-}
-
-// ReadReplicaScaleDownProvider allows init managers to optionally expose a
-// safe steady-state read-replica scale-down runtime.
-type ReadReplicaScaleDownProvider interface {
-	ReadReplicaScaleDownRuntime() ReadReplicaScaleDownRuntime
-}
-
-// MembershipProvider allows init managers to optionally expose an authenticated
-// Raft membership read runtime.
-type MembershipProvider interface {
-	MembershipRuntime() MembershipRuntime
 }

--- a/internal/service/init/manager.go
+++ b/internal/service/init/manager.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
-	"github.com/dc-tec/openbao-operator/internal/adapter/raft"
 	initmanagerport "github.com/dc-tec/openbao-operator/internal/port/initmanager"
-	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
 
 const (
@@ -34,25 +34,36 @@ type Manager struct {
 	config      *rest.Config
 	clientset   kubernetes.Interface
 	clientMgr   *openbao.ClientManager
-	raftManager *raft.Manager
+	raftRuntime RaftRuntime
 	recorder    events.EventRecorder
 }
 
-type raftClientFactoryProvider struct {
-	clientMgr *openbao.ClientManager
+// RaftRuntime exposes the Raft operations required during cluster
+// initialization.
+type RaftRuntime interface {
+	initmanagerport.AutopilotRuntime
+	ConfigureAutopilot(
+		ctx context.Context,
+		logger logr.Logger,
+		cluster *openbaov1alpha1.OpenBaoCluster,
+		rootToken string,
+	) error
 }
 
-type raftClientFactoryAdapter struct {
-	factory *openbao.ClientFactory
-}
+// NewManager creates an initialization Manager. The client manager provides
+// per-cluster OpenBao client state. The required Raft runtime configures
+// Autopilot during operator-managed and self-initialization.
+func NewManager(
+	config *rest.Config,
+	clientset kubernetes.Interface,
+	clientMgr *openbao.ClientManager,
+	raftOps RaftRuntime,
+	recorder ...events.EventRecorder,
+) (*Manager, error) {
+	if raftOps == nil {
+		return nil, fmt.Errorf("raft runtime is required")
+	}
 
-type raftClientAdapter struct {
-	client *openbao.Client
-}
-
-// NewManager creates a new initialization Manager.
-// The clientMgr is used to create OpenBao clients with proper state isolation.
-func NewManager(config *rest.Config, clientset kubernetes.Interface, clientMgr *openbao.ClientManager, recorder ...events.EventRecorder) *Manager {
 	var eventRecorder events.EventRecorder
 	if len(recorder) > 0 {
 		eventRecorder = recorder[0]
@@ -61,116 +72,7 @@ func NewManager(config *rest.Config, clientset kubernetes.Interface, clientMgr *
 		config:      config,
 		clientset:   clientset,
 		clientMgr:   clientMgr,
-		raftManager: raft.NewManager(clientset, raftClientFactoryProvider{clientMgr: clientMgr}),
+		raftRuntime: raftOps,
 		recorder:    eventRecorder,
-	}
-}
-
-func (p raftClientFactoryProvider) FactoryFor(clusterKey string, caCert []byte, tlsServerName string) raft.ClientFactory {
-	if p.clientMgr == nil {
-		return nil
-	}
-
-	factory := p.clientMgr.FactoryFor(clusterKey, caCert, tlsServerName)
-	if factory == nil {
-		return nil
-	}
-
-	return raftClientFactoryAdapter{factory: factory}
-}
-
-func (a raftClientFactoryAdapter) NewWithJWT(ctx context.Context, baseURL, role, jwtToken string) (raft.Client, error) {
-	if a.factory == nil {
-		return nil, fmt.Errorf("OpenBao client factory is required")
-	}
-
-	client, err := a.factory.NewWithJWT(ctx, baseURL, role, jwtToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return raftClientAdapter{client: client}, nil
-}
-
-func (a raftClientFactoryAdapter) NewWithToken(baseURL, token string) (raft.Client, error) {
-	if a.factory == nil {
-		return nil, fmt.Errorf("OpenBao client factory is required")
-	}
-
-	client, err := a.factory.NewWithToken(baseURL, token)
-	if err != nil {
-		return nil, err
-	}
-
-	return raftClientAdapter{client: client}, nil
-}
-
-func (a raftClientAdapter) ConfigureRaftAutopilot(ctx context.Context, config portopenbao.AutopilotConfig) error {
-	if a.client == nil {
-		return fmt.Errorf("OpenBao client is required")
-	}
-	return a.client.ConfigureRaftAutopilot(ctx, config)
-}
-
-func (a raftClientAdapter) ReadRaftConfiguration(ctx context.Context) (*portopenbao.RaftConfigurationResponse, error) {
-	if a.client == nil {
-		return nil, fmt.Errorf("OpenBao client is required")
-	}
-	return a.client.ReadRaftConfiguration(ctx)
-}
-
-func (a raftClientAdapter) ReadRaftAutopilotState(ctx context.Context) (*portopenbao.RaftAutopilotStateResponse, error) {
-	if a.client == nil {
-		return nil, fmt.Errorf("OpenBao client is required")
-	}
-	return a.client.ReadRaftAutopilotState(ctx)
-}
-
-func (a raftClientAdapter) RemoveRaftPeer(ctx context.Context, serverID string) error {
-	if a.client == nil {
-		return fmt.Errorf("OpenBao client is required")
-	}
-	return a.client.RemoveRaftPeer(ctx, serverID)
-}
-
-func (a raftClientAdapter) StepDownLeader(ctx context.Context) error {
-	if a.client == nil {
-		return fmt.Errorf("OpenBao client is required")
-	}
-	return a.client.StepDownLeader(ctx)
-}
-
-// RaftManager returns the Raft Manager for autopilot configuration.
-func (m *Manager) RaftManager() *raft.Manager {
-	return m.raftManager
-}
-
-// AutopilotRuntime returns the optional day-2 autopilot runtime.
-func (m *Manager) AutopilotRuntime() initmanagerport.AutopilotRuntime {
-	return m.raftManager
-}
-
-// ScaleDownRuntime returns the optional day-2 scale-down runtime.
-func (m *Manager) ScaleDownRuntime() initmanagerport.ScaleDownRuntime {
-	return m.raftManager
-}
-
-// MembershipRuntime returns the optional authenticated raft membership reader.
-func (m *Manager) MembershipRuntime() initmanagerport.MembershipRuntime {
-	return m.raftManager
-}
-
-// ReadReplicaScaleDownRuntime returns the optional read-replica scale-down runtime.
-func (m *Manager) ReadReplicaScaleDownRuntime() initmanagerport.ReadReplicaScaleDownRuntime {
-	return m.raftManager
-}
-
-// Clientset returns the Kubernetes clientset.
-func (m *Manager) Clientset() kubernetes.Interface {
-	return m.clientset
-}
-
-// ClientManager returns the OpenBao ClientManager.
-func (m *Manager) ClientManager() *openbao.ClientManager {
-	return m.clientMgr
+	}, nil
 }

--- a/internal/service/init/manager_initialize.go
+++ b/internal/service/init/manager_initialize.go
@@ -83,10 +83,8 @@ func (m *Manager) initializeCluster(ctx context.Context, logger logr.Logger, clu
 		return err
 	}
 
-	if m.raftManager != nil {
-		if err := m.raftManager.ConfigureAutopilot(ctx, logger, cluster, initResp.RootToken); err != nil {
-			logger.Error(err, "Failed to configure Raft Autopilot; dead server cleanup may not work automatically")
-		}
+	if err := m.raftRuntime.ConfigureAutopilot(ctx, logger, cluster, initResp.RootToken); err != nil {
+		logger.Error(err, "Failed to configure Raft Autopilot; dead server cleanup may not work automatically")
 	}
 
 	logger.Info("OpenBao cluster initialized successfully via HTTP API")

--- a/internal/service/init/manager_reconcile.go
+++ b/internal/service/init/manager_reconcile.go
@@ -197,7 +197,7 @@ func (m *Manager) markSelfInitComplete(ctx context.Context, logger logr.Logger, 
 	cluster.Status.Initialized = true
 	cluster.Status.SelfInitialized = true
 
-	if err := m.raftManager.ReconcileAutopilotConfig(ctx, logger, cluster); err != nil {
+	if err := m.raftRuntime.ReconcileAutopilotConfig(ctx, logger, cluster); err != nil {
 		if operatorerrors.IsTransient(err) {
 			logger.V(1).Info("Raft Autopilot configuration not ready for self-init cluster; will retry via reconciler", "error", err)
 		} else {

--- a/internal/service/init/manager_test.go
+++ b/internal/service/init/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
@@ -26,6 +27,69 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceidentity"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
+
+type initRaftRuntimeStub struct {
+	reconcileAutopilotCalls int
+}
+
+func (*initRaftRuntimeStub) ConfigureAutopilot(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+	string,
+) error {
+	return nil
+}
+
+func (s *initRaftRuntimeStub) ReconcileAutopilotConfig(
+	context.Context,
+	logr.Logger,
+	*openbaov1alpha1.OpenBaoCluster,
+) error {
+	s.reconcileAutopilotCalls++
+	return nil
+}
+
+func newTestManager(
+	t *testing.T,
+	config *rest.Config,
+	clientset kubernetes.Interface,
+	clientManager *openbao.ClientManager,
+	recorder ...events.EventRecorder,
+) *Manager {
+	t.Helper()
+
+	manager, err := NewManager(config, clientset, clientManager, &initRaftRuntimeStub{}, recorder...)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	return manager
+}
+
+func TestNewManagerUsesInjectedRaftRuntime(t *testing.T) {
+	clientset := kubernetesfake.NewClientset()
+	clientManager := openbao.NewClientManager(portopenbao.ClientConfig{})
+	raftRuntime := &initRaftRuntimeStub{}
+
+	manager, err := NewManager(&rest.Config{}, clientset, clientManager, raftRuntime)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if manager.raftRuntime != raftRuntime {
+		t.Fatal("NewManager() did not retain the injected Raft runtime")
+	}
+}
+
+func TestNewManagerRequiresRaftRuntime(t *testing.T) {
+	manager, err := NewManager(&rest.Config{}, kubernetesfake.NewClientset(), nil, nil)
+	if err == nil {
+		t.Fatal("NewManager() error = nil, want missing Raft runtime error")
+	}
+	if manager != nil {
+		t.Fatal("NewManager() manager is non-nil after validation error")
+	}
+}
 
 func expectEventContains(t *testing.T, recorder *events.FakeRecorder, parts ...string) {
 	t.Helper()
@@ -44,10 +108,11 @@ func expectEventContains(t *testing.T, recorder *events.FakeRecorder, parts ...s
 
 func TestReconcileSelfInitUsesPodReadiness(t *testing.T) {
 	tests := []struct {
-		name            string
-		podReady        bool
-		wantInitialized bool
-		wantSelfInit    bool
+		name               string
+		podReady           bool
+		wantInitialized    bool
+		wantSelfInit       bool
+		wantAutopilotCalls int
 	}{
 		{
 			name:            "pod not ready does not mark initialized",
@@ -56,10 +121,11 @@ func TestReconcileSelfInitUsesPodReadiness(t *testing.T) {
 			wantSelfInit:    false,
 		},
 		{
-			name:            "pod ready marks initialized",
-			podReady:        true,
-			wantInitialized: true,
-			wantSelfInit:    true,
+			name:               "pod ready marks initialized",
+			podReady:           true,
+			wantInitialized:    true,
+			wantSelfInit:       true,
+			wantAutopilotCalls: 1,
 		},
 	}
 
@@ -116,7 +182,11 @@ func TestReconcileSelfInitUsesPodReadiness(t *testing.T) {
 
 			clientset := kubernetesfake.NewClientset(pod)
 			clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-			manager := NewManager(&rest.Config{}, clientset, clientMgr)
+			raftRuntime := &initRaftRuntimeStub{}
+			manager, err := NewManager(&rest.Config{}, clientset, clientMgr, raftRuntime)
+			if err != nil {
+				t.Fatalf("NewManager() error = %v", err)
+			}
 
 			if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err != nil {
 				t.Fatalf("Reconcile() error = %v, want no error", err)
@@ -128,6 +198,14 @@ func TestReconcileSelfInitUsesPodReadiness(t *testing.T) {
 
 			if cluster.Status.SelfInitialized != tt.wantSelfInit {
 				t.Fatalf("Status.SelfInitialized = %t, want %t", cluster.Status.SelfInitialized, tt.wantSelfInit)
+			}
+
+			if raftRuntime.reconcileAutopilotCalls != tt.wantAutopilotCalls {
+				t.Fatalf(
+					"ReconcileAutopilotConfig() calls = %d, want %d",
+					raftRuntime.reconcileAutopilotCalls,
+					tt.wantAutopilotCalls,
+				)
 			}
 		})
 	}
@@ -178,7 +256,7 @@ func TestReconcileSelfInitReady_EmitsInitEvents(t *testing.T) {
 	recorder := events.NewFakeRecorder(10)
 	clientset := kubernetesfake.NewClientset(pod)
 	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-	manager := NewManager(&rest.Config{}, clientset, clientMgr, recorder)
+	manager := newTestManager(t, &rest.Config{}, clientset, clientMgr, recorder)
 
 	if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
@@ -241,7 +319,7 @@ func TestReconcileSelfInitReady_InertizesConfigMapBeforeStatus(t *testing.T) {
 
 	clientset := kubernetesfake.NewClientset(pod, configMap)
 	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-	manager := NewManager(&rest.Config{}, clientset, clientMgr)
+	manager := newTestManager(t, &rest.Config{}, clientset, clientMgr)
 
 	if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
@@ -318,7 +396,7 @@ func TestReconcileSelfInitReady_DoesNotMarkCompleteWhenConfigMapUpdateFails(t *t
 		return true, nil, apierrors.NewTooManyRequests("too many requests", 0)
 	})
 	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-	manager := NewManager(&rest.Config{}, clientset, clientMgr)
+	manager := newTestManager(t, &rest.Config{}, clientset, clientMgr)
 
 	_, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
 	if err == nil {
@@ -377,7 +455,7 @@ func TestReconcileOperatorInitFailure_EmitsInitFailedEvent(t *testing.T) {
 	recorder := events.NewFakeRecorder(10)
 	clientset := kubernetesfake.NewClientset(pod, tlsServerSecret)
 	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-	manager := NewManager(&rest.Config{}, clientset, clientMgr, recorder)
+	manager := newTestManager(t, &rest.Config{}, clientset, clientMgr, recorder)
 
 	if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err == nil {
 		t.Fatal("expected reconcile to fail when TLS CA Secret is missing")
@@ -430,7 +508,7 @@ func TestReconcileIgnoresServiceLabelsWhenSelfInitDisabled(t *testing.T) {
 
 	clientset := kubernetesfake.NewClientset(pod)
 	clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-	manager := NewManager(&rest.Config{}, clientset, clientMgr)
+	manager := newTestManager(t, &rest.Config{}, clientset, clientMgr)
 
 	if _, err := manager.Reconcile(context.Background(), logr.Discard(), cluster); err != nil {
 		t.Fatalf("Reconcile() error = %v, want no error", err)
@@ -504,7 +582,7 @@ func TestStoreRootTokenCreatesOrUpdatesSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			clientset := kubernetesfake.NewClientset()
 			clientMgr := openbao.NewClientManager(portopenbao.ClientConfig{})
-			manager := NewManager(&rest.Config{}, clientset, clientMgr)
+			manager := newTestManager(t, &rest.Config{}, clientset, clientMgr)
 
 			createFailuresObserved := 0
 			if tt.transientCreateFailures > 0 {
@@ -598,7 +676,7 @@ func TestStoreRootTokenRejectsImmutableOwnedSecretWithDifferentToken(t *testing.
 		},
 	}
 	clientset := kubernetesfake.NewClientset(existingSecret)
-	manager := NewManager(&rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
+	manager := newTestManager(t, &rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
 	cluster := &openbaov1alpha1.OpenBaoCluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "openbao.org/v1alpha1",
@@ -645,7 +723,7 @@ func TestEnsureRootTokenSecretPresent(t *testing.T) {
 			},
 		}
 		clientset := kubernetesfake.NewClientset(secret)
-		manager := NewManager(&rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
+		manager := newTestManager(t, &rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
 
 		if err := manager.ensureRootTokenSecretPresent(context.Background(), newCluster()); err != nil {
 			t.Fatalf("ensureRootTokenSecretPresent() error = %v, want nil", err)
@@ -654,7 +732,7 @@ func TestEnsureRootTokenSecretPresent(t *testing.T) {
 
 	t.Run("returns transient error when root token Secret is missing", func(t *testing.T) {
 		clientset := kubernetesfake.NewClientset()
-		manager := NewManager(&rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
+		manager := newTestManager(t, &rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
 
 		err := manager.ensureRootTokenSecretPresent(context.Background(), newCluster())
 		if err == nil {
@@ -670,7 +748,7 @@ func TestEnsureRootTokenSecretPresent(t *testing.T) {
 		clientset.PrependReactor("get", "secrets", func(clienttesting.Action) (bool, runtime.Object, error) {
 			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "cluster-root-token", fmt.Errorf("forbidden"))
 		})
-		manager := NewManager(&rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
+		manager := newTestManager(t, &rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
 
 		err := manager.ensureRootTokenSecretPresent(context.Background(), newCluster())
 		if err == nil {
@@ -686,7 +764,7 @@ func TestEnsureRootTokenSecretPresent(t *testing.T) {
 		clientset.PrependReactor("get", "secrets", func(clienttesting.Action) (bool, runtime.Object, error) {
 			return true, nil, fmt.Errorf("boom")
 		})
-		manager := NewManager(&rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
+		manager := newTestManager(t, &rest.Config{}, clientset, openbao.NewClientManager(portopenbao.ClientConfig{}))
 
 		err := manager.ensureRootTokenSecretPresent(context.Background(), newCluster())
 		if err == nil {


### PR DESCRIPTION
## Summary

Construct one Raft manager in the controller composition root and share it with initialization and application orchestration.

Replace capability discovery through initialization-manager type assertions with one required `RuntimeRaft` contract. Make production startup fail when the initialization or Raft runtime is missing, and tighten the architecture rules so the old concrete dependency and discovery pattern cannot return.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, upgrade, or operational behavior change is intended. The initialization manager constructor changes only inside the repository. Reduced test fixtures can still omit collaborators, while production startup now requires both runtimes.

## Verification

- `go test -race -count=1 ./cmd/controller ./internal/app/openbaocluster ./internal/service/init ./internal/adapter/raft`
- `make lint-ci`
- `make test-ci`
- `make generate-ast-rules`
- `make verify-arch-policy`
- `make test-ast`
- `make lint-ast`
- `make verify-fmt`
- `make report-internal-deps`

The completed two-PR stack passes 3,671 tests with 4 expected skips and 70.58% internal coverage against the 68% minimum.

## Reviewer Notes

Stack 1 of 2 and the base for #701. Merge the top PR after every required check passes to land the complete stack.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
