### PR TITLE
fix(startup): validate platform discovery and return errors

### DIFF
--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -27,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
@@ -53,19 +56,21 @@ func init() {
 // The Controller is responsible for reconciling OpenBaoCluster resources,
 // managing StatefulSets, and executing upgrades.
 // args are the command-line arguments (typically os.Args[2:] after the command name).
-func Run(args []string) {
-	oldArgs := os.Args
-	os.Args = append([]string{oldArgs[0]}, args...)
-	defer func() { os.Args = oldArgs }()
-
-	cfg, err := parseRunConfig()
+func Run(ctx context.Context, args []string) error {
+	cfg, err := parseRunConfig(args, os.Stderr)
 	if err != nil {
-		setupLog.Error(err, entrypoint.AdmissionEnforcementExpectedMsg)
-		os.Exit(2)
+		return &entrypoint.UsageError{Err: err}
 	}
 
-	config := ctrl.GetConfigOrDie()
-	platform := resolvePlatform(config, cfg.platform)
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&cfg.logOptions)))
+	config, err := entrypoint.LoadConfig(cfg.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("load Kubernetes configuration: %w", err)
+	}
+	platform, err := resolvePlatform(ctx, config, cfg.platform)
+	if err != nil {
+		return err
+	}
 	setupLog.Info("Target platform configured", "platform", platform)
 
 	watchNamespace := watchNamespaceFromEnv()
@@ -81,29 +86,25 @@ func Run(args []string) {
 	)
 	mgr, err := ctrl.NewManager(config, mgrOpts)
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
-	processRuntime, err := buildControllerProcessRuntime(mgr, cfg, platform, singleTenantMode)
+	processRuntime, err := buildControllerProcessRuntime(ctx, mgr, cfg, platform, singleTenantMode)
 	if err != nil {
-		setupLog.Error(err, "unable to initialize controller runtime")
-		os.Exit(1)
+		return fmt.Errorf("unable to initialize controller runtime: %w", err)
 	}
 
 	if err := setupControllers(mgr, processRuntime); err != nil {
-		setupLog.Error(err, "unable to register controllers")
-		os.Exit(1)
+		return fmt.Errorf("unable to register controllers: %w", err)
 	}
 
 	if err := addManagerHealthChecks(mgr); err != nil {
-		setupLog.Error(err, "unable to configure manager probes")
-		os.Exit(1)
+		return fmt.Errorf("unable to configure manager probes: %w", err)
 	}
 
 	setupLog.Info("starting controller manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("problem running manager: %w", err)
 	}
+	return nil
 }

--- a/cmd/controller/run_config.go
+++ b/cmd/controller/run_config.go
@@ -3,11 +3,11 @@ package controller
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
+	"io"
 	"os"
