### PR TITLE
ci(api): enforce released CRD compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       toolchain: ${{ steps.diff.outputs.toolchain }}
       docs: ${{ steps.diff.outputs.docs }}
       go_quality: ${{ steps.diff.outputs.go_quality }}
+      api_contract: ${{ steps.diff.outputs.api_contract }}
       go_toolchain: ${{ steps.diff.outputs.go_toolchain }}
       go_tests: ${{ steps.diff.outputs.go_tests }}
       config_compat: ${{ steps.diff.outputs.config_compat }}
@@ -107,7 +108,7 @@ jobs:
               echo "manual_upgrade_e2e=${MANUAL_UPGRADE_E2E}"
               echo "manual_hardened_e2e=${MANUAL_HARDENED_E2E}"
               echo "manual_seal_e2e=${MANUAL_SEAL_E2E}"
-              for key in chart workflow toolchain docs go_quality go_toolchain go_tests config_compat security_scan security_image fuzz e2e operator_upgrade_e2e e2e_backup e2e_upgrade e2e_hardened e2e_seal; do
+              for key in chart workflow toolchain docs go_quality api_contract go_toolchain go_tests config_compat security_scan security_image fuzz e2e operator_upgrade_e2e e2e_backup e2e_upgrade e2e_hardened e2e_seal; do
                 echo "${key}=false"
               done
             } >> "${GITHUB_OUTPUT}"
@@ -174,6 +175,12 @@ jobs:
             echo "go_quality=true" >> "${GITHUB_OUTPUT}"
           else
             echo "go_quality=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+          if changed_matches '^(api/|config/crd/|hack/tools/(api_inventory|crd_compatibility)/|test/manifests/apicontract/|go\.(mod|sum)$|vendor/|Makefile$|mk/|\.github/(workflows/(ci|release)\.yml|actions/setup-repo-tools/))'; then
+            echo "api_contract=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "api_contract=false" >> "${GITHUB_OUTPUT}"
           fi
 
           if changed_matches '^(Dockerfile(\..*)?|go\.mod$|Makefile|mk/|hack/ci/verify-go-toolchain-sync\.sh|\.github/workflows/ci\.yml)'; then
@@ -500,6 +507,26 @@ jobs:
 
       - name: Verify generated files
         run: make verify-generated
+
+  api-contract:
+    name: API Contract
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.changes.outputs.api_contract == 'true'
+    runs-on: *runner
+    env:
+      GOFLAGS: -mod=vendor
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup repo tools
+        uses: ./.github/actions/setup-repo-tools
+
+      - name: Test API contract enforcement
+        run: go test -count=1 ./hack/tools/api_inventory ./hack/tools/crd_compatibility ./test/manifests/apicontract
+
+      - name: Verify API contract
+        run: make verify-api-contract
 
   test-unit:
     name: Unit Tests
@@ -1183,6 +1210,7 @@ jobs:
       - go-toolchain-sync
       - verify-vendor
       - verify-generated
+      - api-contract
       - test-unit
       - test-integration
       - fuzz
@@ -1209,6 +1237,7 @@ jobs:
           GO_TOOLCHAIN_SYNC: ${{ needs.go-toolchain-sync.result }}
           VERIFY_VENDOR: ${{ needs.verify-vendor.result }}
           VERIFY_GENERATED: ${{ needs.verify-generated.result }}
+          API_CONTRACT: ${{ needs.api-contract.result }}
           TEST_UNIT: ${{ needs.test-unit.result }}
           TEST_INTEGRATION: ${{ needs.test-integration.result }}
           FUZZ: ${{ needs.fuzz.result }}
@@ -1245,6 +1274,7 @@ jobs:
           go-toolchain-sync=${GO_TOOLCHAIN_SYNC}
           verify-vendor=${VERIFY_VENDOR}
           verify-generated=${VERIFY_GENERATED}
+          api-contract=${API_CONTRACT}
           test-unit=${TEST_UNIT}
           test-integration=${TEST_INTEGRATION}
           fuzz=${FUZZ}
@@ -1337,6 +1367,7 @@ jobs:
       - go-toolchain-sync
       - verify-vendor
       - verify-generated
+      - api-contract
       - test-unit
       - test-integration
       - openbao-config-compat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,35 @@ jobs:
           echo "Merge the release-please PR and allow the tag workflow to create the tag and draft release." >&2
           exit 1
 
+  api-contract:
+    name: API Contract Gate
+    runs-on: *runner
+    needs: prepare
+    env:
+      GOFLAGS: -mod=vendor
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup repo tools
+        uses: ./.github/actions/setup-repo-tools
+
+      - name: Test API contract enforcement
+        run: go test -count=1 ./hack/tools/api_inventory ./hack/tools/crd_compatibility ./test/manifests/apicontract
+
+      - name: Verify generated files
+        run: make verify-generated
+
+      - name: Verify API contract
+        env:
+          CRD_COMPAT_TARGET: ${{ needs.prepare.outputs.version }}
+        run: make verify-api-contract
+
   build:
     name: Build Images
-    needs: prepare
+    needs: [prepare, api-contract]
     permissions:
       contents: read
       packages: write
@@ -119,7 +145,7 @@ jobs:
 
   rebuild:
     name: Independent Rebuild Images
-    needs: prepare
+    needs: [prepare, api-contract]
     permissions:
       contents: read
       packages: write
@@ -783,6 +809,7 @@ jobs:
     needs:
       - prepare
       - build
+      - api-contract
       - security-govulncheck
       - security-images
       - e2e

--- a/api/stability/README.md
+++ b/api/stability/README.md
@@ -4,6 +4,11 @@
 `spec` and `status` path in the three served CRDs. It is a release-planning contract,
 not a declaration that `v1alpha1` is already stable.
 
+Its `baseline: 0.4.2` and `release: 0.5.0` preserve the approved migration's
+provenance. The operator-upgrade E2E harness uses these fields to select its
+release notes and migration fixtures. They do not select the schema checker's
+compatibility baseline, which advances independently after a supported release.
+
 The inventory uses inherited path rules. Every top-level field requires an explicit
 rule, while nested fields inherit the closest matching rule unless a more specific
 decision overrides it. The checker expands those rules against the generated CRD
@@ -98,7 +103,9 @@ go run ./hack/tools/crd_compatibility \
   --baseline-bundle /path/to/released/crds.yaml --release <release>
 ```
 
-Review the recorded digest, update the checker default and inventory baseline,
-then run `make verify-api-contract`. Never replace a released baseline with
-schemas generated from the current checkout. A planned incompatible change
-requires a reviewed migration and compatibility-policy change before integration.
+Review the recorded digest and update the checker default. Preserve the inventory's
+approved migration metadata unless a new migration plan, release notes, and upgrade
+fixtures are reviewed together. Run `make verify-api-contract verify-operator-upgrade-e2e`
+to check both contracts. Never replace a released baseline with schemas generated
+from the current checkout. A planned incompatible change requires a reviewed
+migration and compatibility-policy change before integration.

--- a/api/stability/README.md
+++ b/api/stability/README.md
@@ -54,21 +54,51 @@ Render the fully resolved field table for review with:
 go run ./hack/tools/api_inventory --format markdown
 ```
 
-## CRD compatibility report
+## CRD compatibility gate
 
