### PR TITLE
refactor(restore): separate lifecycle decisions from effects

### DIFF
--- a/internal/service/restore/manager_decision.go
+++ b/internal/service/restore/manager_decision.go
@@ -1,0 +1,100 @@
+package restore
+
+import (
+	"fmt"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+type restoreDecisionKind uint8
+
+const (
+	restoreDecisionIdle restoreDecisionKind = iota
+	restoreDecisionMarkUnknown
+	restoreDecisionCreateJob
+	restoreDecisionAdoptLegacyJob
+	restoreDecisionRecordCreatedReceipt
+	restoreDecisionRecordSucceededJob
+	restoreDecisionRecordFailedJob
+	restoreDecisionPollJob
+	restoreDecisionContinueRecovery
+	restoreDecisionFailRestore
+	restoreDecisionCompleteRestore
+)
+
+type restoreJobState uint8
+
+const (
+	restoreJobNotObserved restoreJobState = iota
+	restoreJobRunning
+	restoreJobSucceeded
+	restoreJobFailed
+)
+
+// restoreState projects observed facts into the next operation. The execution
+// receipt on OpenBaoRestore remains the durable lifecycle state.
+type restoreState struct {
+	executionStage openbaov1alpha1.RestoreExecutionStage
+	terminalResult openbaov1alpha1.RestoreExecutionResult
+	legacy         bool
+	jobState       restoreJobState
+	unknownMessage string
+}
+
+type restoreDecision struct {
+	kind    restoreDecisionKind
+	message string
+}
+
+func decideRestore(state restoreState) restoreDecision {
+	if state.unknownMessage != "" {
+		return restoreDecision{kind: restoreDecisionMarkUnknown, message: state.unknownMessage}
+	}
+	if state.legacy {
+		return restoreDecision{kind: restoreDecisionAdoptLegacyJob}
+	}
+
+	switch state.executionStage {
+	case openbaov1alpha1.RestoreExecutionStagePrepared:
+		return restoreDecision{kind: restoreDecisionCreateJob}
+	case openbaov1alpha1.RestoreExecutionStageCommitted:
+		// Persist creation before acting on a terminal Job, even if it has finished.
+		return restoreDecision{kind: restoreDecisionRecordCreatedReceipt}
+	case openbaov1alpha1.RestoreExecutionStageCreated:
+		switch state.jobState {
+		case restoreJobSucceeded:
+			return restoreDecision{kind: restoreDecisionRecordSucceededJob}
+		case restoreJobFailed:
+			return restoreDecision{kind: restoreDecisionRecordFailedJob}
+		default:
+			return restoreDecision{kind: restoreDecisionPollJob}
+		}
+	case openbaov1alpha1.RestoreExecutionStageTerminalObserved:
+		switch state.terminalResult {
+		case openbaov1alpha1.RestoreExecutionResultSucceeded:
+			return restoreDecision{kind: restoreDecisionContinueRecovery}
+		case openbaov1alpha1.RestoreExecutionResultFailed:
+			return restoreDecision{kind: restoreDecisionFailRestore}
+		default:
+			return restoreDecision{
+				kind: restoreDecisionMarkUnknown,
+				message: fmt.Sprintf(
+					"Restore terminal receipt has unsupported result %q. The operator will not create or recreate a restore Job.",
+					state.terminalResult,
+				),
+			}
+		}
+	case openbaov1alpha1.RestoreExecutionStageFollowThroughComplete:
+		return restoreDecision{kind: restoreDecisionCompleteRestore}
+	case openbaov1alpha1.RestoreExecutionStageUnknown:
+		return restoreDecision{kind: restoreDecisionIdle}
+	default:
+		return restoreDecision{
+			kind: restoreDecisionMarkUnknown,
+			message: fmt.Sprintf(
+				"Restore execution has unsupported stage %q. The operator will not create or recreate a restore Job.",
+				state.executionStage,
+			),
+		}
+	}
+}

--- a/internal/service/restore/manager_decision_test.go
+++ b/internal/service/restore/manager_decision_test.go
@@ -1,0 +1,132 @@
+package restore
+
+import (
+	"strings"
+	"testing"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestDecideRestore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		state       restoreState
+		want        restoreDecisionKind
+		wantMessage string
+	}{
+		{
+			name: "marks unknown on observed safety issue before stage routing",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStagePrepared,
+				unknownMessage: "identity mismatch",
+			},
+			want:        restoreDecisionMarkUnknown,
+			wantMessage: "identity mismatch",
+		},
+		{
+			name:  "adopts legacy job before stage routing",
+			state: restoreState{legacy: true},
+			want:  restoreDecisionAdoptLegacyJob,
+		},
+		{
+			name:  "creates prepared execution",
+			state: restoreState{executionStage: openbaov1alpha1.RestoreExecutionStagePrepared},
+			want:  restoreDecisionCreateJob,
+		},
+		{
+			name: "records committed job before terminal handling",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageCommitted,
+				jobState:       restoreJobSucceeded,
+			},
+			want: restoreDecisionRecordCreatedReceipt,
+		},
+		{
+			name: "polls running created job",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageCreated,
+				jobState:       restoreJobRunning,
+			},
+			want: restoreDecisionPollJob,
+		},
+		{
+			name: "records successful created job",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageCreated,
+				jobState:       restoreJobSucceeded,
+			},
+			want: restoreDecisionRecordSucceededJob,
+		},
+		{
+			name: "records failed created job",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageCreated,
+				jobState:       restoreJobFailed,
+			},
+			want: restoreDecisionRecordFailedJob,
+		},
+		{
+			name: "continues recovery from successful terminal receipt",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageTerminalObserved,
+				terminalResult: openbaov1alpha1.RestoreExecutionResultSucceeded,
+			},
+			want: restoreDecisionContinueRecovery,
+		},
+		{
+			name: "fails restore from failed terminal receipt",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageTerminalObserved,
+				terminalResult: openbaov1alpha1.RestoreExecutionResultFailed,
+			},
+			want: restoreDecisionFailRestore,
+		},
+		{
+			name: "marks unknown for unsupported terminal result",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageTerminalObserved,
+				terminalResult: "Other",
+			},
+			want:        restoreDecisionMarkUnknown,
+			wantMessage: "unsupported result",
+		},
+		{
+			name: "completes restore after follow through",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageFollowThroughComplete,
+			},
+			want: restoreDecisionCompleteRestore,
+		},
+		{
+			name: "idles for unknown execution",
+			state: restoreState{
+				executionStage: openbaov1alpha1.RestoreExecutionStageUnknown,
+			},
+			want: restoreDecisionIdle,
+		},
+		{
+			name: "marks unknown for unsupported stage",
+			state: restoreState{
+				executionStage: "Other",
+			},
+			want:        restoreDecisionMarkUnknown,
+			wantMessage: "unsupported stage",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			decision := decideRestore(test.state)
+			if decision.kind != test.want {
+				t.Fatalf("decision kind = %d, want %d", decision.kind, test.want)
+			}
+			if test.wantMessage != "" && !strings.Contains(decision.message, test.wantMessage) {
+				t.Fatalf("decision message = %q, want substring %q", decision.message, test.wantMessage)
+			}
+		})
+	}
+}

