### PR TITLE
refactor(upgrade): make rolling decisions explicit

### DIFF
--- a/internal/service/upgrade/rolling/events_test.go
+++ b/internal/service/upgrade/rolling/events_test.go
@@ -207,12 +207,9 @@ func TestPrepareFailedUpgradeRetry_EmitsRetryEvents(t *testing.T) {
 		adminOpsMutator: testAdminOpsMutator(k8sClient),
 	}
 
-	resumed, err := manager.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster)
+	err := manager.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster, upgrade.RetryRequestValue(cluster))
 	if err != nil {
 		t.Fatalf("prepareFailedUpgradeRetry() error = %v", err)
-	}
-	if !resumed {
-		t.Fatal("resumed = false, want true")
 	}
 
 	expectEventContains(t, recorder, "Normal", upgrade.ReasonRollingRetryRequested)

--- a/internal/service/upgrade/rolling/manager.go
+++ b/internal/service/upgrade/rolling/manager.go
@@ -116,12 +116,18 @@ func (m *Manager) reconcile(ctx context.Context, logger logr.Logger, cluster *op
 		return result, nil
 	}
 
-	upgradeNeeded, resumeUpgrade := m.detectUpgradeState(logger, cluster, acknowledgements)
-	if result, done, err := m.ensureUpgradeLock(ctx, logger, cluster, metrics, strategy, upgradeNeeded, resumeUpgrade); done || err != nil {
+	decision := decideUpgrade(cluster)
+	acknowledgements.Merge(decision.acknowledgements)
+	if decision.action != upgradeIdle {
+		logger.Info("Selected rolling upgrade action", "action", decision.action,
+			"failureReason", upgrade.UpgradeFailureReason(cluster.Status.Upgrade),
+			"retryRequestField", upgrade.RequestRetryFieldPath)
+	}
+	if result, done, err := m.ensureUpgradeLock(ctx, logger, cluster, metrics, strategy, decision.action); done || err != nil {
 		return result, err
 	}
 
-	if result, done, err := m.prepareUpgradeExecution(ctx, logger, cluster, metrics, strategy, resumeUpgrade); done || err != nil {
+	if result, done, err := m.prepareUpgradeExecution(ctx, logger, cluster, metrics, strategy, decision); done || err != nil {
 		return result, err
 	}
 

--- a/internal/service/upgrade/rolling/manager_test.go
+++ b/internal/service/upgrade/rolling/manager_test.go
@@ -33,205 +33,6 @@ func testLogger() logr.Logger {
 	return logr.Discard()
 }
 
-func TestDetectUpgradeState(t *testing.T) {
-	tests := []struct {
-		name              string
-		cluster           *openbaov1alpha1.OpenBaoCluster
-		wantUpgradeNeeded bool
-		wantResumeUpgrade bool
-	}{
-		{
-			name: "no upgrade needed - versions match",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.4.0",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-				},
-			},
-			wantUpgradeNeeded: false,
-			wantResumeUpgrade: false,
-		},
-		{
-			name: "upgrade needed - version mismatch",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.5.0",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-				},
-			},
-			wantUpgradeNeeded: true,
-			wantResumeUpgrade: false,
-		},
-		{
-			name: "stale retry request is ignored when no failed upgrade is waiting",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.5.0",
-					Upgrade: &openbaov1alpha1.UpgradeConfig{
-						Requests: &openbaov1alpha1.UpgradeRequestConfig{
-							Retry: "retry-1",
-						},
-					},
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-				},
-			},
-			wantUpgradeNeeded: true,
-			wantResumeUpgrade: false,
-		},
-		{
-			name: "resume upgrade - in progress",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.5.0",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion:    "2.5.0",
-						FromVersion:      "2.4.0",
-						CurrentPartition: 2,
-					},
-				},
-			},
-			wantUpgradeNeeded: false,
-			wantResumeUpgrade: true,
-		},
-		{
-			name: "failed upgrade waits for manual retry",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.5.0",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion:    "2.5.0",
-						FromVersion:      "2.4.0",
-						CurrentPartition: 1,
-						Failure: &openbaov1alpha1.ControllerErrorStatus{
-							Reason:  upgrade.ReasonUpgradeFailed,
-							Message: "step-down timeout",
-						},
-					},
-				},
-			},
-			wantUpgradeNeeded: false,
-			wantResumeUpgrade: false,
-		},
-		{
-			name: "failed upgrade resumes when retry request is set",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.5.0",
-					Upgrade: &openbaov1alpha1.UpgradeConfig{
-						Requests: &openbaov1alpha1.UpgradeRequestConfig{
-							Retry: "retry-1",
-						},
-					},
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion:    "2.5.0",
-						FromVersion:      "2.4.0",
-						CurrentPartition: 1,
-						Failure: &openbaov1alpha1.ControllerErrorStatus{
-							Reason:  upgrade.ReasonUpgradeFailed,
-							Message: "step-down timeout",
-						},
-					},
-				},
-			},
-			wantUpgradeNeeded: false,
-			wantResumeUpgrade: true,
-		},
-		{
-			name: "failed upgrade resumes when target version changes",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.5.1",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion:    "2.5.0",
-						FromVersion:      "2.4.0",
-						CurrentPartition: 1,
-						Failure: &openbaov1alpha1.ControllerErrorStatus{
-							Reason:  upgrade.ReasonUpgradeFailed,
-							Message: "step-down timeout",
-						},
-					},
-				},
-			},
-			wantUpgradeNeeded: false,
-			wantResumeUpgrade: true,
-		},
-		{
-			name: "first reconcile - current version empty",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.4.0",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "",
-					Initialized:    true,
-				},
-			},
-			wantUpgradeNeeded: false,
-			wantResumeUpgrade: false,
-		},
-		{
-			name: "downgrade scenario still detects as upgrade needed",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version: "2.3.0",
-				},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					CurrentVersion: "2.4.0",
-					Initialized:    true,
-				},
-			},
-			wantUpgradeNeeded: true, // Detection doesn't block; validation does
-			wantResumeUpgrade: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := &Manager{}
-
-			var acknowledgements upgrade.RequestAcknowledgements
-			gotUpgradeNeeded, gotResumeUpgrade := m.detectUpgradeState(testLogger(), tt.cluster, &acknowledgements)
-
-			if gotUpgradeNeeded != tt.wantUpgradeNeeded {
-				t.Errorf("detectUpgradeState() upgradeNeeded = %v, want %v", gotUpgradeNeeded, tt.wantUpgradeNeeded)
-			}
-			if gotResumeUpgrade != tt.wantResumeUpgrade {
-				t.Errorf("detectUpgradeState() resumeUpgrade = %v, want %v", gotResumeUpgrade, tt.wantResumeUpgrade)
-			}
-			if tt.name == "stale retry request is ignored when no failed upgrade is waiting" {
-				if acknowledgements.Retry != "retry-1" {
-					t.Fatalf("retry acknowledgement = %q, want retry-1", acknowledgements.Retry)
-				}
-			}
-		})
-	}
-}
-
 func TestValidateUpgrade_BlocksInvalidVersionSelection(t *testing.T) {
 	t.Parallel()
 
@@ -1088,70 +889,84 @@ func TestReconcile_HaltsDuringBreakGlassWithoutAck(t *testing.T) {
 func TestReconcile_ReleasesStaleUpgradeLockWhenUpgradeIsIdle(t *testing.T) {
 	t.Parallel()
 
-	scheme := newScheme()
-	now := metav1.Now()
-	cluster := &openbaov1alpha1.OpenBaoCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster",
-			Namespace: "default",
-		},
-		Spec: openbaov1alpha1.OpenBaoClusterSpec{
-			Version:  "2.4.0",
-			Replicas: 3,
-		},
-		Status: openbaov1alpha1.OpenBaoClusterStatus{
-			Initialized:    true,
-			CurrentVersion: "2.4.0",
-			OperationLock: &openbaov1alpha1.OperationLockStatus{
-				Operation:  openbaov1alpha1.ClusterOperationUpgrade,
-				Holder:     upgradecore.UpgradeOperationLockHolder,
-				Message:    "stale upgrade lock",
-				AcquiredAt: &now,
-				RenewedAt:  &now,
-			},
-		},
-	}
+	for _, waitingForRetry := range []bool{false, true} {
+		t.Run(strconv.FormatBool(waitingForRetry), func(t *testing.T) {
+			scheme := newScheme()
+			now := metav1.Now()
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Version:  "2.4.0",
+					Replicas: 3,
+				},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Initialized:    true,
+					CurrentVersion: "2.4.0",
+					OperationLock: &openbaov1alpha1.OperationLockStatus{
+						Operation:  openbaov1alpha1.ClusterOperationUpgrade,
+						Holder:     upgradecore.UpgradeOperationLockHolder,
+						Message:    "stale upgrade lock",
+						AcquiredAt: &now,
+						RenewedAt:  &now,
+					},
+				},
+			}
 
-	var patchPayloads []string
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
-		WithObjects(cluster).
-		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-				if subResourceName == "status" {
-					payload, err := patch.Data(obj)
-					if err != nil {
-						return err
-					}
-					patchPayloads = append(patchPayloads, string(payload))
+			if waitingForRetry {
+				cluster.Status.Upgrade = &openbaov1alpha1.UpgradeProgress{
+					TargetVersion: cluster.Spec.Version,
+					Failure:       &openbaov1alpha1.ControllerErrorStatus{Reason: upgrade.ReasonUpgradeFailed},
 				}
-				return c.Status().Patch(ctx, obj, patch, opts...)
-			},
-		}).
-		Build()
-	mgr := NewManager(k8sClient, scheme, nil, portopenbao.ClientConfig{}, nil, "")
-	mgr.WithReader(k8sClient).WithAdminOpsStatusMutator(testAdminOpsMutator(k8sClient))
+			}
 
