### PR TITLE
fix(readiness): require synchronized caches and fresh admission checks

### DIFF
--- a/cmd/controller/readiness_integration_test.go
+++ b/cmd/controller/readiness_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package controller
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
+	"github.com/dc-tec/openbao-operator/internal/adapter/raft"
+	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
+	"github.com/dc-tec/openbao-operator/internal/platform/testutil/managerprobe"
+	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
+	initmanager "github.com/dc-tec/openbao-operator/internal/service/init"
+)
+
+func TestControllerReadinessCacheAndWatchContract(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+	config := managerprobe.Environment(t)
+	for _, singleTenant := range []bool{false, true} {
+		t.Run(map[bool]string{false: "multi-tenant", true: "single-tenant"}[singleTenant], func(t *testing.T) {
+			watchNamespace := ""
+			resource := "openbaoclusters"
+			if singleTenant {
+				watchNamespace = "default"
+				resource = "secrets"
+			}
+			gate := managerprobe.NewListGate(resource)
+			t.Cleanup(gate.Release)
+			managerConfig := rest.CopyConfig(config)
+			managerConfig.WrapTransport = gate.Wrap
+			address := managerprobe.ProbeAddress(t)
+			options := newManagerOptions(scheme, metricsserver.Options{BindAddress: "0"}, address, false, watchNamespace)
+			warmup := true
+			options.Controller.EnableWarmup = &warmup
+			options.Controller.SkipNameValidation = &warmup
+			var recording *managerprobe.RecordingCache
+			options.NewCache = func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+				var err error
+				recording, err = managerprobe.NewRecordingCache(config, opts)
+				return recording, err
+			}
+			mgr, err := ctrl.NewManager(managerConfig, options)
+			require.NoError(t, err)
+			observed := &managerprobe.WarmupObserver{Manager: mgr}
+			require.NoError(t, setupControllers(observed, readinessControllerRuntime(t, mgr, singleTenant)))
+			require.NoError(t, addManagerHealthChecks(t.Context(), mgr, singleTenant))
+			managerprobe.Start(t, mgr)
+			select {
+			case <-gate.Observed:
+			case <-time.After(10 * time.Second):
+				t.Fatal("cache did not request initial population")
+			}
+			require.Eventually(t, func() bool {
+				return managerprobe.Status(address, "/healthz") == http.StatusOK
+			}, 5*time.Second, 20*time.Millisecond)
+			require.Equal(t, http.StatusInternalServerError, managerprobe.Status(address, "/readyz"))
+			gate.Release()
+			select {
+			case <-mgr.Elected():
+			case <-time.After(10 * time.Second):
+				t.Fatal("controller warmup did not finish")
+			}
+			observed.Wait(t)
+			recording.AssertMatchesWatches(t)
+			require.Eventually(t, func() bool {
+				return managerprobe.Status(address, "/readyz") == http.StatusOK
+			}, 5*time.Second, 20*time.Millisecond)
+		})
+	}
+}
+
+func TestControllerStandbyReadinessAdmissionLifecycle(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "")
+	config := managerprobe.Environment(t)
+	address := managerprobe.ProbeAddress(t)
+	options := newManagerOptions(scheme, metricsserver.Options{BindAddress: "0"}, address, true, "")
+	options.LeaderElectionNamespace = "default"
+	skipNames := true
+	options.Controller.SkipNameValidation = &skipNames
+	kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+	managerprobe.HoldLeadership(t, kubeClient, options.LeaderElectionID)
+	mgr, err := ctrl.NewManager(config, options)
+	require.NoError(t, err)
+	require.NoError(t, setupControllers(mgr, readinessControllerRuntime(t, mgr, false)))
+	require.NoError(t, addManagerHealthChecks(t.Context(), mgr, false))
+	managerprobe.Start(t, mgr)
+	managerprobe.AdmissionLifecycle(t, mgr, address)
+}
+
+func readinessControllerRuntime(t *testing.T, mgr ctrl.Manager, singleTenant bool) controllerProcessRuntime {
+	t.Helper()
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	require.NoError(t, err)
+	clientManager := openbao.NewClientManager(portopenbao.ClientConfig{})
+	raftManager := raft.NewManager(clientset, raftClientFactoryProvider{clientManager: clientManager})
+	initialization, err := initmanager.NewManager(mgr.GetConfig(), clientset, clientManager, raftManager)
+	require.NoError(t, err)
+	return controllerProcessRuntime{
+		operatorNamespace: "default", singleTenantMode: singleTenant,
+		openBaoRuntime: appopenbaocluster.RuntimeOpenBaoConfig{Raft: raftManager, InitManager: initialization},
+	}
+}

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -98,7 +98,7 @@ func Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("unable to register controllers: %w", err)
 	}
 
