### PR TITLE
refactor(status): clarify adminops ownership policies

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -17,7 +17,7 @@ See [Architecture Documentation](../../website/content/docs/architecture/_index.
 - `L4` Services/managers:
   `internal/service/{backup,bootstrap,certs,configuration,identity,init,networking,opslifecycle,provisioner,restore,upgrade,workload,workloadidentity}`
 - `L5` Ports/contracts:
-  `internal/port/{auth,backup,blobstore,imageverify,initmanager,openbao,security,workload}`
+  `internal/port/{adminops,auth,backup,blobstore,imageverify,initmanager,openbao,security,workload}`
 - `L6` Adapters/integrations:
   `internal/adapter/{auth,cluster,config,kube,openbao,probe,raft,revision,security,storage,storageenv}`
 - `L7` Platform/cross-cutting:

--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -185,17 +185,7 @@ func buildReconcilers(deps Dependencies) reconcilerPlan {
 	if strategyReader == nil {
 		strategyReader = deps.Client
 	}
-	adminOpsMutator := func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, deps.APIReader, deps.Client, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	}
+	adminOpsMutator := adminopsstatus.NewMutator(deps.APIReader, deps.Client)
 
 	return reconcilerPlan{
 		upgradeReconcilers: []subReconciler{

--- a/internal/app/openbaocluster/adminopsstatus/mutate.go
+++ b/internal/app/openbaocluster/adminopsstatus/mutate.go
@@ -10,12 +10,15 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/statusapply"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
 
-// MutateOptions controls how adminops-plane SSA writes handle ownership.
-type MutateOptions struct {
-	ForceOwnership  bool
-	RetryOnConflict bool
+// NewMutator binds the shared AdminOps status writer to its Kubernetes reader
+// and client. Use an uncached APIReader for immediate read-back visibility.
+func NewMutator(reader client.Reader, c client.Client) adminops.StatusMutator {
+	return func(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, mutate func(*openbaov1alpha1.OpenBaoCluster) error, ownership adminops.OwnershipPolicy) error {
+		return MutateWithReader(ctx, reader, c, cluster, mutate, ownership)
+	}
 }
 
 // MutateWithReader applies an SSA read-modify-apply update for the
@@ -28,13 +31,21 @@ func MutateWithReader(
 	c client.Client,
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-	opts MutateOptions,
+	ownership adminops.OwnershipPolicy,
 ) error {
 	if cluster == nil {
 		return nil
 	}
 	if mutate == nil {
 		return fmt.Errorf("mutate function is required")
+	}
+	var forceOwnership bool
+	switch ownership {
+	case adminops.RespectOwnership, adminops.ForceOwnershipOnConflict:
+	case adminops.ForceOwnership:
+		forceOwnership = true
+	default:
+		return fmt.Errorf("unsupported adminops ownership policy %d", ownership)
 	}
 
 	key := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
@@ -44,8 +55,8 @@ func MutateWithReader(
 		})
 	}
 
-	updated, err := applyAdminOps(opts.ForceOwnership)
-	if err != nil && apierrors.IsConflict(err) && opts.RetryOnConflict && !opts.ForceOwnership {
+	updated, err := applyAdminOps(forceOwnership)
+	if err != nil && apierrors.IsConflict(err) && ownership == adminops.ForceOwnershipOnConflict {
 		updated, err = applyAdminOps(true)
 	}
 	if err != nil {

--- a/internal/app/openbaocluster/adminopsstatus/mutate_test.go
+++ b/internal/app/openbaocluster/adminopsstatus/mutate_test.go
@@ -6,16 +6,107 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
 
-func TestMutateWithReader_SyncsCallerOnlyAfterSuccessfulReadBack(t *testing.T) {
+func TestMutateWithReader_OwnershipPolicy(t *testing.T) {
+	t.Parallel()
+	versionConflict := apierrors.NewConflict(schema.GroupResource{Group: "openbao.org", Resource: "openbaoclusters"}, "ownership", errors.New("stale resource version"))
+	ownershipConflict := apierrors.NewApplyConflict([]metav1.StatusCause{{Type: metav1.CauseTypeFieldManagerConflict, Field: ".status.backup.lastFailureReason"}}, "another manager owns the field")
+	unavailable := errors.New("API unavailable")
+	attempts := retry.DefaultRetry.Steps
+	tests := []struct {
+		name         string
+		ownership    adminops.OwnershipPolicy
+		applyErr     error
+		failures     int
+		wantUnforced int
+		wantForced   int
+		wantErr      error
+	}{
+		{name: "respect retries stale versions", applyErr: versionConflict, failures: 1, wantUnforced: 2},
+		{name: "respect returns ownership conflicts", applyErr: ownershipConflict, failures: attempts, wantUnforced: attempts, wantErr: ownershipConflict},
+		{name: "fallback succeeds without force", ownership: adminops.ForceOwnershipOnConflict, wantUnforced: 1},
+		{name: "fallback retries stale versions without force", ownership: adminops.ForceOwnershipOnConflict, applyErr: versionConflict, failures: 1, wantUnforced: 2},
+		{name: "fallback forces after ownership conflicts", ownership: adminops.ForceOwnershipOnConflict, applyErr: ownershipConflict, failures: attempts, wantUnforced: attempts, wantForced: 1},
+		{name: "fallback also forces after exhausted version conflicts", ownership: adminops.ForceOwnershipOnConflict, applyErr: versionConflict, failures: attempts, wantUnforced: attempts, wantForced: 1},
+		{name: "fallback stops after forced conflicts", ownership: adminops.ForceOwnershipOnConflict, applyErr: versionConflict, failures: 2 * attempts, wantUnforced: attempts, wantForced: attempts, wantErr: versionConflict},
+		{name: "fallback does not force other errors", ownership: adminops.ForceOwnershipOnConflict, applyErr: unavailable, failures: 1, wantUnforced: 1, wantErr: unavailable},
+		{name: "force applies immediately", ownership: adminops.ForceOwnership, wantForced: 1},
+		{name: "force retries stale versions", ownership: adminops.ForceOwnership, applyErr: versionConflict, failures: 1, wantForced: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scheme := runtime.NewScheme()
+			require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+			cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Name: "ownership", Namespace: "default"}}
+			var forces []bool
+			reads, mutations := 0, 0
+			c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(cluster).WithObjects(cluster.DeepCopy()).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						reads++
+						return c.Get(ctx, key, obj, opts...)
+					},
+					SubResourceApply: func(ctx context.Context, c client.Client, subresource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+						options := (&client.SubResourceApplyOptions{}).ApplyOpts(opts)
+						forces = append(forces, options.Force != nil && *options.Force)
+						if len(forces) <= tt.failures {
+							return tt.applyErr
+						}
+						return c.SubResource(subresource).Apply(ctx, obj, opts...)
+					},
+				}).Build()
+			before := cluster.DeepCopy()
+			err := MutateWithReader(t.Context(), c, c, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				mutations++
+				require.Equal(t, mutations, reads, "each mutation needs a fresh read")
+				obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "persisted"}
+				return nil
+			}, tt.ownership)
+
+			require.Len(t, forces, tt.wantUnforced+tt.wantForced)
+			for i, force := range forces {
+				require.Equal(t, i >= tt.wantUnforced, force, "force ownership on attempt %d", i+1)
+			}
+			require.Equal(t, len(forces), mutations)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Equal(t, before, cluster)
+				require.Equal(t, mutations, reads)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cluster.Status.Backup)
+				require.Equal(t, "persisted", cluster.Status.Backup.LastFailureReason)
+				require.NotEmpty(t, cluster.ResourceVersion)
+				require.Equal(t, mutations+1, reads, "successful writes require read-back")
+			}
+		})
+	}
+}
+
+func TestMutateWithReader_RejectsUnknownOwnershipPolicy(t *testing.T) {
+	t.Parallel()
+	err := MutateWithReader(t.Context(), nil, nil, &openbaov1alpha1.OpenBaoCluster{}, func(*openbaov1alpha1.OpenBaoCluster) error {
+		t.Fatal("invalid policy must be rejected before mutation")
+		return nil
+	}, adminops.OwnershipPolicy(255))
+	require.ErrorContains(t, err, "unsupported adminops ownership policy 255")
+}
+
+func TestNewMutator_SyncsCallerOnlyAfterSuccessfulReadBack(t *testing.T) {
 	t.Parallel()
 	for _, readFails := range []bool{false, true} {
 		name := "successful read-back updates only owned fields and resource version"
@@ -47,11 +138,12 @@ func TestMutateWithReader_SyncsCallerOnlyAfterSuccessfulReadBack(t *testing.T) {
 			cluster := stored.DeepCopy()
 			cluster.Status.CurrentVersion = "2.4.4"
 			before := cluster.DeepCopy()
-			err := MutateWithReader(context.Background(), reader, c, cluster,
+			mutateStatus := NewMutator(reader, c)
+			err := mutateStatus(context.Background(), cluster,
 				func(obj *openbaov1alpha1.OpenBaoCluster) error {
 					obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "persist-me"}
 					return nil
-				}, MutateOptions{})
+				}, adminops.RespectOwnership)
 
 			persisted := &openbaov1alpha1.OpenBaoCluster{}
 			if getErr := c.Get(context.Background(), client.ObjectKeyFromObject(cluster), persisted); getErr != nil {

--- a/internal/app/openbaocluster/patch.go
+++ b/internal/app/openbaocluster/patch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/statusapply"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
 
 // PatchStatusOwnedFields patches only status-controller owned status fields.
@@ -153,7 +154,7 @@ func PatchAdminOpsOwnedFieldsWithReader(
 		obj.Status.BreakGlass = cluster.Status.BreakGlass
 		obj.Status.AdminOps = adminOps
 		return nil
-	}, adminopsstatus.MutateOptions{RetryOnConflict: true})
+	}, adminops.ForceOwnershipOnConflict)
 	if err != nil {
 		return fmt.Errorf("failed to patch adminops status (%s) for OpenBaoCluster %s/%s: %w", reason, cluster.Namespace, cluster.Name, err)
 	}

