### PR TITLE
docs(tenancy): clarify namespace Pod Security label ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Start with:
 
 Install the operator from our OCI registry.
 
+If your platform manages or restricts namespace Pod Security labels, configure
+[external label ownership](https://dc-tec.github.io/openbao-operator/docs/get-started/install/#choose-namespace-pod-security-label-ownership)
+before onboarding tenants. This requires `tenancy.namespacePodSecurityLabels.mode=external` in the operator's Helm values.
+
 ```bash
 # 1. Create namespace
 kubectl create namespace openbao-operator-system

--- a/website/content-versions/next/docs/get-started/install.md
+++ b/website/content-versions/next/docs/get-started/install.md
@@ -8,6 +8,10 @@ verifiedBy:
   - .github/workflows/publish-edge.yml
   - hack/ci/generate-channel-manifests.sh
   - charts/openbao-operator/values.yaml
+  - charts/openbao-operator/templates/provisioner/deployment.yaml
+  - charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
+  - charts/openbao-operator/templates/admission/provisioner-namespace-mutations.yaml
+  - internal/service/provisioner/manager_tenant.go
   - config/default/kustomization.yaml
   - cmd/controller/startup_helpers.go
 ---
@@ -27,6 +31,32 @@ and a pinned release for production. OpenBao Operator 0.5.0 is the current stabl
 - Install `kubectl`. Source deployments also require the repository toolchain and a registry the cluster can pull
   from.
 - Decide the tenancy model. Use the [single-tenant procedure](../single-tenant/) for one watched namespace.
+
+## Choose namespace Pod Security label ownership
+
+In multi-tenant mode, the Provisioner sets the namespace labels `pod-security.kubernetes.io/enforce`,
+`pod-security.kubernetes.io/audit`, and `pod-security.kubernetes.io/warn` to `restricted` by default.
+
+If a platform controller owns these labels or an admission policy restricts their updates, configure external
+ownership before onboarding a namespace. Add this fragment to the operator's Helm values file:
+
+```yaml
+tenancy:
+  namespacePodSecurityLabels:
+    mode: external
+```
+
+This setting applies to all tenant namespaces served by the installation; it is not an `OpenBaoTenant` field.
+The chart removes namespace update and patch permissions from the Provisioner and configures admission to deny its
+namespace updates. Existing labels remain unchanged. The platform team must apply the required Pod Security policy.
+The operator still manages tenant RBAC, Secret allowlists, ResourceQuota, and LimitRange.
+
+Rancher is one example: its webhook requires separate authorization to update Pod Security labels. See
+[Rancher's namespace admission guidance](https://ranchermanager.docs.rancher.com/reference-guides/rancher-webhook#application-fails-to-deploy-due-to-rancher-webhook-blocking-access).
+Other platform controllers and admission policies can impose similar restrictions.
+
+The generated edge installer and default source deployment use `enforce` mode. Helm values do not configure those
+manifests. Use the [local Helm rendering path](#render-the-local-helm-contract) to evaluate external label ownership.
 
 ## Install the latest validated edge build
 
@@ -115,9 +145,13 @@ Use a source deployment when you need a local change or an exact checkout that h
 Use the checked-out chart when you need to evaluate Helm rendering, including the single-tenant or OpenShift paths.
 The edge image and operator version keep helper-image selection aligned with the unreleased build.
 
+Save any overrides in `operator-values.yaml`, including [label ownership](#choose-namespace-pod-security-label-ownership)
+when required. If you do not need overrides, create an empty file with `touch operator-values.yaml`.
+
 {{< command label="inspect" title="Render the local edge chart" >}}
 helm template openbao-operator charts/openbao-operator \
   --namespace openbao-operator-system \
+  --values operator-values.yaml \
   --include-crds \
   --set image.tag=edge \
   --set operatorVersion=edge
@@ -165,6 +199,7 @@ kubectl delete -f "${EDGE_ROOT}/install.yaml"
 | Symptom | Check |
 | --- | --- |
 | Controller starts but Provisioner is absent | Confirm that you did not render `tenancy.mode=single` |
+| Tenant provisioning fails on a namespace label update | Inspect the tenant error and [configure label ownership](#choose-namespace-pod-security-label-ownership) if the platform restricts Pod Security label updates |
 | Pods cannot pull the source image | Push it to a cluster-reachable registry or load it into every local node |
 | Pods run but admission rejects ordinary resources | Inspect policy bindings, rendered identity variables, and API-server ValidatingAdmissionPolicy support |
 | Custom names break reconciliation | Compare every ServiceAccount, RoleBinding subject, admission variable, and JWT bound subject |

--- a/website/content-versions/next/docs/get-started/onboard-namespace.md
+++ b/website/content-versions/next/docs/get-started/onboard-namespace.md
@@ -20,6 +20,12 @@ create the namespace or an `OpenBaoCluster`.
 Skip this page only when the operator uses the verified [single-tenant mode](../single-tenant/).
 Review [tenant boundaries](../../security/tenant-boundaries/) when you need the authority model behind this handoff.
 
+{{< callout type="note" title="Check namespace Pod Security label ownership first" >}}
+If your platform manages or restricts Pod Security labels, ask the operator administrator to configure
+[`tenancy.namespacePodSecurityLabels.mode=external`](../install/#choose-namespace-pod-security-label-ownership)
+before you create `OpenBaoTenant`. This operator-wide Helm setting leaves label management to the platform.
+{{< /callout >}}
+
 ## Choose the onboarding owner
 
 | Model | Where to create `OpenBaoTenant` | Allowed customization |
@@ -114,9 +120,6 @@ The default per-container LimitRange is:
 | CPU | 100m | 500m |
 | Memory | 128Mi | 512Mi |
 
-Set `tenancy.namespacePodSecurityLabels.mode=external` when another platform controller owns the Pod Security labels.
-This delegates only label mutation; the operator still manages tenant RBAC, Secret allowlists, quota, and LimitRange.
-
 ## Apply tenant and cluster together
 
 GitOps can apply `OpenBaoTenant` and `OpenBaoCluster` in one synchronization. The cluster controller pauses until
@@ -130,9 +133,21 @@ failure. Watching the tenant status first still gives the clearest rollout signa
 | Security violation | A self-service request targets another namespace | `metadata.namespace` and `spec.targetNamespace` |
 | `status.provisioned` stays false with namespace-not-found | The target namespace does not exist | Namespace name and platform provisioning |
 | Cluster keeps waiting after the tenant is true | The handoff RoleBinding is absent or wrong | `openbao-operator-tenant-rolebinding` and its subject |
-| Namespace label update is unauthorized | Another policy layer owns labels | Set Pod Security label mode to `external` after review |
+| Namespace label update is unauthorized | A platform controller or admission policy restricts Pod Security label updates | Inspect `status.lastError` and follow [external label ownership configuration](../install/#choose-namespace-pod-security-label-ownership) |
 | Custom quota is ignored | The request used self-service | Create the request in the operator namespace through the platform path |
 | Admission dependency errors | Required policies or bindings are not ready | Operator installation and admission-policy status |
+
+For a rejected label update, inspect the tenant's error and conditions:
+
+{{< command label="inspect" title="Inspect tenant provisioning errors" >}}
+kubectl -n <request-namespace> get openbaotenant <name> -o yaml
+{{< /command >}}
+
+If the error identifies a platform restriction on Pod Security label updates, ask the operator administrator to
+re-render the installation with `tenancy.namespacePodSecurityLabels.mode=external` and apply the updated resources.
+Preserve the installation's other values and keep the required namespace policy under platform control. After the
+Provisioner restarts, repeat the tenant verification step above. The `Provisioned` condition must become `True`;
+inspect its message if it remains `False`.
 
 ## Remove or retarget a tenant
 

--- a/website/content/docs/get-started/install.md
+++ b/website/content/docs/get-started/install.md
@@ -8,7 +8,9 @@ verifiedBy:
   - charts/openbao-operator/values.yaml
   - charts/openbao-operator/templates/controller/deployment.yaml
   - charts/openbao-operator/templates/provisioner/deployment.yaml
+  - charts/openbao-operator/templates/rbac/provisioner-clusterroles.yaml
   - charts/openbao-operator/templates/admission
+  - internal/service/provisioner/manager_tenant.go
   - config/default/kustomization.yaml
   - config/overlays/custom-identity/kustomization.yaml
   - internal/adapter/config/builder.go
@@ -38,6 +40,32 @@ The core procedure uses Helm in the chart's default multi-tenant mode.
 | OpenShift | Helm with `platform=openshift`, or auto-detection | SCC-compatible workload security context |
 | Local development | Source deployment | Development image and generated resources |
 
+## Choose namespace Pod Security label ownership
+
+In multi-tenant mode, the Provisioner sets the namespace labels `pod-security.kubernetes.io/enforce`,
+`pod-security.kubernetes.io/audit`, and `pod-security.kubernetes.io/warn` to `restricted` by default.
+
+If a platform controller owns these labels or an admission policy restricts their updates, configure external
+ownership before onboarding a namespace. Add this fragment to the operator's Helm values file:
+
+```yaml
+tenancy:
+  namespacePodSecurityLabels:
+    mode: external
+```
+
+This setting applies to all tenant namespaces served by the installation; it is not an `OpenBaoTenant` field.
+The chart removes namespace update and patch permissions from the Provisioner and configures admission to deny its
+namespace updates. Existing labels remain unchanged. The platform team must apply the required Pod Security policy.
+The operator still manages tenant RBAC, Secret allowlists, ResourceQuota, and LimitRange.
+
+Rancher is one example: its webhook requires separate authorization to update Pod Security labels. See
+[Rancher's namespace admission guidance](https://ranchermanager.docs.rancher.com/reference-guides/rancher-webhook#application-fails-to-deploy-due-to-rancher-webhook-blocking-access).
+Other platform controllers and admission policies can impose similar restrictions.
+
+Use the Helm procedure below when you need this setting. The published `install.yaml` uses the default `enforce` mode;
+Helm values do not configure that manifest.
+
 ## Install with Helm
 
 1. Set the release values.
@@ -60,30 +88,40 @@ The core procedure uses Helm in the chart's default multi-tenant mode.
    controlled prerelease or test. The complete pinned reference is
    [`values.yaml`](https://github.com/dc-tec/openbao-operator/blob/0.5.0/charts/openbao-operator/values.yaml).
 
-3. Render the installation before applying it when you use non-default values.
+3. Save your overrides in `operator-values.yaml`, including external label ownership when required.
+
+   If you do not need overrides, create an empty values file:
+
+   {{< command label="configure" title="Prepare the operator values file" >}}
+   touch operator-values.yaml
+   {{< /command >}}
+
+4. Render the installation with the values file.
 
    {{< command label="inspect" title="Render the Helm release" >}}
    helm template "${OPERATOR_RELEASE}" \
      oci://ghcr.io/dc-tec/charts/openbao-operator \
      --version "${CHART_VERSION}" \
-     --namespace "${OPERATOR_NAMESPACE}"
+     --namespace "${OPERATOR_NAMESPACE}" \
+     --values operator-values.yaml
    {{< /command >}}
 
    Check the controller and Provisioner ServiceAccounts, RoleBinding subjects, admission-policy identity variables,
    projected token audience, images, and namespaces.
 
-4. Install the chart.
+5. Install the chart with the same values file.
 
    {{< command label="apply" title="Install OpenBao Operator" >}}
    helm upgrade --install "${OPERATOR_RELEASE}" \
      oci://ghcr.io/dc-tec/charts/openbao-operator \
      --version "${CHART_VERSION}" \
      --namespace "${OPERATOR_NAMESPACE}" \
+     --values operator-values.yaml \
      --create-namespace \
      --wait
    {{< /command >}}
 
-5. Wait for both multi-tenant Deployments.
+6. Wait for both multi-tenant Deployments.
 
    {{< command label="verify" title="Verify the controller and Provisioner" >}}
    kubectl -n "${OPERATOR_NAMESPACE}" rollout status \
@@ -92,7 +130,7 @@ The core procedure uses Helm in the chart's default multi-tenant mode.
      deployment/openbao-operator-provisioner --timeout=2m
    {{< /command >}}
 
-6. Verify the installed APIs and admission policies.
+7. Verify the installed APIs and admission policies.
 
    {{< command label="verify" title="Verify cluster-scoped resources" >}}
    kubectl get crd \
@@ -103,7 +141,7 @@ The core procedure uses Helm in the chart's default multi-tenant mode.
      -l app.kubernetes.io/instance="${OPERATOR_RELEASE}"
    {{< /command >}}
 
-7. Verify the default controller JWT contract.
+8. Verify the default controller JWT contract.
 
    {{< command label="inspect" title="Inspect the controller identity and audience" >}}
    kubectl -n "${OPERATOR_NAMESPACE}" get serviceaccount \
@@ -217,6 +255,7 @@ separate CRD-deletion operation.
 | Symptom | Check |
 | --- | --- |
 | Controller starts but Provisioner is absent | Confirm that the chart did not render `tenancy.mode=single` |
+| Tenant provisioning fails on a namespace label update | Inspect the tenant error and [configure label ownership](#choose-namespace-pod-security-label-ownership) if the platform restricts Pod Security label updates |
 | Pods run but admission rejects ordinary resources | Inspect policy bindings, rendered identity variables, and the API server's ValidatingAdmissionPolicy support |
 | Custom names break reconciliation | Compare every ServiceAccount, RoleBinding subject, admission variable, and JWT bound subject |
 | OpenShift rejects Pod identity fields | Confirm auto-detection or set `platform=openshift`, then review SCC ownership |

--- a/website/content/docs/get-started/onboard-namespace.md
+++ b/website/content/docs/get-started/onboard-namespace.md
@@ -20,6 +20,12 @@ create the namespace or an `OpenBaoCluster`.
 Skip this page only when the operator uses the verified [single-tenant mode](../single-tenant/).
 Review [tenant boundaries](../../security/tenant-boundaries/) when you need the authority model behind this handoff.
 
+{{< callout type="note" title="Check namespace Pod Security label ownership first" >}}
+If your platform manages or restricts Pod Security labels, ask the operator administrator to configure
+[`tenancy.namespacePodSecurityLabels.mode=external`](../install/#choose-namespace-pod-security-label-ownership)
+before you create `OpenBaoTenant`. This operator-wide Helm setting leaves label management to the platform.
+{{< /callout >}}
+
 ## Choose the onboarding owner
 
 | Model | Where to create `OpenBaoTenant` | Allowed customization |
@@ -114,9 +120,6 @@ The default per-container LimitRange is:
 | CPU | 100m | 500m |
 | Memory | 128Mi | 512Mi |
 
-Set `tenancy.namespacePodSecurityLabels.mode=external` when another platform controller owns the Pod Security labels.
-This delegates only label mutation; the operator still manages tenant RBAC, Secret allowlists, quota, and LimitRange.
-
 ## Apply tenant and cluster together
 
 GitOps can apply `OpenBaoTenant` and `OpenBaoCluster` in one synchronization. The cluster controller pauses until
@@ -130,9 +133,20 @@ failure. Watching the tenant status first still gives the clearest rollout signa
 | Security violation | A self-service request targets another namespace | `metadata.namespace` and `spec.targetNamespace` |
 | `status.provisioned` stays false with namespace-not-found | The target namespace does not exist | Namespace name and platform provisioning |
 | Cluster keeps waiting after the tenant is true | The handoff RoleBinding is absent or wrong | `openbao-operator-tenant-rolebinding` and its subject |
-| Namespace label update is unauthorized | Another policy layer owns labels | Set Pod Security label mode to `external` after review |
+| Namespace label update is unauthorized | A platform controller or admission policy restricts Pod Security label updates | Inspect `status.lastError` and follow [external label ownership configuration](../install/#choose-namespace-pod-security-label-ownership) |
 | Custom quota is ignored | The request used self-service | Create the request in the operator namespace through the platform path |
 | Admission dependency errors | Required policies or bindings are not ready | Operator installation and admission-policy status |
+
+For a rejected label update, inspect the tenant's error and conditions:
+
+{{< command label="inspect" title="Inspect tenant provisioning errors" >}}
+kubectl -n <request-namespace> get openbaotenant <name> -o yaml
+{{< /command >}}
+
+If the error identifies a platform restriction on Pod Security label updates, ask the operator administrator to update
+the Helm release with `tenancy.namespacePodSecurityLabels.mode=external`. Preserve the installation's other values and
+keep the required namespace policy under platform control. After the Provisioner restarts, repeat the tenant
+verification step above. The `Provisioned` condition must become `True`; inspect its message if it remains `False`.
 
 ## Remove or retarget a tenant
 


### PR DESCRIPTION
## Summary

Platforms that manage or restrict namespace Pod Security labels can reject the Provisioner's default label updates. The installation guide now explains how to configure external label ownership before onboarding a tenant, with Rancher as one example.

Update the stable and next installation and onboarding guides, add actionable troubleshooting, and link the guidance from the README. Helm examples pass the same values file to rendering and installation. The guides explain the operator-wide scope, platform policy ownership, and the defaults in prebuilt manifests.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [ ] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Documentation only; no API, CRD, chart, RBAC, or runtime changes. The documented external mode already exists in 0.5.0. The platform remains responsible for Pod Security policy, and existing namespace labels remain unchanged.

## Verification

- `devenv shell make docs-build`: passed API reference checks, strict Hugo build, redirect validation, and rendered-site checks across 843 HTML files.
- Rendered the documented values fragment against the published 0.5.0 chart and the current chart. Verified external mode, read-only namespace RBAC, and admission denial of Provisioner namespace mutations.
- Confirmed that an empty values file renders successfully with chart defaults.
- `git diff --check`: passed.
- Repository pre-commit and pre-push hooks passed, including `make lint-ci`.

No new tests or cluster test runs are needed for these documentation-only changes. No live platform deployment was performed.

## Reviewer Notes

Review the ownership decision before installation and onboarding, and the distinct stable Helm and next edge/source paths. The guidance applies to platforms that manage or restrict Pod Security label updates.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