--- a/internal/service/restore/manager_effects.go
+++ b/internal/service/restore/manager_effects.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,213 +19,123 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/service/workloadidentity"
 )
 
-// handleRunning manages the restore job and checks for completion.
+// handleRunning manages the restore Job and checks for completion.
 func (m *Manager) handleRunning(ctx context.Context, logger logr.Logger, restore *openbaov1alpha1.OpenBaoRestore) (ctrl.Result, error) {
-	cluster := &openbaov1alpha1.OpenBaoCluster{}
-	if err := m.reader.Get(ctx, types.NamespacedName{
-		Namespace: restore.Namespace,
-		Name:      restore.Spec.Cluster,
-	}, cluster); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get target cluster: %w", err)
+	observation, err := m.observeRestore(ctx, restore)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-
-	if restore.Status.Execution == nil {
-		return m.recoverLegacyRunningRestore(ctx, logger, restore, cluster)
-	}
-	if err := validateRestoreExecutionIdentity(restore); err != nil {
-		message := fmt.Sprintf("Restore execution identity is inconsistent: %v. The operator will not create or recreate a restore Job. Investigate the existing Job and delete this OpenBaoRestore only after the cluster state is known.", err)
-		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
-	}
-
-	switch restore.Status.Execution.Stage {
-	case openbaov1alpha1.RestoreExecutionStagePrepared:
-		done, err := m.renewRunningRestoreLock(ctx, logger, restore, cluster)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if done {
-			return ctrl.Result{}, nil
-		}
-		return m.createRestoreJob(ctx, logger, restore, cluster, restore.Status.Execution.JobName)
-	case openbaov1alpha1.RestoreExecutionStageCommitted:
-		job, result, err := m.readCommittedRestoreJob(ctx, restore)
-		if result != nil || err != nil {
-			if result != nil {
-				return *result, err
-			}
-			return ctrl.Result{}, err
-		}
-		if err := m.markRestoreExecutionCreated(ctx, restore, job); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to persist restore Job creation receipt: %w", err)
-		}
-		return ctrl.Result{RequeueAfter: restoreRequeueImmediately}, nil
-	case openbaov1alpha1.RestoreExecutionStageCreated:
-		return m.observeCreatedRestoreJob(ctx, logger, restore, cluster)
-	case openbaov1alpha1.RestoreExecutionStageTerminalObserved:
-		if restore.Status.Execution.TerminalResult == openbaov1alpha1.RestoreExecutionResultFailed {
-			return m.failRestore(ctx, logger, restore, "Restore Job failed. The terminal execution receipt is preserved; inspect the retained Job logs before creating a new OpenBaoRestore.")
-		}
-		if restore.Status.Execution.TerminalResult != openbaov1alpha1.RestoreExecutionResultSucceeded {
-			message := fmt.Sprintf("Restore terminal receipt has unsupported result %q. The operator will not create or recreate a restore Job.", restore.Status.Execution.TerminalResult)
-			return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
-		}
-		if err := m.handleSucceededRestoreJob(ctx, logger, restore, cluster); err != nil {
-			return ctrl.Result{}, err
-		}
-		if restore.Status.Execution.Stage == openbaov1alpha1.RestoreExecutionStageFollowThroughComplete {
-			if err := m.completeRestore(ctx, logger, restore, "Restore completed successfully after post-restore recovery"); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{RequeueAfter: restoreRequeueImmediately}, nil
-	case openbaov1alpha1.RestoreExecutionStageFollowThroughComplete:
-		if err := m.completeRestore(ctx, logger, restore, "Restore completed successfully after post-restore recovery"); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	case openbaov1alpha1.RestoreExecutionStageUnknown:
-		return ctrl.Result{}, nil
-	default:
-		message := fmt.Sprintf("Restore execution has unsupported stage %q. The operator will not create or recreate a restore Job.", restore.Status.Execution.Stage)
-		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
-	}
+	return m.applyRestoreDecision(ctx, logger, restore, observation, decideRestore(observation.state))
 }
 
