### PR TITLE
refactor(status): enforce the adminops read-back contract

### DIFF
--- a/internal/app/openbaocluster/adminopsstatus/mutate.go
+++ b/internal/app/openbaocluster/adminopsstatus/mutate.go
@@ -19,7 +19,9 @@ type MutateOptions struct {
 }
 
 // MutateWithReader applies an SSA read-modify-apply update for the
-// adminops-owned status plane and syncs cluster from the persisted result.
+// adminops-owned status plane and syncs its fields and resource version from
+// the read-back result. On error, cluster is unchanged, even if the apply
+// succeeded and only the read-back failed.
 func MutateWithReader(
 	ctx context.Context,
 	reader client.Reader,

--- a/internal/app/openbaocluster/adminopsstatus/mutate_test.go
+++ b/internal/app/openbaocluster/adminopsstatus/mutate_test.go
@@ -1,0 +1,80 @@
+package adminopsstatus
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestMutateWithReader_SyncsCallerOnlyAfterSuccessfulReadBack(t *testing.T) {
+	t.Parallel()
+	for _, readFails := range []bool{false, true} {
+		name := "successful read-back updates only owned fields and resource version"
+		if readFails {
+			name = "failed read-back leaves caller unchanged"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			scheme := runtime.NewScheme()
+			if err := openbaov1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			stored := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "readback", Namespace: "default", ResourceVersion: "1"},
+				Status:     openbaov1alpha1.OpenBaoClusterStatus{CurrentVersion: "2.5.0"},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stored).WithObjects(stored).Build()
+			readErr := errors.New("read-back unavailable")
+			reads := 0
+			reader := interceptor.NewClient(c, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					reads++
+					if reads == 2 && readFails {
+						return readErr
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			})
+			cluster := stored.DeepCopy()
+			cluster.Status.CurrentVersion = "2.4.4"
+			before := cluster.DeepCopy()
+			err := MutateWithReader(context.Background(), reader, c, cluster,
+				func(obj *openbaov1alpha1.OpenBaoCluster) error {
+					obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "persist-me"}
+					return nil
+				}, MutateOptions{})
+
+			persisted := &openbaov1alpha1.OpenBaoCluster{}
+			if getErr := c.Get(context.Background(), client.ObjectKeyFromObject(cluster), persisted); getErr != nil {
+				t.Fatal(getErr)
+			}
+			if persisted.Status.Backup == nil || persisted.Status.Backup.LastFailureReason != "persist-me" {
+				t.Fatalf("persisted backup = %+v, want successful apply", persisted.Status.Backup)
+			}
+			want := before.DeepCopy()
+			if readFails {
+				if !errors.Is(err, readErr) {
+					t.Fatalf("error = %v, want read-back error", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				want.ResourceVersion = persisted.ResourceVersion
+				want.Status.Backup = persisted.Status.Backup
+			}
+			if !reflect.DeepEqual(cluster, want) {
+				t.Fatalf("caller = %+v, want %+v", cluster, want)
+			}
+		})
+	}
+}

--- a/internal/platform/statusapply/openbaocluster_mutate_apply.go
+++ b/internal/platform/statusapply/openbaocluster_mutate_apply.go
@@ -20,6 +20,8 @@ type OpenBaoClusterAdminOpsStatusMutator func(*openbaov1alpha1.OpenBaoCluster) e
 // read-before-write and read-after-write freshness. A resource-version conflict
 // repeats the fresh read and mutation before another apply attempt. Callers
 // should pass an uncached APIReader when immediate apiserver visibility matters.
