### PR TITLE
fix(metrics): clear finalized reconciliation series

### DIFF
--- a/internal/app/provisioner/tenant_reconcile.go
+++ b/internal/app/provisioner/tenant_reconcile.go
@@ -37,22 +37,28 @@ type TenantRuntime struct {
 	RequeueStandard          time.Duration
 }
 
+// TenantReconcileResult reports requeue timing and the observed tenant lifecycle.
+type TenantReconcileResult struct {
+	recon.Result
+	OwnerAbsent           bool
+	FinalizationCompleted bool
+}
+
 // ReconcileOpenBaoTenant runs the business flow for namespace provisioning.
-func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logger logr.Logger, runtime TenantRuntime) (recon.Result, error) {
+func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logger logr.Logger, runtime TenantRuntime) (TenantReconcileResult, error) {
 	if runtime.Client == nil {
-		return recon.Result{}, fmt.Errorf("client is required")
+		return TenantReconcileResult{}, fmt.Errorf("client is required")
 	}
 	if runtime.Provisioner == nil {
-		return recon.Result{}, fmt.Errorf("provisioner manager is required")
+		return TenantReconcileResult{}, fmt.Errorf("provisioner manager is required")
 	}
 
 	tenant := &openbaov1alpha1.OpenBaoTenant{}
 	if err := runtime.Client.Get(ctx, key, tenant); err != nil {
 		if apierrors.IsNotFound(err) {
-			// OpenBaoTenant deleted - nothing to do.
-			return recon.Result{}, nil
+			return TenantReconcileResult{OwnerAbsent: true}, nil
 		}
-		return recon.Result{}, fmt.Errorf("failed to get OpenBaoTenant %s: %w", key, err)
+		return TenantReconcileResult{}, fmt.Errorf("failed to get OpenBaoTenant %s: %w", key, err)
 	}
 
 	targetNS := tenant.Spec.TargetNamespace
@@ -83,25 +89,30 @@ func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logge
 			err.Error(),
 		)
 		if patchErr := patchStatus(ctx, runtime.Client, tenant, original); patchErr != nil {
-			return recon.Result{}, fmt.Errorf("failed to patch status for security violation: %w", patchErr)
+			return TenantReconcileResult{}, fmt.Errorf("failed to patch status for security violation: %w", patchErr)
 		}
 
 		// Do not requeue. User must fix the CR.
-		return recon.Result{}, nil
+		return TenantReconcileResult{}, nil
 	}
 
 	if !tenant.DeletionTimestamp.IsZero() {
-		return reconcileDeletion(ctx, logger, runtime, tenant, targetNS, key)
+		result, err := reconcileDeletion(ctx, logger, runtime, tenant, targetNS, key)
+		return TenantReconcileResult{
+			Result: result,
+			FinalizationCompleted: err == nil &&
+				!controllerutil.ContainsFinalizer(tenant, openbaov1alpha1.OpenBaoTenantFinalizer),
+		}, err
 	}
 
 	if !controllerutil.ContainsFinalizer(tenant, openbaov1alpha1.OpenBaoTenantFinalizer) {
 		original := tenant.DeepCopy()
 		controllerutil.AddFinalizer(tenant, openbaov1alpha1.OpenBaoTenantFinalizer)
 		if err := runtime.Client.Patch(ctx, tenant, client.MergeFrom(original)); err != nil {
-			return recon.Result{}, fmt.Errorf("failed to add finalizer to OpenBaoTenant %s: %w", key, err)
+			return TenantReconcileResult{}, fmt.Errorf("failed to add finalizer to OpenBaoTenant %s: %w", key, err)
 		}
 		// Requeue to observe the resource with the finalizer attached.
-		return recon.Result{RequeueAfter: resolveRequeueShort(runtime)}, nil
+		return TenantReconcileResult{Result: recon.Result{RequeueAfter: resolveRequeueShort(runtime)}}, nil
 	}
 
 	ns := &corev1.Namespace{}
@@ -114,17 +125,17 @@ func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logge
 			setTenantProvisionedCondition(runtime, tenant, metav1.ConditionFalse, ReasonTenantProvisioningBlocked, message)
 			runtime.emitTenantWarningEvent(tenant, ReasonTenantProvisioningBlocked, fmt.Sprintf("Tenant provisioning blocked because target namespace %s was not found", targetNS))
 			if patchErr := patchStatus(ctx, runtime.Client, tenant, original); patchErr != nil {
-				return recon.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", patchErr)
+				return TenantReconcileResult{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", patchErr)
 			}
 			logger.Info("Target namespace not found; will retry", "target_namespace", targetNS)
-			return recon.Result{RequeueAfter: resolveRequeueStandard(runtime)}, nil
+			return TenantReconcileResult{Result: recon.Result{RequeueAfter: resolveRequeueStandard(runtime)}}, nil
 		}
-		return recon.Result{}, fmt.Errorf("failed to get namespace %s: %w", targetNS, err)
+		return TenantReconcileResult{}, fmt.Errorf("failed to get namespace %s: %w", targetNS, err)
 	}
 
 	ready, result := ensureAdmissionDependenciesReady(ctx, logger, runtime, tenant)
 	if !ready {
-		return result, nil
+		return TenantReconcileResult{Result: result}, nil
 	}
 
 	logger.Info("Provisioning tenant RBAC", "target_namespace", targetNS)