-func (m *Manager) recoverLegacyRunningRestore(
+func (m *Manager) applyRestoreDecision(
 	ctx context.Context,
 	logger logr.Logger,
 	restore *openbaov1alpha1.OpenBaoRestore,
-	cluster *openbaov1alpha1.OpenBaoCluster,
+	observation restoreObservation,
+	decision restoreDecision,
 ) (ctrl.Result, error) {
-	jobName := restoreJobName(restore)
-	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
-		Namespace: restore.Namespace,
-		Name:      jobName,
-	}, restore, openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"), "observe restore")
-	if apierrors.IsNotFound(err) {
-		message := "Restore is Running without an execution receipt and its Job is missing. The Job may have completed before the controller recorded it, so the operator will not recreate it. Verify the cluster state, then delete this OpenBaoRestore to release the operation lock."
-		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
+	switch decision.kind {
+	case restoreDecisionIdle:
+		return ctrl.Result{}, nil
+	case restoreDecisionMarkUnknown:
+		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, decision.message)
+	case restoreDecisionCreateJob:
+		if done, err := m.renewRunningRestoreLock(ctx, logger, restore, observation.cluster); done || err != nil {
+			return ctrl.Result{}, err
+		}
+		return m.createRestoreJob(ctx, logger, restore, observation.cluster, restore.Status.Execution.JobName)
+	case restoreDecisionAdoptLegacyJob:
+		return m.adoptLegacyRestoreJob(ctx, logger, restore, observation)
+	case restoreDecisionRecordCreatedReceipt:
+		if err := m.markRestoreExecutionCreated(ctx, restore, observation.job); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to persist restore Job creation receipt: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: restoreRequeueImmediately}, nil
+	case restoreDecisionRecordSucceededJob:
+		if err := m.markRestoreExecutionTerminal(ctx, restore, openbaov1alpha1.RestoreExecutionResultSucceeded); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to persist successful restore Job receipt: %w", err)
+		}
+		return m.continueRestoreRecovery(ctx, logger, restore, observation.cluster)
+	case restoreDecisionRecordFailedJob:
+		if done, err := m.renewRunningRestoreLock(ctx, logger, restore, observation.cluster); done || err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := m.markRestoreExecutionTerminal(ctx, restore, openbaov1alpha1.RestoreExecutionResultFailed); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to persist failed restore Job receipt: %w", err)
+		}
+		return m.failRestore(ctx, logger, restore, restoreJobFailedStatusMessage(observation.job, workloadidentity.FailureHint(restore.Spec.Source.Target, restoreServiceAccountName(observation.cluster))))
+	case restoreDecisionPollJob:
+		if done, err := m.renewRunningRestoreLock(ctx, logger, restore, observation.cluster); done || err != nil {
+			return ctrl.Result{}, err
+		}
+		original := restore.DeepCopy()
+		restore.Status.Message = restoreJobRunningStatusMessage(observation.job.Name)
+		if err := m.patchStatus(ctx, restore, original); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to patch restore status while job is running: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: restoreRequeueJobPoll}, nil
+	case restoreDecisionContinueRecovery:
+		return m.continueRestoreRecovery(ctx, logger, restore, observation.cluster)
+	case restoreDecisionFailRestore:
+		return m.failRestore(ctx, logger, restore, "Restore Job failed. The terminal execution receipt is preserved; inspect the retained Job logs before creating a new OpenBaoRestore.")
+	case restoreDecisionCompleteRestore:
+		return ctrl.Result{}, m.completeRestore(ctx, logger, restore, "Restore completed successfully after post-restore recovery")
+	default:
+		return ctrl.Result{}, fmt.Errorf("unsupported restore decision %d", decision.kind)
 	}
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get restore job: %w", err)
-	}
+}
 
+func (m *Manager) adoptLegacyRestoreJob(
+	ctx context.Context,
+	logger logr.Logger,
+	restore *openbaov1alpha1.OpenBaoRestore,
+	observation restoreObservation,
+) (ctrl.Result, error) {
 	operationID := restoreExecutionOperationID(restore)
-	if jobOperationID := job.Annotations[restoreExecutionIDAnnotation]; jobOperationID != "" && jobOperationID != operationID {
-		message := fmt.Sprintf("Existing restore Job %s has operation ID %q, expected %q. The operator will not adopt or recreate it.", job.Name, jobOperationID, operationID)
-		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
-	}
-
 	original := restore.DeepCopy()
 	now := metav1.Now()
 	restore.Status.Execution = &openbaov1alpha1.RestoreExecutionStatus{
 		OperationID: operationID,
 		Stage:       openbaov1alpha1.RestoreExecutionStageCreated,
-		JobName:     job.Name,
-		JobUID:      job.UID,
+		JobName:     observation.job.Name,
+		JobUID:      observation.job.UID,
 		PreparedAt:  &now,
 		CommittedAt: &now,
 		CreatedAt:   &now,
 	}
-	restore.Status.Message = fmt.Sprintf("Adopted existing restore Job %s and persisted its execution receipt.", job.Name)
+	restore.Status.Message = fmt.Sprintf("Adopted existing restore Job %s and persisted its execution receipt.", observation.job.Name)
 	if err := m.patchStatus(ctx, restore, original); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to persist legacy restore Job receipt: %w", err)
 	}
-	logger.Info("Adopted existing restore Job without a prior execution receipt", "job", job.Name, "operationID", operationID)
-	return m.observeCreatedRestoreJob(ctx, logger, restore, cluster)
-}
+	logger.Info("Adopted existing restore Job without a prior execution receipt", "job", observation.job.Name, "operationID", operationID)
 