--- a/internal/app/openbaorestore/restore.go
+++ b/internal/app/openbaorestore/restore.go
@@ -66,17 +66,7 @@ func (a restoreManagerAdapter) Reconcile(ctx context.Context, logger logr.Logger
 
 // NewRestoreReconciler constructs the restore reconciler used by the controller.
 func NewRestoreReconciler(deps RestoreDependencies) RestoreReconciler {
-	adminOpsMutator := func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, deps.APIReader, deps.Client, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	}
+	adminOpsMutator := adminopsstatus.NewMutator(deps.APIReader, deps.Client)
 
 	return restoreManagerAdapter{
 		manager: restore.NewManager(

--- a/internal/port/adminops/status.go
+++ b/internal/port/adminops/status.go
@@ -1,0 +1,35 @@
+// Package adminops defines the shared status persistence contract for
+// administrative operations.
+package adminops
+
+import (
+	"context"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+// OwnershipPolicy controls when an AdminOps status write can take SSA field
+// ownership. Conflict retries still use a fresh read under every policy.
+type OwnershipPolicy uint8
+
+const (
+	// RespectOwnership never forces field ownership.
+	RespectOwnership OwnershipPolicy = iota
+	// ForceOwnershipOnConflict starts without force. If conflict retries are
+	// exhausted, it repeats the read-mutate-apply flow with forced ownership.
+	// This applies to both resource-version and field-ownership conflicts.
+	ForceOwnershipOnConflict
+	// ForceOwnership forces field ownership from the first apply attempt.
+	ForceOwnership
+)
+
+// StatusMutator persists the full AdminOps status plane and syncs its fields
+// and resource version on cluster from the read-back result. On error, cluster
+// is unchanged, even if the apply succeeded and only the read-back failed.
+// The callback can run more than once and must only mutate its supplied object.
+type StatusMutator func(
+	ctx context.Context,
+	cluster *openbaov1alpha1.OpenBaoCluster,
+	mutate func(*openbaov1alpha1.OpenBaoCluster) error,
+	ownership OwnershipPolicy,
+) error

--- a/internal/service/backup/manager.go
+++ b/internal/service/backup/manager.go
@@ -3,25 +3,17 @@
 package backup
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 )
-
-type adminOpsStatusMutator func(
-	ctx context.Context,
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-	forceOwnership bool,
-) error
 
 const backupOperationLockHolder = constants.ControllerNameOpenBaoCluster + "/backup"
 
@@ -38,7 +30,7 @@ type Manager struct {
 	recorder              events.EventRecorder
 	clientConfig          portopenbao.ClientConfig
 	operatorImageVerifier imageverify.Verifier
-	adminOpsMutator       adminOpsStatusMutator
+	adminOpsMutator       adminops.StatusMutator
 	Platform              string
 }
 
@@ -69,7 +61,7 @@ func (m *Manager) WithReader(reader client.Reader) *Manager {
 }
 
 // WithAdminOpsStatusMutator configures the adminops-plane status persistence hook.
-func (m *Manager) WithAdminOpsStatusMutator(mutator adminOpsStatusMutator) *Manager {
+func (m *Manager) WithAdminOpsStatusMutator(mutator adminops.StatusMutator) *Manager {
 	if mutator != nil {
 		m.adminOpsMutator = mutator
 	}

--- a/internal/service/backup/manager_status.go
+++ b/internal/service/backup/manager_status.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
 
 // patchStatusSSA updates the backup status using Server-Side Apply.
@@ -19,7 +20,7 @@ func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.O
 	return m.adminOpsMutator(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
 		obj.Status.Backup = cluster.Status.Backup
 		return nil
-	}, false)
+	}, adminops.ForceOwnershipOnConflict)
 }
 
 func (m *Manager) recordBackupAttempt(

--- a/internal/service/backup/manager_test_helpers_test.go
+++ b/internal/service/backup/manager_test_helpers_test.go
@@ -63,17 +63,7 @@ func newBackupManager(k8sClient client.Client) *Manager {
 }
 
 func withTestAdminOpsStatusPersistence(manager *Manager, k8sClient client.Client) *Manager {
-	return manager.WithReader(k8sClient).WithAdminOpsStatusMutator(func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, k8sClient, k8sClient, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	})
+	return manager.WithReader(k8sClient).WithAdminOpsStatusMutator(adminopsstatus.NewMutator(k8sClient, k8sClient))
 }
 
 func newBackupJobForCluster(cluster *openbaov1alpha1.OpenBaoCluster, name string, createdAt time.Time) *batchv1.Job {

--- a/internal/service/restore/manager.go
+++ b/internal/service/restore/manager.go
@@ -3,25 +3,17 @@
 package restore
 
 import (
-	"context"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 )
-
-type adminOpsStatusMutator func(
-	ctx context.Context,
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-	forceOwnership bool,
-) error
 
 const (
 	// RestoreJobNamePrefix is the prefix for restore job names.
@@ -43,13 +35,13 @@ type Manager struct {
 	scheme                *runtime.Scheme
 	recorder              events.EventRecorder
 	operatorImageVerifier imageverify.Verifier
-	adminOpsMutator       adminOpsStatusMutator
+	adminOpsMutator       adminops.StatusMutator
 	clientConfig          portopenbao.ClientConfig
 	Platform              string
 }
 
 // WithAdminOpsStatusMutator configures the adminops-plane status persistence hook.
-func (m *Manager) WithAdminOpsStatusMutator(mutator adminOpsStatusMutator) *Manager {
+func (m *Manager) WithAdminOpsStatusMutator(mutator adminops.StatusMutator) *Manager {
 	if mutator != nil {
 		m.adminOpsMutator = mutator
 	}

--- a/internal/service/restore/manager_test.go
+++ b/internal/service/restore/manager_test.go
@@ -39,17 +39,7 @@ func testLogger() logr.Logger {
 }
 
 func withTestAdminOpsStatusPersistence(manager *Manager, k8sClient client.Client) *Manager {
-	return manager.WithAdminOpsStatusMutator(func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, k8sClient, k8sClient, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	})
+	return manager.WithAdminOpsStatusMutator(adminopsstatus.NewMutator(k8sClient, k8sClient))
 }
 
 const statusSubresourceName = "status"

--- a/internal/service/restore/post_restore_restart.go
+++ b/internal/service/restore/post_restore_restart.go
@@ -13,6 +13,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	portworkload "github.com/dc-tec/openbao-operator/internal/port/workload"
 )
 
@@ -59,7 +60,7 @@ func (m *Manager) requestPostRestoreRestart(
 			}
 			return nil
 		},
-		false,
+		adminops.ForceOwnershipOnConflict,
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed to request post-restore workload restart: %w", err)
@@ -91,7 +92,7 @@ func (m *Manager) markPostRestoreRestartCompleted(
 			obj.Status.Restore.RestartCompletedAt = &completedAt
 			return nil
 		},
-		false,
+		adminops.ForceOwnershipOnConflict,
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed to record post-restore workload restart completion: %w", err)

--- a/internal/service/upgrade/bluegreen/hooks.go
+++ b/internal/service/upgrade/bluegreen/hooks.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/adapter/security"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 )
 
@@ -107,7 +108,7 @@ func (m *Manager) persistBlueGreenStatus(ctx context.Context, cluster *openbaov1
 	if err := m.adminOpsMutator(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
 		obj.Status.BlueGreen = desired
 		return nil
-	}, false); err != nil {
+	}, adminops.ForceOwnershipOnConflict); err != nil {
 		return fmt.Errorf("failed to persist blue/green validation hook status: %w", err)
 	}
 	return nil

--- a/internal/service/upgrade/bluegreen/hooks_lifecycle_test.go
+++ b/internal/service/upgrade/bluegreen/hooks_lifecycle_test.go
@@ -17,20 +17,11 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
 
-func testBlueGreenAdminOpsMutator(c client.Client) adminOpsStatusMutator {
-	return func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, c, c, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	}
+func testBlueGreenAdminOpsMutator(c client.Client) adminops.StatusMutator {
+	return adminopsstatus.NewMutator(c, c)
 }
 
 func newValidationHookLifecycleTest(t *testing.T) (*openbaov1alpha1.OpenBaoCluster, *openbaov1alpha1.ValidationHookConfig, client.Client, *Manager) {

--- a/internal/service/upgrade/bluegreen/manager.go
+++ b/internal/service/upgrade/bluegreen/manager.go
@@ -13,6 +13,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	portbackup "github.com/dc-tec/openbao-operator/internal/port/backup"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
@@ -41,16 +42,9 @@ type Manager struct {
 	clientConfig          portopenbao.ClientConfig
 	imageVerifier         imageverify.Verifier
 	operatorImageVerifier imageverify.Verifier
-	adminOpsMutator       adminOpsStatusMutator
+	adminOpsMutator       adminops.StatusMutator
 	Platform              string
 }
-
-type adminOpsStatusMutator func(
-	ctx context.Context,
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-	forceOwnership bool,
-) error
 
 // NewManager constructs a Manager.
 func NewManager(
@@ -94,7 +88,7 @@ func (m *Manager) WithReader(reader client.Reader) *Manager {
 }
 
 // WithAdminOpsStatusMutator configures the adminops-plane status persistence hook.
-func (m *Manager) WithAdminOpsStatusMutator(mutator adminOpsStatusMutator) *Manager {
+func (m *Manager) WithAdminOpsStatusMutator(mutator adminops.StatusMutator) *Manager {
 	if mutator != nil {
 		m.adminOpsMutator = mutator
 	}

--- a/internal/service/upgrade/rolling/adminops_mutator_test.go
+++ b/internal/service/upgrade/rolling/adminops_mutator_test.go
@@ -8,6 +8,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
 
 // withoutUpgradeStatus leaves upgrade fields for seedUpgradeStatus to create
@@ -25,21 +26,11 @@ func seedUpgradeStatus(t *testing.T, c client.Client, cluster *openbaov1alpha1.O
 		func(obj *openbaov1alpha1.OpenBaoCluster) error {
 			obj.Status.Upgrade = progress.DeepCopy()
 			return nil
-		}, adminopsstatus.MutateOptions{}); err != nil {
+		}, adminops.RespectOwnership); err != nil {
 		t.Fatalf("seed upgrade status: %v", err)
 	}
 }
 
-func testAdminOpsMutator(c client.Client) adminOpsStatusMutator {
-	return func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, c, c, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	}
+func testAdminOpsMutator(c client.Client) adminops.StatusMutator {
+	return adminopsstatus.NewMutator(c, c)
 }

--- a/internal/service/upgrade/rolling/lifecycle.go
+++ b/internal/service/upgrade/rolling/lifecycle.go
@@ -10,6 +10,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade/raftops"
 )
@@ -22,7 +23,7 @@ func (m *Manager) patchFinalizedUpgradeStatus(ctx context.Context, cluster *open
 	if err := m.adminOpsMutator(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
 		obj.Status.Upgrade = nil
 		return nil
-	}, true); err != nil {
+	}, adminops.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to patch finalized rolling upgrade status: %w", err)
 	}
 
@@ -41,7 +42,7 @@ func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.O
 		obj.Status.Upgrade = cluster.Status.Upgrade
 		obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
 		return nil
-	}, false); err != nil {
+	}, adminops.ForceOwnershipOnConflict); err != nil {
 		return fmt.Errorf("failed to apply adminops status plane for rolling upgrade status: %w", err)
 	}
 

