### PR TITLE
refactor(upgrade): centralize blue-green phase state changes

### DIFF
--- a/internal/service/upgrade/bluegreen/lifecycle.go
+++ b/internal/service/upgrade/bluegreen/lifecycle.go
@@ -128,8 +128,7 @@ func (m *Manager) completeBlueGreenUpgrade(
 ) (phaseOutcome, error) {
 	if shouldRestoreSteadyReadReplicas(cluster) {
 		beginSteadyReadReplicaRestore(logger, cluster)
-		m.transitionToPhase(logger, cluster, openbaov1alpha1.PhaseRestoringReadReplicas)
-		return requeueAfterOutcome(constants.RequeueShort), nil
+		return advance(openbaov1alpha1.PhaseRestoringReadReplicas), nil
 	}
 
 	return m.finalizeCompletedBlueGreenUpgrade(ctx, logger, cluster, true)

--- a/internal/service/upgrade/bluegreen/manager_abort_test.go
+++ b/internal/service/upgrade/bluegreen/manager_abort_test.go
@@ -336,6 +336,11 @@ func TestTriggerRollbackOrAbort_EarlyAndLatePhase(t *testing.T) {
 	t.Run("late phase triggers rollback", func(t *testing.T) {
 		cluster := newBlueGreenCluster()
 		cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseCleanup
+		phaseStart := metav1.NewTime(time.Now().Add(-time.Minute))
+		cluster.Status.BlueGreen.StartTime = &phaseStart
+		cluster.Status.BlueGreen.JobFailureCount = 3
+		cluster.Status.BlueGreen.LastJobFailure = "promotion-job"
+
 		manager := &Manager{}
 
 		result, err := manager.triggerRollbackOrAbort(context.Background(), logr.Discard(), cluster, "cleanup failed")
@@ -354,5 +359,9 @@ func TestTriggerRollbackOrAbort_EarlyAndLatePhase(t *testing.T) {
 		if cluster.Status.BlueGreen.RollbackStartTime == nil {
 			t.Fatal("rollback start time not set")
 		}
+		if !cluster.Status.BlueGreen.StartTime.Equal(&phaseStart) || cluster.Status.BlueGreen.JobFailureCount != 3 || cluster.Status.BlueGreen.LastJobFailure != "promotion-job" {
+			t.Fatal("starting rollback must preserve the phase timer and failure history")
+		}
+
 	})
 }

--- a/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
+++ b/internal/service/upgrade/bluegreen/manager_phase_machine_test.go
@@ -827,8 +827,15 @@ func TestHandlePhaseCleanup_Branches(t *testing.T) {
 		if err != nil {
 			t.Fatalf("handlePhaseCleanup() error = %v", err)
 		}
-		if outcome.kind != phaseOutcomeRequeueAfter || outcome.after != constants.RequeueShort {
-			t.Fatalf("handlePhaseCleanup() outcome = %+v, want short requeue", outcome)
+		if outcome.kind != phaseOutcomeAdvance || outcome.nextPhase != openbaov1alpha1.PhaseRestoringReadReplicas {
+			t.Fatalf("handlePhaseCleanup() outcome = %+v, want advance to read replica restore", outcome)
+		}
+		if cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseCleanup {
+			t.Fatal("phase handler advanced before its outcome was applied")
+		}
+		result, err := manager.applyOutcome(t.Context(), logr.Discard(), cluster, outcome)
+		if err != nil || result.RequeueAfter != constants.RequeueShort {
+			t.Fatalf("applyOutcome() = %+v, %v, want short requeue", result, err)
 		}
 		if cluster.Status.BlueGreen.Phase != openbaov1alpha1.PhaseRestoringReadReplicas {
 			t.Fatalf("phase = %s, want %s", cluster.Status.BlueGreen.Phase, openbaov1alpha1.PhaseRestoringReadReplicas)

--- a/internal/service/upgrade/bluegreen/manager_state_machine.go
+++ b/internal/service/upgrade/bluegreen/manager_state_machine.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/revision"
@@ -13,32 +12,12 @@ import (
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
 	"github.com/dc-tec/openbao-operator/internal/service/opslifecycle"
 	"github.com/dc-tec/openbao-operator/internal/service/upgrade"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade/core"
 )
 
 // calculateRevision computes a deterministic revision hash from relevant spec fields.
 func (m *Manager) calculateRevision(cluster *openbaov1alpha1.OpenBaoCluster) string {
 	return revision.OpenBaoClusterRevision(cluster.Spec.Version, cluster.Spec.Image, cluster.Spec.Replicas)
-}
-
-// transitionToPhase is a helper that sets the phase and restarts the StartTime timer.
-// This reduces boilerplate in phase handlers.
-// It also resets the job failure count when transitioning phases.
-func (m *Manager) transitionToPhase(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, phase openbaov1alpha1.BlueGreenPhase) {
-	previousPhase := cluster.Status.BlueGreen.Phase
-	cluster.Status.BlueGreen.Phase = phase
-	if phase == openbaov1alpha1.PhaseIdle {
-		cluster.Status.BlueGreen.StartTime = nil
-	} else {
-		now := metav1.Now()
-		cluster.Status.BlueGreen.StartTime = &now
-	}
-	// Reset job failure count on phase transition
-	cluster.Status.BlueGreen.JobFailureCount = 0
-	cluster.Status.BlueGreen.LastJobFailure = ""
-	opslifecycle.LogPhaseTransition(logger, logging.EventBlueGreenPhaseTransition, string(previousPhase), string(phase), map[string]string{
-		"cluster_namespace": cluster.Namespace,
-		"cluster_name":      cluster.Name,
-	})
 }
 
 // executeStateMachine runs the blue/green upgrade state machine.
@@ -89,7 +68,12 @@ func (m *Manager) applyOutcome(ctx context.Context, logger logr.Logger, cluster 
 
 	switch outcome.kind {
 	case phaseOutcomeAdvance:
-		m.transitionToPhase(logger, cluster, outcome.nextPhase)
+		previousPhase := cluster.Status.BlueGreen.Phase
+		core.AdvanceBlueGreenPhase(cluster.Status.BlueGreen, outcome.nextPhase)
+		opslifecycle.LogPhaseTransition(logger, logging.EventBlueGreenPhaseTransition, string(previousPhase), string(outcome.nextPhase), map[string]string{
+			"cluster_namespace": cluster.Namespace,
+			"cluster_name":      cluster.Name,
+		})
 		if outcome.nextPhase == openbaov1alpha1.PhaseIdle {
 			return recon.Result{}, nil
 		}

--- a/internal/service/upgrade/bluegreen/read_replica_restore.go
+++ b/internal/service/upgrade/bluegreen/read_replica_restore.go
@@ -35,8 +35,6 @@ func beginSteadyReadReplicaRestore(
 	cluster.Status.BlueGreen.GreenRevision = ""
 	cluster.Status.BlueGreen.ManualPromotionRequired = false
 	maybeResetBlueGreenRollbackState(cluster)
-	cluster.Status.BlueGreen.LastJobFailure = ""
-	cluster.Status.BlueGreen.JobFailureCount = 0
 
 	logger.Info("Blue/green cleanup complete; restoring steady read replicas before finalizing upgrade")
 }

--- a/internal/service/upgrade/bluegreen/rollback_control.go
+++ b/internal/service/upgrade/bluegreen/rollback_control.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/logging"
 	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+	"github.com/dc-tec/openbao-operator/internal/service/upgrade/core"
 )
 
 // checkAbortConditions checks if the upgrade should be aborted due to Green cluster failures.
@@ -90,10 +90,7 @@ func (m *Manager) triggerRollbackOrAbort(ctx context.Context, logger logr.Logger
 
 // triggerRollback initiates rollback from any phase.
 func (m *Manager) triggerRollback(logger logr.Logger, cluster *openbaov1alpha1.OpenBaoCluster, reason string) (recon.Result, error) {
-	now := metav1.Now()
-	cluster.Status.BlueGreen.RollbackReason = reason
-	cluster.Status.BlueGreen.RollbackStartTime = &now
-	cluster.Status.BlueGreen.Phase = openbaov1alpha1.PhaseRollingBack
+	core.BeginBlueGreenRollback(cluster.Status.BlueGreen, reason)
 
 	logger.Info("Rollback initiated", "reason", reason)
 	logging.LogAuditEvent(logger, logging.EventRollbackInitiated, map[string]string{

--- a/internal/service/upgrade/core/bluegreen_state.go
+++ b/internal/service/upgrade/core/bluegreen_state.go
@@ -1,6 +1,10 @@
 package core
 
-import openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+)
 
 // CurrentBlueGreenPhase returns the current blue/green phase, defaulting to Idle.
 func CurrentBlueGreenPhase(cluster *openbaov1alpha1.OpenBaoCluster) openbaov1alpha1.BlueGreenPhase {
@@ -44,17 +48,42 @@ func InitializeBlueGreenManualPromotion(cluster *openbaov1alpha1.OpenBaoCluster)
 		!cluster.Spec.Upgrade.BlueGreen.AutoPromote
 }
 
+// AdvanceBlueGreenPhase starts a new phase timer and clears per-phase job
+// failures. Advancing to Idle clears the timer without clearing operation state.
+func AdvanceBlueGreenPhase(status *openbaov1alpha1.BlueGreenStatus, phase openbaov1alpha1.BlueGreenPhase) {
+	if status == nil {
+		return
+	}
+	status.Phase = phase
+	status.StartTime = nil
+	if phase != openbaov1alpha1.PhaseIdle {
+		now := metav1.Now()
+		status.StartTime = &now
+	}
+	status.JobFailureCount = 0
+	status.LastJobFailure = ""
+}
+
+// BeginBlueGreenRollback starts the rollback timer while retaining the phase
+// timer and job failure history that led to rollback.
+func BeginBlueGreenRollback(status *openbaov1alpha1.BlueGreenStatus, reason string) {
+	if status == nil {
+		return
+	}
+	now := metav1.Now()
+	status.RollbackReason = reason
+	status.RollbackStartTime = &now
+	status.Phase = openbaov1alpha1.PhaseRollingBack
+}
+
 // ResetBlueGreenTransientState clears in-flight blue/green fields after a terminal transition.
 func ResetBlueGreenTransientState(status *openbaov1alpha1.BlueGreenStatus) {
 	if status == nil {
 		return
 	}
-	status.Phase = openbaov1alpha1.PhaseIdle
+	AdvanceBlueGreenPhase(status, openbaov1alpha1.PhaseIdle)
 	status.GreenRevision = ""
 	status.ManualPromotionRequired = false
-	status.StartTime = nil
-	status.JobFailureCount = 0
-	status.LastJobFailure = ""
 	if status.ValidationHook == nil {
 		status.OperationID = ""
 	}

--- a/internal/service/upgrade/core/bluegreen_state_test.go
+++ b/internal/service/upgrade/core/bluegreen_state_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,4 +114,114 @@ func TestResetBlueGreenTransientStatePreservesOperationUntilHookCleanup(t *testi
 	status.ValidationHook = nil
 	core.ResetBlueGreenTransientState(status)
 	require.Empty(t, status.OperationID)
+}
+
+func TestBlueGreenTransitionState(t *testing.T) {
+	t.Parallel()
+	const (
+		clearTimer    = "clear"
+		restartTimer  = "restart"
+		preserveTimer = "preserve"
+	)
+	tests := []struct {
+		name          string
+		transition    func(*openbaov1alpha1.BlueGreenStatus)
+		wantPhase     openbaov1alpha1.BlueGreenPhase
+		phaseTimer    string
+		rollbackTimer string
+		clearFailures bool
+		terminal      bool
+	}{
+		{
+			name:       "advance to syncing",
+			transition: func(s *openbaov1alpha1.BlueGreenStatus) { core.AdvanceBlueGreenPhase(s, openbaov1alpha1.PhaseSyncing) },
+			wantPhase:  openbaov1alpha1.PhaseSyncing, phaseTimer: restartTimer, rollbackTimer: preserveTimer, clearFailures: true,
+		},
+		{
+			name: "advance to read replica restore",
+			transition: func(s *openbaov1alpha1.BlueGreenStatus) {
+				core.AdvanceBlueGreenPhase(s, openbaov1alpha1.PhaseRestoringReadReplicas)
+			},
+			wantPhase: openbaov1alpha1.PhaseRestoringReadReplicas, phaseTimer: restartTimer, rollbackTimer: preserveTimer, clearFailures: true,
+		},
+		{
+			name:       "start rollback retains phase timer and failures",
+			transition: func(s *openbaov1alpha1.BlueGreenStatus) { core.BeginBlueGreenRollback(s, "new rollback") },
+			wantPhase:  openbaov1alpha1.PhaseRollingBack, phaseTimer: preserveTimer, rollbackTimer: restartTimer,
+		},
+		{
+			name: "advance to rollback cleanup",
+			transition: func(s *openbaov1alpha1.BlueGreenStatus) {
+				core.AdvanceBlueGreenPhase(s, openbaov1alpha1.PhaseRollbackCleanup)
+			},
+			wantPhase: openbaov1alpha1.PhaseRollbackCleanup, phaseTimer: restartTimer, rollbackTimer: preserveTimer, clearFailures: true,
+		},
+		{
+			name:       "advance to idle only resets phase state",
+			transition: func(s *openbaov1alpha1.BlueGreenStatus) { core.AdvanceBlueGreenPhase(s, openbaov1alpha1.PhaseIdle) },
+			wantPhase:  openbaov1alpha1.PhaseIdle, phaseTimer: clearTimer, rollbackTimer: preserveTimer, clearFailures: true,
+		},
+		{
+			name:       "terminal reset retains rollback history",
+			transition: core.ResetBlueGreenTransientState,
+			wantPhase:  openbaov1alpha1.PhaseIdle, phaseTimer: clearTimer, rollbackTimer: preserveTimer, clearFailures: true, terminal: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			old := metav1.NewTime(time.Now().Add(-time.Hour))
+			status := &openbaov1alpha1.BlueGreenStatus{
+				Phase:     openbaov1alpha1.PhasePromoting,
+				StartTime: &old, JobFailureCount: 3, LastJobFailure: "failed-job",
+				RollbackStartTime: &old, RollbackReason: "old rollback", RollbackAttempt: 2,
+				GreenRevision: "green", BlueRevision: "blue", BlueImage: "openbao:2.4.0",
+				OperationID: "operation-1", ManualPromotionRequired: true,
+			}
+			before := status.DeepCopy()
+			started := time.Now()
+			tt.transition(status)
+			finished := time.Now()
+			require.Equal(t, tt.wantPhase, status.Phase)
+			assertTimer := func(timer *metav1.Time, policy string) {
+				t.Helper()
+				switch policy {
+				case clearTimer:
+					require.Nil(t, timer)
+				case preserveTimer:
+					require.Equal(t, &old, timer)
+				case restartTimer:
+					require.NotNil(t, timer)
+					require.False(t, timer.Time.Before(started))
+					require.False(t, timer.After(finished))
+				}
+			}
+			assertTimer(status.StartTime, tt.phaseTimer)
+			assertTimer(status.RollbackStartTime, tt.rollbackTimer)
+			if tt.clearFailures {
+				require.Zero(t, status.JobFailureCount)
+				require.Empty(t, status.LastJobFailure)
+			} else {
+				require.Equal(t, before.JobFailureCount, status.JobFailureCount)
+				require.Equal(t, before.LastJobFailure, status.LastJobFailure)
+			}
+			if tt.rollbackTimer == restartTimer {
+				require.Equal(t, "new rollback", status.RollbackReason)
+			} else {
+				require.Equal(t, before.RollbackReason, status.RollbackReason)
+			}
+			require.Equal(t, before.RollbackAttempt, status.RollbackAttempt)
+			require.Equal(t, before.BlueRevision, status.BlueRevision)
+			require.Equal(t, before.BlueImage, status.BlueImage)
+			if tt.terminal {
+				require.Empty(t, status.GreenRevision)
+				require.Empty(t, status.OperationID)
+				require.False(t, status.ManualPromotionRequired)
+			} else {
+				require.Equal(t, before.GreenRevision, status.GreenRevision)
+				require.Equal(t, before.OperationID, status.OperationID)
+				require.Equal(t, before.ManualPromotionRequired, status.ManualPromotionRequired)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Blue/green phase advancement, rollback entry, and terminal resets mutated phase fields in different places. Keep their status rules together in `upgrade/core` and reuse phase advancement for terminal timer and failure resets.

Read-replica restoration now returns an advance outcome through the existing state machine. Normal advancement restarts the phase timer and clears per-phase failures; rollback entry starts its separate timer while preserving the phase timer and failure history.

## Related Issues

Layer 3 of stack #715; depends on #713.

## Type of Change

- [x] Refactor (code improvement/cleanup)

## Risk and Compatibility

No API, CRD, Helm, RBAC, dependency, or user configuration changes. This changes upgrade orchestration, so persistence ordering and recovery behavior are covered by focused tests.

## Verification

- Focused upgrade and OpenBaoCluster application tests passed for this layer.
- Full stack: `devenv shell -- make lint-ci verify-fmt test-ci docs-build report-internal-deps` passed (3,800 tests, four skips; internal coverage 70.99%). The rebase onto main preserved the tested tree.
- Focused Kind validation passed on the combined stack: rolling retry, held blue/green promotion, and late-phase rollback recovery (three scenarios, 14m15s). The test manager image used the repository Dockerfile and source, with temporary build cache mounts; unchanged helper images were reused.

## Reviewer Notes

The timer/reset table preserves the differences between ordinary advancement, rollback entry, and terminal cleanup. Terminal cleanup retains rollback history and keeps the operation ID until validation-hook cleanup finishes. Lock release and completion events retain their existing order.

No user documentation or generated artifact changes are needed. The dependency report retains the existing constants fan-in warning (36, target 12).

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