-func (m *Manager) readCommittedRestoreJob(
-	ctx context.Context,
-	restore *openbaov1alpha1.OpenBaoRestore,
-) (*batchv1.Job, *ctrl.Result, error) {
-	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
-		Namespace: restore.Namespace,
-		Name:      restore.Status.Execution.JobName,
-	}, restore, openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"), "observe committed restore")
-	if apierrors.IsNotFound(err) {
-		message := fmt.Sprintf("Committed restore Job %s is missing before a creation receipt was persisted. Its execution result is unknown, so the operator will not recreate it. Verify the cluster state, then delete this OpenBaoRestore to release the operation lock.", restore.Status.Execution.JobName)
-		if statusErr := m.markRestoreExecutionUnknown(ctx, restore, message); statusErr != nil {
-			return nil, nil, statusErr
-		}
-		result := ctrl.Result{}
-		return nil, &result, nil
-	}
+	nextObservation, err := m.observeRestoreJob(ctx, restore, restoreObservation{
+		cluster: observation.cluster,
+		state:   restoreState{executionStage: openbaov1alpha1.RestoreExecutionStageCreated},
+	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get committed restore Job: %w", err)
+		return ctrl.Result{}, err
 	}
-	if err := validateRestoreExecutionJob(restore.Status.Execution, job); err != nil {
-		message := fmt.Sprintf("Committed restore Job identity is inconsistent: %v. The operator will not recreate it.", err)
-		if statusErr := m.markRestoreExecutionUnknown(ctx, restore, message); statusErr != nil {
-			return nil, nil, statusErr
-		}
-		result := ctrl.Result{}
-		return nil, &result, nil
-	}
-	return job, nil, nil
+	return m.applyRestoreDecision(ctx, logger, restore, nextObservation, decideRestore(nextObservation.state))
 }
 
-func (m *Manager) observeCreatedRestoreJob(
+func (m *Manager) continueRestoreRecovery(
 	ctx context.Context,
 	logger logr.Logger,
 	restore *openbaov1alpha1.OpenBaoRestore,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 ) (ctrl.Result, error) {
-	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
-		Namespace: restore.Namespace,
-		Name:      restore.Status.Execution.JobName,
-	}, restore, openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"), "observe restore")
-	if apierrors.IsNotFound(err) {
-		message := fmt.Sprintf("Restore Job %s is missing after its creation receipt was persisted. Its execution result is unknown, so the operator will not recreate it. Verify the cluster state, then delete this OpenBaoRestore to release the operation lock.", restore.Status.Execution.JobName)
-		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
-	}
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get restore Job: %w", err)
-	}
-	if err := validateRestoreExecutionJob(restore.Status.Execution, job); err != nil {
-		message := fmt.Sprintf("Restore Job identity no longer matches its creation receipt: %v. The operator will not recreate it.", err)
-		return ctrl.Result{}, m.markRestoreExecutionUnknown(ctx, restore, message)
-	}
-
-	if job.Status.Succeeded > 0 {
-		if err := m.markRestoreExecutionTerminal(ctx, restore, openbaov1alpha1.RestoreExecutionResultSucceeded); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to persist successful restore Job receipt: %w", err)
-		}
-		if err := m.handleSucceededRestoreJob(ctx, logger, restore, cluster); err != nil {
-			return ctrl.Result{}, err
-		}
-		if restore.Status.Execution.Stage == openbaov1alpha1.RestoreExecutionStageFollowThroughComplete {
-			if err := m.completeRestore(ctx, logger, restore, "Restore completed successfully after post-restore recovery"); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{RequeueAfter: restoreRequeueImmediately}, nil
-	}
-
-	done, err := m.renewRunningRestoreLock(ctx, logger, restore, cluster)
-	if err != nil {
+	if err := m.handleSucceededRestoreJob(ctx, logger, restore, cluster); err != nil {
 		return ctrl.Result{}, err
 	}
-	if done {
+	if restore.Status.Execution.Stage == openbaov1alpha1.RestoreExecutionStageFollowThroughComplete {
+		if err := m.completeRestore(ctx, logger, restore, "Restore completed successfully after post-restore recovery"); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
-
-	if job.Status.Failed > 0 {
-		if err := m.markRestoreExecutionTerminal(ctx, restore, openbaov1alpha1.RestoreExecutionResultFailed); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to persist failed restore Job receipt: %w", err)
-		}
-		return m.failRestore(ctx, logger, restore, restoreJobFailedStatusMessage(job, workloadidentity.FailureHint(restore.Spec.Source.Target, restoreServiceAccountName(cluster))))
-	}
-
-	original := restore.DeepCopy()
-	restore.Status.Message = restoreJobRunningStatusMessage(job.Name)
-	if err := m.patchStatus(ctx, restore, original); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to patch restore status while job is running: %w", err)
-	}
-
-	return ctrl.Result{RequeueAfter: restoreRequeueJobPoll}, nil
+	return ctrl.Result{RequeueAfter: restoreRequeueImmediately}, nil
 }
 
 func (m *Manager) renewRunningRestoreLock(
@@ -476,6 +385,5 @@ func (m *Manager) createRestoreJob(
 	}
 	m.emitNormalEvent(restore, ReasonRestoreJobCreated, "Created restore Job %s", jobName)
 
-	// Requeue to check job status.
 	return ctrl.Result{RequeueAfter: restoreRequeueJobCheck}, nil
 }