-	if err := addManagerHealthChecks(mgr); err != nil {
+	if err := addManagerHealthChecks(ctx, mgr, singleTenantMode); err != nil {
 		return fmt.Errorf("unable to configure manager probes: %w", err)
 	}
 

--- a/cmd/controller/runtime_setup.go
+++ b/cmd/controller/runtime_setup.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	"github.com/dc-tec/openbao-operator/internal/adapter/auth"
 	"github.com/dc-tec/openbao-operator/internal/adapter/openbao"
 	"github.com/dc-tec/openbao-operator/internal/adapter/raft"
@@ -17,6 +21,7 @@ import (
 	openbaoclustercontroller "github.com/dc-tec/openbao-operator/internal/controller/openbaocluster"
 	openbaorestorecontroller "github.com/dc-tec/openbao-operator/internal/controller/openbaorestore"
 	"github.com/dc-tec/openbao-operator/internal/platform/admission"
+	"github.com/dc-tec/openbao-operator/internal/platform/entrypoint"
 	portauth "github.com/dc-tec/openbao-operator/internal/port/auth"
 	portopenbao "github.com/dc-tec/openbao-operator/internal/port/openbao"
 	certmanager "github.com/dc-tec/openbao-operator/internal/service/certs"
@@ -166,13 +171,14 @@ func setupControllers(mgr ctrl.Manager, runtime controllerProcessRuntime) error 
 	return nil
 }
 
-func addManagerHealthChecks(mgr ctrl.Manager) error {
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return err
+func addManagerHealthChecks(ctx context.Context, mgr ctrl.Manager, singleTenantMode bool) error {
+	// Match the watches in OpenBaoCluster and OpenBaoRestore SetupWithManager.
+	watchedObjects := []client.Object{&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoRestore{}}
+	if singleTenantMode {
+		watchedObjects = append(watchedObjects,
+			&appsv1.StatefulSet{}, &corev1.Service{}, &corev1.ConfigMap{},
+			&corev1.Secret{}, &batchv1.Job{}, &corev1.ServiceAccount{},
+		)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return err
-	}
-
-	return nil
+	return entrypoint.AddManagerHealthChecks(ctx, mgr, watchedObjects...)
 }

--- a/cmd/provisioner/readiness_integration_test.go
+++ b/cmd/provisioner/readiness_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package provisioner
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	appprovisioner "github.com/dc-tec/openbao-operator/internal/app/provisioner"
+	"github.com/dc-tec/openbao-operator/internal/platform/testutil/managerprobe"
+)
+
+func TestProvisionerReadinessCacheAndWatchContract(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+	config := managerprobe.Environment(t)
+	gate := managerprobe.NewListGate("openbaorestores")
+	t.Cleanup(gate.Release)
+	config.WrapTransport = gate.Wrap
+	address := managerprobe.ProbeAddress(t)
+	options := newManagerOptions(metricsserver.Options{BindAddress: "0"}, address, false)
+	warmup := true
+	options.Controller.EnableWarmup = &warmup
+	options.Controller.SkipNameValidation = &warmup
+	var recording *managerprobe.RecordingCache
+	options.NewCache = func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+		var err error
+		recording, err = managerprobe.NewRecordingCache(config, opts)
+		return recording, err
+	}
+	mgr, err := ctrl.NewManager(config, options)
+	require.NoError(t, err)
+	observed := &managerprobe.WarmupObserver{Manager: mgr}
+	require.NoError(t, setupControllers(observed, readinessProvisionerRuntime(t, mgr)))
+	require.NoError(t, addManagerHealthChecks(t.Context(), mgr))
+	managerprobe.Start(t, mgr)
+	select {
+	case <-gate.Observed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("cache did not request initial population")
+	}
+	require.Eventually(t, func() bool {
+		return managerprobe.Status(address, "/healthz") == http.StatusOK
+	}, 5*time.Second, 20*time.Millisecond)
+	require.Equal(t, http.StatusInternalServerError, managerprobe.Status(address, "/readyz"))
+	gate.Release()
+	select {
+	case <-mgr.Elected():
+	case <-time.After(10 * time.Second):
+		t.Fatal("controller warmup did not finish")
+	}
+	observed.Wait(t)
+	recording.AssertMatchesWatches(t)
+	require.Eventually(t, func() bool {
+		return managerprobe.Status(address, "/readyz") == http.StatusOK
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestProvisionerStandbyReadinessAdmissionLifecycle(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "")
+	config := managerprobe.Environment(t)
+	address := managerprobe.ProbeAddress(t)
+	options := newManagerOptions(metricsserver.Options{BindAddress: "0"}, address, true)
+	options.LeaderElectionNamespace = "default"
+	skipNames := true
+	options.Controller.SkipNameValidation = &skipNames
+	kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+	managerprobe.HoldLeadership(t, kubeClient, options.LeaderElectionID)
+	mgr, err := ctrl.NewManager(config, options)
+	require.NoError(t, err)
+	require.NoError(t, setupControllers(mgr, readinessProvisionerRuntime(t, mgr)))
+	require.NoError(t, addManagerHealthChecks(t.Context(), mgr))
+	managerprobe.Start(t, mgr)
+	managerprobe.AdmissionLifecycle(t, mgr, address)
+}
+
+func readinessProvisionerRuntime(t *testing.T, mgr ctrl.Manager) provisionerProcessRuntime {
+	t.Helper()
+	provisioner, err := appprovisioner.NewProvisioner(appprovisioner.ProvisionerDependencies{
+		Client: mgr.GetClient(), Logger: mgr.GetLogger(),
+	})
+	require.NoError(t, err)
+	return provisionerProcessRuntime{provisioner: provisioner, operatorNamespace: "default"}
+}

--- a/cmd/provisioner/run.go
+++ b/cmd/provisioner/run.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("unable to register provisioner controllers: %w", err)
 	}
 
-	if err := addManagerHealthChecks(mgr); err != nil {
+	if err := addManagerHealthChecks(ctx, mgr); err != nil {
 		return fmt.Errorf("unable to configure manager probes: %w", err)
 	}
 

--- a/cmd/provisioner/runtime_setup.go
+++ b/cmd/provisioner/runtime_setup.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 	appprovisioner "github.com/dc-tec/openbao-operator/internal/app/provisioner"
 	provisionercontroller "github.com/dc-tec/openbao-operator/internal/controller/provisioner"
 	"github.com/dc-tec/openbao-operator/internal/platform/admission"
@@ -73,13 +73,8 @@ func setupControllers(mgr ctrl.Manager, runtime provisionerProcessRuntime) error
 	return nil
 }
 
-func addManagerHealthChecks(mgr ctrl.Manager) error {
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return err
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return err
-	}
-
-	return nil
+func addManagerHealthChecks(ctx context.Context, mgr ctrl.Manager) error {
+	return entrypoint.AddManagerHealthChecks(ctx, mgr,
+		&openbaov1alpha1.OpenBaoCluster{}, &openbaov1alpha1.OpenBaoTenant{}, &openbaov1alpha1.OpenBaoRestore{},
+	)
 }

--- a/internal/platform/entrypoint/health.go
+++ b/internal/platform/entrypoint/health.go
@@ -1,0 +1,122 @@
+package entrypoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/admission"
+)
+
+const (
+	admissionReadinessRefreshInterval = 15 * time.Second
+	admissionReadinessTimeout         = 10 * time.Second
+	admissionReadinessMaxAge          = 30 * time.Second
+)
+
+// AddManagerHealthChecks registers process liveness and cache/admission readiness.
+// watchedObjects must contain the types watched by this manager. Registering their
+// informers before startup makes cache synchronization independent of leadership.
+func AddManagerHealthChecks(ctx context.Context, mgr ctrl.Manager, watchedObjects ...client.Object) error {
+	readiness := &managerReadiness{reader: mgr.GetAPIReader()}
+	for _, object := range watchedObjects {
+		informer, err := mgr.GetCache().GetInformer(ctx, object, cache.BlockUntilSynced(false))
+		if err != nil {
+			return fmt.Errorf("register readiness informer for %T: %w", object, err)
+		}
+		readiness.informers = append(readiness.informers, informer)
+	}
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("register liveness check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", readiness.Check); err != nil {
+		return fmt.Errorf("register readiness check: %w", err)
+	}
+	if err := mgr.Add(readiness); err != nil {
+		return fmt.Errorf("register readiness refresh: %w", err)
+	}
+	return nil
+}
+
+type managerReadiness struct {
+	reader    client.Reader
+	informers []cache.Informer
+	running   atomic.Bool
+
+	mu              sync.RWMutex
+	admissionStatus *admission.Status
+}
+
+// NeedLeaderElection keeps readiness current on idle and standby replicas.
+func (r *managerReadiness) NeedLeaderElection() bool { return false }
+
+func (r *managerReadiness) Start(ctx context.Context) error {
+	// The manager starts non-leader runnables after its registered caches sync.
+	// This does not imply completion of controller warmup or reconciliation.
+	r.running.Store(true)
+	defer r.running.Store(false)
+	ticker := time.NewTicker(admissionReadinessRefreshInterval)
+	defer ticker.Stop()
+	r.refresh(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			r.refresh(ctx)
+		}
+	}
+}
+
+func (r *managerReadiness) refresh(ctx context.Context) {
+	if admission.UnsafeAdmissionDisabled() {
+		return
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, admissionReadinessTimeout)
+	defer cancel()
+	status, err := admission.CheckDependencies(
+		checkCtx, r.reader, admission.DefaultDependencies(), admission.DefaultNamePrefixes(),
+	)
+	if err != nil {
+		status = admission.Status{CheckedAt: time.Now()}
+	}
+	// Keep probe observations separate from mutation-path trackers and their gauge.
+	r.mu.Lock()
+	r.admissionStatus = &status
+	r.mu.Unlock()
+}
+
+func (r *managerReadiness) Check(_ *http.Request) error {
+	if !r.running.Load() {
+		return fmt.Errorf("manager cache synchronization is incomplete or the manager is stopping")
+	}
+	for _, informer := range r.informers {
+		if !informer.HasSynced() || informer.IsStopped() {
+			return fmt.Errorf("a watched resource cache has not synchronized or has stopped")
+		}
+	}
+	if admission.UnsafeAdmissionDisabled() {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.admissionStatus == nil {
+		return fmt.Errorf("admission dependencies have not been checked")
+	}
+	age := time.Since(r.admissionStatus.CheckedAt)
+	if age < 0 || age >= admissionReadinessMaxAge {
+		return fmt.Errorf("admission dependency status is stale")
+	}
+	if !r.admissionStatus.OverallReady {
+		return fmt.Errorf("admission dependencies are not ready")
+	}
+	return nil
+}

--- a/internal/platform/entrypoint/health_test.go
+++ b/internal/platform/entrypoint/health_test.go
@@ -1,0 +1,106 @@
+package entrypoint
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/admission"
+)
+
+type readinessInformer struct {
+	cache.Informer
+	synced, stopped bool
+}
+
+func (i readinessInformer) HasSynced() bool { return i.synced }
+func (i readinessInformer) IsStopped() bool { return i.stopped }
+
+func TestManagerReadiness(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		running, synced, stopped bool
+		unsafe                   string
+		status                   *admission.Status
+		wantError                string
+	}{
+		{name: "not started", wantError: "manager cache synchronization"},
+		{name: "cache pending", running: true, wantError: "watched resource cache"},
+		{name: "cache stopped", running: true, synced: true, stopped: true, wantError: "watched resource cache"},
+		{name: "absent admission", running: true, synced: true, wantError: "have not been checked"},
+		{name: "unready admission", running: true, synced: true,
+			status: &admission.Status{CheckedAt: time.Now()}, wantError: "not ready"},
+		{name: "stale admission", running: true, synced: true,
+			status: &admission.Status{CheckedAt: time.Now().Add(-31 * time.Second), OverallReady: true}, wantError: "stale"},
+		{name: "future admission", running: true, synced: true,
+			status: &admission.Status{CheckedAt: time.Now().Add(time.Minute), OverallReady: true}, wantError: "stale"},
+		{name: "fresh ready", running: true, synced: true,
+			status: &admission.Status{CheckedAt: time.Now(), OverallReady: true}},
+		{name: "unsafe cache pending", running: true, unsafe: "true", wantError: "watched resource cache"},
+		{name: "unsafe not started", synced: true, unsafe: "true", wantError: "manager cache synchronization"},
+		{name: "unsafe ready", running: true, synced: true, unsafe: "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", tc.unsafe)
+			r := &managerReadiness{
+				informers:       []cache.Informer{readinessInformer{synced: tc.synced, stopped: tc.stopped}},
+				admissionStatus: tc.status,
+			}
+			r.running.Store(tc.running)
+			for range 3 {
+				err := r.Check(httptest.NewRequest("GET", "/readyz", nil))
+				if tc.wantError == "" {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, tc.wantError)
+				}
+			}
+			require.False(t, r.NeedLeaderElection())
+		})
+	}
+}
+
+type readinessErrorReader struct {
+	client.Reader
+	calls    int
+	deadline time.Time
+}
+
+func (r *readinessErrorReader) Get(ctx context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	r.calls++
+	r.deadline, _ = ctx.Deadline()
+	return fmt.Errorf("API unavailable")
+}
+
+func TestReadinessRefreshIsBoundedAndProbesDoNotReadAPI(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "")
+	reader := &readinessErrorReader{}
+	r := &managerReadiness{reader: reader}
+	r.running.Store(true)
+	r.refresh(t.Context())
+	require.Equal(t, 12, reader.calls, "each missing binding stops its dependency check")
+	require.Positive(t, time.Until(reader.deadline))
+	require.LessOrEqual(t, time.Until(reader.deadline), 10*time.Second)
+	for range 10 {
+		require.ErrorContains(t, r.Check(nil), "admission dependencies are not ready")
+	}
+	require.Equal(t, 12, reader.calls)
+	require.Equal(t, 15*time.Second, admissionReadinessRefreshInterval)
+	require.Equal(t, 30*time.Second, admissionReadinessMaxAge)
+}
+
+func TestReadinessStopsOnCancellation(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	r := &managerReadiness{}
+	require.NoError(t, r.Start(ctx))
+	require.False(t, r.running.Load())
+	require.Error(t, r.Check(nil))
+}

