### PR TITLE
perf(raft): avoid redundant Autopilot configuration writes

### DIFF
--- a/internal/adapter/openbao/client_autopilot_test.go
+++ b/internal/adapter/openbao/client_autopilot_test.go
@@ -1,0 +1,53 @@
+package openbao
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientReadRaftAutopilotConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		status    int
+		body      string
+		wantError string
+	}{
+		{"configuration", http.StatusOK, `{"data":{"cleanup_dead_servers":true,"min_quorum":3,"max_trailing_logs":1000,"last_contact_threshold":"10s","server_stabilization_time":"10s","dead_server_last_contact_threshold":"5m0s"}}`, ""},
+		{"missing data", http.StatusOK, `{}`, "missing data"},
+		{"null data", http.StatusOK, `{"data":null}`, "missing data"},
+		{"malformed JSON", http.StatusOK, `{`, "failed to parse"},
+		{"wrong type", http.StatusOK, `{"data":{"min_quorum":"three"}}`, "failed to parse"},
+		{"forbidden", http.StatusForbidden, `{"errors":["permission denied"]}`, "autopilot config read request failed"},
+		{"not found", http.StatusNotFound, `{}`, "autopilot config read request failed"},
+		{"sealed", http.StatusServiceUnavailable, `{}`, "transient remote overloaded"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			handlerErrors := newHTTPHandlerErrors(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != apiPathRaftAutopilotConfig || r.Header.Get("X-Vault-Token") != "test-token" {
+					handlerErrors.Errorf("unexpected authenticated config read: %s %s", r.Method, r.URL.Path)
+				}
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+			c, err := NewClient(ClientConfig{BaseURL: server.URL, Token: "test-token"})
+			require.NoError(t, err)
+			config, err := c.ReadRaftAutopilotConfig(t.Context())
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				if tt.status != http.StatusOK && tt.status != http.StatusServiceUnavailable {
+					assertStatusCode(t, err, tt.status)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, config.CleanupDeadServers)
+			require.Equal(t, 3, config.MinQuorum)
+			require.Equal(t, "5m0s", config.DeadServerLastContactThreshold)
+		})
+	}
+}

--- a/internal/adapter/openbao/client_raft.go
+++ b/internal/adapter/openbao/client_raft.go
@@ -164,6 +164,37 @@ func (c *Client) ReadRaftAutopilotState(ctx context.Context) (*portopenbao.RaftA
 	return &envelope.RaftAutopilotStateResponse, nil
 }
 