-`baselines/0.4.2.json` is a normalized snapshot of the CRDs shipped in the
-`0.4.2` release asset. The snapshot records the source asset SHA-256 digest so
-the comparison remains tied to what users installed rather than to a mutable
-source checkout.
+`baselines/0.5.0.json` is the supported baseline. It records the normalized schemas
+from the [released 0.5.0 CRD bundle](https://github.com/dc-tec/openbao-operator/releases/download/0.5.0/crds.yaml),
+whose SHA-256 digest is `58bf30cec5c7a98e931f25a80c60deaa5bbcad3df7e57d227445d4b0a0f62af8`.
+Keep `baselines/0.4.2.json` for historical comparisons.
 
-Run the report with:
+Run the inventory and compatibility gate with:
+
+```sh
+make verify-api-contract
+```
+
+The gate rejects breaking and review-required schema changes, including field
+removal, validation tightening, and changed defaults. Updating the inventory
+snapshot does not authorize an incompatible schema change. The approved 0.5.0
+field decisions remain in effect; this gate does not graduate `v1alpha1` to beta.
+
+The `API Contract` job runs for API, CRD, checker, gate-test, dependency, build-rule,
+and gate-workflow changes, every push to `main`, and manual CI runs. `CI Required`
+includes its result. Edge candidate builds and release image builds also depend
+on this gate. Release validation verifies generated artifacts before checking
+the API contract and labels the report with the release tag. Other runs use `next`.
+
+For a diagnostic report that does not reject schema differences, run:
 
 ```sh
 make report-crd-compatibility
 ```
 
-The 0.5.0 stabilization cycle runs this check in report-only mode so intentional
-pre-beta removals and validation tightening stay visible without blocking the
-work. After 0.5.0 is published, generate a baseline from its released
-`crds.yaml` asset and switch `CRD_COMPAT_MODE` to `enforce` so breaking or
-review-required changes fail CI by default.
+`verify-api-contract` always enforces compatibility. The former
+`CRD_COMPAT_MODE=report` override cannot weaken this gate. The Go checker also
+defaults to enforcement; use `--mode report` for a direct diagnostic invocation.
+
+After a supported release, download its published `crds.yaml` and generate the
+next baseline from that asset. Replace `<release>` with the published tag and
+`/path/to/released/crds.yaml` with the downloaded asset path:
+
+```sh
+go run ./hack/tools/crd_compatibility \
+  --write-baseline api/stability/baselines/<release>.json \
+  --baseline-bundle /path/to/released/crds.yaml --release <release>
+```
+
+Review the recorded digest, update the checker default and inventory baseline,
+then run `make verify-api-contract`. Never replace a released baseline with
+schemas generated from the current checkout. A planned incompatible change
+requires a reviewed migration and compatibility-policy change before integration.

--- a/api/stability/baselines/0.5.0.json
+++ b/api/stability/baselines/0.5.0.json
@@ -1,0 +1,8901 @@
+{
+  "schemaVersion": 1,
+  "release": "0.5.0",
+  "source": "crds.yaml",
+  "sourceSHA256": "58bf30cec5c7a98e931f25a80c60deaa5bbcad3df7e57d227445d4b0a0f62af8",
+  "nodes": [
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec",
+      "type": "object",
+      "required": true,
+      "cel": [
+        {
+          "rule": "!has(self.recoveryKeys) || !has(self.recoveryKeys.initial) || (has(self.selfInit) \u0026\u0026 self.selfInit.enabled)",
+          "message": "spec.recoveryKeys.initial requires spec.selfInit.enabled=true"
+        },
+        {
+          "rule": "!has(self.recoveryKeys) || !has(self.recoveryKeys.initial) || (has(self.unseal) \u0026\u0026 self.unseal.type != 'static')",
+          "message": "spec.recoveryKeys.initial requires a non-static spec.unseal.type"
+        },
+        {
+          "rule": "!has(self.unseal) || self.unseal.type != 'ocikms' || !has(self.unseal.credentialsSecretRef) || (has(self.unseal.ocikms) \u0026\u0026 has(self.unseal.ocikms.authTypeAPIKey) \u0026\u0026 self.unseal.ocikms.authTypeAPIKey == true)",
+          "message": "spec.unseal.credentialsSecretRef for ocikms requires spec.unseal.ocikms.authTypeAPIKey=true"
+        },
+        {
+          "rule": "self.tls.mode != 'ACME' || ((self.replicas \u003c= 1) \u0026\u0026 (!has(self.upgrade) || self.upgrade.strategy != 'BlueGreen')) || (has(self.tls.acme) \u0026\u0026 has(self.tls.acme.sharedCache))",
+          "message": "HA ACME clusters require spec.tls.acme.sharedCache when more than one Pod can serve the same hostname"
+        },
+        {
+          "rule": "self.tls.mode != 'OperatorManaged' || size(self.tls.rotationPeriod) \u003e 0",
+          "message": "spec.tls.rotationPeriod is required when spec.tls.mode is OperatorManaged"
+        },
+        {
+          "rule": "self.tls.mode == 'ACME' || !has(self.tls.acme) || !has(self.tls.acme.sharedCache)",
+          "message": "spec.tls.acme.sharedCache is only supported when spec.tls.mode is ACME"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit",
+      "type": "array",
+      "constraints": {
+        "listMapKeys": "path",
+        "listType": "map"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.auditFileStorage",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "!has(self.mountPath) || (self.mountPath.startsWith('/') \u0026\u0026 self.mountPath != '/')",
+          "message": "auditFileStorage.mountPath must be an absolute path and must not be /"
+        },
+        {
+          "rule": "self.mode != 'ExistingPVC' || !has(self.size) || size(self.size) == 0",
+          "message": "auditFileStorage.size is only supported when mode is ManagedPVC"
+        },
+        {
+          "rule": "self.mode != 'ExistingPVC' || !has(self.storageClassName) || size(self.storageClassName) == 0",
+          "message": "auditFileStorage.storageClassName is only supported when mode is ManagedPVC"
+        },
+        {
+          "rule": "self.mode != 'ExistingPVC' || size(self.existingClaimName) \u003e 0",
+          "message": "auditFileStorage.existingClaimName is required when mode is ExistingPVC"
+        },
+        {
+          "rule": "self.mode != 'ManagedPVC' || !has(self.existingClaimName) || size(self.existingClaimName) == 0",
+          "message": "auditFileStorage.existingClaimName is only supported when mode is ExistingPVC"
+        },
+        {
+          "rule": "self.mode != 'ManagedPVC' || size(self.size) \u003e 0",
+          "message": "auditFileStorage.size is required when mode is ManagedPVC"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.auditFileStorage.existingClaimName",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.auditFileStorage.mode",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"ExistingPVC\"",
+        "\"ManagedPVC\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.auditFileStorage.mountPath",
+      "type": "string",
+      "default": "\"/openbao/audit\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.auditFileStorage.size",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.auditFileStorage.storageClassName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[]",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "self.type == 'file' || !has(self.fileOptions)",
+          "message": "fileOptions is only supported when type is file"
+        },
+        {
+          "rule": "self.type == 'http' || !has(self.httpOptions)",
+          "message": "httpOptions is only supported when type is http"
+        },
+        {
+          "rule": "self.type == 'socket' || !has(self.socketOptions)",
+          "message": "socketOptions is only supported when type is socket"
+        },
+        {
+          "rule": "self.type == 'syslog' || !has(self.syslogOptions)",
+          "message": "syslogOptions is only supported when type is syslog"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].description",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].fileOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].fileOptions.filePath",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].fileOptions.mode",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].httpOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].httpOptions.headers",
+      "constraints": {
+        "preserveUnknownFields": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].httpOptions.uri",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].options",
+      "constraints": {
+        "preserveUnknownFields": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].path",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].socketOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].socketOptions.address",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].socketOptions.socketType",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].socketOptions.writeTimeout",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].syslogOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].syslogOptions.facility",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].syslogOptions.tag",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.audit[].type",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"file\"",
+        "\"http\"",
+        "\"socket\"",
+        "\"syslog\""
+      ],
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.image",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.jwtAuthRole",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.retention",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.retention.maxAge",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.retention.maxCount",
+      "type": "integer",
+      "constraints": {
+        "format": "int32",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.schedule",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target",
+      "type": "object",
+      "required": true,
+      "cel": [
+        {
+          "rule": "self.provider != 's3' || (has(self.endpoint) \u0026\u0026 size(self.endpoint) \u003e 0)",
+          "message": "backup target endpoint is required when provider is s3"
+        },
+        {
+          "rule": "self.provider == 'azure' || !has(self.azure)",
+          "message": "backup target azure options are only supported when provider is azure"
+        },
+        {
+          "rule": "self.provider == 'gcs' || !has(self.gcs)",
+          "message": "backup target gcs options are only supported when provider is gcs"
+        },
+        {
+          "rule": "self.provider == 's3' || !has(self.roleArn) || size(self.roleArn) == 0",
+          "message": "backup target roleArn is only supported when provider is s3"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.azure",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.azure.container",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.azure.storageAccount",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.bucket",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.concurrency",
+      "type": "integer",
+      "default": "3",
+      "constraints": {
+        "format": "int32",
+        "maximum": "10",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.credentialsSecretRef",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.credentialsSecretRef.name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.endpoint",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.gcs",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.gcs.project",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.insecureSkipVerify",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.partSize",
+      "type": "integer",
+      "default": "10485760",
+      "constraints": {
+        "format": "int64",
+        "minimum": "5.24288e+06"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.pathPrefix",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.provider",
+      "type": "string",
+      "default": "\"s3\"",
+      "enum": [
+        "\"azure\"",
+        "\"gcs\"",
+        "\"s3\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.region",
+      "type": "string",
+      "default": "\"us-east-1\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.roleArn",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.usePathStyle",
+      "type": "boolean",
+      "default": "false"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.workloadIdentity",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.workloadIdentity.podLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.workloadIdentity.podLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.workloadIdentity.serviceAccountAnnotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.target.workloadIdentity.serviceAccountAnnotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.tokenSecretRef",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.backup.tokenSecretRef.name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.breakGlassAck",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.acmeCARoot",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.allowAuditLogPrefixing",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.cacheSize",
+      "type": "integer",
+      "constraints": {
+        "format": "int64",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.defaultLeaseTTL",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.detectDeadlocks",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.disableCache",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.enableResponseHeaderHostname",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.enableResponseHeaderRaftNodeID",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.impreciseLeaseRoleTracking",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.introspectionEndpoint",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.listener",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.listener.proxyProtocolBehavior",
+      "type": "string",
+      "enum": [
+        "\"allow_any\"",
+        "\"deny_unauthorized\"",
+        "\"use_always\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.listener.tlsDisable",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logLevel",
+      "type": "string",
+      "default": "\"info\"",
+      "enum": [
+        "\"debug\"",
+        "\"err\"",
+        "\"info\"",
+        "\"trace\"",
+        "\"warn\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging.file",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging.format",
+      "type": "string",
+      "enum": [
+        "\"json\"",
+        "\"standard\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging.pidFile",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging.rotateBytes",
+      "type": "integer",
+      "constraints": {
+        "format": "int64",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging.rotateDuration",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.logging.rotateMaxFiles",
+      "type": "integer",
+      "constraints": {
+        "format": "int32",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.maxLeaseTTL",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.plugin",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.plugin.autoDownload",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.plugin.autoRegister",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.plugin.downloadBehavior",
+      "type": "string",
+      "enum": [
+        "\"continue\"",
+        "\"fail\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.plugin.filePermissions",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.plugin.fileUID",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot.cleanupDeadServers",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot.deadServerLastContactThreshold",
+      "type": "string",
+      "default": "\"5m\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot.lastContactThreshold",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot.maxTrailingLogs",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot.minQuorum",
+      "type": "integer",
+      "constraints": {
+        "format": "int32",
+        "minimum": "3"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.autopilot.serverStabilizationTime",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.raft.performanceMultiplier",
+      "type": "integer",
+      "constraints": {
+        "format": "int32",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.rawStorageEndpoint",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.ui",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.configuration.unsafeAllowAPIAuditCreation",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.deletionPolicy",
+      "type": "string",
+      "enum": [
+        "\"DeleteAll\"",
+        "\"DeletePVCs\"",
+        "\"Retain\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.backendTLS",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.backendTLS.enabled",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.backendTLS.hostname",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.enabled",
+      "type": "boolean",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.gatewayRef",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.gatewayRef.name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.gatewayRef.namespace",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.hostname",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.listenerName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.path",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.gateway.tlsPassthrough",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.image",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imagePullSecrets",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imagePullSecrets[]",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imagePullSecrets[].name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.enabled",
+      "type": "boolean",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.failurePolicy",
+      "type": "string",
+      "required": true,
+      "default": "\"Block\"",
+      "enum": [
+        "\"Block\"",
+        "\"Warn\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.ignoreTlog",
+      "type": "boolean",
+      "default": "false"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.imagePullSecrets",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.imagePullSecrets[]",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.imagePullSecrets[].name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.issuer",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.issuerRegExp",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.publicKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.subject",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.imageVerification.subjectRegExp",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.className",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.enabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.host",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.path",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.pathType",
+      "type": "string",
+      "default": "\"Prefix\"",
+      "enum": [
+        "\"Exact\"",
+        "\"ImplementationSpecific\"",
+        "\"Prefix\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.readinessMode",
+      "type": "string",
+      "default": "\"LoadBalancerPublished\"",
+      "enum": [
+        "\"Created\"",
+        "\"LoadBalancerPublished\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.ingress.tlsSecretName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.initContainer",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.initContainer.enabled",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.initContainer.image",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.maintenance",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.maintenance.enabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.apiServerCIDR",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.apiServerEndpointIPs",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.apiServerEndpointIPs[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.dnsEndpointIPs",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.dnsEndpointIPs[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.dnsNamespace",
+      "type": "string",
+      "default": "\"kube-system\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports[].endPort",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports[].port",
+      "constraints": {
+        "intOrString": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports[].port.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports[].port.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].ports[].protocol",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].ipBlock",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].ipBlock.cidr",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].ipBlock.except",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].ipBlock.except[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.egressRules[].to[].podSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].ipBlock",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].ipBlock.cidr",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].ipBlock.except",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].ipBlock.except[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].from[].podSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports[].endPort",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports[].port",
+      "constraints": {
+        "intOrString": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports[].port.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports[].port.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.ingressRules[].ports[].protocol",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].ipBlock",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].ipBlock.cidr",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].ipBlock.except",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].ipBlock.except[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.network.trustedIngressPeers[].podSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.enabled",
+      "type": "boolean",
+      "required": true,
+      "default": "false"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.metricsOnlyListener",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.metricsOnlyListener.enabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.metricsOnlyListener.port",
+      "type": "integer",
+      "default": "8202",
+      "constraints": {
+        "format": "int32",
+        "maximum": "65535",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.metricsOnlyListener.unauthenticatedMetricsAccess",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.scrapeProfile",
+      "type": "string",
+      "default": "\"Active\"",
+      "enum": [
+        "\"Active\"",
+        "\"AllNodes\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.authorization",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.authorization.credentialsSecret",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.authorization.credentialsSecret.key",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.authorization.credentialsSecret.name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.authorization.type",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.enabled",
+      "type": "boolean",
+      "required": true,
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.interval",
+      "type": "string",
+      "default": "\"30s\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.jobLabel",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.labels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.labels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.scrapeTimeout",
+      "type": "string",
+      "default": "\"10s\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.caConfigMap",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.caConfigMap.key",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.caConfigMap.name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.caSecret",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.caSecret.key",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.caSecret.name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.insecureSkipVerify",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.observability.metrics.serviceMonitor.tlsConfig.serverName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.enabled",
+      "type": "boolean",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.failurePolicy",
+      "type": "string",
+      "required": true,
+      "default": "\"Block\"",
+      "enum": [
+        "\"Block\"",
+        "\"Warn\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.ignoreTlog",
+      "type": "boolean",
+      "default": "false"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.imagePullSecrets",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.imagePullSecrets[]",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.imagePullSecrets[].name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.issuer",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.issuerRegExp",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.publicKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.subject",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.operatorImageVerification.subjectRegExp",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.paused",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].args",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].args[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].binaryName",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].command",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].env",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].env[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].image",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].sha256sum",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "64",
+        "minLength": "64",
+        "pattern": "^[0-9a-fA-F]{64}$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].type",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.plugins[].version",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.podMetadata",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.podMetadata.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.podMetadata.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.podMetadata.labels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.podMetadata.labels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.profile",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.profile.allOf[0]",
+      "enum": [
+        "\"Development\"",
+        "\"Hardened\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.profile.allOf[1]",
+      "enum": [
+        "\"Development\"",
+        "\"Hardened\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.replicas",
+      "type": "integer",
+      "constraints": {
+        "format": "int32",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.service",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.service.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.service.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.service.enabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.service.type",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.storage",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.storage.size",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.storage.size.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.storage.size.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.storage.storageClassName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.metadata",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.metadata.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.metadata.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.metadata.labels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.metadata.labels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.claims",
+      "type": "array",
+      "constraints": {
+        "listMapKeys": "name",
+        "listType": "map"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.claims[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.claims[].name",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.claims[].request",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.limits",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.limits.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.limits.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.limits.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.requests",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.requests.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.requests.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.resources.requests.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference",
+      "type": "object",
+      "required": true,
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchFields",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchFields[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchFields[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchFields[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchFields[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.matchFields[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].weight",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms",
+      "type": "array",
+      "required": true,
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[]",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.matchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.matchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.mismatchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.mismatchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaces",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaces[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.topologyKey",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].weight",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].matchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].matchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].mismatchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].mismatchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaces",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaces[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[].topologyKey",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.labelSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.matchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.matchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.mismatchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.mismatchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaces",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.namespaces[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.topologyKey",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[].weight",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].labelSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].matchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].matchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].mismatchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].mismatchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaceSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaces",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].namespaces[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[].topologyKey",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.nodeSelector",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.nodeSelector.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations[].effect",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations[].key",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations[].operator",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations[].tolerationSeconds",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.tolerations[].value",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchExpressions[].key",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].labelSelector.matchLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].matchLabelKeys",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].matchLabelKeys[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].maxSkew",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].minDomains",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].nodeAffinityPolicy",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].nodeTaintsPolicy",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].topologyKey",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.readReplicas.template.scheduling.topologySpreadConstraints[].whenUnsatisfiable",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "self.threshold \u003c= self.shares",
+          "message": "recoveryKeys.initial.threshold must be less than or equal to recoveryKeys.initial.shares"
+        },
+        {
+          "rule": "size(self.recipients) == self.shares",
+          "message": "recoveryKeys.initial.recipients must contain exactly recoveryKeys.initial.shares entries"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.recipients",
+      "type": "array",
+      "required": true,
+      "constraints": {
+        "listMapKeys": "name",
+        "listType": "map",
+        "maxItems": "255",
+        "minItems": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.recipients[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.recipients[].fingerprint",
+      "type": "string",
+      "constraints": {
+        "pattern": "^([0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.recipients[].name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "64",
+        "minLength": "1",
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.recipients[].pgpPublicKey",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.shares",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32",
+        "maximum": "255",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.recoveryKeys.initial.threshold",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32",
+        "maximum": "255",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.replicas",
+      "type": "integer",
+      "required": true,
+      "default": "3",
+      "constraints": {
+        "format": "int32",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.claims",
+      "type": "array",
+      "constraints": {
+        "listMapKeys": "name",
+        "listType": "map"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.claims[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.claims[].name",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.claims[].request",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.limits",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.limits.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.limits.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.limits.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.requests",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.requests.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.requests.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.resources.requests.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.restore",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.restore.jwtAuthRole",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.runtime",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.runtime.restartAt",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.appArmorProfile",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.appArmorProfile.localhostProfile",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.appArmorProfile.type",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.fsGroup",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.fsGroupChangePolicy",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.runAsGroup",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.runAsNonRoot",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.runAsUser",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seLinuxChangePolicy",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seLinuxOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seLinuxOptions.level",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seLinuxOptions.role",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seLinuxOptions.type",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seLinuxOptions.user",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seccompProfile",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seccompProfile.localhostProfile",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.seccompProfile.type",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.supplementalGroups",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.supplementalGroupsPolicy",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.supplementalGroups[]",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.sysctls",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.sysctls[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.sysctls[].name",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.sysctls[].value",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.windowsOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.windowsOptions.gmsaCredentialSpec",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.windowsOptions.gmsaCredentialSpecName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.windowsOptions.hostProcess",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.securityContext.windowsOptions.runAsUserName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.enabled",
+      "type": "boolean",
+      "required": true,
+      "default": "false"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "!has(self.additionalSubjects) || self.enabled",
+          "message": "spec.selfInit.oidc.additionalSubjects requires spec.selfInit.oidc.enabled=true"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.backup",
+      "type": "array",
+      "constraints": {
+        "listType": "set",
+        "maxItems": "32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.backup[]",
+      "type": "string",
+      "constraints": {
+        "maxLength": "340",
+        "pattern": "^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.operator",
+      "type": "array",
+      "constraints": {
+        "listType": "set",
+        "maxItems": "32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.operator[]",
+      "type": "string",
+      "constraints": {
+        "maxLength": "340",
+        "pattern": "^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.restore",
+      "type": "array",
+      "constraints": {
+        "listType": "set",
+        "maxItems": "32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.restore[]",
+      "type": "string",
+      "constraints": {
+        "maxLength": "340",
+        "pattern": "^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.upgrade",
+      "type": "array",
+      "constraints": {
+        "listType": "set",
+        "maxItems": "32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.additionalSubjects.upgrade[]",
+      "type": "string",
+      "constraints": {
+        "maxLength": "340",
+        "pattern": "^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.audience",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.enabled",
+      "type": "boolean",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.oidc.issuer",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].allowFailure",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "self.type != 'file' || has(self.fileOptions)",
+          "message": "fileOptions is required when type is file"
+        },
+        {
+          "rule": "self.type != 'http' || has(self.httpOptions)",
+          "message": "httpOptions is required when type is http"
+        },
+        {
+          "rule": "self.type == 'file' || !has(self.fileOptions)",
+          "message": "fileOptions is only supported when type is file"
+        },
+        {
+          "rule": "self.type == 'http' || !has(self.httpOptions)",
+          "message": "httpOptions is only supported when type is http"
+        },
+        {
+          "rule": "self.type == 'socket' || !has(self.socketOptions)",
+          "message": "socketOptions is only supported when type is socket"
+        },
+        {
+          "rule": "self.type == 'syslog' || !has(self.syslogOptions)",
+          "message": "syslogOptions is only supported when type is syslog"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.description",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.fileOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.fileOptions.filePath",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.fileOptions.mode",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.httpOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.httpOptions.headers",
+      "constraints": {
+        "preserveUnknownFields": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.httpOptions.uri",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.socketOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.socketOptions.address",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.socketOptions.socketType",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.socketOptions.writeTimeout",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.syslogOptions",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.syslogOptions.facility",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.syslogOptions.tag",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].auditDevice.type",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"file\"",
+        "\"http\"",
+        "\"socket\"",
+        "\"syslog\""
+      ],
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].authMethod",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].authMethod.config",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].authMethod.config.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].authMethod.description",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].authMethod.type",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].data",
+      "constraints": {
+        "preserveUnknownFields": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].headers",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].headers.*",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].headers.*[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "64",
+        "minLength": "1",
+        "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].operation",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].operation.allOf[0]",
+      "enum": [
+        "\"create\"",
+        "\"delete\"",
+        "\"list\"",
+        "\"patch\"",
+        "\"read\"",
+        "\"update\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].operation.allOf[1]",
+      "enum": [
+        "\"create\"",
+        "\"delete\"",
+        "\"list\"",
+        "\"patch\"",
+        "\"read\"",
+        "\"update\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].path",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].policy",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].policy.policy",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].secretEngine",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].secretEngine.description",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].secretEngine.options",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].secretEngine.options.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].secretEngine.type",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.selfInit.requests[].when",
+      "constraints": {
+        "preserveUnknownFields": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.service",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.service.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.service.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.service.type",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.serviceAccount",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.serviceAccount.annotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.serviceAccount.annotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.serviceAccount.name",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.storage",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.storage.size",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.storage.storageClassName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusAPIApp",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusAPIKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusAPIURL",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusBrokerID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusBrokerSelectTag",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusCheckDisplayName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusCheckForceMetricActivation",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusCheckID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusCheckInstanceID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusCheckSearchTag",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusCheckTags",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.circonusSubmissionInterval",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.disableHostname",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.dogStatsdAddress",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.dogStatsdTags",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.dogStatsdTags[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.enableHostnameLabel",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.leaseMetricsEpsilon",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.maximumGaugeCardinality",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.metricsPrefix",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.prometheusRetentionTime",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.stackdriverDebugLogs",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.stackdriverLocation",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.stackdriverNamespace",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.stackdriverProjectID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.statsdAddress",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.statsiteAddress",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.telemetry.usageGaugePeriod",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.directoryURL",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.domains",
+      "type": "array",
+      "constraints": {
+        "minItems": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.domains[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.email",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.sharedCache",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "self.mode != 'ExistingPVC' || !has(self.size) || size(self.size) == 0",
+          "message": "tls.acme.sharedCache.size is only supported when mode is ManagedPVC"
+        },
+        {
+          "rule": "self.mode != 'ExistingPVC' || !has(self.storageClassName) || size(self.storageClassName) == 0",
+          "message": "tls.acme.sharedCache.storageClassName is only supported when mode is ManagedPVC"
+        },
+        {
+          "rule": "self.mode != 'ExistingPVC' || size(self.existingClaimName) \u003e 0",
+          "message": "tls.acme.sharedCache.existingClaimName is required when mode is ExistingPVC"
+        },
+        {
+          "rule": "self.mode != 'ManagedPVC' || !has(self.existingClaimName) || size(self.existingClaimName) == 0",
+          "message": "tls.acme.sharedCache.existingClaimName is only supported when mode is ExistingPVC"
+        },
+        {
+          "rule": "self.mode != 'ManagedPVC' || size(self.size) \u003e 0",
+          "message": "tls.acme.sharedCache.size is required when mode is ManagedPVC"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.sharedCache.existingClaimName",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.sharedCache.mode",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"ExistingPVC\"",
+        "\"ManagedPVC\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.sharedCache.size",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.acme.sharedCache.storageClassName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.enabled",
+      "type": "boolean",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.extraSANs",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.extraSANs[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.mode",
+      "type": "string",
+      "default": "\"OperatorManaged\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.mode.allOf[0]",
+      "enum": [
+        "\"ACME\"",
+        "\"External\"",
+        "\"OperatorManaged\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.mode.allOf[1]",
+      "enum": [
+        "\"ACME\"",
+        "\"External\"",
+        "\"OperatorManaged\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.tls.rotationPeriod",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "self.type == 'awskms' || !has(self.awskms)",
+          "message": "spec.unseal.awskms is only supported when spec.unseal.type is awskms"
+        },
+        {
+          "rule": "self.type == 'azurekeyvault' || !has(self.azureKeyVault)",
+          "message": "spec.unseal.azureKeyVault is only supported when spec.unseal.type is azurekeyvault"
+        },
+        {
+          "rule": "self.type == 'gcpckms' || !has(self.gcpCloudKMS)",
+          "message": "spec.unseal.gcpCloudKMS is only supported when spec.unseal.type is gcpckms"
+        },
+        {
+          "rule": "self.type == 'kmip' || !has(self.kmip)",
+          "message": "spec.unseal.kmip is only supported when spec.unseal.type is kmip"
+        },
+        {
+          "rule": "self.type == 'kms' || !has(self.kms)",
+          "message": "spec.unseal.kms is only supported when spec.unseal.type is kms"
+        },
+        {
+          "rule": "self.type == 'ocikms' || !has(self.ocikms)",
+          "message": "spec.unseal.ocikms is only supported when spec.unseal.type is ocikms"
+        },
+        {
+          "rule": "self.type == 'pkcs11' || !has(self.pkcs11)",
+          "message": "spec.unseal.pkcs11 is only supported when spec.unseal.type is pkcs11"
+        },
+        {
+          "rule": "self.type == 'static' || !has(self.static)",
+          "message": "spec.unseal.static is only supported when spec.unseal.type is static"
+        },
+        {
+          "rule": "self.type == 'static' || (self.type == 'transit' \u0026\u0026 has(self.transit)) || (self.type == 'awskms' \u0026\u0026 has(self.awskms)) || (self.type == 'azurekeyvault' \u0026\u0026 has(self.azureKeyVault)) || (self.type == 'gcpckms' \u0026\u0026 has(self.gcpCloudKMS)) || (self.type == 'kmip' \u0026\u0026 has(self.kmip)) || (self.type == 'kms' \u0026\u0026 has(self.kms)) || (self.type == 'ocikms' \u0026\u0026 has(self.ocikms)) || (self.type == 'pkcs11' \u0026\u0026 has(self.pkcs11))",
+          "message": "the selected spec.unseal.type requires its matching configuration block"
+        },
+        {
+          "rule": "self.type == 'transit' || !has(self.transit)",
+          "message": "spec.unseal.transit is only supported when spec.unseal.type is transit"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms.accessKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms.endpoint",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms.kmsKeyID",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms.region",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms.secretKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.awskms.sessionToken",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.clientID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.clientSecret",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.environment",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.keyName",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.resource",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.tenantID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.azureKeyVault.vaultName",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.credentialsSecretRef",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.credentialsSecretRef.name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.gcpCloudKMS",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.gcpCloudKMS.credentials",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.gcpCloudKMS.cryptoKey",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.gcpCloudKMS.keyRing",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.gcpCloudKMS.project",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.gcpCloudKMS.region",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.caCert",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.clientCert",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.clientKey",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.disabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.encryptAlg",
+      "type": "string",
+      "enum": [
+        "\"AES_GCM\"",
+        "\"RSA_OAEP_SHA256\"",
+        "\"RSA_OAEP_SHA384\"",
+        "\"RSA_OAEP_SHA512\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.endpoint",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.kmsKeyID",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.serverName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.timeout",
+      "type": "integer",
+      "constraints": {
+        "format": "int32",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kmip.tls12Ciphers",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kms",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kms.config",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true",
+        "maxProperties": "64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kms.config.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.kms.pluginName",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.ocikms",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.ocikms.authTypeAPIKey",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.ocikms.cryptoEndpoint",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.ocikms.disabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.ocikms.keyID",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.ocikms.managementEndpoint",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11",
+      "type": "object",
+      "cel": [
+        {
+          "rule": "!(has(self.slot) \u0026\u0026 size(self.slot) \u003e 0 \u0026\u0026 has(self.tokenLabel) \u0026\u0026 size(self.tokenLabel) \u003e 0)",
+          "message": "spec.unseal.pkcs11.slot and spec.unseal.pkcs11.tokenLabel are mutually exclusive"
+        },
+        {
+          "rule": "(has(self.slot) \u0026\u0026 size(self.slot) \u003e 0) || (has(self.tokenLabel) \u0026\u0026 size(self.tokenLabel) \u003e 0)",
+          "message": "spec.unseal.pkcs11.slot or spec.unseal.pkcs11.tokenLabel is required"
+        }
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.disableSoftwareEncryption",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.disabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.keyID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.keyLabel",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.lib",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.mechanism",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.pin",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.rsaOAEPHash",
+      "type": "string",
+      "enum": [
+        "\"sha1\"",
+        "\"sha224\"",
+        "\"sha256\"",
+        "\"sha384\"",
+        "\"sha512\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.env",
+      "type": "array",
+      "constraints": {
+        "maxItems": "16"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.env[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.env[].name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.env[].secretKey",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1",
+        "pattern": "^[-._A-Za-z0-9]+$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.fileEnv",
+      "type": "array",
+      "constraints": {
+        "maxItems": "16"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.fileEnv[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.fileEnv[].name",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.fileEnv[].secretKey",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1",
+        "pattern": "^[-._A-Za-z0-9]+$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.runtime.libraryPath",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.slot",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.pkcs11.tokenLabel",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.static",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.static.currentKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.static.currentKeyID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.address",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.disableRenewal",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.keyName",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.mountPath",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.namespace",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.tlsCACert",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.tlsClientCert",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.tlsClientKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.tlsServerName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.tlsSkipVerify",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.transit.token",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.unseal.type",
+      "type": "string",
+      "default": "\"static\"",
+      "enum": [
+        "\"awskms\"",
+        "\"azurekeyvault\"",
+        "\"gcpckms\"",
+        "\"kmip\"",
+        "\"kms\"",
+        "\"ocikms\"",
+        "\"pkcs11\"",
+        "\"static\"",
+        "\"transit\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.autoPromote",
+      "type": "boolean",
+      "required": true,
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.autoRollback",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.autoRollback.enabled",
+      "type": "boolean",
+      "required": true,
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.autoRollback.onJobFailure",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.autoRollback.onValidationFailure",
+      "type": "boolean",
+      "default": "true"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.maxJobFailures",
+      "type": "integer",
+      "default": "5",
+      "constraints": {
+        "format": "int32",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.preUpgradeSnapshot",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.minSyncDuration",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook.args",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook.args[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook.command",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook.command[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook.image",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.blueGreen.verification.prePromotionHook.timeoutSeconds",
+      "type": "integer",
+      "default": "300",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.image",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.jwtAuthRole",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.preUpgradeSnapshot",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.requests",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.requests.promote",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.requests.retry",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.requests.rollback",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.upgrade.strategy",
+      "type": "string",
+      "default": "\"RollingUpdate\"",
+      "enum": [
+        "\"BlueGreen\"",
+        "\"RollingUpdate\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.version",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1",
+        "pattern": "^v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.workloadHardening",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "spec.workloadHardening.appArmorEnabled",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.acceptedUpgradeStrategy",
+      "type": "string",
+      "enum": [
+        "\"BlueGreen\"",
+        "\"RollingUpdate\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.activeLeader",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.adminOps",
+      "type": "object",
+      "constraints": {
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.adminOps.lastError",
+      "type": "object",
+      "constraints": {
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.adminOps.lastError.at",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.adminOps.lastError.message",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.adminOps.lastError.reason",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.consecutiveFailures",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastAttemptScheduledTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastAttemptTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastBackupDuration",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastBackupName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastBackupSize",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastBackupTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastFailureMessage",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastFailureReason",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastFailureTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.lastHandledManualTrigger",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.backup.nextScheduledBackup",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.blueControllerRevision",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.blueImage",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.blueRevision",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.greenRevision",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.jobFailureCount",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.lastJobFailure",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.manualPromotionRequired",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.operationID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.phase",
+      "type": "string",
+      "enum": [
+        "\"Cleanup\"",
+        "\"DemotingBlue\"",
+        "\"DeployingGreen\"",
+        "\"Idle\"",
+        "\"JoiningMesh\"",
+        "\"Promoting\"",
+        "\"RestoringReadReplicas\"",
+        "\"RollbackCleanup\"",
+        "\"RollingBack\"",
+        "\"Syncing\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.preUpgradeSnapshotJobName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.rollbackAttempt",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.rollbackReason",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.rollbackStartTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.startTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.committedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.createdAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.greenRevision",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.jobName",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.jobUID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.operationID",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.preparedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.specHash",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.stage",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"Committed\"",
+        "\"Created\"",
+        "\"Prepared\"",
+        "\"TerminalObserved\"",
+        "\"Unknown\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.terminalObservedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.blueGreen.validationHook.terminalResult",
+      "type": "string",
+      "enum": [
+        "\"Failed\"",
+        "\"Succeeded\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.acknowledgedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.active",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.enteredAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.message",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.nonce",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.reason",
+      "type": "string",
+      "enum": [
+        "\"RollbackCleanupPeerRemovalFailed\"",
+        "\"RollbackConsensusRepairFailed\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.steps",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.breakGlass.steps[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions",
+      "type": "array",
+      "constraints": {
+        "listMapKeys": "type",
+        "listType": "map"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[].lastTransitionTime",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[].message",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "32768"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[].observedGeneration",
+      "type": "integer",
+      "constraints": {
+        "format": "int64",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[].reason",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "1024",
+        "minLength": "1",
+        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[].status",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"False\"",
+        "\"True\"",
+        "\"Unknown\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.conditions[].type",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "316",
+        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.currentVersion",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.initialized",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.observedGeneration",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.operationLock",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic",
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.operationLock.acquiredAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.operationLock.holder",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.operationLock.message",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.operationLock.operation",
+      "type": "string",
+      "enum": [
+        "\"Backup\"",
+        "\"Restore\"",
+        "\"Upgrade\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.operationLock.renewedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.phase",
+      "type": "string",
+      "enum": [
+        "\"BackingUp\"",
+        "\"Failed\"",
+        "\"Initializing\"",
+        "\"Running\"",
+        "\"Upgrading\""
+      ]
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas",
+      "type": "object",
+      "constraints": {
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.desiredReplicas",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.healthyReplicas",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.readyReplicas",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.registeredReplicas",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.storage",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.storage.boundPVCs",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.storage.desiredPVCs",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readReplicas.storage.storageClassName",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.readyReplicas",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.restore",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.restore.name",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.restore.restartCompletedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.restore.uid",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.selfInitialized",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.completedPods",
+      "type": "array"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.completedPods[]",
+      "type": "integer",
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.currentPartition",
+      "type": "integer",
+      "required": true,
+      "constraints": {
+        "format": "int32"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.failure",
+      "type": "object",
+      "constraints": {
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.failure.at",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.failure.message",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.failure.reason",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.fromVersion",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.lastStepDownTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.startedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgrade.targetVersion",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgradeRequests",
+      "type": "object"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgradeRequests.lastHandledPromote",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgradeRequests.lastHandledRetry",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.upgradeRequests.lastHandledRollback",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.workload",
+      "type": "object",
+      "constraints": {
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.workload.lastError",
+      "type": "object",
+      "constraints": {
+        "nullable": "true"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.workload.lastError.at",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.workload.lastError.message",
+      "type": "string"
+    },
+    {
+      "crd": "openbaoclusters.openbao.org",
+      "kind": "OpenBaoCluster",
+      "version": "v1alpha1",
+      "path": "status.workload.lastError.reason",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.cluster",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.force",
+      "type": "boolean",
+      "default": "false"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.image",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.jwtAuthRole",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.overrideOperationLock",
+      "type": "boolean",
+      "default": "false"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.key",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target",
+      "type": "object",
+      "required": true,
+      "cel": [
+        {
+          "rule": "self.provider != 's3' || (has(self.endpoint) \u0026\u0026 size(self.endpoint) \u003e 0)",
+          "message": "backup target endpoint is required when provider is s3"
+        },
+        {
+          "rule": "self.provider == 'azure' || !has(self.azure)",
+          "message": "backup target azure options are only supported when provider is azure"
+        },
+        {
+          "rule": "self.provider == 'gcs' || !has(self.gcs)",
+          "message": "backup target gcs options are only supported when provider is gcs"
+        },
+        {
+          "rule": "self.provider == 's3' || !has(self.roleArn) || size(self.roleArn) == 0",
+          "message": "backup target roleArn is only supported when provider is s3"
+        }
+      ]
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.azure",
+      "type": "object"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.azure.container",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.azure.storageAccount",
+      "type": "string",
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.bucket",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.concurrency",
+      "type": "integer",
+      "default": "3",
+      "constraints": {
+        "format": "int32",
+        "maximum": "10",
+        "minimum": "1"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.credentialsSecretRef",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.credentialsSecretRef.name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.endpoint",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.gcs",
+      "type": "object"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.gcs.project",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.insecureSkipVerify",
+      "type": "boolean"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.partSize",
+      "type": "integer",
+      "default": "10485760",
+      "constraints": {
+        "format": "int64",
+        "minimum": "5.24288e+06"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.pathPrefix",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.provider",
+      "type": "string",
+      "default": "\"s3\"",
+      "enum": [
+        "\"azure\"",
+        "\"gcs\"",
+        "\"s3\""
+      ]
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.region",
+      "type": "string",
+      "default": "\"us-east-1\""
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.roleArn",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.usePathStyle",
+      "type": "boolean",
+      "default": "false"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.workloadIdentity",
+      "type": "object"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.workloadIdentity.podLabels",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.workloadIdentity.podLabels.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.workloadIdentity.serviceAccountAnnotations",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.source.target.workloadIdentity.serviceAccountAnnotations.*",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.tokenSecretRef",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "spec.tokenSecretRef.name",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status",
+      "type": "object"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.completionTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions",
+      "type": "array",
+      "constraints": {
+        "listMapKeys": "type",
+        "listType": "map"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[].lastTransitionTime",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[].message",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "32768"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[].observedGeneration",
+      "type": "integer",
+      "constraints": {
+        "format": "int64",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[].reason",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "1024",
+        "minLength": "1",
+        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[].status",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"False\"",
+        "\"True\"",
+        "\"Unknown\""
+      ]
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.conditions[].type",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "316",
+        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution",
+      "type": "object"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.committedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.createdAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.followThroughCompletedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.jobName",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.jobUID",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.operationID",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.preparedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.stage",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"Committed\"",
+        "\"Created\"",
+        "\"FollowThroughComplete\"",
+        "\"Prepared\"",
+        "\"TerminalObserved\"",
+        "\"Unknown\""
+      ]
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.terminalObservedAt",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.execution.terminalResult",
+      "type": "string",
+      "enum": [
+        "\"Failed\"",
+        "\"Succeeded\""
+      ]
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.message",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.phase",
+      "type": "string",
+      "default": "\"Pending\"",
+      "enum": [
+        "\"Completed\"",
+        "\"Failed\"",
+        "\"Pending\"",
+        "\"Running\"",
+        "\"Unknown\"",
+        "\"Validating\""
+      ]
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.snapshotKey",
+      "type": "string"
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.snapshotSize",
+      "type": "integer",
+      "constraints": {
+        "format": "int64"
+      }
+    },
+    {
+      "crd": "openbaorestores.openbao.org",
+      "kind": "OpenBaoRestore",
+      "version": "v1alpha1",
+      "path": "status.startTime",
+      "type": "string",
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec",
+      "type": "object",
+      "required": true
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange",
+      "type": "object"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits",
+      "type": "array",
+      "required": true,
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].default",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].default.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].default.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].default.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].defaultRequest",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].defaultRequest.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].defaultRequest.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].defaultRequest.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].max",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].max.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].max.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].max.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].maxLimitRequestRatio",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].maxLimitRequestRatio.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].maxLimitRequestRatio.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].maxLimitRequestRatio.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].min",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].min.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].min.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].min.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.limitRange.limits[].type",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota",
+      "type": "object"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.hard",
+      "type": "object",
+      "constraints": {
+        "additionalProperties": "true"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.hard.*",
+      "constraints": {
+        "intOrString": "true",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.hard.*.anyOf[0]",
+      "type": "integer"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.hard.*.anyOf[1]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector",
+      "type": "object",
+      "constraints": {
+        "mapType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector.matchExpressions",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector.matchExpressions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector.matchExpressions[].operator",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector.matchExpressions[].scopeName",
+      "type": "string",
+      "required": true
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector.matchExpressions[].values",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopeSelector.matchExpressions[].values[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopes",
+      "type": "array",
+      "constraints": {
+        "listType": "atomic"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.quota.scopes[]",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "spec.targetNamespace",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "minLength": "1"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status",
+      "type": "object"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions",
+      "type": "array",
+      "constraints": {
+        "listMapKeys": "type",
+        "listType": "map"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[]",
+      "type": "object"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[].lastTransitionTime",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "format": "date-time"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[].message",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "32768"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[].observedGeneration",
+      "type": "integer",
+      "constraints": {
+        "format": "int64",
+        "minimum": "0"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[].reason",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "1024",
+        "minLength": "1",
+        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[].status",
+      "type": "string",
+      "required": true,
+      "enum": [
+        "\"False\"",
+        "\"True\"",
+        "\"Unknown\""
+      ]
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.conditions[].type",
+      "type": "string",
+      "required": true,
+      "constraints": {
+        "maxLength": "316",
+        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+      }
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.lastError",
+      "type": "string"
+    },
+    {
+      "crd": "openbaotenants.openbao.org",
+      "kind": "OpenBaoTenant",
+      "version": "v1alpha1",
+      "path": "status.provisioned",
+      "type": "boolean"
+    }
+  ]
+}

--- a/api/stability/v1alpha1.yaml
+++ b/api/stability/v1alpha1.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 1
 release: 0.5.0
-baseline: 0.4.2
+baseline: 0.5.0
 decisionStatus: approved
 snapshot: api/stability/v1alpha1-paths.tsv
 notes:

--- a/api/stability/v1alpha1.yaml
+++ b/api/stability/v1alpha1.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 1
 release: 0.5.0
-baseline: 0.5.0
+baseline: 0.4.2
 decisionStatus: approved
 snapshot: api/stability/v1alpha1-paths.tsv
 notes:

--- a/hack/tools/crd_compatibility/main.go
+++ b/hack/tools/crd_compatibility/main.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	defaultBaselinePath = "api/stability/baselines/0.4.2.json"
+	defaultBaselinePath = "api/stability/baselines/0.5.0.json"
 	defaultCurrentDir   = "config/crd/bases"
-	defaultTarget       = "0.5.0"
+	defaultTarget       = "next"
 	impactBreaking      = "breaking"
 	impactCompatible    = "compatible"
 	impactReview        = "review"
@@ -117,7 +117,7 @@ func parseOptions() (options, error) {
 	flag.StringVar(&opts.BaselinePath, "baseline", defaultBaselinePath, "normalized baseline snapshot")
 	flag.StringVar(&opts.CurrentDir, "current-dir", defaultCurrentDir, "directory containing current generated CRDs")
 	flag.StringVar(&opts.Format, "format", "markdown", "output format: markdown or json")
-	flag.StringVar(&opts.Mode, "mode", "report", "compatibility mode: report or enforce")
+	flag.StringVar(&opts.Mode, "mode", "enforce", "compatibility mode: report or enforce")
 	flag.StringVar(&opts.Target, "target", defaultTarget, "target release label")
 	flag.StringVar(&opts.WriteBaseline, "write-baseline", "", "write a normalized baseline snapshot to this path")
 	flag.StringVar(&opts.BaselineBundle, "baseline-bundle", "", "released CRD YAML bundle used with --write-baseline")
@@ -682,12 +682,16 @@ func writeReport(writer io.Writer, result report, format string) error {
 	for _, item := range result.Changes {
 		counts[item.Impact]++
 	}
+	modeLabel := "enforced"
+	if result.Mode == "report" {
+		modeLabel = "report-only"
+	}
 	if _, err := fmt.Fprintf(
 		writer,
-		"CRD compatibility: %s -> %s (%s-only)\n",
+		"CRD compatibility: %s -> %s (%s)\n",
 		result.Baseline,
 		result.Target,
-		result.Mode,
+		modeLabel,
 	); err != nil {
 		return err
 	}

--- a/mk/ci.mk
+++ b/mk/ci.mk
@@ -15,7 +15,7 @@ endif
 	@echo "✅ All CI checks passed!"
 
 .PHONY: ci-core
-ci-core: security-ci security-scan-built-images lint-ci verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-spdx-normalizer verify-vendor verify-generated verify-api-stability-inventory report-crd-compatibility verify-e2e-manifest verify-operator-upgrade-e2e test-ci fuzz verify-openbao-config-compat docs-build verify-helm helm-test ## Run all CI checks except E2E tests (cluster-independent).
+ci-core: security-ci security-scan-built-images lint-ci verify-fmt verify-tidy verify-go-toolchain-sync verify-workflows verify-spdx-normalizer verify-vendor verify-generated verify-api-contract verify-e2e-manifest verify-operator-upgrade-e2e test-ci fuzz verify-openbao-config-compat docs-build verify-helm helm-test ## Run all CI checks except E2E tests (cluster-independent).
 
 CI_MANAGER_SCAN_IMG ?= local/openbao-operator:ci
 CI_INIT_SCAN_IMG ?= local/openbao-init:ci

--- a/mk/development.mk
+++ b/mk/development.mk
@@ -170,11 +170,18 @@ verify-generated: manifests generate api-reference ## Verify generated artifacts
 verify-api-stability-inventory: ## Verify every served CRD field has a proposed or approved stability classification.
 	@GOFLAGS="$(GOFLAGS_VENDOR)" go run ./hack/tools/api_inventory
 
-CRD_COMPAT_MODE ?= report
+CRD_COMPAT_TARGET ?= next
+
+.PHONY: verify-crd-compatibility
+verify-crd-compatibility: ## Reject breaking or review-required CRD schema changes against the supported release baseline.
+	@GOFLAGS="$(GOFLAGS_VENDOR)" go run ./hack/tools/crd_compatibility --mode enforce --target "$(CRD_COMPAT_TARGET)"
+
+.PHONY: verify-api-contract
+verify-api-contract: verify-api-stability-inventory verify-crd-compatibility ## Enforce the served API inventory and release compatibility contract.
 
 .PHONY: report-crd-compatibility
 report-crd-compatibility: ## Report CRD schema compatibility against the supported release baseline.
-	@GOFLAGS="$(GOFLAGS_VENDOR)" go run ./hack/tools/crd_compatibility --mode "$(CRD_COMPAT_MODE)"
+	@GOFLAGS="$(GOFLAGS_VENDOR)" go run ./hack/tools/crd_compatibility --mode report --target "$(CRD_COMPAT_TARGET)"
 
 .PHONY: update-api-stability-inventory
 update-api-stability-inventory: ## Update the resolved CRD stability snapshot after an intentional API or inventory change.

--- a/test/manifests/apicontract/gate_test.go
+++ b/test/manifests/apicontract/gate_test.go
@@ -1,0 +1,165 @@
+package apicontract
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// Execute the workflow's actual gate in an isolated checkout fixture. Refreshing
+// the inventory must not authorize removal or tighter validation of released fields.
+func TestWorkflowAPIContractCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutation func(*apiextensionsv1.JSONSchemaProps)
+		refresh  bool
+		want     string
+	}{
+		{name: "released schema passes"},
+		{
+			name: "reviewed optional addition passes",
+			mutation: func(spec *apiextensionsv1.JSONSchemaProps) {
+				ingress := spec.Properties["ingress"]
+				ingress.Properties["futureOption"] = apiextensionsv1.JSONSchemaProps{Type: "string"}
+			},
+			refresh: true,
+		},
+		{
+			name: "removed field fails even with refreshed inventory",
+			mutation: func(spec *apiextensionsv1.JSONSchemaProps) {
+				delete(spec.Properties["ingress"].Properties, "className")
+			},
+			refresh: true,
+			want:    "field-removed",
+		},
+		{
+			name: "tightened validation fails even with refreshed inventory",
+			mutation: func(spec *apiextensionsv1.JSONSchemaProps) {
+				ingress := spec.Properties["ingress"]
+				field := ingress.Properties["host"]
+				minimum := int64(2)
+				field.MinLength = &minimum
+				ingress.Properties["host"] = field
+			},
+			refresh: true,
+			want:    "validation-tightened",
+		},
+		{
+			name: "unclassified field fails",
+			mutation: func(spec *apiextensionsv1.JSONSchemaProps) {
+				spec.Properties["unclassified"] = apiextensionsv1.JSONSchemaProps{Type: "string"}
+			},
+			want: "spec.unclassified: top-level field requires an explicit rule",
+		},
+		{
+			name: "unreviewed nested addition fails",
+			mutation: func(spec *apiextensionsv1.JSONSchemaProps) {
+				spec.Properties["ingress"].Properties["futureOption"] = apiextensionsv1.JSONSchemaProps{Type: "string"}
+			},
+			want: "is out of date",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := copyContractFixture(t)
+			if tt.mutation != nil {
+				mutateClusterSchema(t, dir, tt.mutation)
+			}
+			if tt.refresh {
+				output, err := runCommand(t, dir, nil, "make", "update-api-stability-inventory")
+				if err != nil {
+					t.Fatalf("refresh fixture inventory: %v\n%s", err, output)
+				}
+			}
+			for _, workflow := range []string{"ci.yml", "release.yml"} {
+				gate := readWorkflow(t, workflow).Jobs["api-contract"]
+				step := findStep(t, gate, "Verify API contract")
+				output, err := runCommand(t, dir, []string{"CRD_COMPAT_MODE=report"}, "bash", "-ec", step.Run)
+				if tt.want == "" {
+					if err != nil {
+						t.Fatalf("%s gate rejected compatible fixture: %v\n%s", workflow, err, output)
+					}
+					continue
+				}
+				if err == nil || !strings.Contains(output, tt.want) {
+					t.Fatalf("%s gate: error=%v, want rejection containing %q\n%s", workflow, err, tt.want, output)
+				}
+			}
+			if tt.refresh && tt.want != "" {
+				output, err := runCommand(t, dir, nil, "go", "run", "./hack/tools/crd_compatibility")
+				if err == nil || !strings.Contains(output, tt.want) {
+					t.Fatalf("checker default must enforce compatibility: error=%v\n%s", err, output)
+				}
+			}
+		})
+	}
+}
+
+func copyContractFixture(t *testing.T) string {
+	t.Helper()
+	root := repositoryRoot(t)
+	dir := t.TempDir()
+	for _, path := range []string{"mk", "api/stability", "config/crd/bases"} {
+		if err := os.CopyFS(filepath.Join(dir, path), os.DirFS(filepath.Join(root, path))); err != nil {
+			t.Fatalf("copy fixture %s: %v", path, err)
+		}
+	}
+	for _, path := range []string{"Makefile", "go.mod", "go.sum", "vendor", "hack"} {
+		if err := os.Symlink(filepath.Join(root, path), filepath.Join(dir, path)); err != nil {
+			t.Fatalf("link fixture %s: %v", path, err)
+		}
+	}
+	return dir
+}
+
+func mutateClusterSchema(t *testing.T, dir string, mutate func(*apiextensionsv1.JSONSchemaProps)) {
+	t.Helper()
+	path := filepath.Join(dir, "config/crd/bases/openbao.org_openbaoclusters.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := yaml.UnmarshalStrict(data, &crd); err != nil {
+		t.Fatal(err)
+	}
+	root := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	spec := root.Properties["spec"]
+	mutate(&spec)
+	root.Properties["spec"] = spec
+	data, err = yaml.Marshal(crd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func runCommand(t *testing.T, dir string, env []string, command string, args ...string) (string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}

--- a/test/manifests/apicontract/workflows_test.go
+++ b/test/manifests/apicontract/workflows_test.go
@@ -29,6 +29,20 @@ type workflowStep struct {
 	ContinueOnError bool              `yaml:"continue-on-error"`
 }
 
+func TestAPIContractPreservesOperatorUpgradeHarness(t *testing.T) {
+	// The inventory describes an approved migration; its baseline also selects
+	// the operator-upgrade fixtures and must not follow the schema checker baseline.
+	env := []string{
+		"OPERATOR_UPGRADE_E2E_FROM_VERSION=",
+		"OPERATOR_UPGRADE_E2E_TARGET_RELEASE=",
+		"OPERATOR_UPGRADE_E2E_TARGET_VERSION=",
+	}
+	output, err := runCommand(t, repositoryRoot(t), env, "make", "verify-operator-upgrade-e2e")
+	if err != nil {
+		t.Fatalf("API contract changes must preserve the approved operator-upgrade rehearsal: %v\n%s", err, output)
+	}
+}
+
 func TestAPIContractWorkflowDependencies(t *testing.T) {
 	ci := readWorkflow(t, "ci.yml")
 	release := readWorkflow(t, "release.yml")

--- a/test/manifests/apicontract/workflows_test.go
+++ b/test/manifests/apicontract/workflows_test.go
@@ -1,0 +1,179 @@
+package apicontract
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workflow struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	If              string            `yaml:"if"`
+	Needs           yaml.Node         `yaml:"needs"`
+	Outputs         map[string]string `yaml:"outputs"`
+	ContinueOnError bool              `yaml:"continue-on-error"`
+	Steps           []workflowStep    `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name            string            `yaml:"name"`
+	Run             string            `yaml:"run"`
+	Env             map[string]string `yaml:"env"`
+	ContinueOnError bool              `yaml:"continue-on-error"`
+}
+
+func TestAPIContractWorkflowDependencies(t *testing.T) {
+	ci := readWorkflow(t, "ci.yml")
+	release := readWorkflow(t, "release.yml")
+	for _, w := range []workflow{ci, release} {
+		gate, ok := w.Jobs["api-contract"]
+		if !ok || gate.ContinueOnError || findStep(t, gate, "Verify API contract").ContinueOnError {
+			t.Fatal("API contract must be a blocking job and step")
+		}
+	}
+	for _, job := range []string{"ci-required", "build-edge-candidate"} {
+		assertNeeds(t, ci.Jobs[job], "api-contract")
+	}
+	for _, job := range []string{"build", "rebuild", "promote"} {
+		assertNeeds(t, release.Jobs[job], "api-contract")
+	}
+	if release.Jobs["api-contract"].If != "" {
+		t.Fatal("release API contract gate must run unconditionally")
+	}
+	want := "github.event_name == 'workflow_dispatch' || " +
+		"(github.event_name == 'push' && github.ref == 'refs/heads/main') || " +
+		"needs.changes.outputs.api_contract == 'true'"
+	if ci.Jobs["api-contract"].If != want {
+		t.Fatal("CI must gate contract changes, main pushes, and manual runs")
+	}
+	if ci.Jobs["changes"].Outputs["api_contract"] != "${{ steps.diff.outputs.api_contract }}" {
+		t.Fatal("change detection must publish the API contract routing result")
+	}
+}
+
+func TestAPIContractChangeRouting(t *testing.T) {
+	w := readWorkflow(t, "ci.yml")
+	script := findStep(t, w.Jobs["changes"], "Detect chart changes").Run
+	bin := t.TempDir()
+	// Diff input is local and deterministic; the workflow cannot fetch the network.
+	git := "#!/usr/bin/env bash\ncase \"$1\" in\n" +
+		"fetch) exit 0 ;;\ndiff) printf '%s\\n' \"${CHANGED_PATHS}\" ;;\n*) exit 1 ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(git), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{
+		"api/v1alpha1/openbaocluster_types.go",
+		"api/stability/v1alpha1.yaml",
+		"api/stability/v1alpha1-paths.tsv",
+		"api/stability/baselines/0.5.0.json",
+		"config/crd/bases/openbao.org_openbaoclusters.yaml",
+		"hack/tools/api_inventory/main.go",
+		"hack/tools/crd_compatibility/main.go",
+		"test/manifests/apicontract/gate_test.go",
+		"Makefile",
+		"mk/development.mk",
+		"go.mod",
+		"vendor/modules.txt",
+		".github/workflows/ci.yml",
+		".github/workflows/release.yml",
+		".github/actions/setup-repo-tools/action.yml",
+		"website/content/contribute/setup.md",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "outputs")
+			env := []string{
+				"PATH=" + bin + string(os.PathListSeparator) + os.Getenv("PATH"),
+				"EVENT_NAME=pull_request", "GITHUB_SHA=head", "PR_BASE_SHA=base", "PR_HEAD_SHA=head",
+				"GITHUB_OUTPUT=" + outputPath, "CHANGED_PATHS=" + path,
+			}
+			output, err := runCommand(t, repositoryRoot(t), env, "bash", "-ec", script)
+			if err != nil {
+				t.Fatalf("run change detector: %v\n%s", err, output)
+			}
+			data, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "api_contract=true\n"
+			if strings.HasPrefix(path, "website/") {
+				want = "api_contract=false\n"
+			}
+			if !strings.Contains(string(data), want) {
+				t.Fatalf("routing for %s: want %s, got\n%s", path, want, data)
+			}
+		})
+	}
+}
+
+func TestAPIContractResultBlocksRequiredCI(t *testing.T) {
+	w := readWorkflow(t, "ci.yml")
+	step := findStep(t, w.Jobs["ci-required"], "Validate required CI graph")
+	if step.Env["API_CONTRACT"] != "${{ needs.api-contract.result }}" {
+		t.Fatal("required result aggregation must read the API contract result")
+	}
+	for _, result := range []string{"success", "failure", "cancelled"} {
+		t.Run(result, func(t *testing.T) {
+			env := make([]string, 0, len(step.Env))
+			for key := range step.Env {
+				value := "success"
+				if key == "API_CONTRACT" {
+					value = result
+				}
+				env = append(env, key+"="+value)
+			}
+			output, err := runCommand(t, repositoryRoot(t), env, "bash", "-ec", step.Run)
+			if result == "success" {
+				if err != nil {
+					t.Fatalf("passing graph rejected: %v\n%s", err, output)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(output, "api-contract:"+result) {
+				t.Fatalf("API contract %s must block CI Required: error=%v\n%s", result, err, output)
+			}
+		})
+	}
+}
+
+func readWorkflow(t *testing.T, name string) workflow {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repositoryRoot(t), ".github/workflows", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w workflow
+	if err := yaml.Unmarshal(data, &w); err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
+func findStep(t *testing.T, job workflowJob, name string) workflowStep {
+	t.Helper()
+	for _, step := range job.Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	t.Fatalf("workflow step %q is missing", name)
+	return workflowStep{}
+}
+
+func assertNeeds(t *testing.T, job workflowJob, prerequisite string) {
+	t.Helper()
+	var needs []string
+	if err := job.Needs.Decode(&needs); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(needs, prerequisite) {
+		t.Fatalf("job dependencies %v must include %s", needs, prerequisite)
+	}
+}

--- a/website/content/contribute/ci.md
+++ b/website/content/contribute/ci.md
@@ -34,6 +34,7 @@ the project migrates their setup steps incrementally.
 | --- | --- |
 | Pinned environment contract | `devenv test` |
 | Core quality gates | `devenv tasks run operator:ci-core` |
+| API inventory and released CRD compatibility | `make verify-api-contract` |
 | Hugo documentation and redirects | `make docs-build` |
 | Vendored dependencies and licenses | `make verify-vendor`, `make license-check` |
 | Static and filesystem security | `make semgrep-ci`, `make security-ci` |
@@ -42,6 +43,11 @@ the project migrates their setup steps incrementally.
 | Existing platform cluster | `make test-e2e-existing` |
 
 Docs-only changes normally avoid broad cluster E2E. Backup, upgrade, security, provisioner, admission, controller-critical, or seal-path changes expand into targeted shards. Maintainers can request the full E2E set with the repository's CI label.
+
+The required `API Contract` job rejects unclassified API fields, stale inventory snapshots, and breaking or
+review-required schema changes against the released 0.5.0 CRDs. It runs for contract-related changes, pushes to
+`main`, and manual CI runs. Release validation runs the same gate before image builds and publication.
+`make report-crd-compatibility` produces a diagnostic report without weakening the required gate.
 
 The E2E manifest owns suite routing, isolation, parallelism, and supported test versions. Do not duplicate those values in workflow logic. Run `make e2e-ci-matrix` or the nightly matrix commands before changing routing.
 


### PR DESCRIPTION
## Summary

API inventory and compatibility reporting did not block incompatible releases. Add an enforced compatibility gate against the CRDs published in release 0.5.0, and make CI Required, edge builds, and release image builds/publication depend on it.

The required Make target and checker defaults enforce compatibility; the former `CRD_COMPAT_MODE=report` override cannot weaken the gate. Keep a separate diagnostic report command. Preserve the approved inventory's 0.4.2 → 0.5.0 migration metadata because the operator-upgrade harness uses those fields independently of the schema comparison baseline.

## Related Issues

Repository review follow-up; no tracking issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

No served schema or approved field classification changes. The new 1,018-node baseline is generated from the published 0.5.0 CRD bundle, preserving SHA-256 `58bf30cec5c7a98e931f25a80c60deaa5bbcad3df7e57d227445d4b0a0f62af8`.

Breaking and review-required schema changes now fail the required gate, even after inventory refresh. Compatibility exceptions therefore require a reviewed policy/migration decision. The gate does not graduate v1alpha1 to beta. Release checks also verify generated artifacts before checking compatibility.

## Verification

- `GOMAXPROCS=4 GOFLAGS=-mod=vendor go test -count=1 -p 4 ./hack/tools/api_inventory ./hack/tools/crd_compatibility ./test/manifests/apicontract`
- `make verify-api-contract verify-operator-upgrade-e2e`
- Workflow, generated-artifact, strict documentation, focused lint, and normal commit checks passed.
- Negative fixtures execute the actual gate commands and reject removals, tighter validation, unclassified additions, and stale inventory.
- Tests execute change routing, required-result aggregation, and the upgrade harness's verify-only path without network or cluster operations.
- Current schema comparison: 1,018 nodes, zero differences against 0.5.0.

The combined stack tree passed `devenv test`, `devenv tasks run operator:bootstrap`, `devenv tasks run operator:doctor`, and `devenv tasks run operator:ci-core`. The stack tip has the same tracked tree as that validated candidate (`8e22e09ff9de3a3d3d11837986491613c1314e85`). This includes unit/integration tests, the coverage gate, 34 fuzz targets, security scans, configuration compatibility, docs, and Helm checks. Deployed Kind E2E was not run locally; hosted checks validate each published layer.

## Reviewer Notes

Layer 3 of 3, based on the startup/platform layer. Merge from this top PR after the entire stack is reviewed and green. Focus on gate routing, required dependencies, and the distinction between the enforced schema baseline and historical migration metadata.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.