--- a/internal/platform/testutil/managerprobe/probes_integration.go
+++ b/internal/platform/testutil/managerprobe/probes_integration.go
@@ -1,0 +1,259 @@
+//go:build integration
+
+// Package managerprobe tests manager health registration with a real API server.
+package managerprobe
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/admission"
+)
+
+// Environment starts an isolated API server using the repository's CRDs.
+func Environment(t *testing.T) *rest.Config {
+	t.Helper()
+	ctrl.SetLogger(logr.Discard())
+	environment := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	config, err := environment.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, environment.Stop()) })
+	return config
+}
+
+// RecordingCache distinguishes readiness registration from real controller source registration.
+type RecordingCache struct {
+	cache.Cache
+	started       atomic.Bool
+	mu            sync.Mutex
+	before, after map[string]struct{}
+}
+
+// NewRecordingCache wraps a real cache without changing its informer behavior.
+func NewRecordingCache(config *rest.Config, options cache.Options) (*RecordingCache, error) {
+	inner, err := cache.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+	return &RecordingCache{Cache: inner, before: map[string]struct{}{}, after: map[string]struct{}{}}, nil
+}
+
+func (c *RecordingCache) GetInformer(ctx context.Context, object client.Object, options ...cache.InformerGetOption) (cache.Informer, error) {
+	c.mu.Lock()
+	if c.started.Load() {
+		c.after[reflect.TypeOf(object).String()] = struct{}{}
+	} else {
+		c.before[reflect.TypeOf(object).String()] = struct{}{}
+	}
+	c.mu.Unlock()
+	return c.Cache.GetInformer(ctx, object, options...)
+}
+
+func (c *RecordingCache) Start(ctx context.Context) error {
+	c.started.Store(true)
+	return c.Cache.Start(ctx)
+}
+
+// AssertMatchesWatches compares readiness's list with the actual source registrations after warmup.
+func (c *RecordingCache) AssertMatchesWatches(t *testing.T) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	require.NotEmpty(t, c.after)
+	require.Equal(t, c.after, c.before, "readiness registration must exactly match the production controller watches")
+}
+
+// ProbeAddress reserves a currently available local TCP address for a manager probe listener.
+func ProbeAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	return address
+}
+
+// Start starts a manager and registers shutdown before returning.
+func Start(t *testing.T, mgr ctrl.Manager) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			t.Error("manager did not stop")
+		}
+	})
+}
+
+// Status fetches the manager's HTTP probe with a bounded request.
+func Status(address, path string) int {
+	httpClient := &http.Client{Timeout: time.Second}
+	response, err := httpClient.Get("http://" + address + path)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = response.Body.Close() }()
+	_, _ = io.Copy(io.Discard, response.Body)
+	return response.StatusCode
+}
+
+// HoldLeadership prevents the tested manager from acquiring its lease.
+func HoldLeadership(t *testing.T, kubeClient client.Client, name string) {
+	t.Helper()
+	holder := "another-process"
+	duration := int32(3600)
+	now := metav1.NowMicro()
+	require.NoError(t, kubeClient.Create(t.Context(), &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: &duration, AcquireTime: &now, RenewTime: &now},
+	}))
+}
+
+// AdmissionLifecycle checks initial absence, periodic recovery, and loss on an idle standby process.
+func AdmissionLifecycle(t *testing.T, mgr ctrl.Manager, address string) {
+	t.Helper()
+	require.Eventually(t, func() bool { return Status(address, "/healthz") == http.StatusOK }, 10*time.Second, 20*time.Millisecond)
+	require.Equal(t, http.StatusInternalServerError, Status(address, "/readyz"))
+	fail := admissionv1.Fail
+	kubeClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	require.NoError(t, err)
+	for _, dependency := range admission.DefaultDependencies() {
+		require.NoError(t, kubeClient.Create(t.Context(), &admissionv1.ValidatingAdmissionPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: dependency.PolicyName, Annotations: map[string]string{admission.PolicyFingerprintAnnotation: dependency.ExpectedFingerprint}},
+			Spec: admissionv1.ValidatingAdmissionPolicySpec{
+				FailurePolicy: &fail,
+				MatchConstraints: &admissionv1.MatchResources{ResourceRules: []admissionv1.NamedRuleWithOperations{{RuleWithOperations: admissionv1.RuleWithOperations{
+					Operations: []admissionv1.OperationType{admissionv1.Create}, Rule: admissionv1.Rule{APIGroups: []string{"example.invalid"}, APIVersions: []string{"v1"}, Resources: []string{"things"}},
+				}}}},
+				Validations: []admissionv1.Validation{{Expression: "true"}},
+			},
+		}))
+		require.NoError(t, kubeClient.Create(t.Context(), &admissionv1.ValidatingAdmissionPolicyBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: dependency.BindingName},
+			Spec:       admissionv1.ValidatingAdmissionPolicyBindingSpec{PolicyName: dependency.PolicyName, ValidationActions: []admissionv1.ValidationAction{admissionv1.Deny}},
+		}))
+	}
+	require.Eventually(t, func() bool { return Status(address, "/readyz") == http.StatusOK }, 30*time.Second, 100*time.Millisecond)
+	select {
+	case <-mgr.Elected():
+		t.Fatal("standby readiness must not require leadership")
+	default:
+	}
+	binding := &admissionv1.ValidatingAdmissionPolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: admission.DefaultDependencies()[0].BindingName}}
+	require.NoError(t, kubeClient.Delete(t.Context(), binding))
+	require.Eventually(t, func() bool { return Status(address, "/readyz") == http.StatusInternalServerError }, 30*time.Second, 100*time.Millisecond)
+	require.Equal(t, http.StatusOK, Status(address, "/healthz"))
+}
+
+// ListGate withholds an initial LIST or streaming watch-list while probes and discovery run.
+type ListGate struct {
+	Resource    string
+	Observed    chan struct{}
+	release     chan struct{}
+	once        sync.Once
+	releaseOnce sync.Once
+}
+
+// NewListGate creates a cancellable gate for initial cache population.
+func NewListGate(resource string) *ListGate {
+	return &ListGate{Resource: resource, Observed: make(chan struct{}), release: make(chan struct{})}
+}
+
+// Release permits the held request to reach the API server.
+func (g *ListGate) Release() { g.releaseOnce.Do(func() { close(g.release) }) }
+
+// Wrap returns a transport wrapper suitable for rest.Config.WrapTransport.
+func (g *ListGate) Wrap(next http.RoundTripper) http.RoundTripper {
+	return roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		initialPopulation := request.URL.Query().Get("watch") != "true" ||
+			request.URL.Query().Get("sendInitialEvents") == "true"
+		if request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/"+g.Resource) && initialPopulation {
+			g.once.Do(func() { close(g.Observed) })
+			select {
+			case <-g.release:
+			case <-request.Context().Done():
+				return nil, request.Context().Err()
+			}
+		}
+		return next.RoundTrip(request)
+	})
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+// WarmupObserver records completion of actual registered controllers' warmup callbacks.
+type WarmupObserver struct {
+	ctrl.Manager
+	completed []<-chan struct{}
+}
+
+func (m *WarmupObserver) Add(runnable manager.Runnable) error {
+	warmup, ok := runnable.(interface {
+		Warmup(context.Context) error
+		NeedLeaderElection() bool
+	})
+	if !ok {
+		return m.Manager.Add(runnable)
+	}
+	done := make(chan struct{})
+	m.completed = append(m.completed, done)
+	return m.Manager.Add(&observedWarmup{Runnable: runnable, warmup: warmup.Warmup, needLeader: warmup.NeedLeaderElection, done: done})
+}
+
+// Wait waits for every registered warmup to complete, not merely for manager.Elected.
+func (m *WarmupObserver) Wait(t *testing.T) {
+	t.Helper()
+	require.NotEmpty(t, m.completed)
+	for _, done := range m.completed {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("registered controller warmup did not complete")
+		}
+	}
+}
+
+type observedWarmup struct {
+	manager.Runnable
+	warmup     func(context.Context) error
+	needLeader func() bool
+	done       chan struct{}
+}
+
+func (w *observedWarmup) NeedLeaderElection() bool { return w.needLeader() }
+func (w *observedWarmup) Warmup(ctx context.Context) error {
+	err := w.warmup(ctx)
+	close(w.done)
+	return err
+}