--- a/internal/service/restore/manager_effects_test.go
+++ b/internal/service/restore/manager_effects_test.go
@@ -1,0 +1,293 @@
+package restore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestApplyRestoreDecision_CommittedRecordsCreatedReceiptOnly(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add OpenBao API to scheme: %v", err)
+	}
+
+	restore := newRunningRestoreForObservation()
+	setTestResourceVersion(restore)
+	restore.Status.Execution = newRestoreExecutionStatus(restore)
+	restore.Status.Execution.Stage = openbaov1alpha1.RestoreExecutionStageCommitted
+	job := managedRestoreJobForRestore(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      restore.Status.Execution.JobName,
+		Namespace: restore.Namespace,
+		UID:       types.UID("committed-job-uid"),
+	}}, restore)
+	job.Annotations[restoreExecutionIDAnnotation] = restore.Status.Execution.OperationID
+	job.Status.Succeeded = 1
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(restore).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoRestore{}).
+		WithReturnManagedFields().
+		Build()
+	manager := &Manager{client: k8sClient}
+	observation := restoreObservation{
+		job: job,
+		state: restoreState{
+			executionStage: openbaov1alpha1.RestoreExecutionStageCommitted,
+			jobState:       restoreJobSucceeded,
+		},
+	}
+	decision := decideRestore(observation.state)
+
+	result, err := manager.applyRestoreDecision(context.Background(), testLogger(), restore, observation, decision)
+	if err != nil {
+		t.Fatalf("applyRestoreDecision() error = %v", err)
+	}
+	if result.RequeueAfter != restoreRequeueImmediately {
+		t.Fatalf("requeue = %v, want %v", result.RequeueAfter, restoreRequeueImmediately)
+	}
+
+	updated := &openbaov1alpha1.OpenBaoRestore{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(restore), updated); err != nil {
+		t.Fatalf("get updated restore: %v", err)
+	}
+	if updated.Status.Execution.Stage != openbaov1alpha1.RestoreExecutionStageCreated {
+		t.Fatalf("execution stage = %q, want %q", updated.Status.Execution.Stage, openbaov1alpha1.RestoreExecutionStageCreated)
+	}
+	if updated.Status.Execution.TerminalResult != "" {
+		t.Fatalf("terminal result = %q, want empty until the next observation", updated.Status.Execution.TerminalResult)
+	}
+}
+
+func TestHandleRunning_TerminalReceiptFailureOrdering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		succeeded        bool
+		failReceiptWrite bool
+		wantStage        openbaov1alpha1.RestoreExecutionStage
+		wantResult       openbaov1alpha1.RestoreExecutionResult
+		wantClusterReads int
+	}{
+		{
+			name: "success receipt precedes recovery lock renewal", succeeded: true,
+			wantStage:  openbaov1alpha1.RestoreExecutionStageTerminalObserved,
+			wantResult: openbaov1alpha1.RestoreExecutionResultSucceeded, wantClusterReads: 2,
+		},
+		{
+			name:      "failed job renews lock before recording failure",
+			wantStage: openbaov1alpha1.RestoreExecutionStageCreated, wantClusterReads: 2,
+		},
+		{
+			name: "success receipt write failure stops recovery", succeeded: true, failReceiptWrite: true,
+			wantStage: openbaov1alpha1.RestoreExecutionStageCreated, wantClusterReads: 1,
+		},
+		{
+			name: "failure receipt write failure stops terminal transition", failReceiptWrite: true,
+			wantStage: openbaov1alpha1.RestoreExecutionStageCreated, wantClusterReads: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scheme := runtime.NewScheme()
+			require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+
+			restore := newRunningRestoreForObservation()
+			setTestResourceVersion(restore)
+			restore.Status.Execution = newRestoreExecutionStatus(restore)
+			restore.Status.Execution.Stage = openbaov1alpha1.RestoreExecutionStageCreated
+			cluster := newRestoreObservationCluster(restore)
+			setTestResourceVersion(cluster)
+			job := managedRestoreJobForRestore(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name: restore.Status.Execution.JobName, Namespace: restore.Namespace, UID: "terminal-job-uid",
+			}}, restore)
+			restore.Status.Execution.JobUID = job.UID
+			if tt.succeeded {
+				job.Status.Succeeded = 1
+			} else {
+				job.Status.Failed = 1
+			}
+
+			injectedErr := errors.New("injected persistence failure")
+			clusterReads := 0
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(cluster, restore, job).
+				WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
+				WithReturnManagedFields().
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*openbaov1alpha1.OpenBaoCluster); ok {
+							clusterReads++
+							if clusterReads > 1 && !tt.failReceiptWrite {
+								return injectedErr
+							}
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if _, ok := obj.(*openbaov1alpha1.OpenBaoRestore); ok && tt.failReceiptWrite {
+							return injectedErr
+						}
+						return c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+					},
+				}).Build()
+			manager := &Manager{client: k8sClient, reader: k8sClient, scheme: scheme}
+
+			_, err := manager.handleRunning(t.Context(), testLogger(), restore)
+			require.ErrorIs(t, err, injectedErr)
+			require.Equal(t, tt.wantClusterReads, clusterReads)
+			updated := &openbaov1alpha1.OpenBaoRestore{}
+			require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(restore), updated))
+			require.Equal(t, tt.wantStage, updated.Status.Execution.Stage)
+			require.Equal(t, tt.wantResult, updated.Status.Execution.TerminalResult)
+			require.Equal(t, openbaov1alpha1.RestorePhaseRunning, updated.Status.Phase)
+			require.Nil(t, updated.Status.CompletionTime)
+		})
+	}
+}
+
+func TestHandleRunning_LegacyAdoptionRechecksJobIdentity(t *testing.T) {
+	t.Parallel()
+
+	for _, missing := range []bool{false, true} {
+		name := "replaced job"
+		if missing {
+			name = "missing job"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			scheme := runtime.NewScheme()
+			require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+			restore := newRunningRestoreForObservation()
+			setTestResourceVersion(restore)
+			cluster := newRestoreObservationCluster(restore)
+			job := managedRestoreJobForRestore(&batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: restoreJobName(restore), Namespace: restore.Namespace, UID: "legacy-job-uid"},
+				Status:     batchv1.JobStatus{Succeeded: 1},
+			}, restore)
+			jobReads := 0
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(cluster, restore, job).
+				WithStatusSubresource(&openbaov1alpha1.OpenBaoRestore{}).
+				WithReturnManagedFields().
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := c.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						if observedJob, ok := obj.(*batchv1.Job); ok {
+							jobReads++
+							if jobReads == 2 {
+								persisted := &openbaov1alpha1.OpenBaoRestore{}
+								require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+								require.NotNil(t, persisted.Status.Execution)
+								require.Equal(t, openbaov1alpha1.RestoreExecutionStageCreated, persisted.Status.Execution.Stage)
+								if missing {
+									return apierrors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, key.Name)
+								}
+								observedJob.UID = "replacement-job-uid"
+							}
+						}
+						return nil
+					},
+				}).Build()
+			manager := &Manager{client: k8sClient, reader: k8sClient, scheme: scheme}
+
+			result, err := manager.handleRunning(t.Context(), testLogger(), restore)
+			require.NoError(t, err)
+			require.Zero(t, result.RequeueAfter)
+			require.Equal(t, 2, jobReads)
+			updated := &openbaov1alpha1.OpenBaoRestore{}
+			require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(restore), updated))
+			require.Equal(t, openbaov1alpha1.RestorePhaseUnknown, updated.Status.Phase)
+			require.Equal(t, openbaov1alpha1.RestoreExecutionStageUnknown, updated.Status.Execution.Stage)
+			require.Equal(t, job.UID, updated.Status.Execution.JobUID)
+			require.Empty(t, updated.Status.Execution.TerminalResult)
+		})
+	}
+}
+
+func TestHandleRunning_LegacyAdoptionContinuesObservation(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add OpenBao API to scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch API to scheme: %v", err)
+	}
+
+	restore := newRunningRestoreForObservation()
+	setTestResourceVersion(restore)
+	cluster := newRestoreObservationCluster(restore)
+	setTestResourceVersion(cluster)
+	lock := restoreOperationLock(restore)
+	cluster.Status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+		Operation: lock.Operation,
+		Holder:    lock.Holder,
+		Message:   restoreLockMessage(restore),
+	}
+	job := managedRestoreJobForRestore(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      restoreJobName(restore),
+		Namespace: restore.Namespace,
+		UID:       types.UID("legacy-running-job-uid"),
+	}}, restore)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, job).
+		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}).
+		WithReturnManagedFields().
+		Build()
+	manager := &Manager{
+		client: k8sClient,
+		reader: k8sClient,
+		scheme: scheme,
+	}
+
+	result, err := manager.handleRunning(context.Background(), testLogger(), restore)
+	if err != nil {
+		t.Fatalf("handleRunning() error = %v", err)
+	}
+	if result.RequeueAfter != restoreRequeueJobPoll {
+		t.Fatalf("requeue = %v, want %v", result.RequeueAfter, restoreRequeueJobPoll)
+	}
+
+	updated := &openbaov1alpha1.OpenBaoRestore{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(restore), updated); err != nil {
+		t.Fatalf("get updated restore: %v", err)
+	}
+	if updated.Status.Execution == nil {
+		t.Fatal("execution receipt is nil after legacy adoption")
+	}
+	if updated.Status.Execution.Stage != openbaov1alpha1.RestoreExecutionStageCreated {
+		t.Fatalf("execution stage = %q, want %q", updated.Status.Execution.Stage, openbaov1alpha1.RestoreExecutionStageCreated)
+	}
+	if updated.Status.Message != restoreJobRunningStatusMessage(job.Name) {
+		t.Fatalf("status message = %q, want %q", updated.Status.Message, restoreJobRunningStatusMessage(job.Name))
+	}
+}