+// The result is the object read after the apply, which can include concurrent
+// updates. A read-back failure returns an error even though the apply succeeded.
 func MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(
 	ctx context.Context,
 	reader client.Reader,
@@ -41,14 +43,13 @@ func MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(
 		reader = c
 	}
 
-	var current, desired *openbaov1alpha1.OpenBaoCluster
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		current = &openbaov1alpha1.OpenBaoCluster{}
+		current := &openbaov1alpha1.OpenBaoCluster{}
 		if err := reader.Get(ctx, key, current); err != nil {
 			return fmt.Errorf("failed to get cluster %s/%s before adminops status apply: %w", key.Namespace, key.Name, err)
 		}
 
-		desired = current.DeepCopy()
+		desired := current.DeepCopy()
 		if err := mutate(desired); err != nil {
 			return err
 		}
@@ -60,36 +61,7 @@ func MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(
 
 	updated := &openbaov1alpha1.OpenBaoCluster{}
 	if err := reader.Get(ctx, key, updated); err != nil {
-		if desired.Status.Upgrade == nil || upgradeFailureFieldsCleared(current, desired) {
-			// Fake client SSA does not reliably materialize omission-based clears on readback.
-			// Return desired status for clear-oriented flows to keep callers deterministic.
-			return desired, nil
-		}
 		return nil, fmt.Errorf("failed to get cluster %s/%s after adminops status apply: %w", key.Namespace, key.Name, err)
 	}
-	if desired.Status.Upgrade == nil || upgradeFailureFieldsCleared(current, desired) {
-		desired.ResourceVersion = updated.ResourceVersion
-		return desired, nil
-	}
 	return updated, nil
-}
-
-func upgradeFailureFieldsCleared(current, desired *openbaov1alpha1.OpenBaoCluster) bool {
-	if current == nil || desired == nil || current.Status.Upgrade == nil || desired.Status.Upgrade == nil {
-		return false
-	}
-
-	currentFailure := current.Status.Upgrade.Failure
-	desiredFailure := desired.Status.Upgrade.Failure
-	if currentFailure != nil && desiredFailure == nil {
-		return true
-	}
-	if currentFailure != nil && desiredFailure != nil && currentFailure.At != nil && desiredFailure.At == nil {
-		return true
-	}
-	if current.Status.Upgrade.LastStepDownTime != nil && desired.Status.Upgrade.LastStepDownTime == nil {
-		return true
-	}
-
-	return false
 }

--- a/internal/platform/statusapply/openbaocluster_mutate_apply_test.go
+++ b/internal/platform/statusapply/openbaocluster_mutate_apply_test.go
@@ -79,6 +79,107 @@ func (r *stagedReader) List(ctx context.Context, list client.ObjectList, opts ..
 	return r.then.List(ctx, list, opts...)
 }
 
+func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_ReadBackContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		withoutUpgrade bool
+		mutate         OpenBaoClusterAdminOpsStatusMutator
+	}{
+		{name: "upgrade unchanged", mutate: func(*openbaov1alpha1.OpenBaoCluster) error { return nil }},
+		{name: "upgrade cleared", mutate: func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.Upgrade = nil
+			return nil
+		}},
+		{name: "failure cleared", mutate: func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.Upgrade.Failure = nil
+			return nil
+		}},
+		{name: "failure timestamp cleared", mutate: func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.Upgrade.Failure.At = nil
+			return nil
+		}},
+		{name: "step-down timestamp cleared", mutate: func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.Upgrade.LastStepDownTime = nil
+			return nil
+		}},
+		{name: "no upgrade", withoutUpgrade: true, mutate: func(*openbaov1alpha1.OpenBaoCluster) error { return nil }},
+	}
+
+	for _, tt := range tests {
+		for _, readFails := range []bool{false, true} {
+			outcome := "observed result"
+			if readFails {
+				outcome = "read error"
+			}
+			t.Run(tt.name+"/"+outcome, func(t *testing.T) {
+				t.Parallel()
+				now := metav1.Now()
+				cluster := &openbaov1alpha1.OpenBaoCluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "readback", Namespace: "default"},
+					Status: openbaov1alpha1.OpenBaoClusterStatus{
+						Upgrade: &openbaov1alpha1.UpgradeProgress{
+							TargetVersion:    concurrentTargetVersion,
+							Failure:          &openbaov1alpha1.ControllerErrorStatus{Reason: "failed", At: &now},
+							LastStepDownTime: &now,
+						},
+					},
+				}
+				if tt.withoutUpgrade {
+					cluster.Status.Upgrade = nil
+				}
+				c := fake.NewClientBuilder().WithScheme(newOpenBaoClusterStatusTestScheme(t)).
+					WithStatusSubresource(cluster).WithObjects(cluster).Build()
+				readErr := errors.New("read-back unavailable")
+				var observed *openbaov1alpha1.OpenBaoCluster
+				reader := &stagedReader{first: c, then: interceptor.NewClient(c, interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if readFails {
+							return readErr
+						}
+						if err := c.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						// Model another writer's update between the apply and read-back.
+						updated := obj.(*openbaov1alpha1.OpenBaoCluster)
+						updated.ResourceVersion = "later-version"
+						updated.Status.Backup.LastFailureReason = "concurrent update"
+						observed = updated.DeepCopy()
+						return nil
+					},
+				})}
+				mutations := 0
+				updated, err := MutateAndApplyOpenBaoClusterAdminOpsStatusWithReader(
+					context.Background(), reader, c, client.ObjectKeyFromObject(cluster),
+					func(obj *openbaov1alpha1.OpenBaoCluster) error {
+						mutations++
+						obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: persistMe}
+						return tt.mutate(obj)
+					}, OpenBaoClusterAdminOpsStatusApplyOptions{},
+				)
+				if readFails {
+					if !errors.Is(err, readErr) || updated != nil {
+						t.Fatalf("result = (%+v, %v), want (nil, read-back error)", updated, err)
+					}
+				} else if err != nil || !reflect.DeepEqual(updated, observed) {
+					t.Fatalf("result = (%+v, %v), want observed object %+v", updated, err, observed)
+				}
+				if mutations != 1 {
+					t.Fatalf("mutation calls = %d, want 1", mutations)
+				}
+				stored := &openbaov1alpha1.OpenBaoCluster{}
+				if err := c.Get(context.Background(), client.ObjectKeyFromObject(cluster), stored); err != nil {
+					t.Fatal(err)
+				}
+				if stored.Status.Backup == nil || stored.Status.Backup.LastFailureReason != persistMe {
+					t.Fatalf("stored backup = %+v, want successful apply even if read-back fails", stored.Status.Backup)
+				}
+			})
+		}
+	}
+}
+
 func TestMutateAndApplyOpenBaoClusterAdminOpsStatus_UsesLatestStateAndPreservesSiblingFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/upgrade/rolling/adminops_mutator_test.go