--- a/website/content-versions/next/docs/configure/monitor.md
+++ b/website/content-versions/next/docs/configure/monitor.md
@@ -4,6 +4,7 @@ description: Scrape operator and workload metrics with explicit authentication, 
 eyebrow: Configure · Observe
 weight: 9
 verifiedBy:
+  - internal/platform/entrypoint/health.go
   - charts/openbao-operator/values.yaml
   - charts/openbao-operator/templates/networkpolicy.yaml
   - charts/openbao-operator/templates/metrics
@@ -163,6 +164,26 @@ spec:
 
 The operator renders the listener, a headless metrics Service, and ServiceMonitor relabeling for pod and node names.
 Use a pod selector in `trustedIngressPeers` as well when the monitoring namespace contains unrelated workloads.
+
+## Check manager probes
+
+The controller and Provisioner expose separate process probes:
+
+- `/healthz` checks that the process responds. Admission, OpenBao, KMS, and object-storage outages do not fail liveness.
+- `/readyz` requires synchronized caches for the manager's watched resources and a fresh, ready admission-dependency
+  check. Standby replicas can become ready without acquiring leadership. Readiness does not prove that a controller
+  has completed its first reconciliation or that an OpenBao cluster is available.
+
+Each process checks admission dependencies every 15 seconds with a 10-second request deadline. A result becomes stale
+at 30 seconds. Probe requests inspect maintained state and do not query the Kubernetes API. With the current 12
+admission dependencies, a successful scan uses 24 GET requests when the first configured name prefix matches;
+alternate-prefix lookups add requests. This polling cost applies per manager process, independently of cluster count.
+The existing admission metric remains driven by startup and reconciliation checks, not this private probe snapshot.
+
+In `--admission-enforcement=fail` mode, missing dependencies continue to block startup. In `warn` mode, the manager
+starts but remains not-ready until its admission checks pass. If admission is lost after startup, readiness fails
+while liveness continues to pass. The unsafe admission bypass skips only the admission check; cache synchronization
+is still required. Workload and administrative operations retain their immediate admission checks before mutation.
 
 ## Start with a small signal set
 