-	result, err := mgr.Reconcile(context.Background(), testLogger(), cluster)
-	if err != nil {
-		t.Fatalf("Reconcile() error = %v, want nil", err)
-	}
-	if result != (upgrade.ReconcileResult{}) {
-		t.Fatalf("Reconcile() result = %+v, want empty result", result)
-	}
+			var patchPayloads []string
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&openbaov1alpha1.OpenBaoCluster{}).
+				WithObjects(cluster).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if subResourceName == "status" {
+							payload, err := patch.Data(obj)
+							if err != nil {
+								return err
+							}
+							patchPayloads = append(patchPayloads, string(payload))
+						}
+						return c.Status().Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+			mgr := NewManager(k8sClient, scheme, nil, portopenbao.ClientConfig{}, nil, "")
+			mgr.WithReader(k8sClient).WithAdminOpsStatusMutator(testAdminOpsMutator(k8sClient))
 
-	if len(patchPayloads) != 1 {
-		t.Fatalf("expected one optimistic lock clear patch, got %d payloads", len(patchPayloads))
-	}
-	if !strings.Contains(patchPayloads[0], `"operationLock":null`) {
-		t.Fatalf("expected patch to explicitly clear operationLock, got %s", patchPayloads[0])
-	}
-	if !strings.Contains(patchPayloads[0], `"resourceVersion":`) {
-		t.Fatalf("expected patch to include a resourceVersion precondition, got %s", patchPayloads[0])
-	}
-	if cluster.Status.OperationLock != nil {
-		t.Fatalf("expected in-memory operation lock to be released, got %+v", cluster.Status.OperationLock)
+			result, err := mgr.Reconcile(context.Background(), testLogger(), cluster)
+			if err != nil {
+				t.Fatalf("Reconcile() error = %v, want nil", err)
+			}
+			if result != (upgrade.ReconcileResult{}) {
+				t.Fatalf("Reconcile() result = %+v, want empty result", result)
+			}
+
+			if len(patchPayloads) != 1 {
+				t.Fatalf("expected one optimistic lock clear patch, got %d payloads", len(patchPayloads))
+			}
+			if !strings.Contains(patchPayloads[0], `"operationLock":null`) {
+				t.Fatalf("expected patch to explicitly clear operationLock, got %s", patchPayloads[0])
+			}
+			if !strings.Contains(patchPayloads[0], `"resourceVersion":`) {
+				t.Fatalf("expected patch to include a resourceVersion precondition, got %s", patchPayloads[0])
+			}
+			if cluster.Status.OperationLock != nil {
+				t.Fatalf("expected in-memory operation lock to be released, got %+v", cluster.Status.OperationLock)
+			}
+			if waitingForRetry && !upgrade.UpgradeFailed(cluster.Status.Upgrade) {
+				t.Fatal("waiting for retry must preserve failed upgrade progress")
+			}
+		})
 	}
 }
 