@@ -135,9 +146,9 @@ func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logge
 		tenant.Status.LastError = err.Error()
 		setTenantProvisionedCondition(runtime, tenant, metav1.ConditionFalse, ReasonTenantProvisioningFailed, err.Error())
 		if statusErr := patchStatus(ctx, runtime.Client, tenant, original); statusErr != nil {
-			return recon.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w (original error: %w)", statusErr, err)
+			return TenantReconcileResult{}, fmt.Errorf("failed to update OpenBaoTenant status: %w (original error: %w)", statusErr, err)
 		}
-		return recon.Result{}, fmt.Errorf("failed to ensure tenant RBAC for namespace %s: %w", targetNS, err)
+		return TenantReconcileResult{}, fmt.Errorf("failed to ensure tenant RBAC for namespace %s: %w", targetNS, err)
 	}
 
 	original := tenant.DeepCopy()
@@ -151,7 +162,7 @@ func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logge
 		fmt.Sprintf("Tenant RBAC provisioned for namespace %s", targetNS),
 	)
 	if err := patchStatus(ctx, runtime.Client, tenant, original); err != nil {
-		return recon.Result{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", err)
+		return TenantReconcileResult{}, fmt.Errorf("failed to update OpenBaoTenant status: %w", err)
 	}
 
 	logger.Info("Successfully provisioned tenant RBAC", "target_namespace", targetNS)
@@ -161,7 +172,7 @@ func ReconcileOpenBaoTenant(ctx context.Context, key types.NamespacedName, logge
 		"target_namespace": targetNS,
 	})
 	runtime.emitTenantNormalEvent(tenant, ReasonTenantProvisioned, fmt.Sprintf("Provisioned tenant RBAC for namespace %s", targetNS))
-	return recon.Result{}, nil
+	return TenantReconcileResult{}, nil
 }
 
 func reconcileDeletion(

--- a/internal/app/provisioner/tenant_reconcile_test.go
+++ b/internal/app/provisioner/tenant_reconcile_test.go
@@ -163,7 +163,7 @@ func TestReconcileOpenBaoTenant_SecurityViolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != (recon.Result{}) {
+	if result.Result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
 	}
 
@@ -213,7 +213,7 @@ func TestReconcileOpenBaoTenant_FinalizerAndProvisioning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile 2: %v", err)
 	}
-	if result != (recon.Result{}) {
+	if result.Result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
 	}
 
@@ -354,7 +354,7 @@ func TestReconcileOpenBaoTenant_ProvisioningFailure(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "failed to ensure tenant RBAC") {
 		t.Fatalf("expected tenant RBAC provisioning error, got %v", err)
 	}
-	if result != (recon.Result{}) {
+	if result.Result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
 	}
 