### PR DESCRIPTION
## Summary

The controller and Provisioner currently report ready when their probe server responds, even if their caches have not synchronized or admission dependencies are unavailable. Require synchronized watched-resource caches and a fresh successful admission check for `/readyz`.

Pre-register existing watched informers so standby replicas can become ready without leadership. Maintain admission state with a bounded periodic check; HTTP probes only inspect state. Document the behavior and polling cost.

## Related Issues

Repository review follow-up; no tracking issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

In admission `warn` mode, the process starts but remains not ready while dependencies are missing. Liveness remains a process ping. The unsafe bypass still requires synchronized caches. OpenBao, KMS, and object-storage availability do not gate these probes.

Standby replicas now populate the same watched caches as leaders. Multi-tenant child-resource watch restrictions are preserved; no RBAC or CRD changes are required. Admission polling runs every 15 seconds with a 10-second deadline and a 30-second freshness limit. A successful first-prefix scan uses 24 GETs per process. It does not change mutation-path checks or their admission metric.

## Verification

- Pinned Go 1.26.6 focused entrypoint, controller, and Provisioner tests passed.
- Real-manager envtests passed for blocked initial cache population, watched-type drift, and admission loss/recovery on held-lease standby replicas. The cache gate handles ordinary LIST and streaming initial watch requests.
- Focused tagged lint, architecture checks, 65 AST tests, and the test-only export audit passed. The normal commit hook passed with integration tags for the integration-only test helper package.
- `devenv test`, `operator:bootstrap`, `operator:doctor`, and the full `operator:ci-core` passed on the combined tree, identical to the stack top. Internal coverage: 70.91%; all 34 fuzz targets passed.

## Reviewer Notes

First layer of the reliability stack. Readiness does not assert completed reconciliation or workload availability. No local Kind or fleet test was run; hosted CI validates the published stack.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