@@ -1361,112 +1176,6 @@ func TestReconcile_ReleasesUpgradeLockOnValidationFailureBeforeStart(t *testing.
 	}
 }
 
-// TestUpgradeStateTransitions tests the logical state transitions during an upgrade.
-// This is a table-driven test following the testing strategy.
-func TestUpgradeStateTransitions(t *testing.T) {
-	tests := []struct {
-		name              string
-		initialStatus     openbaov1alpha1.OpenBaoClusterStatus
-		specVersion       string
-		wantUpgradeNeeded bool
-		wantResume        bool
-		description       string
-	}{
-		{
-			name: "Running -> Upgrading (new upgrade)",
-			initialStatus: openbaov1alpha1.OpenBaoClusterStatus{
-				Phase:          openbaov1alpha1.ClusterPhaseRunning,
-				CurrentVersion: "2.4.0",
-				Initialized:    true,
-			},
-			specVersion:       "2.5.0",
-			wantUpgradeNeeded: true,
-			wantResume:        false,
-			description:       "A running cluster detects version change and needs upgrade",
-		},
-		{
-			name: "Upgrading -> Upgrading (resume)",
-			initialStatus: openbaov1alpha1.OpenBaoClusterStatus{
-				Phase:          openbaov1alpha1.ClusterPhaseUpgrading,
-				CurrentVersion: "2.4.0",
-				Initialized:    true,
-				Upgrade: &openbaov1alpha1.UpgradeProgress{
-					TargetVersion:    "2.5.0",
-					FromVersion:      "2.4.0",
-					CurrentPartition: 2,
-					CompletedPods:    []int32{2},
-				},
-			},
-			specVersion:       "2.5.0",
-			wantUpgradeNeeded: false,
-			wantResume:        true,
-			description:       "An in-progress upgrade should resume",
-		},
-		{
-			name: "Running -> Running (no change)",
-			initialStatus: openbaov1alpha1.OpenBaoClusterStatus{
-				Phase:          openbaov1alpha1.ClusterPhaseRunning,
-				CurrentVersion: "2.5.0",
-				Initialized:    true,
-			},
-			specVersion:       "2.5.0",
-			wantUpgradeNeeded: false,
-			wantResume:        false,
-			description:       "No upgrade needed when versions match",
-		},
-		{
-			name: "Initializing -> skip (not initialized)",
-			initialStatus: openbaov1alpha1.OpenBaoClusterStatus{
-				Phase:          openbaov1alpha1.ClusterPhaseInitializing,
-				CurrentVersion: "",
-				Initialized:    false,
-			},
-			specVersion:       "2.4.0",
-			wantUpgradeNeeded: false,
-			wantResume:        false,
-			description:       "Cluster not initialized; skip upgrade detection",
-		},
-		{
-			name: "First version set (empty current version)",
-			initialStatus: openbaov1alpha1.OpenBaoClusterStatus{
-				Phase:          openbaov1alpha1.ClusterPhaseRunning,
-				CurrentVersion: "",
-				Initialized:    true,
-			},
-			specVersion:       "2.4.0",
-			wantUpgradeNeeded: false,
-			wantResume:        false,
-			description:       "First reconcile after init; sets version, no upgrade",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cluster := &openbaov1alpha1.OpenBaoCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
-				},
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{
-					Version:  tt.specVersion,
-					Replicas: 3,
-				},
-				Status: tt.initialStatus,
-			}
-
-			m := &Manager{}
-			gotUpgrade, gotResume := m.detectUpgradeState(testLogger(), cluster, &upgrade.RequestAcknowledgements{})
-
-			if gotUpgrade != tt.wantUpgradeNeeded {
-				t.Errorf("%s: upgradeNeeded = %v, want %v", tt.description, gotUpgrade, tt.wantUpgradeNeeded)
-			}
-			if gotResume != tt.wantResume {
-				t.Errorf("%s: resume = %v, want %v", tt.description, gotResume, tt.wantResume)
-			}
-		})
-	}
-}
-
 // TestUpgradeProgressTracking tests that upgrade progress is tracked correctly.
 func TestUpgradeProgressTracking(t *testing.T) {
 	tests := []struct {
@@ -1590,24 +1299,18 @@ func TestVersionMismatchDuringUpgrade(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status := &openbaov1alpha1.OpenBaoClusterStatus{
-				Upgrade: &openbaov1alpha1.UpgradeProgress{
-					TargetVersion: tt.upgradeTarget,
-					FromVersion:   "2.4.0",
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{Version: tt.specVersion},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					Upgrade: &openbaov1alpha1.UpgradeProgress{TargetVersion: tt.upgradeTarget, FromVersion: "2.4.0"},
 				},
 			}
-
-			shouldClear := tt.specVersion != tt.upgradeTarget
-			if shouldClear != tt.shouldClearState {
-				t.Errorf("shouldClearState = %v, want %v", shouldClear, tt.shouldClearState)
+			decision := decideUpgrade(cluster)
+			if err := (&Manager{}).applyUpgradeDecision(t.Context(), logr.Discard(), cluster, decision); err != nil {
+				t.Fatal(err)
 			}
-
-			// If we should clear, verify the clear function works
-			if tt.shouldClearState {
-				upgradecore.ClearUpgrade(status)
-				if status.Upgrade != nil {
-					t.Error("expected Upgrade to be cleared")
-				}
+			if (cluster.Status.Upgrade == nil) != tt.shouldClearState {
+				t.Fatalf("Upgrade=%+v, want cleared=%t", cluster.Status.Upgrade, tt.shouldClearState)
 			}
 		})
 	}

--- a/internal/service/upgrade/rolling/manager_workflow.go
+++ b/internal/service/upgrade/rolling/manager_workflow.go
@@ -41,10 +41,9 @@ func (m *Manager) ensureUpgradeLock(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	metrics *upgrade.Metrics,
 	strategy string,
-	upgradeNeeded bool,
-	resumeUpgrade bool,
+	action upgradeAction,
 ) (recon.Result, bool, error) {
-	if !upgradeNeeded && !resumeUpgrade {
+	if action == upgradeIdle || action == upgradeWaitForRetry {
 		upgrade.SetInactiveProgressMetrics(metrics)
 		if err := m.releaseIdleUpgradeLock(ctx, logger, cluster); err != nil {
 			logger.Error(err, "Failed to release stale upgrade operation lock")

--- a/internal/service/upgrade/rolling/retry.go
+++ b/internal/service/upgrade/rolling/retry.go
@@ -20,24 +20,10 @@ import (
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
-func (m *Manager) prepareFailedUpgradeRetry(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster) (bool, error) {
-	if cluster == nil || cluster.Status.Upgrade == nil {
-		return false, nil
-	}
-
-	if !upgrade.UpgradeFailed(cluster.Status.Upgrade) {
-		return false, nil
-	}
-
-	if cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion {
-		return false, nil
-	}
-
-	retryRequest := upgrade.RetryRequestValue(cluster)
-	if !upgrade.RetryRequestPending(cluster) {
-		return false, nil
-	}
-
+// prepareFailedUpgradeRetry executes a retry selected by decideUpgrade.
+// Lock acquisition only refreshes lock status, so the decision and captured
+// request still describe the same observed upgrade when preparation starts.
+func (m *Manager) prepareFailedUpgradeRetry(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, retryRequest string) error {
 	logger.Info("Preparing retry for failed rolling upgrade",
 		"retryRequest", retryRequest,
 		"targetVersion", cluster.Status.Upgrade.TargetVersion,
@@ -45,21 +31,21 @@ func (m *Manager) prepareFailedUpgradeRetry(ctx context.Context, logger logr.Log
 	m.emitNormalEvent(cluster, upgrade.ReasonRollingRetryRequested, "Rolling upgrade retry requested for target version %s", cluster.Status.Upgrade.TargetVersion)
 
 	if err := m.cleanupStepDownJobForRetry(ctx, logger, cluster); err != nil {
-		return false, err
+		return err
 	}
 	if err := m.resetRolloutPodsForRetry(ctx, logger, cluster); err != nil {
-		return false, err
+		return err
 	}
 
 	if err := m.patchRetryStatusSSA(ctx, cluster, retryRequest); err != nil {
-		return false, fmt.Errorf("failed to clear failed upgrade state for retry: %w", err)
+		return fmt.Errorf("failed to clear failed upgrade state for retry: %w", err)
 	}
 	if cluster.Status.Upgrade == nil {
-		return false, nil
+		return nil
 	}
 	logger.Info("Cleared failed rolling upgrade state and resumed upgrade")
 	m.emitNormalEvent(cluster, upgrade.ReasonRollingRetryAccepted, "Rolling upgrade retry accepted for target version %s", cluster.Status.Upgrade.TargetVersion)
-	return true, nil
+	return nil
 }
 
 func (m *Manager) patchRetryStatusSSA(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, retryRequest string) error {

--- a/internal/service/upgrade/rolling/retry_test.go
+++ b/internal/service/upgrade/rolling/retry_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -317,12 +316,9 @@ func TestPrepareFailedUpgradeRetry_WaitsForStatefulSetTemplateToMatchRetryTarget
 
 	mgr := &Manager{client: k8sClient, scheme: scheme}
 
-	resumed, err := mgr.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster)
+	err := mgr.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster, upgrade.RetryRequestValue(cluster))
 	if err == nil {
 		t.Fatal("prepareFailedUpgradeRetry() error=nil, want transient retry wait")
-	}
-	if resumed {
-		t.Fatal("prepareFailedUpgradeRetry() resumed=true, want false")
 	}
 	if !errors.Is(err, operatorerrors.ErrTransientKubernetesAPI) {
 		t.Fatalf("prepareFailedUpgradeRetry() error = %v, want transient Kubernetes API error", err)
@@ -495,12 +491,9 @@ func TestPrepareFailedUpgradeRetry_DeletesStaleCompletedPod(t *testing.T) {
 		adminOpsMutator: testAdminOpsMutator(k8sClient),
 	}
 
-	resumed, err := manager.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster)
+	err := manager.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster, upgrade.RetryRequestValue(cluster))
 	if err != nil {
 		t.Fatalf("prepareFailedUpgradeRetry() error = %v, want nil", err)
-	}
-	if !resumed {
-		t.Fatal("prepareFailedUpgradeRetry() resumed=false, want true")
 	}
 
 	remainingTargetPod := &corev1.Pod{}
@@ -546,98 +539,6 @@ func retryPodForResetTest(namespace, name, revision, image string, ready bool) *
 		}
 	}
 	return pod
-}
-
-func TestPrepareFailedUpgradeRetry_GuardConditions(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		cluster *openbaov1alpha1.OpenBaoCluster
-	}{
-		{
-			name:    "nil cluster",
-			cluster: nil,
-		},
-		{
-			name: "nil upgrade status",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{Version: "2.5.0"},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					Upgrade: nil,
-				},
-			},
-		},
-		{
-			name: "empty failure reason",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{Version: "2.5.0"},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion: "2.5.0",
-						Failure:       &openbaov1alpha1.ControllerErrorStatus{},
-					},
-				},
-			},
-		},
-		{
-			name: "target version mismatch",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{Version: "2.5.1"},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion: "2.5.0",
-						Failure: &openbaov1alpha1.ControllerErrorStatus{
-							Reason: upgrade.ReasonUpgradeFailed,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "missing retry request",
-			cluster: &openbaov1alpha1.OpenBaoCluster{
-				Spec: openbaov1alpha1.OpenBaoClusterSpec{Version: "2.5.0"},
-				Status: openbaov1alpha1.OpenBaoClusterStatus{
-					Upgrade: &openbaov1alpha1.UpgradeProgress{
-						TargetVersion: "2.5.0",
-						Failure: &openbaov1alpha1.ControllerErrorStatus{
-							Reason: upgrade.ReasonUpgradeFailed,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	mgr := &Manager{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			before := (*openbaov1alpha1.OpenBaoCluster)(nil)
-			if tt.cluster != nil {
-				before = tt.cluster.DeepCopy()
-			}
-
-			resumed, err := mgr.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), tt.cluster)
-			if err != nil {
-				t.Fatalf("prepareFailedUpgradeRetry() unexpected error: %v", err)
-			}
-			if resumed {
-				t.Fatalf("prepareFailedUpgradeRetry() resumed=true, want false")
-			}
-
-			if tt.cluster != nil && before != nil {
-				if tt.cluster.Status.Upgrade == nil && before.Status.Upgrade != nil {
-					t.Fatalf("Upgrade unexpectedly changed from non-nil to nil")
-				}
-				if tt.cluster.Status.Upgrade != nil && before.Status.Upgrade != nil && !reflect.DeepEqual(tt.cluster.Status.Upgrade.Failure, before.Status.Upgrade.Failure) {
-					t.Fatalf("Failure mutated to %#v, want unchanged %#v", tt.cluster.Status.Upgrade.Failure, before.Status.Upgrade.Failure)
-				}
-			}
-		})
-	}
 }
 
 func TestPrepareFailedUpgradeRetry_SuccessClearsFailureAndRemovesRetrySignal(t *testing.T) {
@@ -773,12 +674,9 @@ func TestPrepareFailedUpgradeRetry_SuccessClearsFailureAndRemovesRetrySignal(t *
 				adminOpsMutator: testAdminOpsMutator(k8sClient),
 			}
 
-			resumed, err := mgr.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster)
+			err := mgr.prepareFailedUpgradeRetry(context.Background(), logr.Discard(), cluster, upgrade.RetryRequestValue(cluster))
 			if err != nil {
 				t.Fatalf("prepareFailedUpgradeRetry() unexpected error: %v", err)
-			}
-			if !resumed {
-				t.Fatalf("prepareFailedUpgradeRetry() resumed=false, want true")
 			}
 
 			if cluster.Status.Upgrade == nil {

--- a/internal/service/upgrade/rolling/upgrade_state.go
+++ b/internal/service/upgrade/rolling/upgrade_state.go
@@ -1,71 +1,52 @@
 package rolling
 
 import (
-	"github.com/go-logr/logr"
-
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
 )
 
-// detectUpgradeState determines whether an upgrade is needed or if we're resuming one.
-func (m *Manager) detectUpgradeState(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, acknowledgements *upgrade.RequestAcknowledgements) (upgradeNeeded bool, resumeUpgrade bool) {
-	if upgrade.RetryRequestPending(cluster) &&
-		(cluster.Status.Upgrade == nil ||
-			!upgrade.UpgradeFailed(cluster.Status.Upgrade) ||
-			cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion) {
-		retryRequest := upgrade.RetryRequestValue(cluster)
-		acknowledgements.Retry = retryRequest
-		logger.Info("Ignoring retry request because no failed rolling upgrade is waiting to resume",
-			"retryRequest", retryRequest,
-			"retryRequestField", upgrade.RequestRetryFieldPath)
-	}
+type upgradeAction string
 
-	if cluster.Status.Upgrade != nil {
-		if upgrade.UpgradeFailed(cluster.Status.Upgrade) {
-			failureReason := upgrade.UpgradeFailureReason(cluster.Status.Upgrade)
-			failureMessage := upgrade.UpgradeFailureMessage(cluster.Status.Upgrade)
-			if cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion {
-				logger.Info("Failed upgrade target differs from spec; resuming to re-evaluate upgrade target",
-					"failedTargetVersion", cluster.Status.Upgrade.TargetVersion,
-					"specVersion", cluster.Spec.Version,
-					"failureReason", failureReason)
-				return false, true
-			}
+const (
+	upgradeIdle         upgradeAction = "idle"
+	upgradeStart        upgradeAction = "start"
+	upgradeResume       upgradeAction = "resume"
+	upgradeRetry        upgradeAction = "retry"
+	upgradeRetarget     upgradeAction = "retarget"
+	upgradeWaitForRetry upgradeAction = "wait-for-retry"
+)
 
-			if !upgrade.RetryRequestPending(cluster) {
-				logger.Info("Upgrade is in failed state; waiting for manual retry request",
-					"failureReason", failureReason,
-					"failureMessage", failureMessage,
-					"retryRequestField", upgrade.RequestRetryFieldPath)
-				return false, false
-			}
+type upgradeDecision struct {
+	action           upgradeAction
+	retryRequest     string
+	acknowledgements upgrade.RequestAcknowledgements
+}
 
-			logger.Info("Manual retry requested for failed upgrade",
-				"retryRequest", upgrade.RetryRequestValue(cluster),
-				"targetVersion", cluster.Status.Upgrade.TargetVersion,
-				"currentPartition", cluster.Status.Upgrade.CurrentPartition)
-			return false, true
+// decideUpgrade selects work from the observed state without changing it.
+// A retry is acknowledged by the retry checkpoint; an ignored request is
+// acknowledged by the enclosing AdminOps reconciliation.
+func decideUpgrade(cluster *openbaov1alpha1.OpenBaoCluster) upgradeDecision {
+	progress := cluster.Status.Upgrade
+	retryPending := upgrade.RetryRequestPending(cluster)
+	decision := upgradeDecision{}
+	switch {
+	case progress == nil:
+		decision.action = upgradeIdle
+		if cluster.Status.CurrentVersion != "" && cluster.Spec.Version != cluster.Status.CurrentVersion {
+			decision.action = upgradeStart
 		}
-
-		logger.Info("Resuming in-progress upgrade",
-			"fromVersion", cluster.Status.Upgrade.FromVersion,
-			"targetVersion", cluster.Status.Upgrade.TargetVersion,
-			"currentPartition", cluster.Status.Upgrade.CurrentPartition)
-		return false, true
+	case cluster.Spec.Version != progress.TargetVersion:
+		decision.action = upgradeRetarget
+	case !upgrade.UpgradeFailed(progress):
+		decision.action = upgradeResume
+	case retryPending:
+		decision.action = upgradeRetry
+		decision.retryRequest = upgrade.RetryRequestValue(cluster)
+	default:
+		decision.action = upgradeWaitForRetry
 	}
-
-	if cluster.Status.CurrentVersion == "" {
-		logger.Info("Setting initial CurrentVersion from spec", "version", cluster.Spec.Version)
-		return false, false
+	if retryPending && decision.action != upgradeRetry {
+		decision.acknowledgements.Retry = upgrade.RetryRequestValue(cluster)
 	}
-
-	if cluster.Spec.Version == cluster.Status.CurrentVersion {
-		logger.V(1).Info("No upgrade needed; versions match")
-		return false, false
-	}
-
-	logger.Info("Upgrade detected",
-		"from", cluster.Status.CurrentVersion,
-		"to", cluster.Spec.Version)
-	return true, false
+	return decision
 }

--- a/internal/service/upgrade/rolling/upgrade_state_property_test.go
+++ b/internal/service/upgrade/rolling/upgrade_state_property_test.go
@@ -2,10 +2,10 @@ package rolling
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -14,7 +14,7 @@ import (
 	"pgregory.net/rapid"
 )
 
-func TestDetectUpgradeStateRetryProperties(t *testing.T) {
+func TestUpgradeDecisionProperties(t *testing.T) {
 	t.Parallel()
 
 	rapid.Check(t, func(rt *rapid.T) {
@@ -46,72 +46,44 @@ func TestDetectUpgradeStateRetryProperties(t *testing.T) {
 			},
 		}
 
-		wantUpgradeNeeded, wantResumeUpgrade, wantHandledRetry := expectedDetectUpgradeState(cluster)
-
-		var acknowledgements upgrade.RequestAcknowledgements
-		gotUpgradeNeeded, gotResumeUpgrade := (&Manager{}).detectUpgradeState(logr.Discard(), cluster, &acknowledgements)
-		if cluster.Status.UpgradeRequests.LastHandledRetry != lastHandledRetry {
-			t.Fatal("detectUpgradeState changed the observed retry acknowledgement")
+		before := cluster.DeepCopy()
+		decision := decideUpgrade(cluster)
+		if !reflect.DeepEqual(before, cluster) {
+			rt.Fatal("decision changed observed state")
 		}
-
-		if gotUpgradeNeeded != wantUpgradeNeeded {
-			t.Fatalf("upgradeNeeded = %t, want %t for cluster=%+v", gotUpgradeNeeded, wantUpgradeNeeded, cluster)
+		pending := strings.TrimSpace(retryRequest) != "" && strings.TrimSpace(retryRequest) != strings.TrimSpace(lastHandledRetry)
+		failed := upgrade.UpgradeFailed(upgradeProgress)
+		matchingTarget := upgradeProgress != nil && upgradeProgress.TargetVersion == specVersion
+		valid := false
+		switch decision.action {
+		case upgradeIdle:
+			valid = upgradeProgress == nil && (currentVersion == "" || currentVersion == specVersion)
+		case upgradeStart:
+			valid = upgradeProgress == nil && currentVersion != "" && currentVersion != specVersion
+		case upgradeResume:
+			valid = matchingTarget && !failed
+		case upgradeRetarget:
+			valid = upgradeProgress != nil && !matchingTarget
+		case upgradeRetry:
+			valid = matchingTarget && failed && pending
+		case upgradeWaitForRetry:
+			valid = matchingTarget && failed && !pending
 		}
-		if gotResumeUpgrade != wantResumeUpgrade {
-			t.Fatalf("resumeUpgrade = %t, want %t for cluster=%+v", gotResumeUpgrade, wantResumeUpgrade, cluster)
+		if !valid {
+			rt.Fatalf("action %s violates its preconditions: cluster=%+v", decision.action, cluster)
 		}
-		gotHandledRetry := ""
-		if cluster.Status.UpgradeRequests != nil {
-			gotHandledRetry = cluster.Status.UpgradeRequests.LastHandledRetry
+		wantRetry, wantIgnored := "", ""
+		if pending {
+			if matchingTarget && failed {
+				wantRetry = strings.TrimSpace(retryRequest)
+			} else {
+				wantIgnored = strings.TrimSpace(retryRequest)
+			}
 		}
-		if acknowledgements.Retry != "" {
-			gotHandledRetry = acknowledgements.Retry
-		}
-		if gotHandledRetry != wantHandledRetry {
-			t.Fatalf("LastHandledRetry = %q, want %q for retryRequest=%q upgrade=%+v",
-				gotHandledRetry, wantHandledRetry, retryRequest, upgradeProgress)
+		if decision.retryRequest != wantRetry || decision.acknowledgements.Retry != wantIgnored {
+			rt.Fatalf("retry=%q ignored=%q, want retry=%q ignored=%q", decision.retryRequest, decision.acknowledgements.Retry, wantRetry, wantIgnored)
 		}
 	})
-}
-
-func expectedDetectUpgradeState(cluster *openbaov1alpha1.OpenBaoCluster) (bool, bool, string) {
-	storedHandledRetry := ""
-	handledRetry := ""
-	if cluster.Status.UpgradeRequests != nil {
-		storedHandledRetry = cluster.Status.UpgradeRequests.LastHandledRetry
-		handledRetry = strings.TrimSpace(storedHandledRetry)
-	}
-	retryRequest := upgrade.RetryRequestValue(cluster)
-	retryPending := retryRequest != "" && retryRequest != handledRetry
-
-	if retryPending &&
-		(cluster.Status.Upgrade == nil ||
-			!upgrade.UpgradeFailed(cluster.Status.Upgrade) ||
-			cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion) {
-		storedHandledRetry = retryRequest
-		retryPending = false
-	}
-
-	if cluster.Status.Upgrade != nil {
-		if upgrade.UpgradeFailed(cluster.Status.Upgrade) {
-			if cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion {
-				return false, true, storedHandledRetry
-			}
-			if !retryPending {
-				return false, false, storedHandledRetry
-			}
-			return false, true, storedHandledRetry
-		}
-		return false, true, storedHandledRetry
-	}
-
-	if cluster.Status.CurrentVersion == "" {
-		return false, false, storedHandledRetry
-	}
-	if cluster.Spec.Version == cluster.Status.CurrentVersion {
-		return false, false, storedHandledRetry
-	}
-	return true, false, storedHandledRetry
 }
 
 func upgradeProgressGenerator(specVersion string) *rapid.Generator[*openbaov1alpha1.UpgradeProgress] {

--- a/internal/service/upgrade/rolling/upgrade_state_test.go
+++ b/internal/service/upgrade/rolling/upgrade_state_test.go
@@ -1,0 +1,69 @@
+package rolling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
+)
+
+func TestDecideUpgrade(t *testing.T) {
+	t.Parallel()
+	failure := &openbaov1alpha1.ControllerErrorStatus{Reason: upgrade.ReasonUpgradeFailed}
+	tests := []struct {
+		name             string
+		currentVersion   string
+		targetVersion    string
+		failure          *openbaov1alpha1.ControllerErrorStatus
+		retry            string
+		handledRetry     string
+		wantAction       upgradeAction
+		wantRetry        string
+		wantIgnoredRetry string
+	}{
+		{name: "initial version", wantAction: upgradeIdle},
+		{name: "matching version", currentVersion: "2.5.0", wantAction: upgradeIdle},
+		{name: "new version", currentVersion: "2.4.0", wantAction: upgradeStart},
+		{name: "downgrade still needs validation", currentVersion: "2.6.0", wantAction: upgradeStart},
+		{name: "retry without observed version", retry: "retry-1", wantAction: upgradeIdle, wantIgnoredRetry: "retry-1"},
+		{name: "retry while idle", currentVersion: "2.5.0", retry: "retry-1", wantAction: upgradeIdle, wantIgnoredRetry: "retry-1"},
+		{name: "retry before start", currentVersion: "2.4.0", retry: "retry-1", wantAction: upgradeStart, wantIgnoredRetry: "retry-1"},
+		{name: "active upgrade", targetVersion: "2.5.0", wantAction: upgradeResume},
+		{name: "empty failure is not failed", targetVersion: "2.5.0", failure: &openbaov1alpha1.ControllerErrorStatus{}, wantAction: upgradeResume},
+		{name: "retry during healthy upgrade", targetVersion: "2.5.0", retry: "retry-1", wantAction: upgradeResume, wantIgnoredRetry: "retry-1"},
+		{name: "failed without retry", targetVersion: "2.5.0", failure: failure, wantAction: upgradeWaitForRetry},
+		{name: "failed with empty retry", targetVersion: "2.5.0", failure: failure, retry: " \t", wantAction: upgradeWaitForRetry},
+		{name: "failed with handled retry", targetVersion: "2.5.0", failure: failure, retry: " retry-1 ", handledRetry: "retry-1", wantAction: upgradeWaitForRetry},
+		{name: "failed with fresh retry", targetVersion: "2.5.0", failure: failure, retry: " retry-2 ", handledRetry: "retry-1", wantAction: upgradeRetry, wantRetry: "retry-2"},
+		{name: "retarget healthy upgrade", targetVersion: "2.4.1", wantAction: upgradeRetarget},
+		{name: "retarget failed upgrade", targetVersion: "2.4.1", failure: failure, wantAction: upgradeRetarget},
+		{name: "retarget takes precedence over retry", targetVersion: "2.4.1", failure: failure, retry: "retry-1", wantAction: upgradeRetarget, wantIgnoredRetry: "retry-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cluster := &openbaov1alpha1.OpenBaoCluster{
+				Spec: openbaov1alpha1.OpenBaoClusterSpec{
+					Version: "2.5.0",
+					Upgrade: &openbaov1alpha1.UpgradeConfig{Requests: &openbaov1alpha1.UpgradeRequestConfig{Retry: tt.retry}},
+				},
+				Status: openbaov1alpha1.OpenBaoClusterStatus{
+					CurrentVersion:  tt.currentVersion,
+					UpgradeRequests: &openbaov1alpha1.UpgradeRequestStatus{LastHandledRetry: tt.handledRetry},
+				},
+			}
+			if tt.targetVersion != "" {
+				cluster.Status.Upgrade = &openbaov1alpha1.UpgradeProgress{TargetVersion: tt.targetVersion, Failure: tt.failure}
+			}
+			before := cluster.DeepCopy()
+			decision := decideUpgrade(cluster)
+			require.Equal(t, upgradeDecision{
+				action: tt.wantAction, retryRequest: tt.wantRetry,
+				acknowledgements: upgrade.RequestAcknowledgements{Retry: tt.wantIgnoredRetry},
+			}, decision)
+			require.Equal(t, before, cluster, "decisions must preserve observed state")
+		})
+	}
+}

--- a/internal/service/upgrade/rolling/workflow_prepare.go
+++ b/internal/service/upgrade/rolling/workflow_prepare.go
@@ -20,9 +20,9 @@ func (m *Manager) prepareUpgradeExecution(
 	cluster *openbaov1alpha1.OpenBaoCluster,
 	metrics *upgrade.Metrics,
 	strategy string,
-	resumeUpgrade bool,
+	decision upgradeDecision,
 ) (recon.Result, bool, error) {
-	if err := m.resumeUpgradeState(ctx, logger, cluster, resumeUpgrade); err != nil {
+	if err := m.applyUpgradeDecision(ctx, logger, cluster, decision); err != nil {
 		return recon.Result{}, false, err
 	}
 
@@ -110,20 +110,17 @@ func (m *Manager) startUpgradeExecutionIfNeeded(
 	return nil
 }
 
-func (m *Manager) resumeUpgradeState(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, resumeUpgrade bool) error {
-	if !resumeUpgrade || cluster.Status.Upgrade == nil {
-		return nil
-	}
-
-	if cluster.Spec.Version != cluster.Status.Upgrade.TargetVersion {
+func (m *Manager) applyUpgradeDecision(ctx context.Context, logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, decision upgradeDecision) error {
+	switch decision.action {
+	case upgradeRetarget:
 		logger.Info("Spec.Version changed during upgrade; clearing upgrade state and starting fresh",
 			"previousTarget", cluster.Status.Upgrade.TargetVersion,
 			"newTarget", cluster.Spec.Version)
 		core.ClearUpgrade(&cluster.Status)
+	case upgradeRetry:
+		return m.prepareFailedUpgradeRetry(ctx, logger, cluster, decision.retryRequest)
 	}
-
-	_, err := m.prepareFailedUpgradeRetry(ctx, logger, cluster)
-	return err
+	return nil
 }
 
 func (m *Manager) persistValidationFailure(ctx context.Context, cluster *openbaov1alpha1.OpenBaoCluster, validationErr error) error {


### PR DESCRIPTION
## Summary

Rolling reconciliation represented start, resume, retry, and retarget work with two booleans, then repeated the retry and target checks during preparation. Select one named action from observed state and pass the decision into lock handling and preparation.

Retargeting takes precedence over retry. A selected retry carries its captured request token into the immediate retry checkpoint; ignored requests remain pending write intent for the AdminOps final patch. Idle and failed-waiting decisions retain stale-lock cleanup.

## Related Issues

Layer 2 of stack #715; depends on #712 and is followed by #714.

## Type of Change

- [x] Refactor (code improvement/cleanup)

## Risk and Compatibility

No API, CRD, Helm, RBAC, dependency, or user configuration changes. This changes upgrade orchestration, so persistence ordering and recovery behavior are covered by focused tests.

## Verification

- Focused upgrade and OpenBaoCluster application tests passed for this layer.
- Full stack: `devenv shell -- make lint-ci verify-fmt test-ci docs-build report-internal-deps` passed (3,800 tests, four skips; internal coverage 70.99%). The rebase onto main preserved the tested tree.
- Focused Kind validation passed on the combined stack: rolling retry, held blue/green promotion, and late-phase rollback recovery (three scenarios, 14m15s). The test manager image used the repository Dockerfile and source, with temporary build cache mounts; unchanged helper images were reused.

## Reviewer Notes

Review the decision table and property tests, then follow the selected action through lock acquisition and retry preparation. Lock acquisition refreshes only lock status. Retry cleanup, forced status ownership, and status read-back remain in place.

API-server checks cover acknowledgement preservation and write failures. No user documentation or generated artifact changes are needed.

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