--- a/internal/service/restore/manager_observation.go
+++ b/internal/service/restore/manager_observation.go
@@ -1,0 +1,153 @@
+package restore
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
+)
+
+type restoreObservation struct {
+	state   restoreState
+	cluster *openbaov1alpha1.OpenBaoCluster
+	job     *batchv1.Job
+}
+
+func (m *Manager) observeRestore(
+	ctx context.Context,
+	restore *openbaov1alpha1.OpenBaoRestore,
+) (restoreObservation, error) {
+	cluster := &openbaov1alpha1.OpenBaoCluster{}
+	if err := m.reader.Get(ctx, types.NamespacedName{
+		Namespace: restore.Namespace,
+		Name:      restore.Spec.Cluster,
+	}, cluster); err != nil {
+		return restoreObservation{}, fmt.Errorf("failed to get target cluster: %w", err)
+	}
+
+	if restore.Status.Execution == nil {
+		return m.observeLegacyRestoreJob(ctx, restore, cluster)
+	}
+	if err := validateRestoreExecutionIdentity(restore); err != nil {
+		return unknownRestoreObservation(
+			cluster,
+			fmt.Sprintf("Restore execution identity is inconsistent: %v. The operator will not create or recreate a restore Job. Investigate the existing Job and delete this OpenBaoRestore only after the cluster state is known.", err),
+		), nil
+	}
+
+	observation := restoreObservation{
+		cluster: cluster,
+		state: restoreState{
+			executionStage: restore.Status.Execution.Stage,
+			terminalResult: restore.Status.Execution.TerminalResult,
+		},
+	}
+
+	switch observation.state.executionStage {
+	case openbaov1alpha1.RestoreExecutionStageCommitted, openbaov1alpha1.RestoreExecutionStageCreated:
+		return m.observeRestoreJob(ctx, restore, observation)
+	default:
+		return observation, nil
+	}
+}
+
+func (m *Manager) observeLegacyRestoreJob(
+	ctx context.Context,
+	restore *openbaov1alpha1.OpenBaoRestore,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+) (restoreObservation, error) {
+	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
+		Namespace: restore.Namespace,
+		Name:      restoreJobName(restore),
+	}, restore, openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"), "observe restore")
+	if apierrors.IsNotFound(err) {
+		return unknownRestoreObservation(
+			cluster,
+			"Restore is Running without an execution receipt and its Job is missing. The Job may have completed before the controller recorded it, so the operator will not recreate it. Verify the cluster state, then delete this OpenBaoRestore to release the operation lock.",
+		), nil
+	}
+	if err != nil {
+		return restoreObservation{}, fmt.Errorf("failed to get restore job: %w", err)
+	}
+
+	operationID := restoreExecutionOperationID(restore)
+	if jobOperationID := job.Annotations[restoreExecutionIDAnnotation]; jobOperationID != "" && jobOperationID != operationID {
+		return unknownRestoreObservation(
+			cluster,
+			fmt.Sprintf("Existing restore Job %s has operation ID %q, expected %q. The operator will not adopt or recreate it.", job.Name, jobOperationID, operationID),
+		), nil
+	}
+
+	return restoreObservation{
+		cluster: cluster,
+		job:     job,
+		state:   restoreState{legacy: true},
+	}, nil
+}
+
+func (m *Manager) observeRestoreJob(
+	ctx context.Context,
+	restore *openbaov1alpha1.OpenBaoRestore,
+	observation restoreObservation,
+) (restoreObservation, error) {
+	committed := observation.state.executionStage == openbaov1alpha1.RestoreExecutionStageCommitted
+	operation := "observe restore"
+	jobDescription := "restore Job"
+	if committed {
+		operation = "observe committed restore"
+		jobDescription = "committed restore Job"
+	}
+	job, err := opslifecycle.ReadManagedJob(ctx, m.reader, types.NamespacedName{
+		Namespace: restore.Namespace,
+		Name:      restore.Status.Execution.JobName,
+	}, restore, openbaov1alpha1.GroupVersion.WithKind("OpenBaoRestore"), operation)
+	if apierrors.IsNotFound(err) {
+		if committed {
+			observation.state.unknownMessage = fmt.Sprintf("Committed restore Job %s is missing before a creation receipt was persisted. Its execution result is unknown, so the operator will not recreate it. Verify the cluster state, then delete this OpenBaoRestore to release the operation lock.", restore.Status.Execution.JobName)
+		} else {
+			observation.state.unknownMessage = fmt.Sprintf("Restore Job %s is missing after its creation receipt was persisted. Its execution result is unknown, so the operator will not recreate it. Verify the cluster state, then delete this OpenBaoRestore to release the operation lock.", restore.Status.Execution.JobName)
+		}
+		return observation, nil
+	}
+	if err != nil {
+		return restoreObservation{}, fmt.Errorf("failed to get %s: %w", jobDescription, err)
+	}
+	if err := validateRestoreExecutionJob(restore.Status.Execution, job); err != nil {
+		if committed {
+			observation.state.unknownMessage = fmt.Sprintf("Committed restore Job identity is inconsistent: %v. The operator will not recreate it.", err)
+		} else {
+			observation.state.unknownMessage = fmt.Sprintf("Restore Job identity no longer matches its creation receipt: %v. The operator will not recreate it.", err)
+		}
+		return observation, nil
+	}
+
+	observation.job = job
+	observation.state.jobState = classifyRestoreJob(job)
+	return observation, nil
+}
+
+func classifyRestoreJob(job *batchv1.Job) restoreJobState {
+	switch {
+	case job.Status.Succeeded > 0:
+		return restoreJobSucceeded
+	case job.Status.Failed > 0:
+		return restoreJobFailed
+	default:
+		return restoreJobRunning
+	}
+}
+
+func unknownRestoreObservation(
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	message string,
+) restoreObservation {
+	return restoreObservation{
+		cluster: cluster,
+		state:   restoreState{unknownMessage: message},
+	}
+}

