### PR TITLE
refactor(upgrade): separate request acknowledgements from status

### DIFF
--- a/internal/app/openbaocluster/adminops.go
+++ b/internal/app/openbaocluster/adminops.go
@@ -7,6 +7,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	adminopsapp "github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminops"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 // AdminOpsDependencies holds dependencies required to build admin operations reconcilers.
@@ -24,9 +25,10 @@ func NewAdminOpsApplication(deps AdminOpsDependencies) *AdminOpsApplication {
 			logger logr.Logger,
 			original *openbaov1alpha1.OpenBaoCluster,
 			cluster *openbaov1alpha1.OpenBaoCluster,
+			acknowledgements upgrade.RequestAcknowledgements,
 			reason string,
 		) error {
-			return PatchAdminOpsOwnedFieldsWithReader(ctx, deps.APIReader, deps.Client, logger, original, cluster, reason)
+			return PatchAdminOpsOwnedFieldsWithReader(ctx, deps.APIReader, deps.Client, logger, original, cluster, acknowledgements, reason)
 		},
 		controllerErrorStatus,
 	)

--- a/internal/app/openbaocluster/adminops/reconcile.go
+++ b/internal/app/openbaocluster/adminops/reconcile.go
@@ -46,6 +46,7 @@ type StatusPatcher func(
 	logger logr.Logger,
 	original *openbaov1alpha1.OpenBaoCluster,
 	cluster *openbaov1alpha1.OpenBaoCluster,
+	acknowledgements upgrademanager.RequestAcknowledgements,
 	reason string,
 ) error
 