+++ b/internal/service/upgrade/rolling/adminops_mutator_test.go
@@ -2,12 +2,33 @@ package rolling
 
 import (
 	"context"
+	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
 )
+
+// withoutUpgradeStatus leaves upgrade fields for seedUpgradeStatus to create
+// through SSA. Fields seeded by fake.WithObjects have a different owner.
+func withoutUpgradeStatus(cluster *openbaov1alpha1.OpenBaoCluster) *openbaov1alpha1.OpenBaoCluster {
+	stored := cluster.DeepCopy()
+	stored.Status.Upgrade = nil
+	return stored
+}
+
+func seedUpgradeStatus(t *testing.T, c client.Client, cluster *openbaov1alpha1.OpenBaoCluster) {
+	t.Helper()
+	progress := cluster.Status.Upgrade.DeepCopy()
+	if err := adminopsstatus.MutateWithReader(context.Background(), c, c, cluster,
+		func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			obj.Status.Upgrade = progress.DeepCopy()
+			return nil
+		}, adminopsstatus.MutateOptions{}); err != nil {
+		t.Fatalf("seed upgrade status: %v", err)
+	}
+}
 
 func testAdminOpsMutator(c client.Client) adminOpsStatusMutator {
 	return func(

--- a/internal/service/upgrade/rolling/events_test.go
+++ b/internal/service/upgrade/rolling/events_test.go
@@ -211,10 +211,11 @@ func TestPrepareFailedUpgradeRetry_EmitsRetryEvents(t *testing.T) {
 	recorder := events.NewFakeRecorder(10)
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(cluster, staleJob, sts, staleTargetPod).
+		WithObjects(withoutUpgradeStatus(cluster), staleJob, sts, staleTargetPod).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
 		WithReturnManagedFields().
 		Build()
+	seedUpgradeStatus(t, k8sClient, cluster)
 	manager := &Manager{
 		client:          k8sClient,
 		reader:          k8sClient,

--- a/internal/service/upgrade/rolling/lifecycle_test.go
+++ b/internal/service/upgrade/rolling/lifecycle_test.go
@@ -311,8 +311,9 @@ func TestPatchFinalizedUpgradeStatus_ClearsUpgradeWithoutTouchingCurrentVersion(
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
-		WithObjects(cluster).
+		WithObjects(withoutUpgradeStatus(cluster)).
 		Build()
+	seedUpgradeStatus(t, c, cluster)
 	mgr := newManagerWithClientFactory(c, scheme, backup.NewUpgradeStrategyRuntime(c, scheme), nil, nil).
 		WithReader(c).
 		WithAdminOpsStatusMutator(testAdminOpsMutator(c))

--- a/internal/service/upgrade/rolling/retry_test.go
+++ b/internal/service/upgrade/rolling/retry_test.go
@@ -374,7 +374,7 @@ func TestPatchRetryStatusSSA_ApplyPayloadOmitsClearedFailureFields(t *testing.T)
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
-		WithObjects(stored.DeepCopy()).
+		WithObjects(withoutUpgradeStatus(stored)).
 		WithInterceptorFuncs(interceptor.Funcs{
 			SubResourceApply: func(ctx context.Context, c client.Client, subResource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 				payload, err := json.Marshal(obj)
@@ -393,6 +393,7 @@ func TestPatchRetryStatusSSA_ApplyPayloadOmitsClearedFailureFields(t *testing.T)
 		adminOpsMutator: testAdminOpsMutator(k8sClient),
 	}
 	cluster := stored.DeepCopy()
+	seedUpgradeStatus(t, k8sClient, cluster)
 	if err := manager.patchRetryStatusSSA(context.Background(), cluster, "retry-now"); err != nil {
 		t.Fatalf("patchRetryStatusSSA() error = %v", err)
 	}
@@ -484,8 +485,9 @@ func TestPrepareFailedUpgradeRetry_DeletesStaleCompletedPod(t *testing.T) {
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
-		WithObjects(cluster, sts, currentTargetPod, staleCompletedPod).
+		WithObjects(withoutUpgradeStatus(cluster), sts, currentTargetPod, staleCompletedPod).
 		Build()
+	seedUpgradeStatus(t, k8sClient, cluster)
 	manager := &Manager{
 		client:          k8sClient,
 		reader:          k8sClient,
@@ -757,11 +759,12 @@ func TestPrepareFailedUpgradeRetry_SuccessClearsFailureAndRemovesRetrySignal(t *
 			builder := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
-				WithObjects(cluster, staleJob, sts, staleTargetPod)
+				WithObjects(withoutUpgradeStatus(cluster), staleJob, sts, staleTargetPod)
 			if tt.withManagedFields {
 				builder = builder.WithReturnManagedFields()
 			}
 			k8sClient := builder.Build()
+			seedUpgradeStatus(t, k8sClient, cluster)
 
 			mgr := &Manager{
 				client:          k8sClient,

--- a/test/integration/adminops_status_test.go
+++ b/test/integration/adminops_status_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+)
+
+func TestAdminOpsStatusReadBackAfterUpgradeClears(t *testing.T) {
+	tests := []struct {
+		name  string
+		clear func(*openbaov1alpha1.UpgradeProgress) *openbaov1alpha1.UpgradeProgress
+	}{
+		{name: "upgrade", clear: func(*openbaov1alpha1.UpgradeProgress) *openbaov1alpha1.UpgradeProgress {
+			return nil
+		}},
+		{name: "failure", clear: func(progress *openbaov1alpha1.UpgradeProgress) *openbaov1alpha1.UpgradeProgress {
+			progress.Failure = nil
+			return progress
+		}},
+		{name: "failure-time", clear: func(progress *openbaov1alpha1.UpgradeProgress) *openbaov1alpha1.UpgradeProgress {
+			progress.Failure.At = nil
+			return progress
+		}},
+		{name: "step-down-time", clear: func(progress *openbaov1alpha1.UpgradeProgress) *openbaov1alpha1.UpgradeProgress {
+			progress.LastStepDownTime = nil
+			return progress
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := createMinimalCluster(t, newTestNamespace(t), "adminops-clear-"+tt.name)
+			updateClusterStatus(t, cluster, func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+				status.CurrentVersion = testOpenBaoVersion244
+				status.Initialized = true
+				status.OperationLock = &openbaov1alpha1.OperationLockStatus{
+					Operation: openbaov1alpha1.ClusterOperationUpgrade,
+					Holder:    "test/upgrade",
+				}
+			})
+
+			// Seed through the shared field manager so it owns the fields to clear.
+			now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+			if err := adminopsstatus.MutateWithReader(ctx, k8sClient, k8sClient, cluster,
+				func(obj *openbaov1alpha1.OpenBaoCluster) error {
+					obj.Status.Upgrade = &openbaov1alpha1.UpgradeProgress{
+						FromVersion:      testOpenBaoVersion244,
+						TargetVersion:    "2.5.0",
+						CurrentPartition: 2,
+						StartedAt:        &now,
+						CompletedPods:    []int32{2},
+						Failure: &openbaov1alpha1.ControllerErrorStatus{
+							Reason: "UpgradeFailed", Message: "step-down timed out", At: &now,
+						},
+						LastStepDownTime: &now,
+					}
+					obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "preserve-backup"}
+					return nil
+				}, adminopsstatus.MutateOptions{}); err != nil {
+				t.Fatalf("seed adminops status: %v", err)
+			}
+
+			beforeVersion := cluster.ResourceVersion
+			wantStatus := cluster.Status.DeepCopy()
+			wantStatus.Upgrade = tt.clear(wantStatus.Upgrade)
+			if err := adminopsstatus.MutateWithReader(ctx, k8sClient, k8sClient, cluster,
+				func(obj *openbaov1alpha1.OpenBaoCluster) error {
+					obj.Status.Upgrade = tt.clear(obj.Status.Upgrade)
+					return nil
+				}, adminopsstatus.MutateOptions{}); err != nil {
+				t.Fatalf("clear upgrade status: %v", err)
+			}
+
+			stored := &openbaov1alpha1.OpenBaoCluster{}
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored); err != nil {
+				t.Fatalf("read persisted status: %v", err)
+			}
+			if !reflect.DeepEqual(stored.Status, *wantStatus) {
+				t.Fatalf("persisted status = %+v, want %+v", stored.Status, *wantStatus)
+			}
+			if !reflect.DeepEqual(cluster.Status, stored.Status) {
+				t.Fatalf("caller status = %+v, want persisted status %+v", cluster.Status, stored.Status)
+			}
+			if cluster.ResourceVersion != stored.ResourceVersion || cluster.ResourceVersion == beforeVersion {
+				t.Fatalf("caller resourceVersion = %q, stored = %q, before clear = %q",
+					cluster.ResourceVersion, stored.ResourceVersion, beforeVersion)
+			}
+		})
+	}
+}
+
+func TestAdminOpsStatusReadBackPreservesFieldsOwnedByAnotherWriter(t *testing.T) {
+	cluster := createMinimalCluster(t, newTestNamespace(t), "adminops-foreign-upgrade")
+	cluster.Status.Upgrade = &openbaov1alpha1.UpgradeProgress{
+		FromVersion: testOpenBaoVersion244, TargetVersion: "2.5.0", CurrentPartition: 2,
+	}
+	if err := k8sClient.Status().Update(ctx, cluster, client.FieldOwner("other-status-writer")); err != nil {
+		t.Fatalf("seed upgrade status with another owner: %v", err)
+	}
+	wantUpgrade := cluster.Status.Upgrade.DeepCopy()
+
+	if err := adminopsstatus.MutateWithReader(ctx, k8sClient, k8sClient, cluster,
+		func(obj *openbaov1alpha1.OpenBaoCluster) error {
+			// Omission does not remove fields owned by another writer.
+			obj.Status.Upgrade = nil
+			obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "persist-backup"}
+			return nil
+		}, adminopsstatus.MutateOptions{}); err != nil {
+		t.Fatalf("apply adminops status: %v", err)
+	}
+
+	stored := &openbaov1alpha1.OpenBaoCluster{}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored); err != nil {
+		t.Fatalf("read persisted status: %v", err)
+	}
+	if !reflect.DeepEqual(stored.Status.Upgrade, wantUpgrade) {
+		t.Fatalf("persisted upgrade = %+v, want other writer's status %+v", stored.Status.Upgrade, wantUpgrade)
+	}
+	if stored.Status.Backup == nil || stored.Status.Backup.LastFailureReason != "persist-backup" {
+		t.Fatalf("persisted backup = %+v, want successful apply", stored.Status.Backup)
+	}
+	if !reflect.DeepEqual(cluster.Status, stored.Status) || cluster.ResourceVersion != stored.ResourceVersion {
+		t.Fatalf("caller status = %+v (version %s), want persisted status %+v (version %s)",
+			cluster.Status, cluster.ResourceVersion, stored.Status, stored.ResourceVersion)
+	}
+}

--- a/website/content/docs/architecture/invariants-and-boundaries.md
+++ b/website/content/docs/architecture/invariants-and-boundaries.md
@@ -86,6 +86,11 @@ A writer applies only its plane. Within the shared AdminOps plane, a writer must
 concern, and apply the complete plane; omitting a sibling field with the same field manager can clear it. Read directly
 from the API after a write when the next decision depends on the committed value because the controller cache can lag.
 
+The AdminOps mutation gateway returns the object read after the apply, including any concurrent updates visible to that
+read. It does not substitute the intended state for the observed state. If read-back fails, it returns an error even
+though the apply succeeded. The application wrapper updates the caller's AdminOps fields and resource version only
+after a successful read-back; it leaves other fields unchanged.
+
 ## Account for tenancy watch boundaries
 
 Single-tenant mode can watch owned child resources in the operator namespace. Multi-tenant mode avoids cluster-wide


### PR DESCRIPTION
## Summary

The AdminOps status gateway could return its intended state instead of the API read-back when upgrade fields were absent or cleared. Those paths could also hide a read-back error after a successful apply.

Return the observed object consistently and propagate read-back errors. Remove the upgrade-specific fallback, document the contract, and seed rolling-upgrade test fixtures through SSA so AdminOps owns the fields it clears.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

A read-back failure now returns an error even when the write succeeded. The application wrapper leaves its caller object unchanged on error and updates only AdminOps fields and the resource version on success. SSA write ownership and conflict handling remain unchanged. No API, CRD, Helm, or RBAC changes.

## Verification

- `devenv shell -- make lint-ci verify-fmt test-ci report-internal-deps`: passed; 3,733 tests, 4 skipped, 70.86% internal coverage.
- Targeted race tests for `internal/platform/statusapply` and `internal/app/openbaocluster/adminopsstatus`: passed.
- Envtest coverage verifies owned upgrade-field clears, sibling preservation, and read-back of fields retained by another owner.
- Candidate manager image build and the Kind E2E scenario `recovers a failed rolling upgrade after a retry request clears stale state`: passed through successful upgrade completion.

The full local `ci-core` aggregate was not run because of workstation disk limits. The remaining gates must pass in PR CI before merge.

## Reviewer Notes

Read-back can include concurrent updates. A successful apply does not guarantee that omission removed a field owned by another writer; callers now see the stored result in that case.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