@@ -433,7 +433,7 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if result != (recon.Result{}) {
+		if result.Result != (recon.Result{}) {
 			t.Fatalf("result=%v, want zero", result)
 		}
 
@@ -496,7 +496,7 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		if err == nil || !errors.Is(err, listErr) {
 			t.Fatalf("ReconcileOpenBaoTenant() error = %v, want tenant list error", err)
 		}
-		if result != (recon.Result{}) {
+		if result.Result != (recon.Result{}) {
 			t.Fatalf("result=%v, want zero", result)
 		}
 
@@ -532,7 +532,7 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		if err == nil || !errors.Is(err, cleanupErr) {
 			t.Fatalf("ReconcileOpenBaoTenant() error = %v, want cleanup error", err)
 		}
-		if result != (recon.Result{}) {
+		if result.Result != (recon.Result{}) {
 			t.Fatalf("result=%v, want zero", result)
 		}
 
@@ -569,7 +569,7 @@ func TestReconcileOpenBaoTenant_DeletionPaths(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReconcileOpenBaoTenant() error = %v", err)
 		}
-		if result != (recon.Result{}) {
+		if result.Result != (recon.Result{}) {
 			t.Fatalf("result=%v, want zero", result)
 		}
 		if getErr := runtime.Client.Get(context.Background(), req, &openbaov1alpha1.OpenBaoTenant{}); !apierrors.IsNotFound(getErr) {
@@ -760,7 +760,7 @@ func TestReconcileOpenBaoTenant_FinalizerRemoveFailureUsesMergePatchAndRetainsFi
 	if err == nil || !errors.Is(err, patchErr) {
 		t.Fatalf("ReconcileOpenBaoTenant() error = %v, want finalizer patch error", err)
 	}
-	if result != (recon.Result{}) {
+	if result.Result != (recon.Result{}) {
 		t.Fatalf("result=%v, want zero", result)
 	}
 	if updates != 0 {

--- a/internal/controller/openbaocluster/reconcile_metrics_test.go
+++ b/internal/controller/openbaocluster/reconcile_metrics_test.go
@@ -1,0 +1,168 @@
+package openbaocluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/observability"
+)
+
+func TestClusterReconcileMetrics_OwnerAbsent(t *testing.T) {
+	for _, controller := range []string{controllerNameWorkload, controllerNameAdminOps, controllerNameStatus} {
+		t.Run(controller, func(t *testing.T) {
+			key := client.ObjectKey{Namespace: "metrics", Name: t.Name()}
+			c := fake.NewClientBuilder().WithScheme(newOpenBaoClusterTestScheme(t)).Build()
+			parent := &OpenBaoClusterReconciler{Client: c, ControllerRuntime: ControllerRuntime{APIReader: c}}
+			r := metricTestClusterReconciler(parent, controller)
+			seedReconcileMetrics(t, key, controller)
+			for range 2 {
+				_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+				require.NoError(t, err)
+				require.Empty(t, reconcileMetricCounts(t, key, controller), "deferred observations must stay suppressed")
+			}
+		})
+	}
+}
+
+func TestClusterReconcileMetrics_DeletingOwner(t *testing.T) {
+	for _, controller := range []string{controllerNameWorkload, controllerNameAdminOps} {
+		for _, pending := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/pending=%t", controller, pending), func(t *testing.T) {
+				key := client.ObjectKey{Namespace: "metrics", Name: t.Name()}
+				cluster := deletingMetricsCluster(key, pending)
+				c := fake.NewClientBuilder().WithScheme(newOpenBaoClusterTestScheme(t)).WithObjects(cluster).Build()
+				parent := &OpenBaoClusterReconciler{Client: c, ControllerRuntime: ControllerRuntime{APIReader: c}}
+				seedReconcileMetrics(t, key, controller)
+				_, err := metricTestClusterReconciler(parent, controller).Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+				require.NoError(t, err)
+				counts := reconcileMetricCounts(t, key, controller)
+				if pending {
+					require.Equal(t, 2.0, counts["duration"])
+					require.Equal(t, 1.0, counts["FirstReason"])
+					require.Equal(t, 1.0, counts["SecondReason"])
+				} else {
+					require.Empty(t, counts)
+				}
+			})
+		}
+	}
+}
+
+func TestClusterReconcileMetrics_StatusFinalization(t *testing.T) {
+	for _, tc := range []struct {
+		name                                     string
+		alreadyFinalized, failPatch, childAbsent bool
+	}{
+		{name: "completed"},
+		{name: "already finalized", alreadyFinalized: true},
+		{name: "finalizer patch failed", failPatch: true},
+		{name: "child list not found", childAbsent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := client.ObjectKey{Namespace: "metrics", Name: t.Name()}
+			cluster := deletingMetricsCluster(key, !tc.alreadyFinalized)
+			cluster.Spec.DeletionPolicy = openbaov1alpha1.DeletionPolicyDeletePVCs
+			scheme := newOpenBaoClusterTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if tc.failPatch {
+							return fmt.Errorf("finalizer patch failed")
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+					List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if tc.childAbsent {
+							return apierrors.NewNotFound(schema.GroupResource{Resource: "persistentvolumeclaims"}, "child")
+						}
+						return c.List(ctx, list, opts...)
+					},
+				}).Build()
+			parent := &OpenBaoClusterReconciler{Client: c, Applications: newStatusTestApplications(c, scheme)}
+			seedReconcileMetrics(t, key, controllerNameStatus)
+			_, err := (&openBaoClusterStatusReconciler{parent: parent}).Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+			counts := reconcileMetricCounts(t, key, controllerNameStatus)
+			if tc.failPatch || tc.childAbsent {
+				require.Error(t, err)
+				require.Equal(t, 2.0, counts["duration"])
+				require.Equal(t, 1.0, counts["FirstReason"])
+				require.Equal(t, 1.0, counts["SecondReason"])
+			} else {
+				require.NoError(t, err)
+				require.Empty(t, counts)
+			}
+		})
+	}
+}
+
+func deletingMetricsCluster(key client.ObjectKey, pending bool) *openbaov1alpha1.OpenBaoCluster {
+	now := metav1.Now()
+	cluster := &openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{
+		Namespace: key.Namespace, Name: key.Name, DeletionTimestamp: &now,
+		Finalizers: []string{"test.example/retained"},
+	}}
+	if pending {
+		cluster.Finalizers = append(cluster.Finalizers, openbaov1alpha1.OpenBaoClusterFinalizer)
+	}
+	return cluster
+}
+
+func metricTestClusterReconciler(parent *OpenBaoClusterReconciler, controller string) reconcile.Reconciler {
+	switch controller {
+	case controllerNameWorkload:
+		return &openBaoClusterWorkloadReconciler{parent: parent}
+	case controllerNameAdminOps:
+		return &openBaoClusterAdminOpsReconciler{parent: parent}
+	default:
+		return &openBaoClusterStatusReconciler{parent: parent}
+	}
+}
+
+func reconcileMetricCounts(t *testing.T, key client.ObjectKey, controller string) map[string]float64 {
+	t.Helper()
+	families, err := controllermetrics.Registry.Gather()
+	require.NoError(t, err)
+	counts := make(map[string]float64)
+	for _, family := range families {
+		if family.GetName() != "openbao_reconcile_duration_seconds" && family.GetName() != "openbao_reconcile_errors_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["namespace"] != key.Namespace || labels["name"] != key.Name || labels["controller"] != controller {
+				continue
+			}
+			if family.GetName() == "openbao_reconcile_duration_seconds" {
+				counts["duration"] = float64(metric.GetHistogram().GetSampleCount())
+			} else {
+				counts[labels["reason"]] = metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return counts
+}
+
+func seedReconcileMetrics(t *testing.T, key client.ObjectKey, controller string) {
+	t.Helper()
+	m := observability.NewReconcileMetrics(key.Namespace, key.Name, controller)
+	t.Cleanup(m.Clear)
+	m.ObserveDuration(1)
+	m.IncrementError("FirstReason")
+	m.IncrementError("SecondReason")
+}

--- a/internal/controller/openbaocluster/setup_integration_test.go
+++ b/internal/controller/openbaocluster/setup_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -33,6 +34,7 @@ import (
 	appopenbaocluster "github.com/dc-tec/openbao-operator/internal/app/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/controller/openbaocluster"
 	"github.com/dc-tec/openbao-operator/internal/platform/constants"
+	"github.com/dc-tec/openbao-operator/internal/platform/observability"
 	portsecurity "github.com/dc-tec/openbao-operator/internal/port/security"
 )
 
@@ -140,6 +142,72 @@ func TestSetupWithManager_MultiTenantRecreatesDeletedChildrenOnPoll(t *testing.T
 		}
 		return current.UID != originalStatefulSetUID
 	}, 20*time.Second, 200*time.Millisecond, "expected multi-tenant polling to recreate deleted StatefulSet")