--- a/internal/service/restore/manager_observation_test.go
+++ b/internal/service/restore/manager_observation_test.go
@@ -1,0 +1,173 @@
+package restore
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestObserveRestore_DoesNotMutateRestore(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add OpenBao API to scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch API to scheme: %v", err)
+	}
+
+	restore := newRunningRestoreForObservation()
+	restore.Status.Execution = newRestoreExecutionStatus(restore)
+	restore.Status.Execution.Stage = openbaov1alpha1.RestoreExecutionStageCreated
+	job := managedRestoreJobForRestore(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      restore.Status.Execution.JobName,
+		Namespace: restore.Namespace,
+		UID:       types.UID("restore-job-uid"),
+	}}, restore)
+	job.Annotations[restoreExecutionIDAnnotation] = restore.Status.Execution.OperationID
+	restore.Status.Execution.JobUID = job.UID
+	cluster := newRestoreObservationCluster(restore)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, job).
+		Build()
+	manager := &Manager{reader: k8sClient}
+	original := restore.DeepCopy()
+
+	observation, err := manager.observeRestore(context.Background(), restore)
+	if err != nil {
+		t.Fatalf("observeRestore() error = %v", err)
+	}
+	if !reflect.DeepEqual(restore, original) {
+		t.Fatal("observeRestore() mutated the restore")
+	}
+	if observation.job == nil || observation.job.Name != job.Name {
+		t.Fatalf("observed Job = %v, want %s", observation.job, job.Name)
+	}
+	if observation.state.jobState != restoreJobRunning {
+		t.Fatalf("job state = %d, want %d", observation.state.jobState, restoreJobRunning)
+	}
+	if got := decideRestore(observation.state).kind; got != restoreDecisionPollJob {
+		t.Fatalf("decision kind = %d, want %d", got, restoreDecisionPollJob)
+	}
+}
+
+func TestObserveRestore_LegacyJobDefersAdoption(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add OpenBao API to scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch API to scheme: %v", err)
+	}
+
+	restore := newRunningRestoreForObservation()
+	job := managedRestoreJobForRestore(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      restoreJobName(restore),
+		Namespace: restore.Namespace,
+		UID:       types.UID("legacy-restore-job-uid"),
+	}}, restore)
+	cluster := newRestoreObservationCluster(restore)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore, job).
+		Build()
+	manager := &Manager{reader: k8sClient}
+
+	observation, err := manager.observeRestore(context.Background(), restore)
+	if err != nil {
+		t.Fatalf("observeRestore() error = %v", err)
+	}
+	if restore.Status.Execution != nil {
+		t.Fatal("observeRestore() adopted the legacy Job")
+	}
+	if !observation.state.legacy {
+		t.Fatal("legacy = false, want true")
+	}
+	if got := decideRestore(observation.state).kind; got != restoreDecisionAdoptLegacyJob {
+		t.Fatalf("decision kind = %d, want %d", got, restoreDecisionAdoptLegacyJob)
+	}
+}
+
+func TestObserveRestore_MissingCommittedJobBlocksRecreation(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add OpenBao API to scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch API to scheme: %v", err)
+	}
+
+	restore := newRunningRestoreForObservation()
+	restore.Status.Execution = newRestoreExecutionStatus(restore)
+	restore.Status.Execution.Stage = openbaov1alpha1.RestoreExecutionStageCommitted
+	cluster := newRestoreObservationCluster(restore)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, restore).
+		Build()
+	manager := &Manager{reader: k8sClient}
+
+	observation, err := manager.observeRestore(context.Background(), restore)
+	if err != nil {
+		t.Fatalf("observeRestore() error = %v", err)
+	}
+	decision := decideRestore(observation.state)
+	if decision.kind != restoreDecisionMarkUnknown {
+		t.Fatalf("decision kind = %d, want %d", decision.kind, restoreDecisionMarkUnknown)
+	}
+	if !strings.Contains(decision.message, "operator will not recreate it") {
+		t.Fatalf("decision message = %q, want no-recreation guidance", decision.message)
+	}
+}
+
+func newRunningRestoreForObservation() *openbaov1alpha1.OpenBaoRestore {
+	return &openbaov1alpha1.OpenBaoRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "observation-restore",
+			Namespace: "default",
+			UID:       types.UID("observation-restore-uid"),
+		},
+		Spec: openbaov1alpha1.OpenBaoRestoreSpec{Cluster: "observation-cluster"},
+		Status: openbaov1alpha1.OpenBaoRestoreStatus{
+			Phase: openbaov1alpha1.RestorePhaseRunning,
+		},
+	}
+}
+
+func newRestoreObservationCluster(restore *openbaov1alpha1.OpenBaoRestore) *openbaov1alpha1.OpenBaoCluster {
+	return &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Name:      restore.Spec.Cluster,
+		Namespace: restore.Namespace,
+		UID:       types.UID("observation-cluster-uid"),
+	}}
+}
+
+func TestClassifyRestoreJob_PrefersSuccess(t *testing.T) {
+	t.Parallel()
+
+	job := &batchv1.Job{}
+	job.Status.Succeeded = 1
+	job.Status.Failed = 1
+
+	if got := classifyRestoreJob(job); got != restoreJobSucceeded {
+		t.Fatalf("classifyRestoreJob() = %d, want %d", got, restoreJobSucceeded)
+	}
+}


