### PR TITLE
fix(status): preserve restore state in final adminops patch

### DIFF
--- a/internal/app/openbaocluster/patch.go
+++ b/internal/app/openbaocluster/patch.go
@@ -112,9 +112,9 @@ func PatchWorkloadOwnedFields(
 	return nil
 }
 
-// PatchAdminOpsOwnedFieldsWithReader patches only admin-ops controller owned
-// status fields, using reader for live read-before-write freshness when
-// available.
+// PatchAdminOpsOwnedFieldsWithReader persists pending application status changes.
+// Backup, Upgrade, and Restore are persisted by their managers and preserved
+// from the live read performed by the shared AdminOps mutation gateway.
 func PatchAdminOpsOwnedFieldsWithReader(
 	ctx context.Context,
 	reader client.Reader,
@@ -128,13 +128,12 @@ func PatchAdminOpsOwnedFieldsWithReader(
 		return nil
 	}
 
-	// Backup-only diffs are persisted by the backup manager. When we do patch
-	// adminops status for other reasons, we still apply the full current adminops
-	// plane so shared SSA ownership does not clear backup or peer fields by omission.
+	// Manager-owned fields do not trigger a final patch. When application fields
+	// change, the gateway still applies the full current AdminOps plane so shared
+	// SSA ownership does not clear sibling fields by omission.
 	if original.Status.AcceptedUpgradeStrategy == cluster.Status.AcceptedUpgradeStrategy &&
 		reflect.DeepEqual(original.Status.BlueGreen, cluster.Status.BlueGreen) &&
 		reflect.DeepEqual(original.Status.UpgradeRequests, cluster.Status.UpgradeRequests) &&
-		reflect.DeepEqual(original.Status.Restore, cluster.Status.Restore) &&
 		reflect.DeepEqual(original.Status.BreakGlass, cluster.Status.BreakGlass) &&
 		reflect.DeepEqual(original.Status.AdminOps, cluster.Status.AdminOps) {
 		return nil
@@ -150,7 +149,6 @@ func PatchAdminOpsOwnedFieldsWithReader(
 		obj.Status.AcceptedUpgradeStrategy = cluster.Status.AcceptedUpgradeStrategy
 		obj.Status.BlueGreen = cluster.Status.BlueGreen
 		obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
-		obj.Status.Restore = cluster.Status.Restore
 		obj.Status.BreakGlass = cluster.Status.BreakGlass
 		obj.Status.AdminOps = adminOps
 		return nil

--- a/internal/app/openbaocluster/patch_test.go
+++ b/internal/app/openbaocluster/patch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -158,53 +159,54 @@ func TestPatchAdminOpsOwnedFields_PatchesAdminOpsFieldsWithoutBackup(t *testing.
 	}
 }
 
-func TestPatchAdminOpsOwnedFields_IgnoresBackupOnlyChanges(t *testing.T) {
+func TestPatchAdminOpsOwnedFields_IgnoresManagerOwnedChanges(t *testing.T) {
 	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		mutate func(*openbaov1alpha1.OpenBaoClusterStatus)
+	}{
+		{name: "backup", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+			status.Backup.LastFailureReason = "new-backup-state"
+		}},
+		{name: "upgrade", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+			status.Upgrade.CurrentPartition = 1
+		}},
+		{name: "restore", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+			status.Restore.UID = "new-restore"
+		}},
+		{name: "restore-clear", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+			status.Restore = nil
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "adminops-manager-owned", Namespace: "default"},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Backup:  &openbaov1alpha1.BackupStatus{LastFailureReason: "existing-backup-state"},
+					Upgrade: &openbaov1alpha1.UpgradeProgress{TargetVersion: "2.6.2", CurrentPartition: 2},
+					Restore: &openbaov1alpha1.ClusterRestoreStatus{Name: "restore", UID: "existing-restore"},
+				},
+			}
+			original := cluster.DeepCopy()
+			desired := cluster.DeepCopy()
+			tt.mutate(&desired.Status)
+			applies := 0
+			c := fake.NewClientBuilder().WithScheme(newPatchTestScheme(t)).
+				WithStatusSubresource(cluster).WithObjects(cluster.DeepCopy()).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceApply: func(ctx context.Context, c client.Client, subresource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+						applies++
+						return c.SubResource(subresource).Apply(ctx, obj, opts...)
+					},
+				}).Build()
 