+}
+
+func TestSetupWithManager_RemovesReconcileMetricsAfterDeletion(t *testing.T) {
+	ctx := t.Context()
+	const namespace = "metric-cleanup-test"
+	controllers := []string{"openbaocluster-workload", "openbaocluster-adminops", "openbaocluster-status"}
+	liveClient := startOpenBaoClusterManager(t, namespace, true)
+	cluster := newManagerTestCluster(namespace, "metric-cleanup-cluster")
+	cluster.Spec.Paused = true
+	require.NoError(t, liveClient.Create(ctx, cluster))
+	key := client.ObjectKeyFromObject(cluster)
+	waitForClusterFinalizer(t, ctx, liveClient, cluster)
+	for _, controller := range controllers {
+		require.Eventually(t, func() bool {
+			return reconcileMetricCounts(t, key, controller)["duration"] > 0
+		}, 10*time.Second, 100*time.Millisecond, "expected initial reconcile for %s", controller)
+		observability.NewReconcileMetrics(namespace, cluster.Name, controller).IncrementError("BeforeDeletion")
+	}
+
+	require.NoError(t, liveClient.Delete(ctx, cluster))
+	waitForNotFound(t, ctx, liveClient, cluster)
+	for _, controller := range controllers {
+		require.Eventually(t, func() bool {
+			return len(reconcileMetricCounts(t, key, controller)) == 0
+		}, 10*time.Second, 100*time.Millisecond, "expected deletion watch to clear %s", controller)
+	}
+
+	recreated := newManagerTestCluster(namespace, cluster.Name)
+	recreated.Spec.Paused = true
+	require.NoError(t, liveClient.Create(ctx, recreated))
+	require.NotEqual(t, cluster.UID, recreated.UID)
+	t.Cleanup(func() { _ = liveClient.Delete(context.Background(), recreated) })
+	waitForClusterFinalizer(t, ctx, liveClient, recreated)
+	for _, controller := range controllers {
+		require.Eventually(t, func() bool {
+			return reconcileMetricCounts(t, key, controller)["duration"] > 0
+		}, 10*time.Second, 100*time.Millisecond, "expected metrics for recreated owner in %s", controller)
+		require.NotContains(t, reconcileMetricCounts(t, key, controller), "BeforeDeletion")
+	}
+}
+
+func reconcileMetricCounts(t *testing.T, key client.ObjectKey, controller string) map[string]float64 {
+	t.Helper()
+	families, err := controllermetrics.Registry.Gather()
+	require.NoError(t, err)
+	counts := make(map[string]float64)
+	for _, family := range families {
+		if family.GetName() != "openbao_reconcile_duration_seconds" && family.GetName() != "openbao_reconcile_errors_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["namespace"] != key.Namespace || labels["name"] != key.Name || labels["controller"] != controller {
+				continue
+			}
+			if family.GetName() == "openbao_reconcile_duration_seconds" {
+				counts["duration"] = float64(metric.GetHistogram().GetSampleCount())
+			} else {
+				counts[labels["reason"]] = metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return counts
 }
 
 func startOpenBaoClusterManager(t *testing.T, namespace string, singleTenant bool) client.Client {

--- a/internal/controller/openbaocluster/split_reconcilers.go
+++ b/internal/controller/openbaocluster/split_reconcilers.go
@@ -64,12 +64,17 @@ func (r *openBaoClusterWorkloadReconciler) Reconcile(ctx context.Context, req ct
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
 	if err := r.parent.Get(ctx, req.NamespacedName, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
+			reconcileMetrics.Clear()
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get OpenBaoCluster %s/%s: %w", req.Namespace, req.Name, err)
 	}
 
 	if shouldSkipWorkloadReconcile(cluster) {
+		if !cluster.DeletionTimestamp.IsZero() &&
+			!controllerutil.ContainsFinalizer(cluster, openbaov1alpha1.OpenBaoClusterFinalizer) {
+			reconcileMetrics.Clear()
+		}
 		return ctrl.Result{}, nil
 	}
 	if result, err, blocked := r.parent.pauseForTenantOnboarding(ctx, logger, controllerNameWorkload, cluster.Namespace); blocked {
@@ -150,12 +155,17 @@ func (r *openBaoClusterAdminOpsReconciler) Reconcile(ctx context.Context, req ct
 	}
 	if err := reader.Get(ctx, req.NamespacedName, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
+			reconcileMetrics.Clear()
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get OpenBaoCluster %s/%s: %w", req.Namespace, req.Name, err)
 	}
 
 	if !cluster.DeletionTimestamp.IsZero() || cluster.Spec.Paused || cluster.Spec.Profile == "" {
+		if !cluster.DeletionTimestamp.IsZero() &&
+			!controllerutil.ContainsFinalizer(cluster, openbaov1alpha1.OpenBaoClusterFinalizer) {
+			reconcileMetrics.Clear()
+		}
 		return ctrl.Result{}, nil
 	}
 	if result, err, blocked := r.parent.pauseForTenantOnboarding(ctx, logger, controllerNameAdminOps, cluster.Namespace); blocked {
@@ -201,6 +211,7 @@ func (r *openBaoClusterStatusReconciler) Reconcile(ctx context.Context, req ctrl
 	cluster := &openbaov1alpha1.OpenBaoCluster{}
 	if err := r.parent.Get(ctx, req.NamespacedName, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
+			reconcileMetrics.Clear()
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get OpenBaoCluster %s/%s: %w", req.Namespace, req.Name, err)
@@ -221,6 +232,7 @@ func (r *openBaoClusterStatusReconciler) Reconcile(ctx context.Context, req ctrl
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from OpenBaoCluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
 			}
 		}
+		reconcileMetrics.Clear()
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/openbaorestore/controller.go
+++ b/internal/controller/openbaorestore/controller.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
@@ -80,6 +81,7 @@ func (r *OpenBaoRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	restoreResource := &openbaov1alpha1.OpenBaoRestore{}
 	if getErr := r.Get(ctx, req.NamespacedName, restoreResource); getErr != nil {
 		if apierrors.IsNotFound(getErr) {
+			reconcileMetrics.Clear()
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get OpenBaoRestore before admission dependency check: %w", getErr)
@@ -106,6 +108,10 @@ func (r *OpenBaoRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		recordError(err)
 		return result, err
+	}
+	if !restoreResource.DeletionTimestamp.IsZero() &&
+		!controllerutil.ContainsFinalizer(restoreResource, openbaov1alpha1.OpenBaoRestoreFinalizer) {
+		reconcileMetrics.Clear()
 	}
 
 	return result, nil

--- a/internal/controller/openbaorestore/reconcile_metrics_test.go
+++ b/internal/controller/openbaorestore/reconcile_metrics_test.go
@@ -1,0 +1,124 @@
+package openbaorestore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	"github.com/dc-tec/openbao-operator/internal/platform/observability"
+	recon "github.com/dc-tec/openbao-operator/internal/platform/reconcile"
+)
+
+func TestRestoreReconcileMetrics_Lifecycle(t *testing.T) {
+	t.Setenv("OPENBAO_UNSAFE_ADMISSION_DISABLED", "true")
+	for _, tc := range []struct {
+		name                                     string
+		absent, deleting, removeFinalizer, clear bool
+		result                                   recon.Result
+		err                                      error
+	}{
+		{name: "owner absent", absent: true, clear: true},
+		{name: "completed finalization", deleting: true, removeFinalizer: true, clear: true},
+		{name: "committed execution draining", deleting: true, result: recon.Result{RequeueAfter: time.Second}},
+		{name: "finalizer patch failed", deleting: true, removeFinalizer: true, err: fmt.Errorf("patch failed")},
+		{name: "child Job not found", deleting: true, err: apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "child")},
+		{name: "target cluster not found", err: apierrors.NewNotFound(schema.GroupResource{Resource: "openbaoclusters"}, "target")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := client.ObjectKey{Namespace: "metrics", Name: t.Name()}
+			scheme := runtime.NewScheme()
+			require.NoError(t, openbaov1alpha1.AddToScheme(scheme))
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if !tc.absent {
+				restore := &openbaov1alpha1.OpenBaoRestore{ObjectMeta: metav1.ObjectMeta{
+					Namespace: key.Namespace, Name: key.Name,
+					Finalizers: []string{openbaov1alpha1.OpenBaoRestoreFinalizer},
+				}, Spec: openbaov1alpha1.OpenBaoRestoreSpec{Cluster: "target"}}
+				if tc.deleting {
+					now := metav1.Now()
+					restore.DeletionTimestamp = &now
+				}
+				builder.WithObjects(restore)
+			}
+			r := &OpenBaoRestoreReconciler{
+				Client:            builder.Build(),
+				RestoreReconciler: metricRestoreReconciler{removeFinalizer: tc.removeFinalizer, result: tc.result, err: tc.err},
+			}
+			seedReconcileMetrics(t, key, controllerNameOpenBaoRestore)
+			result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+			require.ErrorIs(t, err, tc.err)
+			require.Equal(t, tc.result.RequeueAfter, result.RequeueAfter)
+			counts := reconcileMetricCounts(t, key, controllerNameOpenBaoRestore)
+			if tc.clear {
+				require.Empty(t, counts)
+			} else {
+				require.Equal(t, 2.0, counts["duration"])
+				require.Equal(t, 1.0, counts["FirstReason"])
+				require.Equal(t, 1.0, counts["SecondReason"])
+			}
+		})
+	}
+}
+
+type metricRestoreReconciler struct {
+	removeFinalizer bool
+	result          recon.Result
+	err             error
+}
+
+func (r metricRestoreReconciler) Reconcile(_ context.Context, _ logr.Logger, restore *openbaov1alpha1.OpenBaoRestore) (recon.Result, error) {
+	if r.removeFinalizer {
+		controllerutil.RemoveFinalizer(restore, openbaov1alpha1.OpenBaoRestoreFinalizer)
+	}
+	return r.result, r.err
+}
+
+func reconcileMetricCounts(t *testing.T, key client.ObjectKey, controller string) map[string]float64 {
+	t.Helper()
+	families, err := controllermetrics.Registry.Gather()
+	require.NoError(t, err)
+	counts := make(map[string]float64)
+	for _, family := range families {
+		if family.GetName() != "openbao_reconcile_duration_seconds" && family.GetName() != "openbao_reconcile_errors_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["namespace"] != key.Namespace || labels["name"] != key.Name || labels["controller"] != controller {
+				continue
+			}
+			if family.GetName() == "openbao_reconcile_duration_seconds" {
+				counts["duration"] = float64(metric.GetHistogram().GetSampleCount())
+			} else {
+				counts[labels["reason"]] = metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return counts
+}
+
+func seedReconcileMetrics(t *testing.T, key client.ObjectKey, controller string) {
+	t.Helper()
+	m := observability.NewReconcileMetrics(key.Namespace, key.Name, controller)
+	t.Cleanup(m.Clear)
+	m.ObserveDuration(1)
+	m.IncrementError("FirstReason")
+	m.IncrementError("SecondReason")
+}

--- a/internal/controller/provisioner/controller.go
+++ b/internal/controller/provisioner/controller.go
@@ -89,10 +89,12 @@ func (r *NamespaceProvisionerReconciler) Reconcile(ctx context.Context, req ctrl
 	)
 
 	appResult, appErr := appprovisioner.ReconcileOpenBaoTenant(ctx, req.NamespacedName, logger, r.tenantRuntime())
-	result = controllerResult(appResult)
+	result = controllerResult(appResult.Result)
 	err = appErr
 	if err != nil {
 		recordError(err)
+	} else if appResult.OwnerAbsent || appResult.FinalizationCompleted {
+		reconcileMetrics.Clear()
 	}
 
 	return result, err

--- a/internal/controller/provisioner/reconcile_metrics_test.go
+++ b/internal/controller/provisioner/reconcile_metrics_test.go
@@ -1,0 +1,147 @@
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
+	appprovisioner "github.com/dc-tec/openbao-operator/internal/app/provisioner"
+	"github.com/dc-tec/openbao-operator/internal/platform/observability"
+)
+
+func TestProvisionerReconcileMetrics_Lifecycle(t *testing.T) {
+	for _, tc := range []struct {
+		name                                                                                string
+		absent, deleting, alreadyFinalized, clusterRemaining, failPatch, childAbsent, clear bool
+	}{
+		{name: "owner absent", absent: true, clear: true},
+		{name: "target namespace absent"},
+		{name: "finalization completed", deleting: true, clear: true},
+		{name: "already finalized", deleting: true, alreadyFinalized: true, clear: true},
+		{name: "waiting for cluster deletion", deleting: true, clusterRemaining: true},
+		{name: "finalizer patch failed", deleting: true, failPatch: true},
+		{name: "child cleanup not found", deleting: true, childAbsent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := client.ObjectKey{Namespace: "metrics", Name: t.Name()}
+			const targetNamespace = "target"
+			ownerReads := 0
+			builder := fake.NewClientBuilder().WithScheme(testScheme).
+				WithStatusSubresource(&openbaov1alpha1.OpenBaoTenant{}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*openbaov1alpha1.OpenBaoTenant); ok {
+							ownerReads++
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if tc.failPatch {
+							return fmt.Errorf("finalizer patch failed")
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				})
+			if !tc.absent {
+				tenant := &openbaov1alpha1.OpenBaoTenant{ObjectMeta: metav1.ObjectMeta{
+					Namespace: key.Namespace, Name: key.Name, Finalizers: []string{"test.example/retained"},
+				}, Spec: openbaov1alpha1.OpenBaoTenantSpec{TargetNamespace: targetNamespace}}
+				if !tc.alreadyFinalized {
+					tenant.Finalizers = append(tenant.Finalizers, openbaov1alpha1.OpenBaoTenantFinalizer)
+				}
+				if tc.deleting {
+					now := metav1.Now()
+					tenant.DeletionTimestamp = &now
+				}
+				builder.WithObjects(tenant)
+			}
+			if tc.clusterRemaining {
+				builder.WithObjects(&openbaov1alpha1.OpenBaoCluster{ObjectMeta: metav1.ObjectMeta{Namespace: targetNamespace, Name: "cluster"}})
+			}
+			c := builder.Build()
+			service := metricProvisioner{Provisioner: newProvisionerManager(t, c)}
+			if tc.childAbsent {
+				service.cleanupError = apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "child")
+			}
+			r := &NamespaceProvisionerReconciler{Client: c, APIReader: c, Provisioner: service, OperatorNamespace: key.Namespace}
+			seedReconcileMetrics(t, key, controllerNameNamespaceProvisioner)
+			result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+			if tc.failPatch || tc.childAbsent {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, 1, ownerReads, "metric cleanup must reuse the existing tenant read")
+			counts := reconcileMetricCounts(t, key, controllerNameNamespaceProvisioner)
+			if tc.clear {
+				require.Empty(t, counts)
+			} else {
+				require.Equal(t, 2.0, counts["duration"])
+				require.Equal(t, 1.0, counts["FirstReason"])
+				require.Equal(t, 1.0, counts["SecondReason"])
+			}
+			if tc.clusterRemaining || !tc.absent && !tc.deleting {
+				require.Positive(t, result.RequeueAfter)
+			}
+		})
+	}
+}
+
+type metricProvisioner struct {
+	appprovisioner.Provisioner
+	cleanupError error
+}
+
+func (p metricProvisioner) CleanupTenantResources(ctx context.Context, namespace string) error {
+	if p.cleanupError != nil {
+		return p.cleanupError
+	}
+	return p.Provisioner.CleanupTenantResources(ctx, namespace)
+}
+
+func reconcileMetricCounts(t *testing.T, key client.ObjectKey, controller string) map[string]float64 {
+	t.Helper()
+	families, err := controllermetrics.Registry.Gather()
+	require.NoError(t, err)
+	counts := make(map[string]float64)
+	for _, family := range families {
+		if family.GetName() != "openbao_reconcile_duration_seconds" && family.GetName() != "openbao_reconcile_errors_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["namespace"] != key.Namespace || labels["name"] != key.Name || labels["controller"] != controller {
+				continue
+			}
+			if family.GetName() == "openbao_reconcile_duration_seconds" {
+				counts["duration"] = float64(metric.GetHistogram().GetSampleCount())
+			} else {
+				counts[labels["reason"]] = metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return counts
+}
+
+func seedReconcileMetrics(t *testing.T, key client.ObjectKey, controller string) {
+	t.Helper()
+	m := observability.NewReconcileMetrics(key.Namespace, key.Name, controller)
+	t.Cleanup(m.Clear)
+	m.ObserveDuration(1)
+	m.IncrementError("FirstReason")
+	m.IncrementError("SecondReason")
+}

--- a/internal/platform/observability/metrics.go
+++ b/internal/platform/observability/metrics.go
@@ -157,12 +157,13 @@ func init() {
 	)
 }
 
-// ReconcileMetrics provides helpers to record reconcile-level metrics for a
-// specific controller and OpenBaoCluster.
+// ReconcileMetrics records metrics for one reconciliation of a controller's
+// resource. Create a new helper for each reconciliation.
 type ReconcileMetrics struct {
 	namespace  string
 	name       string
 	controller string
+	cleared    bool
 }
 
 // NewReconcileMetrics creates a new ReconcileMetrics instance.
@@ -176,6 +177,9 @@ func NewReconcileMetrics(namespace, name, controller string) *ReconcileMetrics {
 
 // ObserveDuration records the duration of a reconcile loop in seconds.
 func (m *ReconcileMetrics) ObserveDuration(durationSeconds float64) {
+	if m.cleared {
+		return
+	}
 	reconcileDurationHistogram.
 		WithLabelValues(m.namespace, m.name, m.controller).
 		Observe(durationSeconds)
@@ -184,9 +188,27 @@ func (m *ReconcileMetrics) ObserveDuration(durationSeconds float64) {
 // IncrementError increments the reconcile error counter with the given reason.
 // Reason values should be low-cardinality strings (for example, "KubernetesAPIError").
 func (m *ReconcileMetrics) IncrementError(reason string) {
+	if m.cleared {
+		return
+	}
 	reconcileErrorsTotal.
 		WithLabelValues(m.namespace, m.name, m.controller, reason).
 		Inc()
+}
+
+// Clear removes this controller's metrics for an absent or finalized resource.
+// Further observations through this helper are ignored, including deferred ones.
+func (m *ReconcileMetrics) Clear() {
+	if m.cleared {
+		return
+	}
+	m.cleared = true
+	reconcileDurationHistogram.DeleteLabelValues(m.namespace, m.name, m.controller)
+	reconcileErrorsTotal.DeletePartialMatch(prometheus.Labels{
+		"namespace":  m.namespace,
+		"name":       m.name,
+		"controller": m.controller,
+	})
 }
 
 // ClusterMetrics provides helpers to record per-cluster state metrics.

--- a/internal/platform/observability/metrics_test.go
+++ b/internal/platform/observability/metrics_test.go
@@ -6,19 +6,83 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	openbaov1alpha1 "github.com/dc-tec/openbao-operator/api/v1alpha1"
 )
 
-func TestReconcileMetrics_NoPanic(t *testing.T) {
-	m := NewReconcileMetrics("ns", "name", "ctrl")
+func TestReconcileMetrics_Clear(t *testing.T) {
+	for _, tc := range []struct {
+		name, namespace, resource, controller string
+	}{
+		{name: "other namespace", namespace: "other", resource: "cluster", controller: "workload"},
+		{name: "other resource", namespace: "ns", resource: "other", controller: "workload"},
+		{name: "other controller", namespace: "ns", resource: "cluster", controller: "restore"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewReconcileMetrics("ns", "cluster", "workload")
+			other := NewReconcileMetrics(tc.namespace, tc.resource, tc.controller)
+			t.Cleanup(m.Clear)
+			t.Cleanup(other.Clear)
+			for _, helper := range []*ReconcileMetrics{m, other} {
+				helper.ObserveDuration(0.5)
+				helper.ObserveDuration(1)
+				helper.IncrementError("FirstReason")
+				helper.IncrementError("SecondReason")
+			}
+			before := gatherReconcileSeries(t, m)
+			require.Len(t, before["openbao_reconcile_errors_total"], 2)
+			histogram := before["openbao_reconcile_duration_seconds"][0].GetHistogram()
+			require.Equal(t, uint64(2), histogram.GetSampleCount())
+			require.Equal(t, 1.5, histogram.GetSampleSum())
+			require.NotEmpty(t, histogram.GetBucket())
+			otherBefore := gatherReconcileSeries(t, other)
 
-	// These calls should not panic and will register/update metrics for the
-	// given label set.
-	m.ObserveDuration(0.5)
-	m.ObserveDuration(1.0)
-	m.IncrementError("Error")
+			func() {
+				defer m.ObserveDuration(2)
+				defer m.IncrementError("DeferredError")
+				m.Clear()
+				m.Clear()
+			}()
+			require.Empty(t, gatherReconcileSeries(t, m))
+			require.Equal(t, otherBefore, gatherReconcileSeries(t, other))
+
+			// A replacement observed after cleanup starts with fresh counters.
+			recreated := NewReconcileMetrics("ns", "cluster", "workload")
+			t.Cleanup(recreated.Clear)
+			recreated.ObserveDuration(3)
+			recreated.IncrementError("FirstReason")
+			m.Clear()
+			m.ObserveDuration(4)
+			m.IncrementError("LateError")
+			after := gatherReconcileSeries(t, recreated)
+			require.Len(t, after["openbao_reconcile_errors_total"], 1)
+			require.Equal(t, 1.0, after["openbao_reconcile_errors_total"][0].GetCounter().GetValue())
+			require.Equal(t, uint64(1), after["openbao_reconcile_duration_seconds"][0].GetHistogram().GetSampleCount())
+		})
+	}
+}
+
+func gatherReconcileSeries(t *testing.T, m *ReconcileMetrics) map[string][]*dto.Metric {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(reconcileDurationHistogram, reconcileErrorsTotal)
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	result := make(map[string][]*dto.Metric)
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["namespace"] == m.namespace && labels["name"] == m.name && labels["controller"] == m.controller {
+				result[family.GetName()] = append(result[family.GetName()], metric)
+			}
+		}
+	}
+	return result
 }
 
 func TestClusterMetrics_SetPhase(t *testing.T) {


### PR DESCRIPTION
## Summary

Reconciliation duration and error series remain registered after their owning resources disappear. Clear the exact namespace/name/controller label owner after observed absence or completed finalization, and suppress further observations through that reconciliation's helper so deferred calls cannot recreate removed series.

Apply cleanup to workload, AdminOps, status, restore, and tenant provisioning. The Provisioner reports owner absence and completed finalization through a small domain result using its existing resource read.

## Related Issues

Repository review follow-up; no tracking issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Metric names and labels are preserved. Blocked or failed finalization retains metrics, and missing child resources do not imply owner deletion. Cleanup is scoped to reconciliation duration/error collectors; backup, restore, and upgrade outcome collectors are unchanged. No API, CRD, Helm, or RBAC changes are required.

## Verification

- Five focused Go packages and focused lint passed on Go 1.26.6.
- Gathered metrics tests cover exact owner isolation, all error reasons, deferred calls, idempotence, blocked finalization, and missing-child errors.
- A real manager envtest passed deletion through finalization/watch handling and same-name recreation with a new UID across all three cluster controllers.
- The original cluster-controller wiring reproduced stale-series regressions through a Go source overlay.
- Architecture checks, 65 AST tests, tagged vet, and the normal commit hook passed.
- `devenv test`, `operator:bootstrap`, `operator:doctor`, and the full `operator:ci-core` passed on the combined tree, identical to the stack top. Internal coverage: 70.91%; all 34 fuzz targets passed.

## Reviewer Notes

Second layer, based on `fix/manager-readiness`. Rapid replacement without an observed deletion/absence is outside this cleanup contract. User-facing metric names and configuration do not change, so no documentation or generated-artifact updates are needed.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