@@ -53,7 +54,19 @@ type StatusPatcher func(
 type ErrorStatusBuilder func(error) *openbaov1alpha1.ControllerErrorStatus
 
 type subReconciler interface {
-	Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error)
+	Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (upgrademanager.ReconcileResult, error)
+}
+
+// reconcilerWithoutRequests adapts collaborators that only return scheduling.
+type reconcilerWithoutRequests struct {
+	inner interface {
+		Reconcile(context.Context, logr.Logger, *openbaov1alpha1.OpenBaoCluster) (recon.Result, error)
+	}
+}
+
+func (r reconcilerWithoutRequests) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (upgrademanager.ReconcileResult, error) {
+	result, err := r.inner.Reconcile(ctx, logger, cluster)
+	return upgrademanager.ReconcileResult{Result: result}, err
 }
 
 type reconcilerPlan struct {
@@ -113,17 +126,20 @@ func (a *Application) Reconcile(
 	recordError ErrorRecorder,
 ) (recon.Result, error) {
 	ensureAdminOpsStatus(cluster)
+	var acknowledgements upgrademanager.RequestAcknowledgements
 
 	for _, rec := range a.plan.orderedFor(cluster) {
 		result, err := rec.Reconcile(ctx, logger, cluster)
+		acknowledgements.Merge(result.Acknowledgements)
 		if err != nil {
 			if recordError != nil {
 				recordError(err)
 			}
+			ensureAdminOpsStatus(cluster)
 			cluster.Status.AdminOps.LastError = a.errorStatus(err)
 
 			if a.patchStatus != nil {
-				if statusErr := a.patchStatus(ctx, logger, original, cluster, "adminops-error"); statusErr != nil {
+				if statusErr := a.patchStatus(ctx, logger, original, cluster, acknowledgements, "adminops-error"); statusErr != nil {
 					return recon.Result{}, statusErr
 				}
 			}
@@ -149,7 +165,7 @@ func (a *Application) Reconcile(
 			ensureAdminOpsStatus(cluster)
 			cluster.Status.AdminOps.LastError = nil
 			if a.patchStatus != nil {
-				if statusErr := a.patchStatus(ctx, logger, original, cluster, "adminops-requeue"); statusErr != nil {
+				if statusErr := a.patchStatus(ctx, logger, original, cluster, acknowledgements, "adminops-requeue"); statusErr != nil {
 					return recon.Result{}, statusErr
 				}
 			}
@@ -161,7 +177,7 @@ func (a *Application) Reconcile(
 	ensureAdminOpsStatus(cluster)
 	cluster.Status.AdminOps.LastError = nil
 	if a.patchStatus != nil {
-		if err := a.patchStatus(ctx, logger, original, cluster, "adminops-complete"); err != nil {
+		if err := a.patchStatus(ctx, logger, original, cluster, acknowledgements, "adminops-complete"); err != nil {
 			return recon.Result{}, fmt.Errorf("failed to patch adminops owned fields: %w", err)
 		}
 	}
@@ -189,7 +205,7 @@ func buildReconcilers(deps Dependencies) reconcilerPlan {
 
 	return reconcilerPlan{
 		upgradeReconcilers: []subReconciler{
-			upgrademanager.NewStrategyTransitionManager(strategyReader),
+			reconcilerWithoutRequests{inner: upgrademanager.NewStrategyTransitionManager(strategyReader)},
 			bluegreen.NewManager(
 				deps.Client,
 				deps.Scheme,
@@ -211,14 +227,14 @@ func buildReconcilers(deps Dependencies) reconcilerPlan {
 				deps.Recorder,
 			).WithReader(deps.APIReader).WithAdminOpsStatusMutator(adminOpsMutator),
 		},
-		backupReconciler: backupmanager.NewManager(
+		backupReconciler: reconcilerWithoutRequests{inner: backupmanager.NewManager(
 			deps.Client,
 			deps.Scheme,
 			deps.SmartClientConfig,
 			deps.OperatorImageVerifier,
 			deps.Platform,
 			deps.Recorder,
-		).WithReader(deps.APIReader).WithAdminOpsStatusMutator(adminOpsMutator),
+		).WithReader(deps.APIReader).WithAdminOpsStatusMutator(adminOpsMutator)},
 	}
 }
 

--- a/internal/app/openbaocluster/adminops/reconcile_test.go
+++ b/internal/app/openbaocluster/adminops/reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
@@ -28,21 +29,22 @@ type fakeSubReconciler struct {
 	err    error
 }
 
-func (f fakeSubReconciler) Reconcile(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
-	return f.result, f.err
+func (f fakeSubReconciler) Reconcile(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster) (upgrademanager.ReconcileResult, error) {
+	return upgrademanager.ReconcileResult{Result: f.result}, f.err
 }
 
 type fakeMutatingSubReconciler struct {
-	result recon.Result
-	err    error
-	mutate func(*openbaov1alpha1.OpenBaoCluster)
+	result           recon.Result
+	err              error
+	mutate           func(*openbaov1alpha1.OpenBaoCluster)
+	acknowledgements upgrademanager.RequestAcknowledgements
 }
 
-func (f fakeMutatingSubReconciler) Reconcile(_ context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
+func (f fakeMutatingSubReconciler) Reconcile(_ context.Context, _ logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (upgrademanager.ReconcileResult, error) {
 	if f.mutate != nil {
 		f.mutate(cluster)
 	}
-	return f.result, f.err
+	return upgrademanager.ReconcileResult{Result: f.result, Acknowledgements: f.acknowledgements}, f.err
 }
 
 type recordingSubReconciler struct {
@@ -51,9 +53,9 @@ type recordingSubReconciler struct {
 	result recon.Result
 }
 
-func (f recordingSubReconciler) Reconcile(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
+func (f recordingSubReconciler) Reconcile(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster) (upgrademanager.ReconcileResult, error) {
 	*f.calls = append(*f.calls, f.name)
-	return f.result, nil
+	return upgrademanager.ReconcileResult{Result: f.result}, nil
 }
 
 func applicationForTest(
@@ -70,6 +72,78 @@ func applicationForTest(
 		patchStatus:  patchStatus,
 		errorStatus:  errorStatus,
 	}
+}
+
+func TestReconcile_PreservesAcknowledgementsAcrossReadBack(t *testing.T) {
+	t.Parallel()
+	checkpointErr := errors.New("checkpoint failed")
+	for _, tt := range []struct {
+		name   string
+		result recon.Result
+		err    error
+		reason string
+	}{
+		{"complete", recon.Result{}, nil, "adminops-complete"},
+		{"requeue", recon.Result{RequeueAfter: time.Minute}, nil, "adminops-requeue"},
+		{"error", recon.Result{}, checkpointErr, "adminops-error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cluster := &openbaov1alpha1.OpenBaoCluster{}
+			want := upgrademanager.RequestAcknowledgements{Rollback: "rollback", Retry: "retry"}
+			patches := 0
+			application := applicationForTest(reconcilerPlan{
+				upgradeReconcilers: []subReconciler{
+					fakeMutatingSubReconciler{acknowledgements: upgrademanager.RequestAcknowledgements{Rollback: "rollback"}},
+					fakeMutatingSubReconciler{
+						result:           tt.result,
+						err:              tt.err,
+						acknowledgements: upgrademanager.RequestAcknowledgements{Retry: "retry"},
+						mutate: func(cluster *openbaov1alpha1.OpenBaoCluster) {
+							// An immediate checkpoint refreshes the observed AdminOps plane.
+							cluster.Status.UpgradeRequests = nil
+							cluster.Status.AdminOps = nil
+						},
+					},
+				},
+			}, func(_ context.Context, _ logr.Logger, _, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements upgrademanager.RequestAcknowledgements, reason string) error {
+				patches++
+				require.Equal(t, tt.reason, reason)
+				require.Equal(t, want, acknowledgements)
+				require.Nil(t, cluster.Status.UpgradeRequests, "pending intent must remain separate from observed status")
+				return nil
+			}, nil)
+			result, err := application.Reconcile(t.Context(), logr.Discard(), cluster.DeepCopy(), cluster, nil)
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.result, result)
+			require.Equal(t, 1, patches)
+		})
+	}
+}
+
+func TestReconcile_AcknowledgementsDoNotLeakBetweenPasses(t *testing.T) {
+	t.Parallel()
+	cluster := &openbaov1alpha1.OpenBaoCluster{}
+	var recorded []upgrademanager.RequestAcknowledgements
+	want := upgrademanager.RequestAcknowledgements{Promote: "promote"}
+	application := applicationForTest(reconcilerPlan{
+		upgradeReconcilers: []subReconciler{fakeMutatingSubReconciler{acknowledgements: want}},
+	}, func(_ context.Context, _ logr.Logger, _, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements upgrademanager.RequestAcknowledgements, _ string) error {
+		recorded = append(recorded, acknowledgements)
+		acknowledgements.ApplyTo(&cluster.Status)
+		return nil
+	}, nil)
+	_, err := application.Reconcile(t.Context(), logr.Discard(), cluster.DeepCopy(), cluster, nil)
+	require.NoError(t, err)
+	application.plan.upgradeReconcilers = []subReconciler{fakeSubReconciler{}}
+	_, err = application.Reconcile(t.Context(), logr.Discard(), cluster.DeepCopy(), cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, []upgrademanager.RequestAcknowledgements{want, {}}, recorded)
+	require.Equal(t, "promote", cluster.Status.UpgradeRequests.LastHandledPromote)
 }
 
 func TestReconcile_RunsCurrentOperationOwnerFirst(t *testing.T) {
@@ -231,7 +305,7 @@ func TestReconcile_AdminOpsErrorPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var recorded []error
 			var patchReasons []string
-			patchStatus := func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, reason string) error {
+			patchStatus := func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, _ upgrademanager.RequestAcknowledgements, reason string) error {
 				patchReasons = append(patchReasons, reason)
 				return tt.patchErr
 			}
@@ -293,7 +367,7 @@ func TestReconcile_AdminOpsRequeueAndSuccess(t *testing.T) {
 		var patchReasons []string
 		application := applicationForTest(
 			reconcilerPlan{upgradeReconcilers: []subReconciler{fakeSubReconciler{result: recon.Result{RequeueAfter: 7 * time.Second}}}},
-			func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, reason string) error {
+			func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, _ upgrademanager.RequestAcknowledgements, reason string) error {
 				patchReasons = append(patchReasons, reason)
 				return nil
 			},
@@ -335,7 +409,7 @@ func TestReconcile_AdminOpsRequeueAndSuccess(t *testing.T) {
 		var patchReasons []string
 		application := applicationForTest(
 			reconcilerPlan{upgradeReconcilers: []subReconciler{fakeSubReconciler{}}},
-			func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, reason string) error {
+			func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, _ upgrademanager.RequestAcknowledgements, reason string) error {
 				patchReasons = append(patchReasons, reason)
 				return nil
 			},
@@ -376,7 +450,7 @@ func TestReconcile_AdminOpsRequeueAndSuccess(t *testing.T) {
 					cluster.Status.AdminOps = nil
 				},
 			}}},
-			func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, reason string) error {
+			func(_ context.Context, _ logr.Logger, _ *openbaov1alpha1.OpenBaoCluster, _ *openbaov1alpha1.OpenBaoCluster, _ upgrademanager.RequestAcknowledgements, reason string) error {
 				patchReasons = append(patchReasons, reason)
 				return nil
 			},
@@ -469,7 +543,7 @@ func TestNewApplication_BuildsReconcilersAndInjectsRecorder(t *testing.T) {
 		t.Fatalf("len(reconcilers) = %d, want 4", len(orderedReconcilers))
 	}
 
-	if _, ok := orderedReconcilers[0].(*upgrademanager.StrategyTransitionManager); !ok {
+	if _, ok := orderedReconcilers[0].(reconcilerWithoutRequests).inner.(*upgrademanager.StrategyTransitionManager); !ok {
 		t.Fatalf("reconcilers[0] = %T, want *upgrade.StrategyTransitionManager", orderedReconcilers[0])
 	}
 
@@ -485,7 +559,7 @@ func TestNewApplication_BuildsReconcilersAndInjectsRecorder(t *testing.T) {
 	}
 	assertRecorderInjected(t, rollingMgr)
 
-	backupMgr, ok := orderedReconcilers[3].(*backupmanager.Manager)
+	backupMgr, ok := orderedReconcilers[3].(reconcilerWithoutRequests).inner.(*backupmanager.Manager)
 	if !ok {
 		t.Fatalf("reconcilers[3] = %T, want *backup.Manager", orderedReconcilers[3])
 	}

--- a/internal/app/openbaocluster/patch.go
+++ b/internal/app/openbaocluster/patch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	"github.com/dc-tec/openbao-operator/internal/platform/statusapply"
 	"github.com/dc-tec/openbao-operator/internal/port/adminops"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 // PatchStatusOwnedFields patches only status-controller owned status fields.
@@ -115,6 +116,8 @@ func PatchWorkloadOwnedFields(
 // PatchAdminOpsOwnedFieldsWithReader persists pending application status changes.
 // Backup, Upgrade, and Restore are persisted by their managers and preserved
 // from the live read performed by the shared AdminOps mutation gateway.
+// Request acknowledgements are applied from per-reconcile intent, never copied
+// from the cluster's observed UpgradeRequests snapshot.
 func PatchAdminOpsOwnedFieldsWithReader(
 	ctx context.Context,
 	reader client.Reader,
@@ -122,6 +125,7 @@ func PatchAdminOpsOwnedFieldsWithReader(
 	logger logr.Logger,
 	original *openbaov1alpha1.OpenBaoCluster,
 	cluster *openbaov1alpha1.OpenBaoCluster,
+	acknowledgements upgrade.RequestAcknowledgements,
 	reason string,
 ) error {
 	if original == nil || cluster == nil {
@@ -133,7 +137,7 @@ func PatchAdminOpsOwnedFieldsWithReader(
 	// SSA ownership does not clear sibling fields by omission.
 	if original.Status.AcceptedUpgradeStrategy == cluster.Status.AcceptedUpgradeStrategy &&
 		reflect.DeepEqual(original.Status.BlueGreen, cluster.Status.BlueGreen) &&
-		reflect.DeepEqual(original.Status.UpgradeRequests, cluster.Status.UpgradeRequests) &&
+		acknowledgements.IsEmpty() &&
 		reflect.DeepEqual(original.Status.BreakGlass, cluster.Status.BreakGlass) &&
 		reflect.DeepEqual(original.Status.AdminOps, cluster.Status.AdminOps) {
 		return nil
@@ -148,7 +152,7 @@ func PatchAdminOpsOwnedFieldsWithReader(
 	err := adminopsstatus.MutateWithReader(ctx, reader, c, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
 		obj.Status.AcceptedUpgradeStrategy = cluster.Status.AcceptedUpgradeStrategy
 		obj.Status.BlueGreen = cluster.Status.BlueGreen
-		obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
+		acknowledgements.ApplyTo(&obj.Status)
 		obj.Status.BreakGlass = cluster.Status.BreakGlass
 		obj.Status.AdminOps = adminOps
 		return nil

--- a/internal/app/openbaocluster/patch_test.go
+++ b/internal/app/openbaocluster/patch_test.go
@@ -19,6 +19,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 func TestPatchStatusOwnedFields_PreservesPointerClearsInApplyPayload(t *testing.T) {
@@ -116,7 +117,7 @@ func TestPatchAdminOpsOwnedFields_PatchesAdminOpsFieldsWithoutBackup(t *testing.
 		}).
 		Build()
 
-	if err := PatchAdminOpsOwnedFieldsWithReader(context.Background(), k8sClient, k8sClient, logr.Discard(), original, desired, "test"); err != nil {
+	if err := PatchAdminOpsOwnedFieldsWithReader(context.Background(), k8sClient, k8sClient, logr.Discard(), original, desired, upgrade.RequestAcknowledgements{Promote: "req-1"}, "test"); err != nil {
 		t.Fatalf("PatchAdminOpsOwnedFieldsWithReader() error = %v", err)
 	}
 
@@ -177,15 +178,22 @@ func TestPatchAdminOpsOwnedFields_IgnoresManagerOwnedChanges(t *testing.T) {
 		{name: "restore-clear", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
 			status.Restore = nil
 		}},
+		{name: "observed-request", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+			status.UpgradeRequests.LastHandledPromote = "observed"
+		}},
+		{name: "observed-request-clear", mutate: func(status *openbaov1alpha1.OpenBaoClusterStatus) {
+			status.UpgradeRequests = nil
+		}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cluster := &openbaov1alpha1.OpenBaoCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "adminops-manager-owned", Namespace: "default"},
 				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					Backup:  &openbaov1alpha1.BackupStatus{LastFailureReason: "existing-backup-state"},
-					Upgrade: &openbaov1alpha1.UpgradeProgress{TargetVersion: "2.6.2", CurrentPartition: 2},
-					Restore: &openbaov1alpha1.ClusterRestoreStatus{Name: "restore", UID: "existing-restore"},
+					Backup:          &openbaov1alpha1.BackupStatus{LastFailureReason: "existing-backup-state"},
+					Upgrade:         &openbaov1alpha1.UpgradeProgress{TargetVersion: "2.6.2", CurrentPartition: 2},
+					Restore:         &openbaov1alpha1.ClusterRestoreStatus{Name: "restore", UID: "existing-restore"},
+					UpgradeRequests: &openbaov1alpha1.UpgradeRequestStatus{LastHandledPromote: "initial"},
 				},
 			}
 			original := cluster.DeepCopy()
@@ -201,7 +209,7 @@ func TestPatchAdminOpsOwnedFields_IgnoresManagerOwnedChanges(t *testing.T) {
 					},
 				}).Build()
 
-			require.NoError(t, PatchAdminOpsOwnedFieldsWithReader(t.Context(), c, c, logr.Discard(), original, desired, tt.name))
+			require.NoError(t, PatchAdminOpsOwnedFieldsWithReader(t.Context(), c, c, logr.Discard(), original, desired, upgrade.RequestAcknowledgements{}, tt.name))
 			require.Zero(t, applies, "manager-owned changes must not trigger a final status write")
 			stored := &openbaov1alpha1.OpenBaoCluster{}
 			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(cluster), stored))

--- a/internal/service/upgrade/acknowledgements.go
+++ b/internal/service/upgrade/acknowledgements.go
@@ -1,0 +1,60 @@
+package upgrade
+
+import (
+	"strings"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+)
+
+// ReconcileResult carries scheduling and request acknowledgements that the
+// application must persist with the resulting status changes, including on error.
+type ReconcileResult struct {
+	recon.Result
+	Acknowledgements RequestAcknowledgements
+}
+
+// RequestAcknowledgements contains the exact request tokens handled during a
+// reconcile pass. Empty fields leave the corresponding observed status unchanged.
+// Keep this intent separate from cluster status: checkpoint read-back replaces
+// observed status before the final application write.
+type RequestAcknowledgements struct {
+	Retry    string
+	Promote  string
+	Rollback string
+}
+
+// IsEmpty reports whether there are no request tokens to acknowledge.
+func (a RequestAcknowledgements) IsEmpty() bool {
+	return strings.TrimSpace(a.Retry) == "" &&
+		strings.TrimSpace(a.Promote) == "" &&
+		strings.TrimSpace(a.Rollback) == ""
+}
+
+// Merge adds acknowledgements from a later sub-reconciler without clearing
+// tokens handled by an earlier one.
+func (a *RequestAcknowledgements) Merge(next RequestAcknowledgements) {
+	if token := strings.TrimSpace(next.Retry); token != "" {
+		a.Retry = token
+	}
+	if token := strings.TrimSpace(next.Promote); token != "" {
+		a.Promote = token
+	}
+	if token := strings.TrimSpace(next.Rollback); token != "" {
+		a.Rollback = token
+	}
+}
+
+// ApplyTo records only the handled tokens on the freshly read status. It does
+// not consult spec, which may contain newer requests that remain pending.
+func (a RequestAcknowledgements) ApplyTo(status *openbaov1alpha1.OpenBaoClusterStatus) {
+	if token := strings.TrimSpace(a.Retry); token != "" {
+		MarkRetryRequestHandled(status, token)
+	}
+	if token := strings.TrimSpace(a.Promote); token != "" {
+		MarkPromoteRequestHandled(status, token)
+	}
+	if token := strings.TrimSpace(a.Rollback); token != "" {
+		MarkRollbackRequestHandled(status, token)
+	}
+}

--- a/internal/service/upgrade/acknowledgements_test.go
+++ b/internal/service/upgrade/acknowledgements_test.go
@@ -1,0 +1,105 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
+
+func TestRequestAcknowledgementsApplyTo(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name             string
+		acknowledgements RequestAcknowledgements
+		want             openbaov1alpha1.UpgradeRequestStatus
+	}{
+		{
+			name: "empty",
+			want: openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "retry", LastHandledPromote: "promote", LastHandledRollback: "rollback"},
+		},
+		{
+			name:             "blank",
+			acknowledgements: RequestAcknowledgements{Retry: " \t", Promote: "\n", Rollback: " "},
+			want:             openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "retry", LastHandledPromote: "promote", LastHandledRollback: "rollback"},
+		},
+		{
+			name:             "retry",
+			acknowledgements: RequestAcknowledgements{Retry: " next "},
+			want:             openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "next", LastHandledPromote: "promote", LastHandledRollback: "rollback"},
+		},
+		{
+			name:             "promote",
+			acknowledgements: RequestAcknowledgements{Promote: " next "},
+			want:             openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "retry", LastHandledPromote: "next", LastHandledRollback: "rollback"},
+		},
+		{
+			name:             "rollback",
+			acknowledgements: RequestAcknowledgements{Rollback: " next "},
+			want:             openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "retry", LastHandledPromote: "promote", LastHandledRollback: "next"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			status := openbaov1alpha1.OpenBaoClusterStatus{UpgradeRequests: &openbaov1alpha1.UpgradeRequestStatus{
+				LastHandledRetry: "retry", LastHandledPromote: "promote", LastHandledRollback: "rollback",
+			}}
+			tt.acknowledgements.ApplyTo(&status)
+			require.Equal(t, &tt.want, status.UpgradeRequests)
+		})
+	}
+}
+
+func TestRequestAcknowledgementsMerge(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name  string
+		first RequestAcknowledgements
+		next  RequestAcknowledgements
+		want  RequestAcknowledgements
+	}{
+		{name: "no requests"},
+		{
+			name:  "different managers",
+			first: RequestAcknowledgements{Rollback: "rollback"},
+			next:  RequestAcknowledgements{Retry: " retry ", Promote: "promote"},
+			want:  RequestAcknowledgements{Retry: "retry", Promote: "promote", Rollback: "rollback"},
+		},
+		{
+			name:  "blank does not clear",
+			first: RequestAcknowledgements{Retry: "retry", Promote: "promote", Rollback: "rollback"},
+			next:  RequestAcknowledgements{Retry: " ", Promote: "\t", Rollback: "\n"},
+			want:  RequestAcknowledgements{Retry: "retry", Promote: "promote", Rollback: "rollback"},
+		},
+		{
+			name:  "later handled token",
+			first: RequestAcknowledgements{Retry: "earlier"},
+			next:  RequestAcknowledgements{Retry: "later"},
+			want:  RequestAcknowledgements{Retry: "later"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.first
+			got.Merge(tt.next)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRequestAcknowledgementsEmptyLeavesNilStatus(t *testing.T) {
+	t.Parallel()
+	for _, acknowledgements := range []RequestAcknowledgements{{}, {Retry: " ", Promote: "\t", Rollback: "\n"}} {
+		status := openbaov1alpha1.OpenBaoClusterStatus{}
+		require.True(t, acknowledgements.IsEmpty())
+		acknowledgements.ApplyTo(&status)
+		require.Nil(t, status.UpgradeRequests)
+	}
+	for _, acknowledgements := range []RequestAcknowledgements{{Retry: "retry"}, {Promote: "promote"}, {Rollback: "rollback"}} {
+		status := openbaov1alpha1.OpenBaoClusterStatus{}
+		require.False(t, acknowledgements.IsEmpty())
+		acknowledgements.ApplyTo(&status)
+		require.NotNil(t, status.UpgradeRequests)
+	}
+}

--- a/internal/service/upgrade/bluegreen/events_test.go
+++ b/internal/service/upgrade/bluegreen/events_test.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 func expectEventContains(t *testing.T, recorder *events.FakeRecorder, parts ...string) {
@@ -82,8 +83,11 @@ func TestHandlePhaseSyncing_EmitsManualHoldAndPromotionEvents(t *testing.T) {
 		if outcome.kind != phaseOutcomeAdvance || outcome.nextPhase != openbaov1alpha1.PhasePromoting {
 			t.Fatalf("handlePhaseSyncing() outcome = %+v, want advance to promoting", outcome)
 		}
-		if cluster.Status.UpgradeRequests == nil || cluster.Status.UpgradeRequests.LastHandledPromote != "2026-03-10T12:00:00Z" {
-			t.Fatalf("LastHandledPromote = %+v, want request to be recorded", cluster.Status.UpgradeRequests)
+		if outcome.acknowledgements.Promote != "2026-03-10T12:00:00Z" {
+			t.Fatalf("promote acknowledgement = %q, want request token", outcome.acknowledgements.Promote)
+		}
+		if cluster.Status.UpgradeRequests != nil {
+			t.Fatal("promotion decision changed observed request status")
 		}
 
 		expectEventContains(t, recorder, "Normal", ReasonBlueGreenPromotionApproved)
@@ -121,7 +125,8 @@ func TestHandleManualRollbackRequest_EmitsRollbackStartedEvent(t *testing.T) {
 	recorder := events.NewFakeRecorder(10)
 	manager := &Manager{recorder: recorder}
 
-	handled, result, err := manager.handleManualRollbackRequest(context.Background(), logr.Discard(), cluster)
+	var acknowledgements upgrade.RequestAcknowledgements
+	handled, result, err := manager.handleManualRollbackRequest(context.Background(), logr.Discard(), cluster, &acknowledgements)
 	if err != nil {
 		t.Fatalf("handleManualRollbackRequest() error = %v", err)
 	}
@@ -131,8 +136,11 @@ func TestHandleManualRollbackRequest_EmitsRollbackStartedEvent(t *testing.T) {
 	if result.RequeueAfter <= 0 {
 		t.Fatalf("result = %+v, want positive requeue", result)
 	}
-	if cluster.Status.UpgradeRequests == nil || cluster.Status.UpgradeRequests.LastHandledRollback != "2026-03-10T12:05:00Z" {
-		t.Fatalf("LastHandledRollback = %+v, want request to be recorded", cluster.Status.UpgradeRequests)
+	if acknowledgements.Rollback != "2026-03-10T12:05:00Z" {
+		t.Fatalf("rollback acknowledgement = %q, want request token", acknowledgements.Rollback)
+	}
+	if cluster.Status.UpgradeRequests != nil {
+		t.Fatal("rollback decision changed observed request status")
 	}
 
 	expectEventContains(t, recorder, "Warning", ReasonRollbackStarted)
@@ -148,15 +156,19 @@ func TestHandleManualRollbackRequest_IgnoresStaleRequestWhenIdle(t *testing.T) {
 	}
 	manager := &Manager{}
 
-	handled, result, err := manager.handleManualRollbackRequest(context.Background(), logr.Discard(), cluster)
+	var acknowledgements upgrade.RequestAcknowledgements
+	handled, result, err := manager.handleManualRollbackRequest(context.Background(), logr.Discard(), cluster, &acknowledgements)
 	if err != nil {
 		t.Fatalf("handleManualRollbackRequest() error = %v", err)
 	}
 	if handled {
 		t.Fatalf("handled = true, want false with result %+v", result)
 	}
-	if cluster.Status.UpgradeRequests == nil || cluster.Status.UpgradeRequests.LastHandledRollback != "2026-03-10T12:15:00Z" {
-		t.Fatalf("LastHandledRollback = %+v, want request to be recorded", cluster.Status.UpgradeRequests)
+	if acknowledgements.Rollback != "2026-03-10T12:15:00Z" {
+		t.Fatalf("rollback acknowledgement = %q, want request token", acknowledgements.Rollback)
+	}
+	if cluster.Status.UpgradeRequests != nil {
+		t.Fatal("ignored rollback request changed observed request status")
 	}
 }
 

--- a/internal/service/upgrade/bluegreen/manager.go
+++ b/internal/service/upgrade/bluegreen/manager.go
@@ -117,7 +117,12 @@ func requeueAfter(duration time.Duration) recon.Result {
 // Note: Image verification for the Blue StatefulSet is handled by the infra reconciler which runs before this.
 // For Green resources (StatefulSet and snapshot Jobs), we verify and pin digests here to ensure the
 // target images are validated when ImageVerification is enabled.
-func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
+func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (outcome upgrade.ReconcileResult, err error) {
+	outcome.Result, err = m.reconcile(ctx, logger, cluster, &outcome.Acknowledgements)
+	return outcome, err
+}
+
+func (m *Manager) reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements *upgrade.RequestAcknowledgements) (recon.Result, error) {
 	updateStrategy := string(upgrade.EffectiveStrategy(cluster))
 	logger.Info("Manager reconciling",
 		"updateStrategy", updateStrategy,
@@ -134,9 +139,9 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 		return result, nil
 	}
 
-	if handled, result, err := m.handleManualRollbackRequest(ctx, logger, cluster); handled || err != nil {
+	if handled, result, err := m.handleManualRollbackRequest(ctx, logger, cluster, acknowledgements); handled || err != nil {
 		return result, err
 	}
 
-	return m.reconcileBlueGreen(ctx, logger, cluster, verifiedImageDigest)
+	return m.reconcileBlueGreen(ctx, logger, cluster, verifiedImageDigest, acknowledgements)
 }

--- a/internal/service/upgrade/bluegreen/manager_orchestration_test.go
+++ b/internal/service/upgrade/bluegreen/manager_orchestration_test.go
@@ -287,7 +287,7 @@ func TestManager_ReconcileBlueGreen_BlocksUnsupportedTargetVersion(t *testing.T)
 				Build()
 			mgr := &Manager{client: client, scheme: scheme}
 
-			_, err := mgr.reconcileBlueGreen(context.Background(), logr.Discard(), cluster, "")
+			_, err := mgr.reconcileBlueGreen(context.Background(), logr.Discard(), cluster, "", &upgrade.RequestAcknowledgements{})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErrSubstr) {
 				t.Fatalf("reconcileBlueGreen() error = %v, want contains %q", err, tt.wantErrSubstr)
 			}

--- a/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
+++ b/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
@@ -532,8 +532,8 @@ func TestHandlePhaseSyncing_Branches(t *testing.T) {
 		if outcome.kind != phaseOutcomeAdvance || outcome.nextPhase != openbaov1alpha1.PhasePromoting {
 			t.Fatalf("handlePhaseSyncing() outcome = %+v, want advance to Promoting", outcome)
 		}
-		if cluster.Status.UpgradeRequests == nil || cluster.Status.UpgradeRequests.LastHandledPromote != "2026-03-10T12:00:00Z" {
-			t.Fatalf("LastHandledPromote = %+v, want request to be recorded", cluster.Status.UpgradeRequests)
+		if outcome.acknowledgements.Promote != "2026-03-10T12:00:00Z" {
+			t.Fatalf("promote acknowledgement = %q, want request token", outcome.acknowledgements.Promote)
 		}
 	})
 
@@ -585,7 +585,7 @@ func TestHandlePhaseSyncing_Branches(t *testing.T) {
 			Build()
 		manager := &Manager{client: client, reader: client, scheme: scheme}
 
-		result, err := manager.executeStateMachine(context.Background(), logr.Discard(), cluster, "")
+		result, err := manager.executeStateMachine(context.Background(), logr.Discard(), cluster, "", &upgrade.RequestAcknowledgements{})
 		if err != nil {
 			t.Fatalf("executeStateMachine() error = %v", err)
 		}

--- a/internal/service/upgrade/bluegreen/manager_state_machine.go
+++ b/internal/service/upgrade/bluegreen/manager_state_machine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 // calculateRevision computes a deterministic revision hash from relevant spec fields.
@@ -41,7 +42,7 @@ func (m *Manager) transitionToPhase(logger logr.Logger, cluster *openbaov1alpha1
 }
 
 // executeStateMachine runs the blue/green upgrade state machine.
-func (m *Manager) executeStateMachine(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, verifiedImageDigest string) (recon.Result, error) {
+func (m *Manager) executeStateMachine(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, verifiedImageDigest string, acknowledgements *upgrade.RequestAcknowledgements) (recon.Result, error) {
 	phase := cluster.Status.BlueGreen.Phase
 
 	logger = logger.WithValues("phase", phase)
@@ -74,7 +75,11 @@ func (m *Manager) executeStateMachine(ctx context.Context, logger logr.Logger, c
 	if err != nil {
 		return recon.Result{}, err
 	}
-	return m.applyOutcome(ctx, logger, cluster, outcome)
+	result, err := m.applyOutcome(ctx, logger, cluster, outcome)
+	if err == nil {
+		acknowledgements.Merge(outcome.acknowledgements)
+	}
+	return result, err
 }
 
 func (m *Manager) applyOutcome(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, outcome phaseOutcome) (recon.Result, error) {

--- a/internal/service/upgrade/bluegreen/manager_workflow.go
+++ b/internal/service/upgrade/bluegreen/manager_workflow.go
@@ -11,7 +11,7 @@ import (
 )
 
 // reconcileBlueGreen is the internal reconcile method that handles blue/green upgrades.
-func (m *Manager) reconcileBlueGreen(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, verifiedImageDigest string) (result recon.Result, err error) {
+func (m *Manager) reconcileBlueGreen(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, verifiedImageDigest string, acknowledgements *upgrade.RequestAcknowledgements) (result recon.Result, err error) {
 	if !m.shouldReconcileBlueGreen(logger, cluster) {
 		return recon.Result{}, nil
 	}
@@ -34,7 +34,7 @@ func (m *Manager) reconcileBlueGreen(ctx context.Context, logger logr.Logger, cl
 
 	defer m.finalizeBlueGreenMetrics(metrics, strategy, cluster, initialPhase, initialRollbackSet)
 
-	if result, done, err := m.prepareBlueGreenReconcile(ctx, logger, cluster); done || err != nil {
+	if result, done, err := m.prepareBlueGreenReconcile(ctx, logger, cluster, acknowledgements); done || err != nil {
 		return result, err
 	}
 
@@ -42,6 +42,6 @@ func (m *Manager) reconcileBlueGreen(ctx context.Context, logger logr.Logger, cl
 		"currentVersion", cluster.Status.CurrentVersion,
 		"specVersion", cluster.Spec.Version)
 
-	result, err = m.executeStateMachine(ctx, logger, cluster, verifiedImageDigest)
+	result, err = m.executeStateMachine(ctx, logger, cluster, verifiedImageDigest, acknowledgements)
 	return result, err
 }

--- a/internal/service/upgrade/bluegreen/outcome.go
+++ b/internal/service/upgrade/bluegreen/outcome.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 type phaseOutcomeKind string
@@ -19,10 +20,11 @@ const (
 )
 
 type phaseOutcome struct {
-	kind      phaseOutcomeKind
-	nextPhase openbaov1alpha1.BlueGreenPhase
-	after     time.Duration
-	reason    string
+	kind             phaseOutcomeKind
+	nextPhase        openbaov1alpha1.BlueGreenPhase
+	after            time.Duration
+	reason           string
+	acknowledgements upgrade.RequestAcknowledgements
 }
 
 func (o phaseOutcome) validate() error {

--- a/internal/service/upgrade/bluegreen/outcome_test.go
+++ b/internal/service/upgrade/bluegreen/outcome_test.go
@@ -11,6 +11,7 @@ import (
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 func TestPhaseOutcomeValidate_TableDriven(t *testing.T) {
@@ -253,7 +254,7 @@ func TestExecuteStateMachine_UnknownPhaseRejected(t *testing.T) {
 	before := cluster.DeepCopy()
 
 	mgr := &Manager{}
-	_, err := mgr.executeStateMachine(context.Background(), logr.Discard(), cluster, "")
+	_, err := mgr.executeStateMachine(context.Background(), logr.Discard(), cluster, "", &upgrade.RequestAcknowledgements{})
 	if err == nil {
 		t.Fatalf("executeStateMachine() error=nil, want unknown phase error")
 	}

--- a/internal/service/upgrade/bluegreen/requests.go
+++ b/internal/service/upgrade/bluegreen/requests.go
@@ -18,7 +18,7 @@ func blueGreenPhaseString(cluster *openbaov1alpha1.OpenBaoCluster) string {
 	return string(cluster.Status.BlueGreen.Phase)
 }
 
-func (m *Manager) handleManualRollbackRequest(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (bool, recon.Result, error) {
+func (m *Manager) handleManualRollbackRequest(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements *upgrade.RequestAcknowledgements) (bool, recon.Result, error) {
 	if !upgrade.RollbackRequestPending(cluster) {
 		return false, recon.Result{}, nil
 	}
@@ -26,7 +26,7 @@ func (m *Manager) handleManualRollbackRequest(ctx context.Context, logger logr.L
 	rollbackRequest := upgrade.RollbackRequestValue(cluster)
 
 	if cluster.Status.BlueGreen == nil || cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseIdle {
-		upgrade.MarkRollbackRequestHandled(&cluster.Status, rollbackRequest)
+		acknowledgements.Rollback = rollbackRequest
 		logger.Info("Ignoring rollback request because no blue/green upgrade is active",
 			"rollbackRequest", rollbackRequest,
 			"rollbackRequestField", upgrade.RequestRollbackFieldPath)
@@ -35,7 +35,7 @@ func (m *Manager) handleManualRollbackRequest(ctx context.Context, logger logr.L
 
 	if cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseRollingBack ||
 		cluster.Status.BlueGreen.Phase == openbaov1alpha1.PhaseRollbackCleanup {
-		upgrade.MarkRollbackRequestHandled(&cluster.Status, rollbackRequest)
+		acknowledgements.Rollback = rollbackRequest
 		logger.Info("Ignoring rollback request because rollback is already in progress",
 			"rollbackRequest", rollbackRequest,
 			"phase", cluster.Status.BlueGreen.Phase,
@@ -52,13 +52,13 @@ func (m *Manager) handleManualRollbackRequest(ctx context.Context, logger logr.L
 		if err := m.abortUpgrade(ctx, logger, cluster); err != nil {
 			return false, recon.Result{}, fmt.Errorf("failed to abort upgrade via %s: %w", upgrade.RequestRollbackFieldPath, err)
 		}
-		upgrade.MarkRollbackRequestHandled(&cluster.Status, rollbackRequest)
+		acknowledgements.Rollback = rollbackRequest
 		return true, recon.Result{}, nil
 	}
 
 	result, err := m.triggerRollback(logger, cluster, fmt.Sprintf("manual rollback request via %s", upgrade.RequestRollbackFieldPath))
 	if err == nil {
-		upgrade.MarkRollbackRequestHandled(&cluster.Status, rollbackRequest)
+		acknowledgements.Rollback = rollbackRequest
 	}
 	return true, result, err
 }

--- a/internal/service/upgrade/bluegreen/syncing.go
+++ b/internal/service/upgrade/bluegreen/syncing.go
@@ -89,12 +89,13 @@ func (m *Manager) decideSyncPromotion(logger logr.Logger, cluster *openbaov1alph
 
 	if upgrade.PromoteRequestPending(cluster) {
 		promoteRequest := upgrade.PromoteRequestValue(cluster)
-		upgrade.MarkPromoteRequestHandled(&cluster.Status, promoteRequest)
 		logger.Info("Promotion request accepted for held blue/green upgrade",
 			"promoteRequest", promoteRequest,
 			"promoteRequestField", upgrade.RequestPromoteFieldPath)
 		m.emitNormalEvent(cluster, ReasonBlueGreenPromotionApproved, "Promotion approved for Green revision %s", cluster.Status.BlueGreen.GreenRevision)
-		return advance(openbaov1alpha1.PhasePromoting), nil
+		outcome := advance(openbaov1alpha1.PhasePromoting)
+		outcome.acknowledgements.Promote = promoteRequest
+		return outcome, nil
 	}
 
 	logger.Info("Blue/green upgrade is waiting for manual approval",

--- a/internal/service/upgrade/bluegreen/workflow_preflight.go
+++ b/internal/service/upgrade/bluegreen/workflow_preflight.go
@@ -48,6 +48,7 @@ func (m *Manager) prepareBlueGreenReconcile(
 	ctx context.Context,
 	logger logr.Logger,
 	cluster *openbaov1alpha1.OpenBaoCluster,
+	acknowledgements *upgrade.RequestAcknowledgements,
 ) (recon.Result, bool, error) {
 	if err := upgrade.EnsureUpgradeServiceAccount(ctx, m.client, cluster, constants.FieldOwnerOpenBaoOperator); err != nil {
 		return recon.Result{}, false, fmt.Errorf("failed to ensure upgrade ServiceAccount: %w", err)
@@ -63,7 +64,7 @@ func (m *Manager) prepareBlueGreenReconcile(
 		return requeueStandard(), true, nil
 	}
 
-	m.handleUnexpectedPromoteRequest(logger, cluster)
+	m.handleUnexpectedPromoteRequest(logger, cluster, acknowledgements)
 
 	upgradeActive, upgradeNeeded := core.BlueGreenUpgradeState(cluster)
 
@@ -100,7 +101,7 @@ func shouldWaitForSteadyReadReplicaDrain(cluster *openbaov1alpha1.OpenBaoCluster
 	return core.CurrentBlueGreenPhase(cluster) != openbaov1alpha1.PhaseRestoringReadReplicas
 }
 
-func (m *Manager) handleUnexpectedPromoteRequest(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) {
+func (m *Manager) handleUnexpectedPromoteRequest(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements *upgrade.RequestAcknowledgements) {
 	if !upgrade.PromoteRequestPending(cluster) {
 		return
 	}
@@ -111,7 +112,7 @@ func (m *Manager) handleUnexpectedPromoteRequest(logger logr.Logger, cluster *op
 	}
 
 	promoteRequest := upgrade.PromoteRequestValue(cluster)
-	upgrade.MarkPromoteRequestHandled(&cluster.Status, promoteRequest)
+	acknowledgements.Promote = promoteRequest
 	logger.Info("Ignoring promote request because no held blue/green upgrade is waiting for approval",
 		"promoteRequest", promoteRequest,
 		"promoteRequestField", upgrade.RequestPromoteFieldPath)

--- a/internal/service/upgrade/rolling/lifecycle.go
+++ b/internal/service/upgrade/rolling/lifecycle.go
@@ -30,9 +30,8 @@ func (m *Manager) patchFinalizedUpgradeStatus(ctx context.Context, cluster *open
 	return nil
 }
 
-// patchStatusSSA updates the cluster status using Server-Side Apply.
-// SSA eliminates race conditions by having the API server merge changes,
-// rather than requiring the client to refresh and merge manually.
+// patchStatusSSA persists rolling progress while preserving the latest request
+// acknowledgements and sibling AdminOps fields through the shared mutation gateway.
 func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster) error {
 	if m.adminOpsMutator == nil {
 		return fmt.Errorf("adminops status mutator is required")
@@ -40,7 +39,6 @@ func (m *Manager) patchStatusSSA(ctx context.Context, cluster *openbaov1alpha1.O
 
 	if err := m.adminOpsMutator(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
 		obj.Status.Upgrade = cluster.Status.Upgrade
-		obj.Status.UpgradeRequests = cluster.Status.UpgradeRequests
 		return nil
 	}, adminops.ForceOwnershipOnConflict); err != nil {
 		return fmt.Errorf("failed to apply adminops status plane for rolling upgrade status: %w", err)

--- a/internal/service/upgrade/rolling/lifecycle_test.go
+++ b/internal/service/upgrade/rolling/lifecycle_test.go
@@ -44,6 +44,7 @@ func TestPatchStatusSSA_PreservesSiblingAdminOpsFieldsFromLatestObject(t *testin
 	}
 	cluster := stored.DeepCopy()
 	cluster.Status.Backup = nil
+	cluster.Status.UpgradeRequests = &openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: "stale"}
 	cluster.Status.Upgrade.CurrentPartition = 2
 
 	c := fake.NewClientBuilder().
@@ -71,6 +72,9 @@ func TestPatchStatusSSA_PreservesSiblingAdminOpsFieldsFromLatestObject(t *testin
 	}
 	if updated.Status.Upgrade == nil || updated.Status.Upgrade.CurrentPartition != 2 {
 		t.Fatalf("persisted upgrade = %#v, want updated rolling status", updated.Status.Upgrade)
+	}
+	if updated.Status.UpgradeRequests == nil || updated.Status.UpgradeRequests.LastHandledRetry != "retry-1" {
+		t.Fatalf("persisted requests = %#v, want latest acknowledgement preserved", updated.Status.UpgradeRequests)
 	}
 }
 

--- a/internal/service/upgrade/rolling/manager.go
+++ b/internal/service/upgrade/rolling/manager.go
@@ -98,7 +98,12 @@ func (m *Manager) WithAdminOpsStatusMutator(mutator adminops.StatusMutator) *Man
 //  5. Finalization: Clear upgrade state, update current version
 //
 // Returns the reconcile result for follow-up scheduling along with any error.
-func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (recon.Result, error) {
+func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (outcome upgrade.ReconcileResult, err error) {
+	outcome.Result, err = m.reconcile(ctx, logger, cluster, &outcome.Acknowledgements)
+	return outcome, err
+}
+
+func (m *Manager) reconcile(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements *upgrade.RequestAcknowledgements) (recon.Result, error) {
 	logger = logger.WithValues(
 		"specVersion", cluster.Spec.Version,
 		"statusVersion", cluster.Status.CurrentVersion,
@@ -111,7 +116,7 @@ func (m *Manager) Reconcile(ctx context.Context, logger logr.Logger, cluster *op
 		return result, nil
 	}
 
-	upgradeNeeded, resumeUpgrade := m.detectUpgradeState(logger, cluster)
+	upgradeNeeded, resumeUpgrade := m.detectUpgradeState(logger, cluster, acknowledgements)
 	if result, done, err := m.ensureUpgradeLock(ctx, logger, cluster, metrics, strategy, upgradeNeeded, resumeUpgrade); done || err != nil {
 		return result, err
 	}

--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -21,7 +21,6 @@ import (
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
 	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
-	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	openbaoapi "github.com/dc-tec/openbao-operator/internal/platform/testutil/openbao"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
@@ -215,7 +214,8 @@ func TestDetectUpgradeState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &Manager{}
 
-			gotUpgradeNeeded, gotResumeUpgrade := m.detectUpgradeState(testLogger(), tt.cluster)
+			var acknowledgements upgrade.RequestAcknowledgements
+			gotUpgradeNeeded, gotResumeUpgrade := m.detectUpgradeState(testLogger(), tt.cluster, &acknowledgements)
 
 			if gotUpgradeNeeded != tt.wantUpgradeNeeded {
 				t.Errorf("detectUpgradeState() upgradeNeeded = %v, want %v", gotUpgradeNeeded, tt.wantUpgradeNeeded)
@@ -224,8 +224,8 @@ func TestDetectUpgradeState(t *testing.T) {
 				t.Errorf("detectUpgradeState() resumeUpgrade = %v, want %v", gotResumeUpgrade, tt.wantResumeUpgrade)
 			}
 			if tt.name == "stale retry request is ignored when no failed upgrade is waiting" {
-				if tt.cluster.Status.UpgradeRequests == nil || tt.cluster.Status.UpgradeRequests.LastHandledRetry != "retry-1" {
-					t.Fatalf("LastHandledRetry = %+v, want retry-1 to be recorded as handled", tt.cluster.Status.UpgradeRequests)
+				if acknowledgements.Retry != "retry-1" {
+					t.Fatalf("retry acknowledgement = %q, want retry-1", acknowledgements.Retry)
 				}
 			}
 		})
@@ -1048,7 +1048,7 @@ func TestReconcile_SkipsBlueGreenStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v, want nil", err)
 	}
-	if result != (recon.Result{}) {
+	if result != (upgrade.ReconcileResult{}) {
 		t.Fatalf("Reconcile() result = %+v, want empty result", result)
 	}
 }
@@ -1137,7 +1137,7 @@ func TestReconcile_ReleasesStaleUpgradeLockWhenUpgradeIsIdle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v, want nil", err)
 	}
-	if result != (recon.Result{}) {
+	if result != (upgrade.ReconcileResult{}) {
 		t.Fatalf("Reconcile() result = %+v, want empty result", result)
 	}
 
@@ -1223,7 +1223,7 @@ func TestReconcile_RetriesStaleUpgradeLockReleaseAfterFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second Reconcile() error = %v, want nil", err)
 	}
-	if result != (recon.Result{}) {
+	if result != (upgrade.ReconcileResult{}) {
 		t.Fatalf("second Reconcile() result = %+v, want empty result", result)
 	}
 	if freshCluster.Status.OperationLock != nil {
@@ -1455,7 +1455,7 @@ func TestUpgradeStateTransitions(t *testing.T) {
 			}
 
 			m := &Manager{}
-			gotUpgrade, gotResume := m.detectUpgradeState(testLogger(), cluster)
+			gotUpgrade, gotResume := m.detectUpgradeState(testLogger(), cluster, &upgrade.RequestAcknowledgements{})
 
 			if gotUpgrade != tt.wantUpgradeNeeded {
 				t.Errorf("%s: upgradeNeeded = %v, want %v", tt.description, gotUpgrade, tt.wantUpgradeNeeded)

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -57,8 +57,6 @@ func (m *Manager) prepareFailedUpgradeRetry(ctx context.Context, logger logr.Log
 	if cluster.Status.Upgrade == nil {
 		return false, nil
 	}
-	upgrade.MarkRetryRequestHandled(&cluster.Status, retryRequest)
-
 	logger.Info("Cleared failed rolling upgrade state and resumed upgrade")
 	m.emitNormalEvent(cluster, upgrade.ReasonRollingRetryAccepted, "Rolling upgrade retry accepted for target version %s", cluster.Status.Upgrade.TargetVersion)
 	return true, nil

--- a/internal/service/upgrade/rolling/upgrade_state.go
+++ b/internal/service/upgrade/rolling/upgrade_state.go
@@ -8,13 +8,13 @@ import (
 )
 
 // detectUpgradeState determines whether an upgrade is needed or if we're resuming one.
-func (m *Manager) detectUpgradeState(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (upgradeNeeded bool, resumeUpgrade bool) {
+func (m *Manager) detectUpgradeState(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements *upgrade.RequestAcknowledgements) (upgradeNeeded bool, resumeUpgrade bool) {
 	if upgrade.RetryRequestPending(cluster) &&
 		(cluster.Status.Upgrade == nil ||
 			!upgrade.UpgradeFailed(cluster.Status.Upgrade) ||
 			cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion) {
 		retryRequest := upgrade.RetryRequestValue(cluster)
-		upgrade.MarkRetryRequestHandled(&cluster.Status, retryRequest)
+		acknowledgements.Retry = retryRequest
 		logger.Info("Ignoring retry request because no failed rolling upgrade is waiting to resume",
 			"retryRequest", retryRequest,
 			"retryRequestField", upgrade.RequestRetryFieldPath)

--- a/internal/service/upgrade/rolling/upgrade_state_property_test.go
+++ b/internal/service/upgrade/rolling/upgrade_state_property_test.go
@@ -48,7 +48,11 @@ func TestDetectUpgradeStateRetryProperties(t *testing.T) {
 
 		wantUpgradeNeeded, wantResumeUpgrade, wantHandledRetry := expectedDetectUpgradeState(cluster)
 
-		gotUpgradeNeeded, gotResumeUpgrade := (&Manager{}).detectUpgradeState(logr.Discard(), cluster)
+		var acknowledgements upgrade.RequestAcknowledgements
+		gotUpgradeNeeded, gotResumeUpgrade := (&Manager{}).detectUpgradeState(logr.Discard(), cluster, &acknowledgements)
+		if cluster.Status.UpgradeRequests.LastHandledRetry != lastHandledRetry {
+			t.Fatal("detectUpgradeState changed the observed retry acknowledgement")
+		}
 
 		if gotUpgradeNeeded != wantUpgradeNeeded {
 			t.Fatalf("upgradeNeeded = %t, want %t for cluster=%+v", gotUpgradeNeeded, wantUpgradeNeeded, cluster)
@@ -59,6 +63,9 @@ func TestDetectUpgradeStateRetryProperties(t *testing.T) {
 		gotHandledRetry := ""
 		if cluster.Status.UpgradeRequests != nil {
 			gotHandledRetry = cluster.Status.UpgradeRequests.LastHandledRetry
+		}
+		if acknowledgements.Retry != "" {
+			gotHandledRetry = acknowledgements.Retry
 		}
 		if gotHandledRetry != wantHandledRetry {
 			t.Fatalf("LastHandledRetry = %q, want %q for retryRequest=%q upgrade=%+v",

--- a/test/integration/adminops_restore_status_test.go
+++ b/test/integration/adminops_restore_status_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
 	"github.com/dc-tec/openbao-operator/internal/port/adminops"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
 func TestAdminOpsFinalPatchPreservesConcurrentRestore(t *testing.T) {
@@ -91,7 +92,7 @@ func TestAdminOpsFinalPatchPreservesConcurrentRestore(t *testing.T) {
 						return err
 					},
 				})
-				require.NoError(t, openbaocluster.PatchAdminOpsOwnedFieldsWithReader(ctx, k8sClient, writer, logr.Discard(), original, desired, "adminops-error"))
+				require.NoError(t, openbaocluster.PatchAdminOpsOwnedFieldsWithReader(ctx, k8sClient, writer, logr.Discard(), original, desired, upgrade.RequestAcknowledgements{}, "adminops-error"))
 
 				stored := &openbaov1alpha1.OpenBaoCluster{}
 				require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored))

--- a/test/integration/adminops_upgrade_requests_test.go
+++ b/test/integration/adminops_upgrade_requests_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
+	"github.com/dc-tec/openbao-operator/internal/app/openbaocluster/adminopsstatus"
+	"github.com/dc-tec/openbao-operator/internal/port/adminops"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
+)
+
+var upgradeAcknowledgementCases = []struct {
+	name             string
+	mark             func(*openbaov1alpha1.OpenBaoClusterStatus, string)
+	acknowledgements upgrade.RequestAcknowledgements
+	pending          func(*openbaov1alpha1.OpenBaoCluster) bool
+	phase            openbaov1alpha1.BlueGreenPhase
+}{
+	{"retry", upgrade.MarkRetryRequestHandled, upgrade.RequestAcknowledgements{Retry: "handled"}, upgrade.RetryRequestPending, ""},
+	{"promote", upgrade.MarkPromoteRequestHandled, upgrade.RequestAcknowledgements{Promote: "handled"}, upgrade.PromoteRequestPending, openbaov1alpha1.PhasePromoting},
+	{"rollback", upgrade.MarkRollbackRequestHandled, upgrade.RequestAcknowledgements{Rollback: "handled"}, upgrade.RollbackRequestPending, openbaov1alpha1.PhaseRollingBack},
+}
+
+func TestAdminOpsFinalPatchPreservesUpgradeRequestSiblings(t *testing.T) {
+	baseWriter, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sScheme})
+	require.NoError(t, err)
+	for _, tt := range upgradeAcknowledgementCases {
+		for _, raceApply := range []bool{false, true} {
+			timing := "before-read"
+			if raceApply {
+				timing = "after-read"
+			}
+			t.Run(tt.name+"/"+timing, func(t *testing.T) {
+				cluster := createMinimalCluster(t, newTestNamespace(t), "request-siblings")
+				mutateStatus := adminopsstatus.NewMutator(k8sClient, k8sClient)
+				require.NoError(t, mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+					if tt.phase != "" {
+						obj.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseSyncing}
+					}
+					obj.Status.UpgradeRequests = &openbaov1alpha1.UpgradeRequestStatus{
+						LastHandledRetry: "initial", LastHandledPromote: "initial", LastHandledRollback: "initial",
+					}
+					return nil
+				}, adminops.RespectOwnership))
+				cluster.Spec.Upgrade = &openbaov1alpha1.UpgradeConfig{Requests: &openbaov1alpha1.UpgradeRequestConfig{
+					Retry: "handled", Promote: "handled", Rollback: "handled",
+				}}
+				require.NoError(t, k8sClient.Update(ctx, cluster))
+				original := cluster.DeepCopy()
+				desired := cluster.DeepCopy()
+				if tt.phase != "" {
+					desired.Status.BlueGreen.Phase = tt.phase
+				}
+				latest := original.Status.DeepCopy()
+				latest.UpgradeRequests = &openbaov1alpha1.UpgradeRequestStatus{
+					LastHandledRetry: "latest", LastHandledPromote: "latest", LastHandledRollback: "latest",
+				}
+				tt.mark(latest, "initial")
+				want := latest.DeepCopy()
+				tt.mark(want, "handled")
+				writeSiblings := func() {
+					t.Helper()
+					cluster.Spec.Upgrade.Requests = &openbaov1alpha1.UpgradeRequestConfig{
+						Retry: "newer", Promote: "newer", Rollback: "newer",
+					}
+					require.NoError(t, k8sClient.Update(ctx, cluster))
+					require.NoError(t, mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+						obj.Status.UpgradeRequests = latest.UpgradeRequests.DeepCopy()
+						return nil
+					}, adminops.RespectOwnership))
+				}
+				if !raceApply {
+					writeSiblings()
+				}
+				applies, conflicts := 0, 0
+				writer := interceptor.NewClient(baseWriter, interceptor.Funcs{
+					SubResourceApply: func(ctx context.Context, c client.Client, subresource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+						applies++
+						if raceApply && applies == 1 {
+							writeSiblings()
+						}
+						err := c.SubResource(subresource).Apply(ctx, obj, opts...)
+						if apierrors.IsConflict(err) {
+							conflicts++
+						}
+						return err
+					},
+				})
+				require.NoError(t, openbaocluster.PatchAdminOpsOwnedFieldsWithReader(ctx, k8sClient, writer, logr.Discard(), original, desired, tt.acknowledgements, "request"))
+				stored := &openbaov1alpha1.OpenBaoCluster{}
+				require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored))
+				require.Equal(t, want.UpgradeRequests, stored.Status.UpgradeRequests)
+				require.Equal(t, stored.Status.UpgradeRequests, desired.Status.UpgradeRequests)
+				require.True(t, tt.pending(stored), "a newer spec token must remain pending after the captured token is acknowledged")
+				if tt.phase != "" {
+					require.Equal(t, tt.phase, stored.Status.BlueGreen.Phase, "transition and acknowledgement must be saved together")
+				}
+				if raceApply {
+					require.Equal(t, 1, conflicts)
+					require.Equal(t, 2, applies)
+				} else {
+					require.Zero(t, conflicts)
+					require.Equal(t, 1, applies)
+				}
+			})
+		}
+	}
+}
+
+func TestAdminOpsAcknowledgementAndTransitionWriteFailures(t *testing.T) {
+	baseWriter, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sScheme})
+	require.NoError(t, err)
+	for _, failReadBack := range []bool{false, true} {
+		name := "apply"
+		if failReadBack {
+			name = "read-back"
+		}
+		t.Run(name, func(t *testing.T) {
+			cluster := createMinimalCluster(t, newTestNamespace(t), "request-failure")
+			mutateStatus := adminopsstatus.NewMutator(k8sClient, k8sClient)
+			require.NoError(t, mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.BlueGreen = &openbaov1alpha1.BlueGreenStatus{Phase: openbaov1alpha1.PhaseSyncing}
+				return nil
+			}, adminops.RespectOwnership))
+			original := cluster.DeepCopy()
+			desired := cluster.DeepCopy()
+			desired.Status.BlueGreen.Phase = openbaov1alpha1.PhasePromoting
+			acknowledgements := upgrade.RequestAcknowledgements{Promote: "handled"}
+			writeErr := errors.New("injected status write failure")
+			reads := 0
+			c := interceptor.NewClient(baseWriter, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					reads++
+					if failReadBack && reads == 2 {
+						return writeErr
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+				SubResourceApply: func(ctx context.Context, c client.Client, subresource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+					if !failReadBack {
+						return writeErr
+					}
+					return c.SubResource(subresource).Apply(ctx, obj, opts...)
+				},
+			})
+			err := openbaocluster.PatchAdminOpsOwnedFieldsWithReader(ctx, c, c, logr.Discard(), original, desired, acknowledgements, "request")
+			require.ErrorIs(t, err, writeErr)
+			stored := &openbaov1alpha1.OpenBaoCluster{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored))
+			if failReadBack {
+				require.Equal(t, 2, reads)
+				require.Equal(t, openbaov1alpha1.PhasePromoting, stored.Status.BlueGreen.Phase)
+				require.Equal(t, "handled", stored.Status.UpgradeRequests.LastHandledPromote)
+			} else {
+				require.Equal(t, openbaov1alpha1.PhaseSyncing, stored.Status.BlueGreen.Phase)
+				require.Nil(t, stored.Status.UpgradeRequests)
+			}
+			require.Nil(t, desired.Status.UpgradeRequests, "an error must not invent observed acknowledgement state")
+			require.Equal(t, "handled", acknowledgements.Promote, "write intent remains available for retry")
+		})
+	}
+}
+
+func TestAdminOpsPendingUpgradeAcknowledgementSurvivesCheckpoint(t *testing.T) {
+	for _, tt := range upgradeAcknowledgementCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := createMinimalCluster(t, newTestNamespace(t), "request-checkpoint")
+			original := cluster.DeepCopy()
+			want := original.Status.DeepCopy()
+			tt.mark(want, "handled")
+			mutateStatus := adminopsstatus.NewMutator(k8sClient, k8sClient)
+			require.NoError(t, mutateStatus(ctx, cluster, func(obj *openbaov1alpha1.OpenBaoCluster) error {
+				obj.Status.Backup = &openbaov1alpha1.BackupStatus{LastFailureReason: "checkpoint"}
+				return nil
+			}, adminops.RespectOwnership))
+			require.Nil(t, cluster.Status.UpgradeRequests, "checkpoint read-back contains only observed acknowledgements")
+			require.NoError(t, openbaocluster.PatchAdminOpsOwnedFieldsWithReader(ctx, k8sClient, k8sClient, logr.Discard(), original, cluster, tt.acknowledgements, "request"))
+			stored := &openbaov1alpha1.OpenBaoCluster{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored))
+			require.Equal(t, want.UpgradeRequests, stored.Status.UpgradeRequests)
+			require.Equal(t, "checkpoint", stored.Status.Backup.LastFailureReason)
+		})
+	}
+}

--- a/website/content/docs/architecture/invariants-and-boundaries.md
+++ b/website/content/docs/architecture/invariants-and-boundaries.md
@@ -15,6 +15,8 @@ verifiedBy:
   - internal/app/openbaocluster/adminopsstatus/mutate_test.go
   - test/integration/adminops_status_test.go
   - test/integration/adminops_restore_status_test.go
+  - test/integration/adminops_upgrade_requests_test.go
+  - internal/service/upgrade/acknowledgements.go
   - internal/platform/statusapply/openbaocluster_test.go
 ---
 
@@ -95,10 +97,18 @@ read. It does not substitute the intended state for the observed state. If read-
 though the apply succeeded. The application wrapper updates the caller's AdminOps fields and resource version only
 after a successful read-back; it leaves other fields unchanged.
 
-The final AdminOps patch persists pending changes to accepted upgrade strategy, blue-green state, upgrade requests,
-break-glass state, and AdminOps state. Managers persist backup, rolling-upgrade progress, and restore restart state.
+The final AdminOps patch persists pending changes to accepted upgrade strategy, blue-green state, break-glass state,
+and AdminOps state. Managers persist backup, rolling-upgrade progress, and restore restart state.
 The final patch preserves the latest API values for those manager-owned fields in the complete SSA payload. Changes to
 those fields alone do not trigger a final patch.
+
+Upgrade managers return pending request acknowledgements in `upgrade.ReconcileResult`, separate from observed cluster
+status. The application accumulates these tokens across sub-reconcilers and applies only those acknowledgements in its
+final write, including error and requeue paths. Checkpoint read-back cannot discard pending acknowledgements. A newer
+request in spec remains pending because the write records the captured token, and unrelated acknowledgement fields
+retain their latest API values. Promotion and rollback acknowledgements are saved with their resulting blue-green
+state. Failed rolling retries retain their immediate checkpoint, which clears failure state and acknowledges the retry
+in the same write.
 
 Managers share the `adminops.StatusMutator` contract. The application layer binds it to the API reader and client through
 `adminopsstatus.NewMutator`. Each write selects an ownership policy:


### PR DESCRIPTION
## Summary

Upgrade request acknowledgements currently serve as both observed status and pending write intent. A checkpoint read-back can discard an unpersisted token, and a later status write can replay stale sibling acknowledgements.

Return handled tokens in a per-reconcile `upgrade.ReconcileResult` and accumulate them through the AdminOps application, including error and requeue paths. The final write applies only those tokens to freshly read status. Rolling progress checkpoints preserve the latest request status. Also guard AdminOps error reporting when read-back clears `status.adminOps`.

## Related Issues

Continues the status-contract refactors after #708, #709, and #710, which are merged. No separate issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Changes the internal upgrade-manager result contract. No public API, CRD, Helm, RBAC, or dependency changes.

Promotion and rollback acknowledgements remain in the same write as their resulting blue/green phase. Failed rolling retries retain the immediate write that clears failure state and acknowledges the retry. A newer request in spec remains pending because persistence records the captured token.

## Verification

Local validation completed on September 5, 2026, against this unchanged source tree:

- `make lint-ci verify-fmt test-ci docs-build report-internal-deps` passed. This includes architecture rule generation, policy verification, and AST tests/scans. The test run reported 3,793 tests with four skips; internal coverage was 70.90% against the 68% floor.
- API-server regressions cover sibling acknowledgements before a fresh read and during a resource-version conflict, checkpoint read-back, newer spec tokens, and apply/read-back failures. Application tests cover complete, requeue, and error paths, plus isolation between reconcile passes.
- Two focused Kind E2Es passed with a freshly built operator on Kubernetes 1.36.1: failed rolling retry recovery from OpenBao 2.5.5 to 2.6.2, and held blue/green promotion from 2.4.4 to 2.5.5 after a successful validation hook.
- `git diff --check` passed.

The full E2E suite and full `operator:ci-core` task were not run locally; validation used the relevant checks above. Remote CI will provide the broader checks.

## Reviewer Notes

Review the separation between pending acknowledgements and observed status, and the preserved write timing in rolling retry and blue/green phase transitions. The new API-server cases reproduced the stale-sibling and lost-acknowledgement failures before the fix.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