+// ReadRaftAutopilotConfig reads the effective Raft Autopilot configuration.
+func (c *Client) ReadRaftAutopilotConfig(ctx context.Context) (*portopenbao.AutopilotConfig, error) {
+	if err := c.requireAuth("raft autopilot configuration read"); err != nil {
+		return nil, err
+	}
+	req, err := c.newRequest(ctx, http.MethodGet, apiPathRaftAutopilotConfig, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create autopilot config read request: %w", err)
+	}
+	if err := c.authorize(req); err != nil {
+		return nil, fmt.Errorf("failed to authorize autopilot config read request: %w", err)
+	}
+	statusCode, body, err := c.doAndReadAll(req, nil, "failed to execute autopilot config read request")
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, portopenbao.NewAPIError("autopilot config read request failed", statusCode, body)
+	}
+	var envelope struct {
+		Data *portopenbao.AutopilotConfig `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to parse autopilot config response: %w", err)
+	}
+	if envelope.Data == nil {
+		return nil, fmt.Errorf("autopilot config response is missing data")
+	}
+	return envelope.Data, nil
+}
+
 // ConfigureRaftAutopilot sets the Raft Autopilot configuration.
 func (c *Client) ConfigureRaftAutopilot(ctx context.Context, config portopenbao.AutopilotConfig) error {
 	if err := c.requireAuth("raft autopilot configuration"); err != nil {

--- a/internal/adapter/raft/autopilot.go
+++ b/internal/adapter/raft/autopilot.go
@@ -30,6 +30,7 @@ const (
 
 type Client interface {
 	portopenbao.AutopilotConfigurer
+	ReadRaftAutopilotConfig(ctx context.Context) (*portopenbao.AutopilotConfig, error)
 	ReadRaftConfiguration(ctx context.Context) (*portopenbao.RaftConfigurationResponse, error)
 	ReadRaftAutopilotState(ctx context.Context) (*portopenbao.RaftAutopilotStateResponse, error)
 	RemoveRaftPeer(ctx context.Context, serverID string) error
@@ -130,26 +131,7 @@ func (m *Manager) ReconcileAutopilotConfig(ctx context.Context, logger logr.Logg
 		}
 	}
 
-	logger.V(1).Info("Reconciling Raft Autopilot configuration",
-		"cluster", cluster.Name,
-		"cleanup_dead_servers", desiredConfig.CleanupDeadServers,
-		"dead_server_last_contact_threshold", desiredConfig.DeadServerLastContactThreshold,
-		"min_quorum", desiredConfig.MinQuorum,
-		"server_stabilization_time", desiredConfig.ServerStabilizationTime,
-	)
-
-	autopilotCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	if err := client.ConfigureRaftAutopilot(autopilotCtx, desiredConfig); err != nil {
-		logger.V(1).Info("Raft Autopilot configuration not ready; will retry on next reconcile", "error", err)
-		return operatorerrors.WrapTransientConnection(
-			fmt.Errorf("failed to configure Raft Autopilot: %w", err),
-		)
-	}
-
-	logger.V(1).Info("Raft Autopilot configuration reconciled successfully")
-	return nil
+	return m.configureAutopilotWithClient(ctx, logger, client, cluster)
 }
 
 // PrepareScaleDown stages a single safe scale-down step by reconciling the
@@ -391,6 +373,19 @@ func (m *Manager) configureAutopilotWithClient(ctx context.Context, logger logr.
 
 	autopilotCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
+
+	currentConfig, err := client.ReadRaftAutopilotConfig(autopilotCtx)
+	if err != nil {
+		return operatorerrors.WrapTransientConnection(
+			fmt.Errorf("failed to read Raft Autopilot configuration: %w", err),
+		)
+	}
+	if currentConfig == nil {
+		return operatorerrors.WrapTransientConnection(fmt.Errorf("raft Autopilot configuration is missing"))
+	}
+	if desiredConfig.Matches(*currentConfig) {
+		return nil
+	}
 
 	if err := client.ConfigureRaftAutopilot(autopilotCtx, desiredConfig); err != nil {
 		logger.V(1).Info("Raft Autopilot configuration not ready; will retry on next reconcile", "error", err)

--- a/internal/adapter/raft/autopilot_runtime_test.go
+++ b/internal/adapter/raft/autopilot_runtime_test.go
@@ -311,21 +311,31 @@ func TestReconcileAutopilotConfig_EarlyBranches(t *testing.T) {
 }
 
 type fakeScaleDownClient struct {
-	calls          []string
-	configureCalls []portopenbao.AutopilotConfig
-	configureErr   error
-	raftConfig     *portopenbao.RaftConfigurationResponse
-	autopilotState *portopenbao.RaftAutopilotStateResponse
-	readErr        error
-	removeCalls    []string
-	removeErr      error
-	stepDownCalls  int
-	stepDownErr    error
+	calls            []string
+	configureCalls   []portopenbao.AutopilotConfig
+	configureErr     error
+	autopilotConfig  portopenbao.AutopilotConfig
+	autopilotReadErr error
+	raftConfig       *portopenbao.RaftConfigurationResponse
+	autopilotState   *portopenbao.RaftAutopilotStateResponse
+	readErr          error
+	removeCalls      []string
+	removeErr        error
+	stepDownCalls    int
+	stepDownErr      error
+}
+
+func (c *fakeScaleDownClient) ReadRaftAutopilotConfig(context.Context) (*portopenbao.AutopilotConfig, error) {
+	c.calls = append(c.calls, "read-autopilot")
+	return &c.autopilotConfig, c.autopilotReadErr
 }
 
 func (c *fakeScaleDownClient) ConfigureRaftAutopilot(_ context.Context, config portopenbao.AutopilotConfig) error {
 	c.calls = append(c.calls, "configure")
 	c.configureCalls = append(c.configureCalls, config)
+	if c.configureErr == nil {
+		c.autopilotConfig = config
+	}
 	return c.configureErr
 }
 
@@ -455,7 +465,7 @@ func TestPrepareScaleDown_RemovesFollowerAndUpdatesAutopilot(t *testing.T) {
 	if provider.tlsServerName != "openbao-cluster-cluster.local" {
 		t.Fatalf("tlsServerName = %q, want openbao-cluster-cluster.local", provider.tlsServerName)
 	}
-	if want := []string{"configure", "read", "remove:cluster-2"}; !slices.Equal(client.calls, want) {
+	if want := []string{"read-autopilot", "configure", "read", "remove:cluster-2"}; !slices.Equal(client.calls, want) {
 		t.Fatalf("calls = %v, want %v", client.calls, want)
 	}
 }
@@ -509,7 +519,7 @@ func TestPrepareScaleDown_StepsDownLeaderVictim(t *testing.T) {
 	if operatorerrors.IsTransient(err) || operatorerrors.IsPermanent(err) {
 		t.Fatalf("leader wait error gained a classification: %v", err)
 	}
-	if want := []string{"configure", "read", "step-down"}; !slices.Equal(client.calls, want) {
+	if want := []string{"read-autopilot", "configure", "read", "step-down"}; !slices.Equal(client.calls, want) {
 		t.Fatalf("calls = %v, want %v", client.calls, want)
 	}
 }
@@ -595,27 +605,27 @@ func TestPrepareScaleDown_OperationResults(t *testing.T) {
 	}{
 		{
 			name: "configure failure stops before membership read", client: &fakeScaleDownClient{configureErr: failure, raftConfig: follower},
-			wantCalls: []string{"configure"}, wantError: "transient connection error: failed to configure Raft Autopilot: injected failure",
+			wantCalls: []string{"read-autopilot", "configure"}, wantError: "transient connection error: failed to configure Raft Autopilot: injected failure",
 			wantClass: operatorerrors.ErrTransientConnection, wantCause: failure,
 		},
 		{
 			name: "membership failure stops before removal", client: &fakeScaleDownClient{readErr: failure, raftConfig: follower},
-			wantCalls: []string{"configure", "read"}, wantError: "failed to read Raft configuration before scale down: injected failure", wantCause: failure,
+			wantCalls: []string{"read-autopilot", "configure", "read"}, wantError: "failed to read Raft configuration before scale down: injected failure", wantCause: failure,
 		},
 		{
 			name: "step-down failure never removes peer", client: &fakeScaleDownClient{raftConfig: leader, stepDownErr: failure},
-			wantCalls: []string{"configure", "read", "step-down"}, wantError: "failed to step down leader cluster-2 before scale down: injected failure", wantCause: failure,
+			wantCalls: []string{"read-autopilot", "configure", "read", "step-down"}, wantError: "failed to step down leader cluster-2 before scale down: injected failure", wantCause: failure,
 		},
 		{
 			name: "successful step-down waits without removal", client: &fakeScaleDownClient{raftConfig: leader},
-			wantCalls: []string{"configure", "read", "step-down"}, wantError: "waiting for leader step-down on cluster-2 to complete",
+			wantCalls: []string{"read-autopilot", "configure", "read", "step-down"}, wantError: "waiting for leader step-down on cluster-2 to complete",
 		},
 		{
 			name: "removal failure preserves server id", client: &fakeScaleDownClient{raftConfig: follower, removeErr: failure},
-			wantCalls: []string{"configure", "read", "remove:peer-id"}, wantError: `failed to remove Raft peer "peer-id" before scale down: injected failure`, wantCause: failure,
+			wantCalls: []string{"read-autopilot", "configure", "read", "remove:peer-id"}, wantError: `failed to remove Raft peer "peer-id" before scale down: injected failure`, wantCause: failure,
 		},
-		{name: "nil membership still configures autopilot", client: &fakeScaleDownClient{}, wantCalls: []string{"configure", "read"}},
-		{name: "absent peer still configures autopilot", client: &fakeScaleDownClient{raftConfig: &portopenbao.RaftConfigurationResponse{}}, wantCalls: []string{"configure", "read"}},
+		{name: "nil membership still configures autopilot", client: &fakeScaleDownClient{}, wantCalls: []string{"read-autopilot", "configure", "read"}},
+		{name: "absent peer still configures autopilot", client: &fakeScaleDownClient{raftConfig: &portopenbao.RaftConfigurationResponse{}}, wantCalls: []string{"read-autopilot", "configure", "read"}},
 		{
 			name: "read replica membership failure", readReplica: true, client: &fakeScaleDownClient{raftConfig: nonvoter, readErr: failure},
 			wantCalls: []string{"read"}, wantError: "failed to read Raft configuration before read-replica scale down: injected failure", wantCause: failure,
@@ -713,7 +723,11 @@ func TestAutopilotConfiguration_ErrorClassification(t *testing.T) {
 			if operatorerrors.IsTransient(err) != !initial || operatorerrors.IsPermanent(err) {
 				t.Errorf("unexpected error classification: %v", err)
 			}
-			if want := []string{"configure"}; !slices.Equal(client.calls, want) {
+			want := []string{"configure"}
+			if !initial {
+				want = append([]string{"read-autopilot"}, want...)
+			}
+			if !slices.Equal(client.calls, want) {
 				t.Errorf("calls = %v, want %v", client.calls, want)
 			}
 		})
@@ -768,5 +782,82 @@ func TestWrapScaleDownPermissionError_SelfInitClusterRequiresUpdatedPolicy(t *te
 	}
 	if !strings.Contains(err.Error(), "remove-peer") {
 		t.Fatalf("expected permission guidance, got %v", err)
+	}
+}
+
+func TestAutopilotReconcileReadsBeforeWriting(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		scaleDown   bool
+		drift       bool
+		readFailure bool
+	}{
+		{name: "steady reconciliation"},
+		{name: "reconciliation repairs drift", drift: true},
+		{name: "reconciliation read failure", readFailure: true},
+		{name: "scale down already configured", scaleDown: true},
+		{name: "scale down configuration drift", scaleDown: true, drift: true},
+		{name: "scale down read failure", scaleDown: true, readFailure: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &fakeScaleDownClient{}
+			mgr, cluster := newMaintenanceTestManager(c)
+			target := cluster.DeepCopy()
+			if tt.scaleDown {
+				target.Spec.Replicas = 2
+			}
+			c.autopilotConfig = portopenbao.BuildAutopilotConfig(target)
+			c.autopilotConfig.DeadServerLastContactThreshold = "300s"
+			if tt.drift {
+				c.autopilotConfig.MinQuorum++
+			}
+			failure := errors.New("config read failed")
+			if tt.readFailure {
+				c.autopilotReadErr = failure
+			}
+			var err error
+			if tt.scaleDown {
+				err = mgr.PrepareScaleDown(t.Context(), logr.Discard(), cluster, "cluster", 3, 2)
+			} else {
+				err = mgr.ReconcileAutopilotConfig(t.Context(), logr.Discard(), cluster)
+			}
+			want := []string{"read-autopilot"}
+			if tt.readFailure {
+				if !errors.Is(err, failure) || !operatorerrors.IsTransient(err) {
+					t.Fatalf("expected transient read failure, got %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if tt.drift {
+					want = append(want, "configure")
+				}
+				if tt.scaleDown {
+					want = append(want, "read")
+				}
+			}
+			if !slices.Equal(c.calls, want) {
+				t.Fatalf("calls = %v, want %v", c.calls, want)
+			}
+			if !tt.readFailure {
+				c.calls = nil
+				if tt.scaleDown {
+					err = mgr.PrepareScaleDown(t.Context(), logr.Discard(), cluster, "cluster", 3, 2)
+				} else {
+					err = mgr.ReconcileAutopilotConfig(t.Context(), logr.Discard(), cluster)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				want = []string{"read-autopilot"}
+				if tt.scaleDown {
+					want = append(want, "read")
+				}
+				if !slices.Equal(c.calls, want) {
+					t.Fatalf("repeat calls = %v, want %v", c.calls, want)
+				}
+			}
+		})
 	}
 }

--- a/internal/port/openbao/autopilot.go
+++ b/internal/port/openbao/autopilot.go
@@ -3,6 +3,9 @@ package openbao
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // AutopilotConfig represents the configuration for Raft Autopilot.
@@ -13,6 +16,45 @@ type AutopilotConfig struct {
 	LastContactThreshold           string `json:"last_contact_threshold,omitempty"`
 	MaxTrailingLogs                int    `json:"max_trailing_logs,omitempty"`
 	ServerStabilizationTime        string `json:"server_stabilization_time,omitempty"`
+}
+
+// Matches reports whether current agrees with the fields sent by the desired
+// configuration. Zero integers and empty durations retain their omitempty meaning.
+func (desired AutopilotConfig) Matches(current AutopilotConfig) bool {
+	return desired.CleanupDeadServers == current.CleanupDeadServers &&
+		(desired.MinQuorum == 0 || desired.MinQuorum == current.MinQuorum) &&
+		(desired.MaxTrailingLogs == 0 || desired.MaxTrailingLogs == current.MaxTrailingLogs) &&
+		managedDurationMatches(desired.DeadServerLastContactThreshold, current.DeadServerLastContactThreshold) &&
+		managedDurationMatches(desired.LastContactThreshold, current.LastContactThreshold) &&
+		managedDurationMatches(desired.ServerStabilizationTime, current.ServerStabilizationTime)
+}
+
+func managedDurationMatches(desired, current string) bool {
+	if desired == "" {
+		return true
+	}
+	desiredDuration, valid := parseAutopilotDuration(desired)
+	currentDuration, currentErr := time.ParseDuration(current)
+	// OpenBao's TypeDurationSecond fields truncate the supplied duration to seconds.
+	return valid && currentErr == nil && desiredDuration.Truncate(time.Second) == currentDuration
+}
+
+// OpenBao accepts Go durations, integer seconds, and integer days.
+func parseAutopilotDuration(value string) (time.Duration, bool) {
+	unit := time.Second
+	number := value
+	if strings.HasSuffix(value, "d") {
+		unit = 24 * time.Hour
+		number = strings.TrimSuffix(value, "d")
+	}
+	if n, err := strconv.ParseInt(number, 10, 64); err == nil {
+		if n < 0 || n > int64((1<<63-1)/unit) {
+			return 0, false
+		}
+		return time.Duration(n) * unit, true
+	}
+	duration, err := time.ParseDuration(value)
+	return duration, err == nil && duration >= 0
 }
 
 // AutopilotConfigurer configures Raft Autopilot state on an authenticated OpenBao client.

--- a/internal/port/openbao/autopilot_test.go
+++ b/internal/port/openbao/autopilot_test.go
@@ -1,0 +1,57 @@
+package openbao
+
+import "testing"
+
+func TestAutopilotConfigMatches(t *testing.T) {
+	const invalidDuration = "bad"
+	base := AutopilotConfig{
+		CleanupDeadServers: true, MinQuorum: 3, MaxTrailingLogs: 1000,
+		DeadServerLastContactThreshold: "5m", LastContactThreshold: "10s", ServerStabilizationTime: "10s",
+	}
+	for _, tt := range []struct {
+		name   string
+		change func(*AutopilotConfig, *AutopilotConfig)
+		want   bool
+	}{
+		{"unchanged", func(_, _ *AutopilotConfig) {}, true},
+		{"equivalent durations", func(_, c *AutopilotConfig) {
+			c.DeadServerLastContactThreshold = "300s"
+			c.LastContactThreshold = "10000ms"
+			c.ServerStabilizationTime = "0m10s"
+		}, true},
+		{"integer seconds", func(d, _ *AutopilotConfig) { d.LastContactThreshold = "10" }, true},
+		{"integer days", func(d, c *AutopilotConfig) {
+			d.DeadServerLastContactThreshold = "1d"
+			c.DeadServerLastContactThreshold = "24h0m0s"
+		}, true},
+		{"fractional seconds truncate", func(d, _ *AutopilotConfig) { d.LastContactThreshold = "10999ms" }, true},
+		{"observed fractional seconds are drift", func(_, c *AutopilotConfig) { c.LastContactThreshold = "10.5s" }, false},
+		{"negative duration", func(d, c *AutopilotConfig) { d.LastContactThreshold = "-10s"; c.LastContactThreshold = "-10s" }, false},
+		{"overflow seconds", func(d, _ *AutopilotConfig) { d.LastContactThreshold = "9223372036854775807" }, false},
+		{"overflow days", func(d, _ *AutopilotConfig) { d.LastContactThreshold = "106752d" }, false},
+		{"fractional days unsupported", func(d, _ *AutopilotConfig) { d.LastContactThreshold = "0.5d" }, false},
+		{"cleanup false is managed", func(d, _ *AutopilotConfig) { d.CleanupDeadServers = false }, false},
+		{"minimum quorum drift", func(_, c *AutopilotConfig) { c.MinQuorum = 5 }, false},
+		{"trailing logs drift", func(_, c *AutopilotConfig) { c.MaxTrailingLogs++ }, false},
+		{"dead server threshold drift", func(_, c *AutopilotConfig) { c.DeadServerLastContactThreshold = "6m" }, false},
+		{"last contact drift", func(_, c *AutopilotConfig) { c.LastContactThreshold = "11s" }, false},
+		{"stabilization drift", func(_, c *AutopilotConfig) { c.ServerStabilizationTime = "11s" }, false},
+		{"omitted fields", func(d, _ *AutopilotConfig) { *d = AutopilotConfig{CleanupDeadServers: true} }, true},
+		{"zero duration is managed", func(d, _ *AutopilotConfig) { d.LastContactThreshold = "0s" }, false},
+		{"equivalent zero durations", func(d, c *AutopilotConfig) { d.LastContactThreshold = "0s"; c.LastContactThreshold = "0" }, true},
+		{"malformed desired", func(d, c *AutopilotConfig) {
+			d.LastContactThreshold = invalidDuration
+			c.LastContactThreshold = invalidDuration
+		}, false},
+		{"malformed observed", func(_, c *AutopilotConfig) { c.LastContactThreshold = invalidDuration }, false},
+		{"missing observed duration", func(_, c *AutopilotConfig) { c.LastContactThreshold = "" }, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			desired, current := base, base
+			tt.change(&desired, &current)
+			if got := desired.Matches(current); got != tt.want {
+				t.Errorf("Matches() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Stable day-2 checks currently submit Autopilot configuration and cause redundant OpenBao storage writes. Read the current configuration and write only when managed fields differ. Stable checks use one GET; changed configuration uses GET followed by POST.

## Related Issues

None.

## Type of Change

- [x] Refactor (code improvement/cleanup)

## Risk and Compatibility

Keep the one-minute reconciliation cadence, omitted-field semantics, equivalent duration handling, and scale-down ordering. Configuration read failures stop the operation before membership changes. Initial post-bootstrap configuration retains its existing write path. No API, CRD, Helm, or RBAC changes.

## Verification

- `go test -race -count=1 ./internal/port/openbao ./internal/adapter/openbao ./internal/adapter/raft`
- Tests cover unchanged and changed fields, duration conversion, omitted values, read/write failures, and scale-down ordering.
- Stack-wide local validation passed: `make test-ci` (4,053 tests, four existing skips, 74.75% internal coverage), lint, 34 fuzz targets, OpenBao compatibility, docs, and Helm checks. Branch-specific race tests passed after splitting the stack. Subsequent rebases change only the unrelated Helm-publication base.

## Reviewer Notes

Layer 1 of 3. The next layers add Kubernetes request attribution and reuse APPLY responses. No cache or polling-interval change is included.

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests.
- [x] Documentation is updated where needed; internal optimizations retain the existing operator contract.
- [x] No generated artifacts are affected.
- [x] This change does not expose secrets or credentials.
- [x] Relevant local checks pass.
- [x] Stack dependencies are called out above.