-	"strings"
 	"time"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -18,6 +18,8 @@ import (
 )
 
 type runConfig struct {
+	kubeconfig               string
+	logOptions               zap.Options
 	metricsAddr              string
 	metricsCertPath          string
 	metricsCertName          string
@@ -36,49 +38,60 @@ type runConfig struct {
 	admissionStartupTimeout  time.Duration
 }
 
-func parseRunConfig() (runConfig, error) {
+func parseRunConfig(args []string, output io.Writer) (runConfig, error) {
 	cfg := runConfig{}
+	fs := flag.NewFlagSet("controller", flag.ContinueOnError)
+	fs.SetOutput(output)
+	fs.StringVar(&cfg.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 
 	entrypoint.BindManagerFlags(
-		flag.CommandLine,
+		fs,
 		&cfg.metricsAddr,
 		&cfg.probeAddr,
 		&cfg.enableLeaderElection,
 		&cfg.secureMetrics,
 	)
-	flag.StringVar(&cfg.metricsCertPath, "metrics-cert-path", "",
+	fs.StringVar(&cfg.metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
-	flag.StringVar(
+	fs.StringVar(
 		&cfg.metricsCertName,
 		"metrics-cert-name",
 		"tls.crt",
 		"The name of the metrics server certificate file.",
 	)
-	flag.StringVar(&cfg.metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
-	flag.BoolVar(&cfg.enableHTTP2, "enable-http2", false,
+	fs.StringVar(&cfg.metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
+	fs.BoolVar(&cfg.enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
-	flag.StringVar(&cfg.platform, "platform", constants.PlatformAuto,
+	fs.StringVar(&cfg.platform, "platform", constants.PlatformAuto,
 		"The target platform (auto, kubernetes, openshift). Defaults to auto. "+
 			"This flag is deprecated and will be removed in a future release. "+
 			"Use the OPERATOR_PLATFORM environment variable instead.")
 
-	flag.Float64Var(&cfg.clientQPS, "openbao-client-qps", 50.0,
+	fs.Float64Var(&cfg.clientQPS, "openbao-client-qps", 50.0,
 		"The queries per second (QPS) limit for OpenBao API clients.")
-	flag.IntVar(&cfg.clientBurst, "openbao-client-burst", 100,
+	fs.IntVar(&cfg.clientBurst, "openbao-client-burst", 100,
 		"The burst limit for OpenBao API clients.")
-	flag.IntVar(&cfg.clientCBFailureThreshold, "openbao-client-cb-failure-threshold", 50,
+	fs.IntVar(&cfg.clientCBFailureThreshold, "openbao-client-cb-failure-threshold", 50,
 		"The number of consecutive failures before opening the circuit breaker.")
-	flag.DurationVar(&cfg.clientCBOpenDuration, "openbao-client-cb-open-duration", 30*time.Second,
+	fs.DurationVar(&cfg.clientCBOpenDuration, "openbao-client-cb-open-duration", 30*time.Second,
 		"The duration the circuit breaker remains open before testing the connection.")
 
-	entrypoint.BindAdmissionFlags(flag.CommandLine, &cfg.admissionEnforcement, &cfg.admissionStartupTimeout)
+	entrypoint.BindAdmissionFlags(fs, &cfg.admissionEnforcement, &cfg.admissionStartupTimeout)
 
-	opts := zap.Options{Development: false}
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	cfg.logOptions = zap.Options{Development: false}
+	cfg.logOptions.BindFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return runConfig{}, err
+	}
+	if fs.NArg() != 0 {
+		return runConfig{}, fmt.Errorf("unexpected positional argument %q", fs.Arg(0))
+	}
 
-	cfg.platform = strings.ToLower(strings.TrimSpace(cfg.platform))
+	platform, err := configuredPlatform(cfg.platform, os.Getenv("OPERATOR_PLATFORM"))
+	if err != nil {
+		return runConfig{}, err
+	}
+	cfg.platform = platform
 
 	jwtAuthStrategy, err := portopenbao.NormalizeJWTAuthStrategy(os.Getenv(constants.EnvOpenBaoJWTAuthStrategy))
 	if err != nil {

--- a/cmd/controller/run_config_test.go
+++ b/cmd/controller/run_config_test.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
+)
+
+func TestParseRunConfig(t *testing.T) {
+	t.Setenv("OPERATOR_PLATFORM", "")
+	t.Setenv("OPENBAO_JWT_AUTH_STRATEGY", "")
+	originalArgs := append([]string(nil), os.Args...)
+	originalFlags := flag.CommandLine
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{name: "unknown flag", args: []string{"--unknown"}, wantError: "flag provided but not defined"},
+		{name: "invalid boolean", args: []string{"--leader-elect=perhaps"}, wantError: "invalid boolean value"},
+		{name: "invalid duration", args: []string{"--admission-startup-timeout=later"}, wantError: "invalid value"},
+		{name: "invalid admission mode", args: []string{"--admission-enforcement=off"}, wantError: "invalid admission"},
+		{name: "invalid platform", args: []string{"--platform=opneshift"}, wantError: "invalid target platform"},
+		{name: "positional argument", args: []string{"cluster"}, wantError: "unexpected positional argument"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseRunConfig(tc.args, io.Discard)
+			require.ErrorContains(t, err, tc.wantError)
+			var usageError *entrypoint.UsageError
+			require.ErrorAs(t, Run(context.Background(), tc.args), &usageError)
+		})
+	}
+
+	for range 2 {
+		cfg, err := parseRunConfig(
+			[]string{"--leader-elect", "--platform= OpenShift ", "--kubeconfig=/test/config"}, io.Discard,
+		)
+		require.NoError(t, err)
+		require.True(t, cfg.enableLeaderElection)
+		require.Equal(t, "openshift", cfg.platform)
+		require.Equal(t, "/test/config", cfg.kubeconfig)
+		defaults, err := parseRunConfig(nil, io.Discard)
+		require.NoError(t, err)
+		require.False(t, defaults.enableLeaderElection)
+		require.Equal(t, "auto", defaults.platform)
+		require.Empty(t, defaults.kubeconfig)
+	}
+	require.Equal(t, originalArgs, os.Args)
+	require.Same(t, originalFlags, flag.CommandLine)
+	require.Nil(t, flag.CommandLine.Lookup("platform"))
+}
+
+func TestParseRunConfigHelp(t *testing.T) {
+	var output bytes.Buffer
+	_, err := parseRunConfig([]string{"--help"}, &output)
+	require.ErrorIs(t, err, flag.ErrHelp)
+	require.Contains(t, output.String(), "Usage of controller:")
+	require.Contains(t, output.String(), "-kubeconfig")
+}
+
+func TestParseRunConfigPlatformEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		name, configured, environment, want string
+		invalid                             bool
+	}{
+		{name: "default", want: "auto"},
+		{name: "flag", configured: " OpenShift ", want: "openshift"},
+		{name: "environment wins", configured: "kubernetes", environment: " OpenShift ", want: "openshift"},
+		{name: "empty environment", configured: "kubernetes", environment: " ", want: "kubernetes"},
+		{name: "invalid environment", configured: "kubernetes", environment: "opneshift", invalid: true},
+		{name: "overridden flag", configured: "typo", environment: "kubernetes", want: "kubernetes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OPERATOR_PLATFORM", tc.environment)
+			cfg, err := parseRunConfig([]string{"--platform=" + tc.configured}, io.Discard)
+			if tc.invalid {
+				require.ErrorContains(t, err, "invalid target platform")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, cfg.platform)
+		})
+	}
+}

--- a/cmd/controller/run_test.go
+++ b/cmd/controller/run_test.go
@@ -24,22 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// Note: OIDC/JWKS tests have been moved to internal/adapter/auth/oidc_test.go
-// These tests verify the controller's integration with the auth package.
-
-// TestRun verifies that Run can be called without panicking.
-// This is a minimal smoke test to ensure the function signature is correct.
-func TestRun(t *testing.T) {
-	// This test verifies that Run accepts []string args as expected
-	// Full integration tests would require a real Kubernetes cluster
-	// and are covered in e2e tests.
-
-	// Test that Run function exists and accepts the correct signature
-	// We can't easily test the full Run() function without a real cluster,
-	// so this is a placeholder for future integration tests.
-	_ = Run
-}
-
 func TestUnavailableHelperImageDefaultFields(t *testing.T) {
 	t.Run("returns all helper image fields when operator version is missing", func(t *testing.T) {
 		t.Setenv(constants.EnvOperatorVersion, "")

--- a/cmd/controller/runtime_setup.go
+++ b/cmd/controller/runtime_setup.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
@@ -33,6 +34,7 @@ type controllerProcessRuntime struct {
 }
 
 func buildControllerProcessRuntime(
+	ctx context.Context,
 	mgr ctrl.Manager,
 	cfg runConfig,
 	platform string,
@@ -82,8 +84,13 @@ func buildControllerProcessRuntime(
 		)
 	}
 
-	oidcConfig := discoverStartupOIDC(config)
-	admissionTracker := initializeAdmissionTracker(mgr, cfg.admissionEnforcement, cfg.admissionStartupTimeout)
+	oidcConfig := discoverStartupOIDC(ctx, config)
+	admissionTracker, err := initializeAdmissionTracker(
+		ctx, mgr.GetAPIReader(), cfg.admissionEnforcement, cfg.admissionStartupTimeout,
+	)
+	if err != nil {
+		return controllerProcessRuntime{}, err
+	}
 	clientFactory := func(config portopenbao.ClientConfig) (portopenbao.ClusterActions, error) {
 		return openbao.NewClient(config)
 	}

--- a/cmd/controller/startup_helpers.go
+++ b/cmd/controller/startup_helpers.go
@@ -14,8 +14,9 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -31,41 +32,59 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func detectPlatform(cfg *rest.Config) string {
-	clientset, err := kubernetes.NewForConfig(cfg)
+const platformDiscoveryTimeout = 10 * time.Second
+
+func detectPlatform(ctx context.Context, cfg *rest.Config) (string, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		return constants.PlatformKubernetes
+		return "", fmt.Errorf("create platform discovery client: %w", err)
 	}
 
-	groups, err := clientset.Discovery().ServerGroups()
-	if err != nil {
-		return constants.PlatformKubernetes
+	discoveryCtx, cancel := context.WithTimeout(ctx, platformDiscoveryTimeout)
+	defer cancel()
+	// Request the named API groups in legacy JSON format so discovery remains
+	// cancellable. ServerGroups does not accept the startup context.
+	groups := &metav1.APIGroupList{}
+	if err := discoveryClient.RESTClient().Get().AbsPath("/apis").
+		SetHeader("Accept", "application/json").Do(discoveryCtx).Into(groups); err != nil {
+		return "", fmt.Errorf("discover target platform: %w", err)
 	}
 
-	for _, g := range groups.Groups {
-		if g.Name == "security.openshift.io" {
-			return constants.PlatformOpenShift
+	for _, group := range groups.Groups {
+		if group.Name == "security.openshift.io" {
+			return constants.PlatformOpenShift, nil
 		}
 	}
-
-	return constants.PlatformKubernetes
+	return constants.PlatformKubernetes, nil
 }
 
-func resolvePlatform(config *rest.Config, configured string) string {
+func configuredPlatform(configured, environment string) (string, error) {
 	platform := configured
-	if envPlatform := strings.TrimSpace(os.Getenv("OPERATOR_PLATFORM")); envPlatform != "" {
-		platform = strings.ToLower(envPlatform)
+	if strings.TrimSpace(environment) != "" {
+		platform = environment
 	}
+	platform = strings.ToLower(strings.TrimSpace(platform))
 	if platform == "" {
 		platform = constants.PlatformAuto
 	}
-	if platform == constants.PlatformAuto {
-		detected := detectPlatform(config)
-		setupLog.Info("Auto-detected target platform", "platform", detected)
-		return detected
+	switch platform {
+	case constants.PlatformAuto, constants.PlatformKubernetes, constants.PlatformOpenShift:
+		return platform, nil
+	default:
+		return "", fmt.Errorf("invalid target platform %q: expected auto, kubernetes, or openshift", platform)
 	}
+}
 
-	return platform
+func resolvePlatform(ctx context.Context, config *rest.Config, configured string) (string, error) {
+	if configured == constants.PlatformAuto {
+		detected, err := detectPlatform(ctx, config)
+		if err != nil {
+			return "", err
+		}
+		setupLog.Info("Auto-detected target platform", "platform", detected)
+		return detected, nil
+	}
+	return configured, nil
 }
 
 func newManagerOptions(
@@ -121,8 +140,8 @@ func newManagerOptions(
 	return mgrOpts
 }
 
-func discoverStartupOIDC(config *rest.Config) *portauth.OIDCConfig {
-	oidcConfig, err := auth.DiscoverConfig(context.Background(), config, "")
+func discoverStartupOIDC(ctx context.Context, config *rest.Config) *portauth.OIDCConfig {
+	oidcConfig, err := auth.DiscoverConfig(ctx, config, "")
 	if err != nil {
 		setupLog.Error(err, "Failed to discover Kubernetes OIDC configuration. Hardened profile requires OIDC.")
 		if oidcConfig == nil {
@@ -144,12 +163,13 @@ func discoverStartupOIDC(config *rest.Config) *portauth.OIDCConfig {
 }
 
 func initializeAdmissionTracker(
-	mgr ctrl.Manager,
+	ctx context.Context,
+	reader client.Reader,
 	admissionEnforcement string,
 	admissionStartupTimeout time.Duration,
-) *admission.Tracker {
+) (*admission.Tracker, error) {
 	admissionTracker := admission.NewTracker(
-		mgr.GetAPIReader(),
+		reader,
 		admission.DefaultDependencies(),
 		admission.DefaultNamePrefixes(),
 		30*time.Second,
@@ -163,7 +183,7 @@ func initializeAdmissionTracker(
 		})
 		admission.SetAdmissionDependenciesReady(true)
 		admissionTracker.MarkReadyForUnsafeMode()
-		return admissionTracker
+		return admissionTracker, nil
 	}
 
 	var admissionStatus admission.Status
@@ -171,8 +191,8 @@ func initializeAdmissionTracker(
 	case entrypoint.AdmissionEnforcementFail:
 		setupLog.Info("Waiting for admission policy dependencies", "timeout", admissionStartupTimeout)
 		status, err := admission.WaitForDependencies(
-			context.Background(),
-			mgr.GetAPIReader(),
+			ctx,
+			reader,
 			admission.DefaultDependencies(),
 			admission.DefaultNamePrefixes(),
 			admissionStartupTimeout,
@@ -194,14 +214,16 @@ func initializeAdmissionTracker(
 				"summary",
 				admissionStatus.SummaryMessage(),
 			)
-			os.Exit(1)
+			admission.SetAdmissionDependenciesReady(false)
+			return nil, fmt.Errorf("admission policy dependencies not ready (%s): %w",
+				admissionStatus.SummaryMessage(), err)
 		}
 	default:
-		admissionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		admissionCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		status, err := admission.CheckDependencies(
 			admissionCtx,
-			mgr.GetAPIReader(),
+			reader,
 			admission.DefaultDependencies(),
 			admission.DefaultNamePrefixes(),
 		)
@@ -229,7 +251,7 @@ func initializeAdmissionTracker(
 		})
 	}
 
-	return admissionTracker
+	return admissionTracker, nil
 }
 
 func operatorNamespaceFromEnv() string {

--- a/cmd/controller/startup_helpers_test.go
+++ b/cmd/controller/startup_helpers_test.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
+)
+
+func TestDetectPlatform(t *testing.T) {
+	for _, tc := range []struct {
+		name, body, want, wantError string
+		status                      int
+	}{
+		{name: "kubernetes", body: `{"kind":"APIGroupList","apiVersion":"v1","groups":[{"name":"apps"}]}`,
+			status: http.StatusOK, want: "kubernetes"},
+		{name: "openshift", body: `{"kind":"APIGroupList","apiVersion":"v1","groups":[{"name":"security.openshift.io"}]}`,
+			status: http.StatusOK, want: "openshift"},
+		{name: "API unavailable", status: http.StatusServiceUnavailable, wantError: "discover target platform"},
+		{name: "API forbidden", status: http.StatusForbidden, wantError: "discover target platform"},
+		{name: "malformed response", body: "invalid json", status: http.StatusOK, wantError: "discover target platform"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/apis", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			t.Cleanup(server.Close)
+			platform, err := resolvePlatform(t.Context(), &rest.Config{Host: server.URL}, "auto")
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				require.Empty(t, platform, "failed discovery must not select Kubernetes")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, platform)
+		})
+	}
+}
+
+func TestDetectPlatformInvalidClientConfig(t *testing.T) {
+	config := &rest.Config{Host: "http://[invalid"}
+	platform, err := detectPlatform(t.Context(), config)
+	require.ErrorContains(t, err, "create platform discovery client")
+	require.Empty(t, platform)
+	for _, configured := range []string{"kubernetes", "openshift"} {
+		platform, err = resolvePlatform(t.Context(), config, configured)
+		require.NoError(t, err, "explicit platform must bypass discovery")
+		require.Equal(t, configured, platform)
+	}
+}
+
+type discoveryRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f discoveryRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestDetectPlatformRequestDeadline(t *testing.T) {
+	config := &rest.Config{
+		Host: "https://api.invalid",
+		Transport: discoveryRoundTripper(func(r *http.Request) (*http.Response, error) {
+			deadline, ok := r.Context().Deadline()
+			require.True(t, ok, "platform discovery must have a deadline")
+			require.Positive(t, time.Until(deadline))
+			require.LessOrEqual(t, time.Until(deadline), platformDiscoveryTimeout)
+			return nil, fmt.Errorf("stop after checking deadline")
+		}),
+	}
+	_, err := detectPlatform(t.Context(), config)
+	require.ErrorContains(t, err, "stop after checking deadline")
+}
+
+func TestDetectPlatformCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		cancel()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	platform, err := detectPlatform(ctx, &rest.Config{Host: server.URL})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, platform)
+}
+
+func TestInitializeAdmissionTracker(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "false")
+	reader := fake.NewClientBuilder().WithScheme(scheme).Build()
+	for _, mode := range []string{entrypoint.AdmissionEnforcementFail, entrypoint.AdmissionEnforcementWarn} {
+		t.Run(mode, func(t *testing.T) {
+			tracker, err := initializeAdmissionTracker(t.Context(), reader, mode, 0)
+			if mode == entrypoint.AdmissionEnforcementFail {
+				require.ErrorContains(t, err, "admission policy dependencies not ready")
+				require.Nil(t, tracker)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, tracker.Current())
+			require.False(t, tracker.Current().OverallReady)
+		})
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	tracker, err := initializeAdmissionTracker(ctx, reader, entrypoint.AdmissionEnforcementFail, time.Minute)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, tracker)
+
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+	tracker, err = initializeAdmissionTracker(t.Context(), nil, entrypoint.AdmissionEnforcementFail, time.Minute)
+	require.NoError(t, err)
+	require.True(t, tracker.Current().OverallReady)
+	require.True(t, tracker.Current().UnsafeMode)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"os"
 
@@ -28,35 +31,46 @@ import (
 
 	"github.com/dc-tec/openbao-operator/cmd/controller"
 	"github.com/dc-tec/openbao-operator/cmd/provisioner"
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
 )
 
-var (
-	setupLog = ctrl.Log.WithName("setup")
-)
-
-func run() error {
-	if len(os.Args) < 2 {
-		return fmt.Errorf("missing command (valid commands: provisioner, controller)")
+func run(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return &entrypoint.UsageError{Err: fmt.Errorf("missing command (valid commands: provisioner, controller)")}
 	}
 
-	// Shift args so flag parsing works inside sub-functions (e.g., --leader-elect)
-	command := os.Args[1]
-	args := os.Args[2:]
-
-	switch command {
+	switch command := args[0]; command {
 	case "provisioner":
-		provisioner.Run(args)
+		return provisioner.Run(ctx, args[1:])
 	case "controller":
-		controller.Run(args)
+		return controller.Run(ctx, args[1:])
+	case "-h", "--help":
+		fmt.Fprintln(os.Stderr, "Usage: manager <controller|provisioner> [flags]")
+		return flag.ErrHelp
 	default:
-		return fmt.Errorf("unknown command %q (valid commands: provisioner, controller)", command)
+		return &entrypoint.UsageError{
+			Err: fmt.Errorf("unknown command %q (valid commands: provisioner, controller)", command),
+		}
 	}
-	return nil
+}
+
+func exitCode(err error) int {
+	if err == nil || errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+	var usageError *entrypoint.UsageError
+	if errors.As(err, &usageError) {
+		return 2
+	}
+	return 1
 }
 
 func main() {
-	if err := run(); err != nil {
-		setupLog.Error(err, "command failed")
-		os.Exit(1)
+	err := run(ctrl.SetupSignalHandler(), os.Args[1:])
+	code := exitCode(err)
+	if code != 0 {
+		// Argument and kubeconfig failures can occur before logging is configured.
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(code)
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandExitCodes(t *testing.T) {
+	t.Setenv("OPERATOR_PLATFORM", "kubernetes")
+	missingConfig := filepath.Join(t.TempDir(), "missing-kubeconfig")
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "missing command", want: 2},
+		{name: "unknown command", args: []string{"unknown"}, want: 2},
+		{name: "top-level help", args: []string{"--help"}, want: 0},
+		{name: "controller help", args: []string{"controller", "--help"}, want: 0},
+		{name: "provisioner help", args: []string{"provisioner", "--help"}, want: 0},
+		{name: "controller invalid flag", args: []string{"controller", "--unknown"}, want: 2},
+		{name: "provisioner invalid flag", args: []string{"provisioner", "--unknown"}, want: 2},
+		{name: "controller invalid config", args: []string{"controller", "--kubeconfig", missingConfig}, want: 1},
+		{name: "provisioner invalid config", args: []string{"provisioner", "--kubeconfig", missingConfig}, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(context.Background(), tc.args)
+			require.Equal(t, tc.want, exitCode(err), "run error: %v", err)
+		})
+	}
+	require.Zero(t, exitCode(nil))
+	require.Equal(t, 1, exitCode(fmt.Errorf("manager failed")))
+}

--- a/cmd/provisioner/run.go
+++ b/cmd/provisioner/run.go
@@ -17,6 +17,8 @@ limitations under the License.
 package provisioner
 
 import (
+	"context"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -27,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
@@ -48,45 +51,41 @@ func init() {
 // The Provisioner is responsible for onboarding new tenant namespaces
 // by creating the necessary RoleBindings that grant the Controller access.
 // args are the command-line arguments (typically os.Args[2:] after the command name).
-func Run(args []string) {
-	oldArgs := os.Args
-	os.Args = append([]string{oldArgs[0]}, args...)
-	defer func() { os.Args = oldArgs }()
-
-	cfg, err := parseRunConfig()
+func Run(ctx context.Context, args []string) error {
+	cfg, err := parseRunConfig(args, os.Stderr)
 	if err != nil {
-		setupLog.Error(err, entrypoint.AdmissionEnforcementExpectedMsg)
-		os.Exit(2)
+		return &entrypoint.UsageError{Err: err}
 	}
 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&cfg.logOptions)))
+	config, err := entrypoint.LoadConfig(cfg.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("load Kubernetes configuration: %w", err)
+	}
 	mgr, err := ctrl.NewManager(
-		ctrl.GetConfigOrDie(),
+		config,
 		newManagerOptions(buildMetricsServerOptions(cfg), cfg.probeAddr, cfg.enableLeaderElection),
 	)
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
-	processRuntime, err := buildProvisionerProcessRuntime(mgr, cfg)
+	processRuntime, err := buildProvisionerProcessRuntime(ctx, mgr, cfg)
 	if err != nil {
-		setupLog.Error(err, "unable to initialize provisioner runtime")
-		os.Exit(1)
+		return fmt.Errorf("unable to initialize provisioner runtime: %w", err)
 	}
 
 	if err := setupControllers(mgr, processRuntime); err != nil {
-		setupLog.Error(err, "unable to register provisioner controllers")
-		os.Exit(1)
+		return fmt.Errorf("unable to register provisioner controllers: %w", err)
 	}
 
 	if err := addManagerHealthChecks(mgr); err != nil {
-		setupLog.Error(err, "unable to configure manager probes")
-		os.Exit(1)
+		return fmt.Errorf("unable to configure manager probes: %w", err)
 	}
 
 	setupLog.Info("starting provisioner manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("problem running manager: %w", err)
 	}
+	return nil
 }

--- a/cmd/provisioner/run_config.go
+++ b/cmd/provisioner/run_config.go
@@ -2,9 +2,10 @@ package provisioner
 
 import (
 	"flag"
+	"fmt"
+	"io"
 	"time"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -13,6 +14,8 @@ import (
 )
 
 type runConfig struct {
+	kubeconfig              string
+	logOptions              zap.Options
 	metricsAddr             string
 	enableLeaderElection    bool
 	probeAddr               string
@@ -22,26 +25,33 @@ type runConfig struct {
 	admissionCanary         bool
 }
 
-func parseRunConfig() (runConfig, error) {
+func parseRunConfig(args []string, output io.Writer) (runConfig, error) {
 	cfg := runConfig{}
+	fs := flag.NewFlagSet("provisioner", flag.ContinueOnError)
+	fs.SetOutput(output)
+	fs.StringVar(&cfg.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 
 	entrypoint.BindManagerFlags(
-		flag.CommandLine,
+		fs,
 		&cfg.metricsAddr,
 		&cfg.probeAddr,
 		&cfg.enableLeaderElection,
 		&cfg.secureMetrics,
 	)
-	entrypoint.BindAdmissionFlags(flag.CommandLine, &cfg.admissionEnforcement, &cfg.admissionStartupTimeout)
-	flag.BoolVar(&cfg.admissionCanary, "admission-canary", false,
+	entrypoint.BindAdmissionFlags(fs, &cfg.admissionEnforcement, &cfg.admissionStartupTimeout)
+	fs.BoolVar(&cfg.admissionCanary, "admission-canary", false,
 		"If set, perform an admission canary (dry-run) that must be denied "+
 			"by the Provisioner RBAC ValidatingAdmissionPolicy. "+
 			"This provides stronger assurance that enforcement is active.")
 
-	opts := zap.Options{Development: false}
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	cfg.logOptions = zap.Options{Development: false}
+	cfg.logOptions.BindFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return runConfig{}, err
+	}
+	if fs.NArg() != 0 {
+		return runConfig{}, fmt.Errorf("unexpected positional argument %q", fs.Arg(0))
+	}
 
 	admissionEnforcement, err := entrypoint.NormalizeAdmissionEnforcement(cfg.admissionEnforcement)
 	if err != nil {

--- a/cmd/provisioner/run_config_test.go
+++ b/cmd/provisioner/run_config_test.go
@@ -1,0 +1,62 @@
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
+)
+
+func TestParseRunConfig(t *testing.T) {
+	originalArgs := append([]string(nil), os.Args...)
+	originalFlags := flag.CommandLine
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{name: "unknown flag", args: []string{"--unknown"}, wantError: "flag provided but not defined"},
+		{name: "invalid boolean", args: []string{"--admission-canary=perhaps"}, wantError: "invalid boolean value"},
+		{name: "invalid duration", args: []string{"--admission-startup-timeout=later"}, wantError: "invalid value"},
+		{name: "invalid admission mode", args: []string{"--admission-enforcement=off"}, wantError: "invalid admission"},
+		{name: "positional argument", args: []string{"namespace"}, wantError: "unexpected positional argument"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseRunConfig(tc.args, io.Discard)
+			require.ErrorContains(t, err, tc.wantError)
+			var usageError *entrypoint.UsageError
+			require.ErrorAs(t, Run(context.Background(), tc.args), &usageError)
+		})
+	}
+	for range 2 {
+		cfg, err := parseRunConfig(
+			[]string{"--admission-canary", "--admission-enforcement= Warn ", "--kubeconfig=/test/config"}, io.Discard,
+		)
+		require.NoError(t, err)
+		require.True(t, cfg.admissionCanary)
+		require.Equal(t, "warn", cfg.admissionEnforcement)
+		require.Equal(t, "/test/config", cfg.kubeconfig)
+		defaults, err := parseRunConfig(nil, io.Discard)
+		require.NoError(t, err)
+		require.False(t, defaults.admissionCanary)
+		require.Equal(t, "fail", defaults.admissionEnforcement)
+		require.Empty(t, defaults.kubeconfig)
+	}
+	require.Equal(t, originalArgs, os.Args)
+	require.Same(t, originalFlags, flag.CommandLine)
+	require.Nil(t, flag.CommandLine.Lookup("admission-canary"))
+}
+
+func TestParseRunConfigHelp(t *testing.T) {
+	var output bytes.Buffer
+	_, err := parseRunConfig([]string{"--help"}, &output)
+	require.ErrorIs(t, err, flag.ErrHelp)
+	require.Contains(t, output.String(), "Usage of provisioner:")
+	require.Contains(t, output.String(), "-kubeconfig")
+}

--- a/cmd/provisioner/runtime_setup.go
+++ b/cmd/provisioner/runtime_setup.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -9,6 +10,7 @@ import (
 	appprovisioner "github.com/dc-tec/openbao-operator/internal/app/provisioner"
 	provisionercontroller "github.com/dc-tec/openbao-operator/internal/controller/provisioner"
 	"github.com/dc-tec/openbao-operator/internal/platform/admission"
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
 )
 
 type provisionerProcessRuntime struct {
@@ -17,7 +19,9 @@ type provisionerProcessRuntime struct {
 	admissionTracker  *admission.Tracker
 }
 
-func buildProvisionerProcessRuntime(mgr ctrl.Manager, cfg runConfig) (provisionerProcessRuntime, error) {
+func buildProvisionerProcessRuntime(
+	ctx context.Context, mgr ctrl.Manager, cfg runConfig,
+) (provisionerProcessRuntime, error) {
 	provisionerRuntime, err := appprovisioner.NewProvisioner(appprovisioner.ProvisionerDependencies{
 		Client: mgr.GetClient(),
 		Logger: setupLog.WithName("provisioner"),
@@ -26,10 +30,21 @@ func buildProvisionerProcessRuntime(mgr ctrl.Manager, cfg runConfig) (provisione
 		return provisionerProcessRuntime{}, fmt.Errorf("unable to create provisioner runtime: %w", err)
 	}
 
+	admissionTracker, err := initializeAdmissionTracker(ctx, mgr.GetAPIReader(), cfg)
+	if err != nil {
+		return provisionerProcessRuntime{}, err
+	}
+	if cfg.admissionCanary && cfg.admissionEnforcement == entrypoint.AdmissionEnforcementFail &&
+		!admission.UnsafeAdmissionDisabled() {
+		if err := verifyAdmissionCanary(ctx, mgr.GetConfig()); err != nil {
+			return provisionerProcessRuntime{}, err
+		}
+	}
+
 	return provisionerProcessRuntime{
 		provisioner:       provisionerRuntime,
 		operatorNamespace: operatorNamespaceFromEnv(),
-		admissionTracker:  initializeAdmissionTracker(mgr, cfg),
+		admissionTracker:  admissionTracker,
 	}, nil
 }
 

--- a/cmd/provisioner/startup_helpers.go
+++ b/cmd/provisioner/startup_helpers.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -42,9 +43,11 @@ func newManagerOptions(
 	}
 }
 
-func initializeAdmissionTracker(mgr ctrl.Manager, cfg runConfig) *admission.Tracker {
+func initializeAdmissionTracker(
+	ctx context.Context, reader client.Reader, cfg runConfig,
+) (*admission.Tracker, error) {
 	admissionTracker := admission.NewTracker(
-		mgr.GetAPIReader(),
+		reader,
 		admission.DefaultDependencies(),
 		admission.DefaultNamePrefixes(),
 		30*time.Second,
@@ -60,15 +63,15 @@ func initializeAdmissionTracker(mgr ctrl.Manager, cfg runConfig) *admission.Trac
 		})
 		admission.SetAdmissionDependenciesReady(true)
 		admissionTracker.MarkReadyForUnsafeMode()
-		return admissionTracker
+		return admissionTracker, nil
 	}
 
 	switch cfg.admissionEnforcement {
 	case entrypoint.AdmissionEnforcementFail:
 		setupLog.Info("Waiting for admission policy dependencies", "timeout", cfg.admissionStartupTimeout)
 		status, err := admission.WaitForDependencies(
-			context.Background(),
-			mgr.GetAPIReader(),
+			ctx,
+			reader,
 			admission.DefaultDependencies(),
 			admission.DefaultNamePrefixes(),
 			cfg.admissionStartupTimeout,
@@ -90,7 +93,8 @@ func initializeAdmissionTracker(mgr ctrl.Manager, cfg runConfig) *admission.Trac
 				"summary",
 				status.SummaryMessage(),
 			)
-			os.Exit(1)
+			return nil, fmt.Errorf("admission policy dependencies not ready (%s): %w",
+				status.SummaryMessage(), err)
 		}
 		admissionTracker.Set(status)
 		setupLog.Info("Admission policy dependencies ready")
@@ -99,16 +103,13 @@ func initializeAdmissionTracker(mgr ctrl.Manager, cfg runConfig) *admission.Trac
 			"admission_enforcement": cfg.admissionEnforcement,
 		})
 
-		if cfg.admissionCanary {
-			verifyAdmissionCanary(mgr)
-		}
 	default:
-		checkCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		status := admission.Status{}
 		checkedStatus, err := admission.CheckDependencies(
 			checkCtx,
-			mgr.GetAPIReader(),
+			reader,
 			admission.DefaultDependencies(),
 			admission.DefaultNamePrefixes(),
 		)
@@ -135,35 +136,34 @@ func initializeAdmissionTracker(mgr ctrl.Manager, cfg runConfig) *admission.Trac
 		}
 	}
 
-	return admissionTracker
+	return admissionTracker, nil
 }
 
-func verifyAdmissionCanary(mgr ctrl.Manager) {
-	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+func verifyAdmissionCanary(ctx context.Context, config *rest.Config) error {
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		logging.LogAuditEvent(setupLog, logging.EventAdmissionCanaryFailed, map[string]string{
 			"component": "provisioner",
 			"reason":    "clientset_creation_failed",
 		})
-		setupLog.Error(err, "Failed to create Kubernetes clientset for admission canary; refusing to start")
-		os.Exit(1)
+		return fmt.Errorf("create Kubernetes clientset for admission canary: %w", err)
 	}
 
-	canaryCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	canaryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := admission.VerifyProvisionerRBACEnforcement(canaryCtx, clientset, "default"); err != nil {
 		logging.LogAuditEvent(setupLog, logging.EventAdmissionCanaryFailed, map[string]string{
 			"component": "provisioner",
 			"reason":    "policy_not_enforced",
 		})
-		setupLog.Error(err, "Admission canary failed; refusing to start")
-		os.Exit(1)
+		return fmt.Errorf("admission canary failed: %w", err)
 	}
 
 	setupLog.Info("Admission canary succeeded")
 	logging.LogAuditEvent(setupLog, logging.EventAdmissionCanaryPassed, map[string]string{
 		"component": "provisioner",
 	})
+	return nil
 }
 
 func operatorNamespaceFromEnv() string {

--- a/cmd/provisioner/startup_helpers_test.go
+++ b/cmd/provisioner/startup_helpers_test.go
@@ -1,0 +1,84 @@
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
+)
+
+func TestAdmissionStartupFailures(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "false")
+	reader := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cfg := runConfig{admissionEnforcement: entrypoint.AdmissionEnforcementFail}
+	tracker, err := initializeAdmissionTracker(t.Context(), reader, cfg)
+	require.Nil(t, tracker)
+	require.ErrorContains(t, err, "admission policy dependencies not ready")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	cfg.admissionStartupTimeout = time.Minute
+	tracker, err = initializeAdmissionTracker(ctx, reader, cfg)
+	require.Nil(t, tracker)
+	require.ErrorIs(t, err, context.Canceled)
+
+	cfg.admissionEnforcement = entrypoint.AdmissionEnforcementWarn
+	tracker, err = initializeAdmissionTracker(t.Context(), reader, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, tracker.Current())
+	require.False(t, tracker.Current().OverallReady)
+
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+	tracker, err = initializeAdmissionTracker(t.Context(), nil, cfg)
+	require.NoError(t, err)
+	require.True(t, tracker.Current().OverallReady)
+	require.True(t, tracker.Current().UnsafeMode)
+}
+
+func TestVerifyAdmissionCanary(t *testing.T) {
+	for _, tc := range []struct {
+		name, body, wantError string
+		status                int
+	}{
+		{name: "allowed", body: `{"kind":"Role","apiVersion":"rbac.authorization.k8s.io/v1"}`,
+			status: http.StatusCreated, wantError: "but it was allowed"},
+		{name: "unrelated denial", body: `{"kind":"Status","apiVersion":"v1","status":"Failure",` +
+			`"reason":"Forbidden","message":"RBAC denied","code":403}`,
+			status: http.StatusForbidden, wantError: "not by the expected VAP message"},
+		{name: "expected denial", body: `{"kind":"Status","apiVersion":"v1","status":"Failure",` +
+			`"reason":"Forbidden","message":"Provisioner can only create Roles","code":403}`,
+			status: http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/apis/rbac.authorization.k8s.io/v1/namespaces/default/roles", r.URL.Path)
+				assert.Equal(t, "All", r.URL.Query().Get("dryRun"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			t.Cleanup(server.Close)
+			err := verifyAdmissionCanary(t.Context(), &rest.Config{Host: server.URL})
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestVerifyAdmissionCanaryClientFailure(t *testing.T) {
+	err := verifyAdmissionCanary(t.Context(), &rest.Config{Host: "http://[invalid"})
+	require.ErrorContains(t, err, "create Kubernetes clientset for admission canary")
+}

--- a/internal/platform/entrypoint/config.go
+++ b/internal/platform/entrypoint/config.go
@@ -21,10 +21,14 @@ func (e *UsageError) Unwrap() error { return e.Err }
 // LoadConfig preserves controller-runtime's configuration precedence without
 // reading the kubeconfig flag registered on the global command line.
 func LoadConfig(kubeconfig string) (*rest.Config, error) {
-	return loadConfig(kubeconfig, rest.InClusterConfig)
+	return loadConfig(kubeconfig, rest.InClusterConfig, clientcmd.NewDefaultClientConfigLoadingRules)
 }
 
-func loadConfig(kubeconfig string, inCluster func() (*rest.Config, error)) (*rest.Config, error) {
+func loadConfig(
+	kubeconfig string,
+	inCluster func() (*rest.Config, error),
+	defaultRules func() *clientcmd.ClientConfigLoadingRules,
+) (*rest.Config, error) {
 	if kubeconfig == "" && os.Getenv(clientcmd.RecommendedConfigPathEnvVar) == "" {
 		if config, err := inCluster(); err == nil {
 			config.QPS = -1
@@ -32,9 +36,10 @@ func loadConfig(kubeconfig string, inCluster func() (*rest.Config, error)) (*res
 		}
 	}
 
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	rules.ExplicitPath = kubeconfig
+	// An explicit path must not trigger default-file migration or inspect home files.
+	rules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
 	if kubeconfig == "" {
+		rules = defaultRules()
 		if _, ok := os.LookupEnv("HOME"); !ok {
 			currentUser, err := user.Current()
 			if err != nil {

--- a/internal/platform/entrypoint/config.go
+++ b/internal/platform/entrypoint/config.go
@@ -1,0 +1,58 @@
+package entrypoint
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// UsageError identifies invalid command-line or environment configuration.
+type UsageError struct {
+	Err error
+}
+
+func (e *UsageError) Error() string { return e.Err.Error() }
+func (e *UsageError) Unwrap() error { return e.Err }
+
+// LoadConfig preserves controller-runtime's configuration precedence without
+// reading the kubeconfig flag registered on the global command line.
+func LoadConfig(kubeconfig string) (*rest.Config, error) {
+	return loadConfig(kubeconfig, rest.InClusterConfig)
+}
+
+func loadConfig(kubeconfig string, inCluster func() (*rest.Config, error)) (*rest.Config, error) {
+	if kubeconfig == "" && os.Getenv(clientcmd.RecommendedConfigPathEnvVar) == "" {
+		if config, err := inCluster(); err == nil {
+			config.QPS = -1
+			return config, nil
+		}
+	}
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = kubeconfig
+	if kubeconfig == "" {
+		if _, ok := os.LookupEnv("HOME"); !ok {
+			currentUser, err := user.Current()
+			if err != nil {
+				return nil, fmt.Errorf("find home directory for kubeconfig: %w", err)
+			}
+			rules.Precedence = append(rules.Precedence,
+				filepath.Join(currentUser.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
+		}
+	}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules, &clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load kubeconfig: %w", err)
+	}
+	// Match controller-runtime: API priority and fairness controls requests by default.
+	if config.QPS == 0 {
+		config.QPS = -1
+	}
+	return config, nil
+}

--- a/internal/platform/entrypoint/config_test.go
+++ b/internal/platform/entrypoint/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfigPrecedence(t *testing.T) {
 			config, err := loadConfig(tc.explicitPath, func() (*rest.Config, error) {
 				called = true
 				return &rest.Config{Host: "https://in-cluster.invalid"}, nil
-			})
+			}, clientcmd.NewDefaultClientConfigLoadingRules)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantHost, config.Host)
 			require.Equal(t, float32(-1), config.QPS)
@@ -63,4 +63,44 @@ func TestUsageErrorPreservesCause(t *testing.T) {
 	err := &UsageError{Err: cause}
 	require.ErrorIs(t, err, cause)
 	require.Equal(t, cause.Error(), err.Error())
+}
+
+func TestExplicitConfigDoesNotMigrateDefaultFiles(t *testing.T) {
+	for _, blockedDestination := range []bool{false, true} {
+		t.Run(fmt.Sprintf("blocked destination %t", blockedDestination), func(t *testing.T) {
+			dir := t.TempDir()
+			explicit := filepath.Join(dir, "explicit")
+			legacy := filepath.Join(dir, "legacy")
+			destination := filepath.Join(dir, "default")
+			config := clientcmdapi.Config{
+				Clusters:       map[string]*clientcmdapi.Cluster{"test": {Server: "https://explicit.invalid"}},
+				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"test": {}},
+				Contexts:       map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				CurrentContext: "test",
+			}
+			require.NoError(t, clientcmd.WriteToFile(config, explicit))
+			require.NoError(t, os.WriteFile(legacy, []byte("legacy config"), 0o600))
+			if blockedDestination {
+				parent := filepath.Join(dir, "blocked-parent")
+				require.NoError(t, os.WriteFile(parent, []byte("not a directory"), 0o600))
+				destination = filepath.Join(parent, "default")
+			}
+			loaded, err := loadConfig(explicit, func() (*rest.Config, error) {
+				t.Fatal("explicit config must not consult in-cluster config")
+				return nil, nil
+			}, func() *clientcmd.ClientConfigLoadingRules {
+				return &clientcmd.ClientConfigLoadingRules{
+					MigrationRules: map[string]string{destination: legacy},
+				}
+			})
+			require.NoError(t, err, "default-file migration must not interfere with explicit config")
+			require.Equal(t, "https://explicit.invalid", loaded.Host)
+			if !blockedDestination {
+				require.NoFileExists(t, destination, "explicit config must not migrate default files")
+			}
+			contents, err := os.ReadFile(legacy)
+			require.NoError(t, err)
+			require.Equal(t, "legacy config", string(contents))
+		})
+	}
 }

--- a/internal/platform/entrypoint/config_test.go
+++ b/internal/platform/entrypoint/config_test.go
@@ -1,0 +1,66 @@
+package entrypoint
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestLoadConfigPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig := func(name string) string {
+		path := filepath.Join(dir, name)
+		config := clientcmdapi.Config{
+			Clusters:       map[string]*clientcmdapi.Cluster{"test": {Server: "https://" + name + ".invalid"}},
+			AuthInfos:      map[string]*clientcmdapi.AuthInfo{"test": {}},
+			Contexts:       map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+			CurrentContext: "test",
+		}
+		require.NoError(t, clientcmd.WriteToFile(config, path))
+		return path
+	}
+	explicit := writeConfig("explicit")
+	environment := writeConfig("environment")
+	for _, tc := range []struct {
+		name, explicitPath, envPath, wantHost string
+		wantInCluster                         bool
+	}{
+		{name: "explicit wins", explicitPath: explicit, envPath: environment, wantHost: "https://explicit.invalid"},
+		{name: "environment before in-cluster", envPath: environment, wantHost: "https://environment.invalid"},
+		{name: "in-cluster before default file", wantHost: "https://in-cluster.invalid", wantInCluster: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(clientcmd.RecommendedConfigPathEnvVar, tc.envPath)
+			called := false
+			config, err := loadConfig(tc.explicitPath, func() (*rest.Config, error) {
+				called = true
+				return &rest.Config{Host: "https://in-cluster.invalid"}, nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.wantHost, config.Host)
+			require.Equal(t, float32(-1), config.QPS)
+			require.Equal(t, tc.wantInCluster, called)
+		})
+	}
+}
+
+func TestLoadConfigDoesNotFallbackFromExplicitError(t *testing.T) {
+	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, filepath.Join(t.TempDir(), "environment"))
+	path := filepath.Join(t.TempDir(), "missing")
+	_, err := LoadConfig(path)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorContains(t, err, path)
+}
+
+func TestUsageErrorPreservesCause(t *testing.T) {
+	cause := fmt.Errorf("invalid option")
+	err := &UsageError{Err: cause}
+	require.ErrorIs(t, err, cause)
+	require.Equal(t, cause.Error(), err.Error())
+}

--- a/internal/platform/entrypoint/flags.go
+++ b/internal/platform/entrypoint/flags.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	AdmissionEnforcementFail        = "fail"
-	AdmissionEnforcementWarn        = "warn"
-	AdmissionEnforcementExpectedMsg = "expected --admission-enforcement=fail or warn"
+	AdmissionEnforcementFail = "fail"
+	AdmissionEnforcementWarn = "warn"
 )
 
 // NormalizeAdmissionEnforcement validates and canonicalizes admission enforcement mode.

--- a/website/content-versions/next/docs/get-started/install.md
+++ b/website/content-versions/next/docs/get-started/install.md
@@ -9,6 +9,7 @@ verifiedBy:
   - hack/ci/generate-channel-manifests.sh
   - charts/openbao-operator/values.yaml
   - config/default/kustomization.yaml
+  - cmd/controller/startup_helpers.go
 ---
 
 Next tracks unreleased behavior on `main`. Use the edge channel for an executable evaluation install, or build from
@@ -124,6 +125,18 @@ helm template openbao-operator charts/openbao-operator \
 
 Review the controller and Provisioner ServiceAccounts, RoleBinding subjects, admission-policy identities, projected
 token audience, images, and namespaces before applying the render.
+
+## Select the target platform
+
+The chart defaults to `platform=auto`. The controller checks the API groups during startup and selects OpenShift
+when `security.openshift.io` is present. A failed discovery request or a request that exceeds 10 seconds blocks startup.
+Check API server connectivity and discovery permissions before restarting the controller.
+
+To bypass discovery, set the chart value to `platform=kubernetes` or `platform=openshift`. OpenShift mode omits fixed
+`runAsUser` and `fsGroup` IDs so the Security Context Constraint can assign namespace-scoped IDs.
+
+The chart sets `OPERATOR_PLATFORM`. This environment variable takes precedence over the deprecated `--platform`
+controller flag. Accepted values are `auto`, `kubernetes`, and `openshift`; other values block startup.
 
 ## Refresh an edge installation
 


### PR DESCRIPTION
## Summary

Controller and Provisioner startup helpers could terminate the process, and failed platform discovery silently selected Kubernetes. Both entrypoints now accept a context and arguments and return errors to main, which owns signal handling and exit codes.

Use local flag sets, preserve kubeconfig precedence, validate effective platform overrides, and bound automatic discovery with a cancellable 10-second request. Admission initialization and canary checks return failures. Explicit kubeconfig loading remains independent of default home-file migration.

## Related Issues

Repository review follow-up; no tracking issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Automatic platform discovery now stops startup when discovery fails. Invalid effective platform values produce usage errors. Existing environment-variable precedence and the deprecated platform flag remain supported; an explicit Kubernetes or OpenShift setting bypasses discovery.

Help exits 0, invalid arguments/configuration values exit 2, and startup failures exit 1. Admission fail/warn/unsafe behavior is preserved. Probe readiness is unchanged and will be handled separately. No CRD, Helm, or RBAC changes are included. Next-version installation documentation describes the startup behavior; no generated artifacts are affected.

## Verification

- `GOMAXPROCS=4 go test -p 4 ./cmd ./cmd/controller ./cmd/provisioner ./internal/platform/entrypoint`
- Focused golangci-lint, architecture checks, and normal commit checks passed.
- Tests cover repeated parsing, exit classification, discovery failures/deadlines/cancellation, admission startup, canary errors, and kubeconfig precedence.
- Explicit-config migration tests reproduced an unrelated file write and an unrelated migration failure before the fix, using temporary paths.

The combined stack tree passed `devenv test`, `devenv tasks run operator:bootstrap`, `devenv tasks run operator:doctor`, and `devenv tasks run operator:ci-core`. The stack tip has the same tracked tree as that validated candidate (`8e22e09ff9de3a3d3d11837986491613c1314e85`). This includes unit/integration tests, the coverage gate, 34 fuzz targets, security scans, configuration compatibility, docs, and Helm checks. Deployed Kind E2E was not run locally; hosted checks validate each published layer.

## Reviewer Notes

Layer 2 of 3, based on the phase-metric fix. Focus on configuration precedence, cancellation, and failure propagation. The three PRs are intended to merge together through the native stack merge. The new focused tests do not start a live manager or use actual in-cluster credentials.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