--- a/internal/service/upgrade/rolling/manager.go
+++ b/internal/service/upgrade/rolling/manager.go
@@ -11,6 +11,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	portbackup "github.com/dc-tec/openbao-operator/internal/port/backup"
 	"github.com/dc-tec/openbao-operator/internal/port/imageverify"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
@@ -33,16 +34,9 @@ type Manager struct {
 	clientFactory         raftops.OpenBaoClientFactory
 	clientConfig          portopenbao.ClientConfig
 	operatorImageVerifier imageverify.Verifier
-	adminOpsMutator       adminOpsStatusMutator
+	adminOpsMutator       adminops.StatusMutator
 	Platform              string
 }
-
-type adminOpsStatusMutator func(
-	ctx context.Context,
-	cluster *openbaov1alpha1.OpenBaoCluster,
-	mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-	forceOwnership bool,
-) error
 
 // NewManager constructs a Manager that uses the provided Kubernetes client and scheme.
 func NewManager(
@@ -87,7 +81,7 @@ func (m *Manager) jobReader() client.Reader {
 }
 
 // WithAdminOpsStatusMutator configures the adminops-plane status persistence hook.
-func (m *Manager) WithAdminOpsStatusMutator(mutator adminOpsStatusMutator) *Manager {
+func (m *Manager) WithAdminOpsStatusMutator(mutator adminops.StatusMutator) *Manager {
 	if mutator != nil {
 		m.adminOpsMutator = mutator
 	}

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -15,6 +15,7 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
@@ -76,7 +77,7 @@ func (m *Manager) patchRetryStatusSSA(ctx context.Context, cluster *openbaov1alp
 		clearUpgradeFailureForRetry(obj)
 		upgrade.MarkRetryRequestHandled(&obj.Status, retryRequest)
 		return nil
-	}, true); err != nil {
+	}, adminops.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply cleared retry status: %w", err)
 	}
 	if retryFailureFieldsRemain(cluster) {

--- a/test/integration/adminops_status_test.go
+++ b/test/integration/adminops_status_test.go
@@ -8,12 +8,57 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
 )
+
+func TestAdminOpsStatusOwnershipPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		ownership adminops.OwnershipPolicy
+		conflict  bool
+	}{
+		{name: "respect", ownership: adminops.RespectOwnership, conflict: true},
+		{name: "fallback", ownership: adminops.ForceOwnershipOnConflict},
+		{name: "force", ownership: adminops.ForceOwnership},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := createMinimalCluster(t, newTestNamespace(t), "adminops-ownership-"+tt.name)
+			cluster.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "other-writer"}
+			cluster.Status.CurrentVersion = testOpenBaoVersion244
+			require.NoError(t, k8sClient.Status().Update(ctx, cluster, client.FieldOwner("other-status-writer")))
+			before := cluster.DeepCopy()
+
+			mutateStatus := adminopsstatus.NewMutator(k8sClient, k8sClient)
+			err := mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.Backup.LastFailureReason = "adminops-writer"
+				return nil
+			}, tt.ownership)
+
+			stored := &openbaov1alpha1.OpenBaoCluster{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored))
+			if tt.conflict {
+				require.True(t, apierrors.HasStatusCause(err, metav1.CauseTypeFieldManagerConflict), "expected ownership conflict, got %v", err)
+				require.Equal(t, before, cluster, "failed writes leave the caller unchanged")
+				require.Equal(t, before.Status, stored.Status)
+				require.Equal(t, before.ResourceVersion, stored.ResourceVersion)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "adminops-writer", stored.Status.Backup.LastFailureReason)
+				require.NotEqual(t, before.ResourceVersion, stored.ResourceVersion)
+				require.Equal(t, stored.Status, cluster.Status)
+				require.Equal(t, stored.ResourceVersion, cluster.ResourceVersion)
+			}
+			require.Equal(t, before.Status.CurrentVersion, stored.Status.CurrentVersion)
+		})
+	}
+}
 
 func TestAdminOpsStatusReadBackAfterUpgradeClears(t *testing.T) {
 	tests := []struct {
@@ -66,7 +111,7 @@ func TestAdminOpsStatusReadBackAfterUpgradeClears(t *testing.T) {
 					}
 					obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "preserve-backup"}
 					return nil
-				}, adminopsstatus.MutateOptions{}); err != nil {
+				}, adminops.RespectOwnership); err != nil {
 				t.Fatalf("seed adminops status: %v", err)
 			}
 
