### PR TITLE
ci(helm): fix edge chart verification after digest pulls

### DIFF
--- a/hack/ci/publish-edge-chart.sh
+++ b/hack/ci/publish-edge-chart.sh
@@ -46,6 +46,16 @@ fi
 chart_digest="$(docker buildx imagetools inspect "${chart_ref}:${CHART_VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
 [[ "${chart_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'invalid chart digest' >&2; exit 1; }
 # Check that the OCI artifact contains the verified package, including after a first publication.
-helm pull "oci://${chart_ref}@${chart_digest}" --destination "${work_dir}"
-cmp "${chart_package}" "${work_dir}/${chart_name}"
+# Isolate the digest pull so a prior version pull cannot satisfy the comparison.
+digest_dir="${work_dir}/digest"
+mkdir "${digest_dir}"
+helm pull "oci://${chart_ref}@${chart_digest}" --destination "${digest_dir}"
+# Helm derives the archive filename from the digest reference, not the chart version.
+shopt -s nullglob
+digest_archives=("${digest_dir}"/*.tgz)
+if [[ "${#digest_archives[@]}" -ne 1 ]]; then
+  echo "expected exactly one chart archive from digest pull, found ${#digest_archives[@]}" >&2
+  exit 1
+fi
+cmp "${chart_package}" "${digest_archives[0]}"
 echo "chart_digest=${chart_digest}" >> "${GITHUB_OUTPUT}"

--- a/hack/ci/test-publish-edge-chart.sh
+++ b/hack/ci/test-publish-edge-chart.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 printf 'helm %s\n' "$*" >> "${TEST_LOG}"
 case "$1" in
   pull)
+    reference="$2"
     if [[ "${TEST_PULL_FAILURE:-}" != "" ]]; then
       echo "${TEST_PULL_FAILURE}" >&2
       exit 1
@@ -26,8 +27,24 @@ case "$1" in
       echo 'chart: not found' >&2
       exit 1
     fi
+    filename="$(basename "${TEST_PACKAGE}")"
+    if [[ "${reference}" == *@sha256:* ]]; then
+      # Helm derives the archive filename from the OCI reference, including its digest.
+      filename="${reference##*/}"
+      filename="${filename%:*}-${filename##*:}.tgz"
+    fi
     while [[ "$1" != --destination ]]; do shift; done
-    cp "${TEST_REGISTRY}" "$2/$(basename "${TEST_PACKAGE}")"
+    if [[ "${reference}" == *@sha256:* ]]; then
+      case "${TEST_DIGEST_PULL_RESULT:-valid}" in
+        missing) exit 0 ;;
+        multiple) cp "${TEST_REGISTRY}" "$2/extra.tgz" ;;
+        different)
+          printf 'different digest archive\n' > "$2/${filename}"
+          exit 0
+          ;;
+      esac
+    fi
+    cp "${TEST_REGISTRY}" "$2/${filename}"
     ;;
   push)
     [[ "$3" == oci://ghcr.io/dc-tec/charts-edge ]]
@@ -60,6 +77,26 @@ if grep -Eq 'helm push|docker buildx imagetools create' "${TEST_LOG}"; then
   echo 'publisher rerun mutated an existing candidate' >&2
   exit 1
 fi
+
+# A successful version pull must not mask a missing, ambiguous, or mismatched digest archive.
+for result in missing multiple different; do
+  : > "${GITHUB_OUTPUT}"
+  : > "${TEST_LOG}"
+  if TEST_DIGEST_PULL_RESULT="${result}" bash "${ROOT_DIR}/hack/ci/publish-edge-chart.sh" >"${work_dir}/publish.err" 2>&1; then
+    echo "publisher accepted a ${result} digest archive on rerun" >&2
+    exit 1
+  fi
+  case "${result}" in
+    missing) grep -q 'expected exactly one chart archive from digest pull, found 0' "${work_dir}/publish.err" ;;
+    multiple) grep -q 'expected exactly one chart archive from digest pull, found 2' "${work_dir}/publish.err" ;;
+    different) grep -q 'differ' "${work_dir}/publish.err" ;;
+  esac
+  test ! -s "${GITHUB_OUTPUT}"
+  if grep -Eq 'helm push|docker buildx imagetools create' "${TEST_LOG}"; then
+    echo 'failed publisher rerun mutated an existing candidate' >&2
+    exit 1
+  fi
+done
 
 if CHART_VERSION=0.5.0 bash "${ROOT_DIR}/hack/ci/publish-edge-chart.sh" >/dev/null 2>&1; then
   echo 'publisher accepted a release chart version' >&2


### PR DESCRIPTION
## Summary

Fix the edge publisher failure after a successful Helm OCI push. Helm names digest-pulled archives from the digest reference, while the publisher expected a version-based filename. Pull into a separate directory, require exactly one chart archive, and compare that archive with the verified CI package.

Update the Helm mock to reproduce digest-based filenames. Cover fresh publication, repeat publication, and reruns with missing, extra, or mismatched digest archives so a prior version pull cannot mask a failed comparison.

## Related Issues

Follow-up to #735. Diagnosed from [failed edge publication run 34475719642](https://github.com/dc-tec/openbao-operator/actions/runs/34475719642/job/102865883629).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code improvement/cleanup)
- [x] CI, release, or build tooling
- [ ] Other maintenance

## Risk and Compatibility

Limited to edge chart publication and its tests. Chart contents, versions, registry destinations, signatures, and installed operator behavior are unchanged. The publisher emits a chart digest only after the downloaded archive matches the verified package.

## Verification

- Confirmed the updated mock reproduces the original CI failure before applying the fix.
- `make verify-edge-chart` passed, including packaging reproducibility, rendering, publication guards, and the new regression cases.
- `make verify-workflows` passed.
- `shellcheck hack/ci/publish-edge-chart.sh hack/ci/test-publish-edge-chart.sh` passed.
- `bash -n hack/ci/publish-edge-chart.sh hack/ci/test-publish-edge-chart.sh` and `git diff --check` passed.
- Ran the fixed publisher with Helm v4.2.3 against the original CI candidate bundle and the existing GHCR chart. The digest pull matched the candidate byte-for-byte. Registry writes were disabled for this check.

The full Devenv baseline was not rerun locally for this two-file shell change. Focused publisher and workflow checks cover the changed behavior; required hosted CI must pass before merge.

## Reviewer Notes

The digest pull must use its own directory. Reusing the version-pull directory can make reruns compare a stale version-named archive. The fresh-publication path is covered by the mock; the existing-chart path also passed the live read-only check. Hosted publication will exercise the fix after merge.

Documentation and generated artifacts do not need changes because the publication contract and chart contents are unchanged. No dependent changes are outstanding.

## Checklist

- [x] My code follows the [project style guide](https://dc-tec.github.io/openbao-operator/contribute/standards/).
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests, or explained why tests are not needed.
- [x] I have updated documentation, or explained why docs are not needed.
- [x] I have updated generated artifacts, or confirmed none are affected.
- [x] I have checked that this change does not log or expose secrets, tokens, credentials, keys, or raw Secret data.
- [x] I have run the relevant local checks, or documented why they were not run.
- [x] Any dependent changes have been merged, published, or clearly called out.