-	cluster := &openbaov1alpha1.OpenBaoCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "adminops-backup-only",
-			Namespace: "default",
-		},
-		Status: openbaov1alpha1.OpenBaoClusterStatus{
-			Backup: &openbaov1alpha1.BackupStatus{
-				LastFailureReason: "existing-backup-state",
-			},
-		},
-	}
-	original := cluster.DeepCopy()
-	desired := cluster.DeepCopy()
-	desired.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "new-backup-state"}
-
-	scheme := newPatchTestScheme(t)
-	var applyCalls int
-
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(cluster).
-		WithObjects(cluster.DeepCopy()).
-		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourceApply: func(ctx context.Context, c client.Client, subResource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
-				applyCalls++
-				return c.Status().Apply(ctx, obj, opts...)
-			},
-		}).
-		Build()
-
-	if err := PatchAdminOpsOwnedFieldsWithReader(context.Background(), k8sClient, k8sClient, logr.Discard(), original, desired, "backup-only"); err != nil {
-		t.Fatalf("PatchAdminOpsOwnedFieldsWithReader() error = %v", err)
-	}
-
-	if applyCalls != 0 {
-		t.Fatalf("status apply calls = %d, want 0 for backup-only change", applyCalls)
-	}
-
-	stored := &openbaov1alpha1.OpenBaoCluster{}
-	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), stored); err != nil {
-		t.Fatalf("Get() error = %v", err)
-	}
-	if !reflect.DeepEqual(stored.Status.Backup, original.Status.Backup) {
-		t.Fatalf("stored backup = %#v, want original %#v", stored.Status.Backup, original.Status.Backup)
+			require.NoError(t, PatchAdminOpsOwnedFieldsWithReader(t.Context(), c, c, logr.Discard(), original, desired, tt.name))
+			require.Zero(t, applies, "manager-owned changes must not trigger a final status write")
+			stored := &openbaov1alpha1.OpenBaoCluster{}
+			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(cluster), stored))
+			require.Equal(t, original.Status, stored.Status)
+		})
 	}
 }
 

--- a/test/integration/adminops_restore_status_test.go
+++ b/test/integration/adminops_restore_status_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
+	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
+)
+
+func TestAdminOpsFinalPatchPreservesConcurrentRestore(t *testing.T) {
+	baseWriter, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sScheme})
+	require.NoError(t, err)
+	completedAt := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	for _, tt := range []struct {
+		name   string
+		before *openbaov1alpha1.ClusterRestoreStatus
+		after  *openbaov1alpha1.ClusterRestoreStatus
+	}{
+		{
+			name:  "new-request",
+			after: &openbaov1alpha1.ClusterRestoreStatus{Name: "restore", UID: "new"},
+		},
+		{
+			name:   "restart-completed",
+			before: &openbaov1alpha1.ClusterRestoreStatus{Name: "restore", UID: "current"},
+			after:  &openbaov1alpha1.ClusterRestoreStatus{Name: "restore", UID: "current", RestartCompletedAt: &completedAt},
+		},
+		{
+			name:   "replacement-request",
+			before: &openbaov1alpha1.ClusterRestoreStatus{Name: "old-restore", UID: "old", RestartCompletedAt: &completedAt},
+			after:  &openbaov1alpha1.ClusterRestoreStatus{Name: "new-restore", UID: "new"},
+		},
+	} {
+		for _, raceApply := range []bool{false, true} {
+			timing := "before-read"
+			if raceApply {
+				timing = "after-read"
+			}
+			t.Run(tt.name+"/"+timing, func(t *testing.T) {
+				cluster := createMinimalCluster(t, newTestNamespace(t), "adminops-restore")
+				mutateStatus := adminopsstatus.NewMutator(k8sClient, k8sClient)
+				require.NoError(t, mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+					obj.Status.Restore = tt.before.DeepCopy()
+					obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "preserve-backup"}
+					return nil
+				}, adminops.RespectOwnership))
+				original := cluster.DeepCopy()
+				desired := cluster.DeepCopy()
+				desired.Status.AdminOps = &openbaov1alpha1.AdminOpsControllerStatus{
+					LastError: &openbaov1alpha1.ControllerErrorStatus{Reason: "TestError", Message: "unrelated adminops error"},
+				}
+				wantAdminOps := desired.Status.AdminOps.DeepCopy()
+				var wantRestore *openbaov1alpha1.ClusterRestoreStatus
+				writeRestore := func() {
+					t.Helper()
+					require.NoError(t, mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+						obj.Status.Restore = tt.after.DeepCopy()
+						return nil
+					}, adminops.RespectOwnership))
+					wantRestore = cluster.Status.Restore.DeepCopy()
+				}
+				if !raceApply {
+					writeRestore()
+				}
+
+				applies, conflicts := 0, 0
+				writer := interceptor.NewClient(baseWriter, interceptor.Funcs{
+					SubResourceApply: func(ctx context.Context, c client.Client, subresource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+						applies++
+						if raceApply && applies == 1 {
+							writeRestore()
+						}
+						err := c.SubResource(subresource).Apply(ctx, obj, opts...)
+						if apierrors.IsConflict(err) {
+							conflicts++
+						}
+						return err
+					},
+				})
+				require.NoError(t, openbaocluster.PatchAdminOpsOwnedFieldsWithReader(ctx, k8sClient, writer, logr.Discard(), original, desired, "adminops-error"))
+
+				stored := &openbaov1alpha1.OpenBaoCluster{}
+				require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored))
+				require.Equal(t, wantRestore, stored.Status.Restore, "final patch must preserve the restore manager's latest state")
+				require.Equal(t, wantAdminOps, stored.Status.AdminOps)
+				require.Equal(t, original.Status.Backup, stored.Status.Backup)
+				require.Equal(t, stored.Status, desired.Status)
+				require.Equal(t, stored.ResourceVersion, desired.ResourceVersion)
+				if raceApply {
+					require.Equal(t, 1, conflicts, "the API server must reject the stale resource version")
+					require.Equal(t, 2, applies)
+				} else {
+					require.Zero(t, conflicts)
+					require.Equal(t, 1, applies)
+				}
+			})
+		}
+	}
+}