@@ -77,7 +122,7 @@ func TestAdminOpsStatusReadBackAfterUpgradeClears(t *testing.T) {
 				func(obj *openbaov1alpha1.OpenBaoCluster) error {
 					obj.Status.Upgrade = tt.clear(obj.Status.Upgrade)
 					return nil
-				}, adminopsstatus.MutateOptions{}); err != nil {
+				}, adminops.RespectOwnership); err != nil {
 				t.Fatalf("clear upgrade status: %v", err)
 			}
 
@@ -115,7 +160,7 @@ func TestAdminOpsStatusReadBackPreservesFieldsOwnedByAnotherWriter(t *testing.T)
 			obj.Status.Upgrade = nil
 			obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "persist-backup"}
 			return nil
-		}, adminopsstatus.MutateOptions{}); err != nil {
+		}, adminops.RespectOwnership); err != nil {
 		t.Fatalf("apply adminops status: %v", err)
 	}
 

--- a/test/integration/backup_manager_test.go
+++ b/test/integration/backup_manager_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -34,17 +33,7 @@ func newIntegrationBackupManager(t *testing.T) *backup.Manager {
 		portopenbao.ClientConfig{},
 		security.NewImageVerifier(logr.Discard(), k8sClient, nil),
 		"",
-	).WithReader(k8sClient).WithAdminOpsStatusMutator(func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, k8sClient, k8sClient, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	})
+	).WithReader(k8sClient).WithAdminOpsStatusMutator(adminopsstatus.NewMutator(k8sClient, k8sClient))
 }
 
 func TestBackupManager_ManualTrigger_CreatesJobAndWiring(t *testing.T) {

--- a/test/integration/restore_manager_test.go
+++ b/test/integration/restore_manager_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -232,17 +231,7 @@ func createSettledRestoreVoterStatefulSet(
 }
 
 func withIntegrationRestoreStatusPersistence(manager *restore.Manager, controllerClient client.Client) *restore.Manager {
-	return manager.WithAdminOpsStatusMutator(func(
-		ctx context.Context,
-		cluster *openbaov1alpha1.OpenBaoCluster,
-		mutate func(obj *openbaov1alpha1.OpenBaoCluster) error,
-		forceOwnership bool,
-	) error {
-		return adminopsstatus.MutateWithReader(ctx, controllerClient, controllerClient, cluster, mutate, adminopsstatus.MutateOptions{
-			ForceOwnership:  forceOwnership,
-			RetryOnConflict: !forceOwnership,
-		})
-	})
+	return manager.WithAdminOpsStatusMutator(adminopsstatus.NewMutator(controllerClient, controllerClient))
 }
 
 func TestRestoreManager_GCSProvider(t *testing.T) {

--- a/website/content/docs/architecture/invariants-and-boundaries.md
+++ b/website/content/docs/architecture/invariants-and-boundaries.md
@@ -11,6 +11,9 @@ verifiedBy:
   - internal/app/openbaocluster/applications.go
   - internal/app/openbaocluster/applications_test.go
   - internal/app/openbaocluster/patch_test.go
+  - internal/port/adminops/status.go
+  - internal/app/openbaocluster/adminopsstatus/mutate_test.go
+  - test/integration/adminops_status_test.go
   - internal/platform/statusapply/openbaocluster_test.go
 ---
 
@@ -90,6 +93,19 @@ The AdminOps mutation gateway returns the object read after the apply, including
 read. It does not substitute the intended state for the observed state. If read-back fails, it returns an error even
 though the apply succeeded. The application wrapper updates the caller's AdminOps fields and resource version only
 after a successful read-back; it leaves other fields unchanged.
+
+Managers share the `adminops.StatusMutator` contract. The application layer binds it to the API reader and client through
+`adminopsstatus.NewMutator`. Each write selects an ownership policy:
+
+| Policy | Field ownership behavior |
+| --- | --- |
+| `RespectOwnership` | Never force ownership. |
+| `ForceOwnershipOnConflict` | Retry without force first. If conflicts persist, retry with forced ownership. |
+| `ForceOwnership` | Force ownership from the first attempt. |
+
+Every policy retries conflicts with a fresh read and mutation. The fallback policy applies to both resource-version and
+field-ownership conflicts. Routine AdminOps writes use that fallback; rolling upgrade finalization and retry cleanup
+force ownership immediately. These policies apply to the AdminOps status plane.
 
 ## Account for tenancy watch boundaries
 


### PR DESCRIPTION
## Summary

AdminOps writers now select named ownership policies instead of combining `ForceOwnership` and `RetryOnConflict` flags. A shared `StatusMutator` contract and constructor replace four duplicate contracts and eight wiring closures across runtime code and tests.

## Related Issues

None.

## Type of Change

- [x] Refactor (code improvement/cleanup)
- [x] Documentation update

## Risk and Compatibility

Internal refactor with no API, CRD, Helm, RBAC, or dependency changes. Existing ownership choices, conflict retries, and read-back behavior are preserved. Forced fallback still applies after exhausted resource-version conflicts as well as field-ownership conflicts.

## Verification

- `devenv shell -- make generate-ast-rules lint-ci verify-fmt test-ci report-internal-deps docs-build` passed: 3,749 tests with four skips, 65 AST tests, and 70.85% internal coverage.
- `devenv shell -- go test -race -p 2 ./internal/app/openbaocluster/adminopsstatus ./internal/platform/statusapply` passed.
- Real API-server tests cover all three ownership policies, field-owner conflicts, caller synchronization, and status preservation.
- Focused Kind E2E passed with the new operator image: rolling upgrade retry clears failed status, records the handled request, removes the stale step-down Job, and completes the upgrade.
- Local validation used the gates listed above; the remaining CI checks run on this PR.

## Reviewer Notes

Review policy selection at the manager call sites and the shared writer boundary. Resource-version retry handling remains in the platform gateway. This change does not narrow which conflicts can trigger forced ownership.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
