### PR TITLE
fix(backup): preserve trigger before job creation

### DIFF
--- a/internal/service/backup/manager_execution_test.go
+++ b/internal/service/backup/manager_execution_test.go
@@ -353,6 +353,36 @@ func TestReconcile_OwnedBackupClearsCrashRecoveredManualTrigger(t *testing.T) {
 	}
 }
 
+func TestReconcile_OwnedBackupWithoutJobPreservesManualTrigger(t *testing.T) {
+	cluster := newTestClusterWithBackup("manual-before-job-crash", "default")
+	cluster.Annotations = map[string]string{constants.AnnotationTriggerBackup: "manual-request-1"}
+	cluster.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+		Operation: openbaov1alpha1.ClusterOperationBackup,
+		Holder:    backupOperationLockHolder,
+	}
+
+	k8sClient := newTestClient(t, cluster)
+	manager := newBackupManager(k8sClient)
+	result, err := manager.Reconcile(context.Background(), logr.Discard(), cluster)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != constants.RequeueShort {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, constants.RequeueShort)
+	}
+
+	updated := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), updated); err != nil {
+		t.Fatalf("Get() cluster error = %v", err)
+	}
+	if got := updated.Annotations[constants.AnnotationTriggerBackup]; got != "manual-request-1" {
+		t.Fatalf("manual trigger = %q, want preserved for retry", got)
+	}
+	if updated.Status.OperationLock != nil {
+		t.Fatalf("operation lock = %#v, want released", updated.Status.OperationLock)
+	}
+}
+
 func TestReconcile_AppliesRetentionOnceForNewSuccessfulJob(t *testing.T) {
 	cluster := newTestClusterWithBackup("async-retention", "default")
 	cluster.Status.Initialized = true

--- a/internal/service/backup/manager_reconcile.go
+++ b/internal/service/backup/manager_reconcile.go
@@ -112,13 +112,15 @@ func (m *Manager) reconcileOwnedBackup(
 		return recon.Result{}, err
 	}
 	m.syncBackupStatusMetrics(cluster, metrics)
-	if err := m.clearManualTriggerAnnotation(ctx, logger, cluster); err != nil {
-		return recon.Result{}, fmt.Errorf("failed to clear manual backup trigger while finishing owned operation: %w", err)
-	}
 
 	observation, err := m.observeBackupJobs(ctx, cluster)
 	if err != nil {
 		return recon.Result{}, fmt.Errorf("failed to observe owned backup Jobs: %w", err)
+	}
+	if observation.hasActive || observation.mostRecentTerminal != nil {
+		if err := m.clearManualTriggerAnnotation(ctx, logger, cluster); err != nil {
+			return recon.Result{}, fmt.Errorf("failed to clear manual backup trigger while finishing owned operation: %w", err)
+		}
 	}
 	if observation.hasActive {
 		m.applyBackupJobSnapshotToMetrics(cluster, metrics, backupJobMetricsSnapshot{inProgress: true})


### PR DESCRIPTION
## Summary

- Preserve a manual backup trigger when recovery finds an owned backup operation lock but no active or terminal backup Job.
- Release the stale lock and requeue so the next reconciliation retries the same manual request instead of dropping it.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No API, CRD, Helm, RBAC, security, or upgrade compatibility changes. The behavior change is limited to backup crash recovery: the controller now clears the manual trigger only after it observes an active or terminal backup Job.

## Verification

- `go test ./internal/service/backup`
- `go test -race ./internal/service/backup`
- `go vet ./internal/service/backup`
- `make verify-fmt`
- `make lint-ci`
- `make test-ci`
- `make generate-ast-rules verify-arch-policy test-ast lint-ast report-internal-deps`
- `devenv test`
- `devenv tasks run operator:bootstrap`
- `devenv tasks run operator:doctor`
- `devenv tasks run operator:ci-core`

The repository-wide checks ran on the stack tip, which includes this change. The focused package and race checks also ran on this branch.

## Reviewer Notes

- The regression test models the crash boundary after lock acquisition and before Job creation.
- #704 builds on this fix and separates the backup lifecycle decision from its effects.
- Documentation and generated artifacts are not affected.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