--- a/website/content/docs/architecture/invariants-and-boundaries.md
+++ b/website/content/docs/architecture/invariants-and-boundaries.md
@@ -14,6 +14,7 @@ verifiedBy:
   - internal/port/adminops/status.go
   - internal/app/openbaocluster/adminopsstatus/mutate_test.go
   - test/integration/adminops_status_test.go
+  - test/integration/adminops_restore_status_test.go
   - internal/platform/statusapply/openbaocluster_test.go
 ---
 
@@ -82,7 +83,7 @@ The `OpenBaoCluster` status is divided among server-side apply field managers.
 | --- | --- |
 | Observed status | Phase, leader, replicas, current version, observed generation, and conditions |
 | Workload status | Initialization, self-initialization, and workload progress |
-| AdminOps status | Backup, upgrade, blue-green, requests, break-glass, and AdminOps state |
+| AdminOps status | Backup, upgrade, restore, blue-green, requests, break-glass, and AdminOps state |
 | Operation lock | `status.operationLock` only |
 
 A writer applies only its plane. Within the shared AdminOps plane, a writer must read the latest object, mutate its
@@ -93,6 +94,11 @@ The AdminOps mutation gateway returns the object read after the apply, including
 read. It does not substitute the intended state for the observed state. If read-back fails, it returns an error even
 though the apply succeeded. The application wrapper updates the caller's AdminOps fields and resource version only
 after a successful read-back; it leaves other fields unchanged.
+
+The final AdminOps patch persists pending changes to accepted upgrade strategy, blue-green state, upgrade requests,
+break-glass state, and AdminOps state. Managers persist backup, rolling-upgrade progress, and restore restart state.
+The final patch preserves the latest API values for those manager-owned fields in the complete SSA payload. Changes to
+those fields alone do not trigger a final patch.
 
 Managers share the `adminops.StatusMutator` contract. The application layer binds it to the API reader and client through
 `adminopsstatus.NewMutator`. Each write selects an ownership policy:


### PR DESCRIPTION
## Summary

A final AdminOps status write could overwrite a newer restore request or restart-completion timestamp with an older reconcile snapshot. Preserve the restore manager's live status in the complete AdminOps SSA payload, and stop treating restore-only changes as a reason for the final patch.

Add six API-server regression cases covering new requests, restart completion, and replacement requests, both before the fresh read and across a real resource-version conflict. Extend the manager-owned no-op tests and document the write boundary.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Risk and Compatibility

No API, CRD, Helm, RBAC, or generated-artifact changes. Restore state remains owned by the restore manager. Shared AdminOps SSA ownership, conflict handling, and read-back behavior are preserved.

## Verification

- All six API-server regression cases failed before the fix and passed afterward.
- `devenv shell -- go test ./internal/app/openbaocluster/... ./internal/service/restore`
- `devenv shell -- go test -tags=integration ./test/integration -run 'TestAdminOps(FinalPatchPreservesConcurrentRestore|Status)' -count=1`
- `devenv shell -- make lint-ci verify-fmt test-ci docs-build`: 3,760 tests, four skipped; internal coverage 70.85%; all gates passed.
- Focused Kind 1.36.1 E2E with the changed operator: `creates a restorable S3 backup` and `restores from S3 backup using OpenBaoRestore CR` both passed. The restore scenario checks voter restart, restart-completion status, read-replica recovery, and restored data.

## Reviewer Notes

The final patch still applies the complete live AdminOps plane to preserve sibling fields under shared SSA ownership. This change removes only the stale restore assignment and its final-patch trigger.

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests.
- [x] I have updated documentation.
- [x] I have confirmed no generated artifacts are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks.
- [x] All dependent changes have been merged.