### PR DESCRIPTION
## Summary

Restore's Running handler combines API reads, lifecycle routing, and writes. Separate these responsibilities so the decision table selects concrete operations from scalar state and can be tested independently of Kubernetes objects.

Consolidate committed and created Job reads. Add regression tests for receipt ordering, persistence failures, and the fresh Job identity check after legacy adoption.

## Related Issues

None.

## Type of Change

- [x] Refactor (code improvement/cleanup)

## Risk and Compatibility

The refactor preserves the durable execution receipts, lock renewal, requeues, and post-restore recovery sequence. Missing or identity-inconsistent Jobs still become Unknown and are not recreated. No API, CRD, Helm, or RBAC changes.

## Verification

- `devenv test`, `operator:bootstrap`, and `operator:doctor` passed.
- `make lint-ci verify-fmt test-ci` passed: 3,711 tests, four expected skips, and 70.71% internal coverage against the 68% floor.
- Race tests passed for the restore service, app, and controller packages. Restore envtest integration tests also passed.
- Architecture checks, dependency reports, generated artifacts, API/CRD compatibility, workflow checks, and vendor verification passed.
- The curated fuzz sweep, OpenBao configuration compatibility matrix, documentation build, and Helm checks passed.
- Source security checks and all four built-image security scans passed.

## Reviewer Notes

Focus on creation receipts preceding terminal handling, successful Job receipts preceding recovery, and legacy adoption re-reading the Job after persisting its identity.

The aggregate local `ci-core` run encountered Docker disk exhaustion. After reclaiming build cache created by the validation run, the affected builds and remaining checks passed in separate runs. Cluster E2E was not run locally.

Documentation and generated artifacts need no changes because the public behavior and API remain unchanged.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
