### PR TITLE
fix(metrics): keep cluster phase gauges one-hot

### DIFF
--- a/internal/platform/observability/metrics.go
+++ b/internal/platform/observability/metrics.go
@@ -8,6 +8,14 @@ import (
 )
 
 var (
+	clusterMetricPhases = [...]openbaov1alpha1.ClusterPhase{
+		openbaov1alpha1.ClusterPhaseInitializing,
+		openbaov1alpha1.ClusterPhaseRunning,
+		openbaov1alpha1.ClusterPhaseUpgrading,
+		openbaov1alpha1.ClusterPhaseBackingUp,
+		openbaov1alpha1.ClusterPhaseFailed,
+	}
+
 	reconcileDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "openbao",
@@ -218,13 +226,24 @@ func (m *ClusterMetrics) SetReadReplicaCounts(desiredReplicas, readyReplicas, re
 		Set(float64(healthyReplicas))
 }
 
-// SetPhase records the current phase for the cluster. The gauge is set to 1
-// for the provided phase. Other historical phase series will naturally age
-// out in Prometheus retention.
+// SetPhase records 1 for the current phase and 0 for other known phases.
+// Only known phase labels are exported. An empty or unrecognized phase leaves
+// all phase gauges at 0.
 func (m *ClusterMetrics) SetPhase(phase openbaov1alpha1.ClusterPhase) {
-	clusterPhaseGauge.
-		WithLabelValues(m.namespace, m.name, string(phase)).
-		Set(1.0)
+	known := false
+	for _, knownPhase := range clusterMetricPhases {
+		if knownPhase == phase {
+			known = true
+		}
+		clusterPhaseGauge.
+			WithLabelValues(m.namespace, m.name, string(knownPhase)).
+			Set(0)
+	}
+	if known {
+		clusterPhaseGauge.
+			WithLabelValues(m.namespace, m.name, string(phase)).
+			Set(1)
+	}
 }
 
 // Clear removes all per-cluster metrics for this cluster. This should be
@@ -242,13 +261,7 @@ func (m *ClusterMetrics) Clear() {
 		DeleteLabelValues(m.namespace, m.name)
 
 	// Clear all known phases for this cluster.
-	for _, phase := range []openbaov1alpha1.ClusterPhase{
-		openbaov1alpha1.ClusterPhaseInitializing,
-		openbaov1alpha1.ClusterPhaseRunning,
-		openbaov1alpha1.ClusterPhaseUpgrading,
-		openbaov1alpha1.ClusterPhaseBackingUp,
-		openbaov1alpha1.ClusterPhaseFailed,
-	} {
+	for _, phase := range clusterMetricPhases {
 		clusterPhaseGauge.
 			DeleteLabelValues(m.namespace, m.name, string(phase))
 	}

--- a/internal/platform/observability/metrics_test.go
+++ b/internal/platform/observability/metrics_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
@@ -19,14 +21,124 @@ func TestReconcileMetrics_NoPanic(t *testing.T) {
 	m.IncrementError("Error")
 }
 
-func TestClusterMetrics_NoPanic(t *testing.T) {
-	m := NewClusterMetrics("ns", "name")
+func TestClusterMetrics_SetPhase(t *testing.T) {
+	tests := []struct {
+		name   string
+		phases []openbaov1alpha1.ClusterPhase
+	}{
+		{
+			name: "phase transitions",
+			phases: []openbaov1alpha1.ClusterPhase{
+				openbaov1alpha1.ClusterPhaseInitializing,
+				openbaov1alpha1.ClusterPhaseRunning,
+				openbaov1alpha1.ClusterPhaseUpgrading,
+				openbaov1alpha1.ClusterPhaseBackingUp,
+				openbaov1alpha1.ClusterPhaseFailed,
+				openbaov1alpha1.ClusterPhaseRunning,
+			},
+		},
+		{
+			name: "repeated phase",
+			phases: []openbaov1alpha1.ClusterPhase{
+				openbaov1alpha1.ClusterPhaseRunning,
+				openbaov1alpha1.ClusterPhaseRunning,
+			},
+		},
+		{
+			name: "empty phase",
+			phases: []openbaov1alpha1.ClusterPhase{
+				"",
+				openbaov1alpha1.ClusterPhaseRunning,
+				"",
+				openbaov1alpha1.ClusterPhaseInitializing,
+			},
+		},
+		{
+			name: "unrecognized phase",
+			phases: []openbaov1alpha1.ClusterPhase{
+				openbaov1alpha1.ClusterPhaseRunning,
+				"Unrecognized",
+				openbaov1alpha1.ClusterPhaseInitializing,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, name := "ns", t.Name()
+			t.Cleanup(NewClusterMetrics(namespace, name).Clear)
+			for _, phase := range tt.phases {
+				// Reconciliation creates a new helper for each update.
+				NewClusterMetrics(namespace, name).SetPhase(phase)
+				want := map[openbaov1alpha1.ClusterPhase]float64{
+					openbaov1alpha1.ClusterPhaseInitializing: 0,
+					openbaov1alpha1.ClusterPhaseRunning:      0,
+					openbaov1alpha1.ClusterPhaseUpgrading:    0,
+					openbaov1alpha1.ClusterPhaseBackingUp:    0,
+					openbaov1alpha1.ClusterPhaseFailed:       0,
+				}
+				if _, known := want[phase]; known {
+					want[phase] = 1
+				}
+				got := gatherClusterPhases(t, namespace, name)
+				for knownPhase, value := range want {
+					require.Equal(t, value, got[knownPhase], "active phase %q, exported phase %q", phase, knownPhase)
+				}
+				for exportedPhase := range got {
+					require.Contains(t, want, exportedPhase, "only known phase labels are exported")
+				}
+			}
+		})
+	}
+}
 
-	m.SetReadyReplicas(3)
-	m.SetReadReplicaCounts(2, 2, 2, 2)
-	m.SetPhase(openbaov1alpha1.ClusterPhaseInitializing)
-	m.SetPhase(openbaov1alpha1.ClusterPhaseRunning)
-	m.Clear()
+func TestClusterMetrics_PhaseIsolationAndClear(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		namespace string
+		cluster   string
+	}{
+		{name: "same namespace", namespace: "ns", cluster: "other"},
+		{name: "same name", namespace: "other-ns", cluster: "cluster"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewClusterMetrics("ns", "cluster")
+			other := NewClusterMetrics(tt.namespace, tt.cluster)
+			t.Cleanup(m.Clear)
+			t.Cleanup(other.Clear)
+			other.SetPhase(openbaov1alpha1.ClusterPhaseBackingUp)
+			otherBefore := gatherClusterPhases(t, tt.namespace, tt.cluster)
+
+			m.SetPhase(openbaov1alpha1.ClusterPhaseInitializing)
+			m.SetPhase(openbaov1alpha1.ClusterPhaseRunning)
+			require.Equal(t, otherBefore, gatherClusterPhases(t, tt.namespace, tt.cluster))
+
+			m.Clear()
+			m.Clear()
+			require.Empty(t, gatherClusterPhases(t, "ns", "cluster"))
+			require.Equal(t, otherBefore, gatherClusterPhases(t, tt.namespace, tt.cluster))
+		})
+	}
+}
+
+func gatherClusterPhases(t *testing.T, namespace, name string) map[openbaov1alpha1.ClusterPhase]float64 {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(clusterPhaseGauge)
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	phases := make(map[openbaov1alpha1.ClusterPhase]float64)
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["namespace"] == namespace && labels["name"] == name {
+				phases[openbaov1alpha1.ClusterPhase(labels["phase"])] = metric.GetGauge().GetValue()
+			}
+		}
+	}
+	return phases
 }
 
 func TestReconcileMetrics_EmitsSeries(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase transitions left earlier `cluster_phase` labelsets at 1. Set all five known phase gauges on every update so only the current valid phase remains active. Empty or unknown phases leave every known phase inactive without creating arbitrary label values.

Gathered-metric tests cover transitions, repeated calls, fresh helper instances, invalid phases, object isolation, and idempotent cleanup.

## Related Issues

Repository review follow-up; no tracking issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Metric names and labels remain unchanged. Known inactive phases now export 0; dashboards and alerts can rely on one active phase after each update. No API, CRD, Helm, RBAC, or lifecycle behavior changes. Source comments document the corrected collector semantics; no generated artifacts are affected.

## Verification

- The transition regression failed against the original implementation.
- `GOMAXPROCS=4 go test -p 4 ./internal/platform/observability -count=1`
- Focused golangci-lint and normal commit checks passed.

The combined stack tree passed `devenv test`, `devenv tasks run operator:bootstrap`, `devenv tasks run operator:doctor`, and `devenv tasks run operator:ci-core`. The stack tip has the same tracked tree as that validated candidate (`8e22e09ff9de3a3d3d11837986491613c1314e85`). This includes unit/integration tests, the coverage gate, 34 fuzz targets, security scans, configuration compatibility, docs, and Helm checks. Deployed Kind E2E was not run locally; hosted checks validate each published layer.

## Reviewer Notes

Layer 1 of 3: metrics → startup/platform → API compatibility enforcement. Review this layer's metric values and cleanup assertions. Reconciliation-metric deletion cleanup is a separate follow-up. The three PRs are intended to merge together through the native stack merge.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

