### PR TITLE
chore(observability): attribute Kubernetes client requests

### DIFF
--- a/internal/platform/entrypoint/config.go
+++ b/internal/platform/entrypoint/config.go
@@ -8,6 +8,8 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/observability"
 )
 
 // UsageError identifies invalid command-line or environment configuration.
@@ -21,7 +23,12 @@ func (e *UsageError) Unwrap() error { return e.Err }
 // LoadConfig preserves controller-runtime's configuration precedence without
 // reading the kubeconfig flag registered on the global command line.
 func LoadConfig(kubeconfig string) (*rest.Config, error) {
-	return loadConfig(kubeconfig, rest.InClusterConfig, clientcmd.NewDefaultClientConfigLoadingRules)
+	config, err := loadConfig(kubeconfig, rest.InClusterConfig, clientcmd.NewDefaultClientConfigLoadingRules)
+	if err != nil {
+		return nil, err
+	}
+	config.Wrap(observability.WrapKubernetesTransport)
+	return config, nil
 }
 
 func loadConfig(

--- a/internal/platform/observability/kubernetes.go
+++ b/internal/platform/observability/kubernetes.go
@@ -1,0 +1,106 @@
+package observability
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const kubeLabelOther = "other"
+
+var kubeClientRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "openbao_kube_client_requests_total",
+	Help: "Kubernetes HTTP requests by operation, resource, subresource, and result; excludes cache hits.",
+}, []string{"verb", "resource", "subresource", "result"})
+
+func init() {
+	metrics.Registry.MustRegister(kubeClientRequestsTotal)
+}
+
+// WrapKubernetesTransport attributes actual HTTP attempts, including retries.
+// Labels exclude object names, namespaces, URLs, and error text.
+func WrapKubernetesTransport(next http.RoundTripper) http.RoundTripper {
+	return &kubernetesTransport{next: next}
+}
+
+type kubernetesTransport struct{ next http.RoundTripper }
+
+func (t *kubernetesTransport) WrappedRoundTripper() http.RoundTripper { return t.next }
+
+func (t *kubernetesTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	verb, resource, subresource := kubernetesRequestLabels(req)
+	response, err := t.next.RoundTrip(req)
+	result := "error"
+	if err == nil && response != nil {
+		switch {
+		case response.StatusCode >= 200 && response.StatusCode < 300:
+			result = "success"
+		case response.StatusCode == http.StatusConflict:
+			result = "conflict"
+		case response.StatusCode == http.StatusNotFound:
+			result = "not_found"
+		case response.StatusCode == http.StatusForbidden:
+			result = "forbidden"
+		}
+	}
+	kubeClientRequestsTotal.WithLabelValues(verb, resource, subresource, result).Inc()
+	return response, err
+}
+
+func kubernetesRequestLabels(req *http.Request) (verb, resource, subresource string) {
+	verb, resource, subresource = kubeLabelOther, kubeLabelOther, "none"
+	parts := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api":
+		parts = parts[2:]
+	case len(parts) >= 4 && parts[0] == "apis":
+		parts = parts[3:]
+	default:
+		return verb, resource, subresource
+	}
+	if len(parts) >= 3 && parts[0] == "namespaces" && parts[2] != "status" && parts[2] != "finalize" {
+		parts = parts[2:]
+	}
+	switch parts[0] {
+	case "configmaps", "secrets", "services", "serviceaccounts", "pods", "persistentvolumeclaims",
+		"namespaces", "nodes", "events", "endpointslices", "statefulsets", "deployments", "replicasets", "jobs", "cronjobs",
+		"leases", "roles", "rolebindings", "clusterroles", "clusterrolebindings", "networkpolicies",
+		"poddisruptionbudgets", "ingresses", "gateways", "httproutes", "tlsroutes", "backendtlspolicies", "referencegrants",
+		"servicemonitors", "podmonitors", "openbaoclusters", "openbaotenants", "openbaorestores",
+		"validatingadmissionpolicies", "validatingadmissionpolicybindings", "customresourcedefinitions":
+		resource = parts[0]
+	}
+	if len(parts) > 2 {
+		switch parts[2] {
+		case "status", "scale", "token", "eviction", "finalize":
+			subresource = parts[2]
+		default:
+			subresource = kubeLabelOther
+		}
+	}
+	switch req.Method {
+	case http.MethodGet:
+		verb = "get"
+		if len(parts) == 1 {
+			verb = "list"
+		}
+		if req.URL.Query().Get("watch") == "true" {
+			verb = "watch"
+		}
+	case http.MethodPost:
+		verb = "create"
+	case http.MethodPut:
+		verb = "update"
+	case http.MethodDelete:
+		verb = "delete"
+	case http.MethodPatch:
+		verb = "patch"
+		contentType := req.Header.Get("Content-Type")
+		if strings.HasPrefix(contentType, "application/apply-patch+") {
+			verb = "apply"
+		}
+	}
+	return verb, resource, subresource
+}

--- a/internal/platform/observability/kubernetes_test.go
+++ b/internal/platform/observability/kubernetes_test.go
@@ -1,0 +1,81 @@
+package observability
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubernetesRequestLabels(t *testing.T) {
+	for _, tt := range []struct {
+		name, method, path, contentType, verb, resource, subresource string
+	}{
+		{"read", "GET", "/api/v1/namespaces/private/configmaps/secret-name", "", "get", "configmaps", "none"},
+		{"apply", "PATCH", "/api/v1/namespaces/private/configmaps/name", "application/apply-patch+yaml", "apply", "configmaps", "none"},
+		{"apply CBOR", "PATCH", "/api/v1/namespaces/private/configmaps/name", "application/apply-patch+cbor", "apply", "configmaps", "none"},
+		{"repair", "PATCH", "/api/v1/namespaces/private/configmaps/name", "application/merge-patch+json", "patch", "configmaps", "none"},
+		{"status", "PATCH", "/apis/openbao.org/v1alpha1/namespaces/private/openbaoclusters/name/status", "", "patch", "openbaoclusters", "status"},
+		{"list", "GET", "/apis/apps/v1/namespaces/private/statefulsets", "", "list", "statefulsets", "none"},
+		{"watch", "GET", "/api/v1/secrets?watch=true", "", "watch", "secrets", "none"},
+		{"endpoint slices", "GET", "/apis/discovery.k8s.io/v1/namespaces/private/endpointslices", "", "list", "endpointslices", "none"},
+		{"backend TLS policy", "GET", "/apis/gateway.networking.k8s.io/v1/namespaces/private/backendtlspolicies/name", "", "get", "backendtlspolicies", "none"},
+		{"cluster list", "GET", "/api/v1/namespaces", "", "list", "namespaces", "none"},
+		{"namespace finalize", "PUT", "/api/v1/namespaces/private/finalize", "", "update", "namespaces", "finalize"},
+		{"token", "POST", "/api/v1/namespaces/private/serviceaccounts/name/token", "", "create", "serviceaccounts", "token"},
+		{"delete", "DELETE", "/api/v1/namespaces/private/pods/name", "", "delete", "pods", "none"},
+		{"unknown resource", "GET", "/apis/private.example/v1/namespaces/private/user-resource/name/user-subresource", "", "get", "other", "other"},
+		{"discovery", "GET", "/apis/private.example/v1", "", "other", "other", "none"},
+		{"nonresource", "GET", "/healthz", "", "other", "other", "none"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("Content-Type", tt.contentType)
+			verb, resource, subresource := kubernetesRequestLabels(req)
+			require.Equal(t, []string{tt.verb, tt.resource, tt.subresource}, []string{verb, resource, subresource})
+		})
+	}
+}
+
+func TestKubernetesTransportRecordsResult(t *testing.T) {
+	failure := errors.New("transport failure")
+	for _, tt := range []struct {
+		name   string
+		status int
+		err    error
+		result string
+	}{
+		{"success", 200, nil, "success"}, {"created", 201, nil, "success"},
+		{"conflict", 409, nil, "conflict"}, {"missing", 404, nil, "not_found"},
+		{"forbidden", 403, nil, "forbidden"}, {"unavailable", 503, nil, "error"},
+		{"transport", 0, failure, "error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := kubeClientRequestsTotal.WithLabelValues("get", "secrets", "none", tt.result)
+			before := testutil.ToFloat64(metric)
+			req := httptest.NewRequest("GET", "/api/v1/namespaces/private/secrets/private", nil)
+			var response *http.Response
+			if tt.status != 0 {
+				response = &http.Response{StatusCode: tt.status, Body: http.NoBody}
+			}
+			rt := WrapKubernetesTransport(kubeRoundTripFunc(func(got *http.Request) (*http.Response, error) {
+				require.Same(t, req, got)
+				return response, tt.err
+			}))
+			got, err := rt.RoundTrip(req)
+			if got != nil {
+				defer func() { require.NoError(t, got.Body.Close()) }()
+			}
+			require.Same(t, response, got)
+			require.ErrorIs(t, err, tt.err)
+			require.Equal(t, before+1, testutil.ToFloat64(metric))
+		})
+	}
+}
+
+type kubeRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f kubeRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/test/integration/resourceapply_requests_test.go
+++ b/test/integration/resourceapply_requests_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/dc-tec/openbao-operator/internal/platform/observability"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceapply"
+	"github.com/dc-tec/openbao-operator/internal/platform/resourceownership"
+)
+
+func TestResourceApplyRequestCounts(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+	actor := newControllerClient(t)
+	config := rest.CopyConfig(cfg)
+	config.Wrap(observability.WrapKubernetesTransport)
+	c := newPrivilegedImpersonatedClientForConfig(t, config, k8sScheme, controllerUsername)
+	var err error
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "apply-request-owner", Namespace: "default"}}
+	require.NoError(t, actor.Create(ctx, owner))
+	t.Cleanup(func() { _ = actor.Delete(ctx, owner) })
+	for _, retained := range []bool{false, true} {
+		name := "owned-request-test"
+		if retained {
+			name = "retained-request-test"
+		}
+		t.Run(name, func(t *testing.T) {
+			desired := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}, Data: map[string]string{"value": "desired"}}
+			t.Cleanup(func() { _ = actor.Delete(ctx, desired) })
+			for _, phase := range []string{"create", "unchanged", "drift"} {
+				t.Run(phase, func(t *testing.T) {
+					if phase == "drift" {
+						live := &corev1.ConfigMap{}
+						require.NoError(t, actor.Get(ctx, client.ObjectKeyFromObject(desired), live))
+						live.Data["value"] = "drifted"
+						require.NoError(t, actor.Update(ctx, live))
+					}
+					before := kubeRequestCounts(t)
+					if retained {
+						err = resourceapply.ApplyRetained(ctx, c, owner, desired.DeepCopy())
+					} else {
+						err = resourceapply.ApplyOwned(ctx, c, k8sScheme, owner, desired.DeepCopy())
+					}
+					require.NoError(t, err)
+					after := kubeRequestCounts(t)
+					counts := map[string]float64{}
+					for verb, value := range after {
+						if delta := value - before[verb]; delta != 0 {
+							counts[verb] = delta
+						}
+					}
+					t.Logf("requests: %v", counts)
+					require.Equal(t, map[string]float64{"get": 2, "apply": 1}, counts)
+					live := &corev1.ConfigMap{}
+					require.NoError(t, actor.Get(ctx, client.ObjectKeyFromObject(desired), live))
+					require.True(t, resourceownership.HasOwnerProof(live, owner))
+					require.Equal(t, desired.Data, live.Data)
+					if retained {
+						require.Empty(t, live.OwnerReferences)
+					}
+				})
+			}
+		})
+	}
+}
+
+func kubeRequestCounts(t *testing.T) map[string]float64 {
+	t.Helper()
+	families, err := metrics.Registry.Gather()
+	require.NoError(t, err)
+	counts := map[string]float64{}
+	for _, family := range families {
+		if family.GetName() != "openbao_kube_client_requests_total" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			var verb, resource string
+			for _, label := range metric.Label {
+				if label.GetName() == "verb" {
+					verb = label.GetValue()
+				}
+				if label.GetName() == "resource" {
+					resource = label.GetValue()
+				}
+			}
+			if resource == "configmaps" {
+				counts[verb] += metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return counts
+}
+
+// Strip the persisted proof and response proof after Apply to exercise the repair
+// fallback. The separate client keeps this injected mutation out of request counts.
+func TestResourceApplyRepairsMissingResponseProof(t *testing.T) {
+	ensureDefaultAdmissionPoliciesApplied(t)
+	actor := newControllerClient(t)
+	config := rest.CopyConfig(cfg)
+	config.Wrap(observability.WrapKubernetesTransport)
+	c := newPrivilegedImpersonatedClientForConfig(t, config, k8sScheme, controllerUsername)
+	var err error
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "repair-request-owner", Namespace: "default"}}
+	require.NoError(t, actor.Create(ctx, owner))
+	t.Cleanup(func() { _ = actor.Delete(ctx, owner) })
+	for _, retained := range []bool{false, true} {
+		name := "owned-repair-test"
+		if retained {
+			name = "retained-repair-test"
+		}
+		t.Run(name, func(t *testing.T) {
+			desired := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}, Data: map[string]string{"value": "desired"}}
+			t.Cleanup(func() { _ = actor.Delete(ctx, desired) })
+			wrapped := &applyResponseClient{Client: c, afterApply: func(response client.Object) {
+				live := &corev1.ConfigMap{}
+				require.NoError(t, actor.Get(ctx, client.ObjectKeyFromObject(desired), live))
+				before := live.DeepCopy()
+				live.SetAnnotations(nil)
+				live.SetOwnerReferences(nil)
+				require.NoError(t, actor.Patch(ctx, live, client.MergeFrom(before)))
+				response.SetAnnotations(nil)
+				response.SetOwnerReferences(nil)
+			}}
+			before := kubeRequestCounts(t)
+			if retained {
+				err = resourceapply.ApplyRetained(ctx, wrapped, owner, desired)
+			} else {
+				err = resourceapply.ApplyOwned(ctx, wrapped, k8sScheme, owner, desired)
+			}
+			require.NoError(t, err)
+			after := kubeRequestCounts(t)
+			require.Equal(t, float64(2), after["get"]-before["get"])
+			require.Equal(t, float64(1), after["apply"]-before["apply"])
+			require.Equal(t, float64(1), after["patch"]-before["patch"])
+			live := &corev1.ConfigMap{}
+			require.NoError(t, actor.Get(ctx, client.ObjectKeyFromObject(desired), live))
+			require.True(t, resourceownership.HasOwnerProof(live, owner))
+			require.Equal(t, desired.Data, live.Data)
+			if retained {
+				require.Empty(t, live.OwnerReferences)
+			}
+		})
+	}
+}
+
+type applyResponseClient struct {
+	client.Client
+	afterApply func(client.Object)
+}
+
+func (c *applyResponseClient) Apply(ctx context.Context, config runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	if err := c.Client.Apply(ctx, config, opts...); err != nil {
+		return err
+	}
+	response, ok := config.(client.Object)
+	if !ok {
+		return fmt.Errorf("apply configuration %T does not expose its response", config)
+	}
+	c.afterApply(response)
+	return nil
+}

--- a/website/content-versions/next/docs/configure/monitor.md
+++ b/website/content-versions/next/docs/configure/monitor.md
@@ -15,6 +15,7 @@ verifiedBy:
   - internal/controller/openbaocluster/split_reconcilers.go
   - internal/platform/constants/timing.go
   - internal/platform/observability/metrics.go
+  - internal/platform/observability/kubernetes.go
   - internal/service/networking/metrics.go
   - internal/service/networking/services.go
 ---
@@ -191,6 +192,7 @@ is still required. Workload and administrative operations retain their immediate
 | --- | --- |
 | Availability | `openbao_cluster_ready_replicas` and `Available` or `Degraded` conditions |
 | Reconciliation | `openbao_reconcile_errors_total` and `openbao_reconcile_duration_seconds` |
+| Kubernetes API requests | `openbao_kube_client_requests_total` |
 | Backup | `openbao_backup_last_success_timestamp` and backup readiness or failure state |
 | Upgrade | `openbao_upgrade_in_progress`, failure, rollback, and duration metrics |
 | Read pool | `openbao_cluster_read_replicas_desired`, `_ready`, `_registered`, and `_healthy` |
@@ -205,3 +207,23 @@ or tamper-resistance boundary.
 
 Finally, verify the Service, ServiceMonitor or VMServiceScrape, Prometheus target state, certificate validation, token
 scope, NetworkPolicy path, and a representative query from each surface.
+
+## Attribute Kubernetes API requests
+
+Use `openbao_kube_client_requests_total` to compare request rates before and after an operator change:
+
+```promql
+sum by (verb, resource, subresource, result) (
+  rate(openbao_kube_client_requests_total[5m])
+)
+```
+
+The counter records HTTP attempts, including retries. It excludes reads served from the client cache.
+The `verb` label distinguishes `apply` from other `patch` requests, as well as `get`, `list`, `watch`, `create`,
+`update`, and `delete`. Discovery and unsupported operations use `other`.
+The `resource` and `subresource` labels use fixed allowlists; unknown values use `other`, and absent subresources use
+`none`. Labels exclude object names, namespaces, URLs, and error text. The `result` label is `success`, `conflict`,
+`not_found`, `forbidden`, or `error`.
+
+Count requests separately from storage writes. A successful APPLY can leave the stored object unchanged.
+Use the request counter to measure API traffic and processing demand; it does not measure etcd writes.


### PR DESCRIPTION
## Summary

Add `openbao_kube_client_requests_total` to attribute Kubernetes HTTP attempts by verb, resource, subresource, and result. Distinguish APPLY from other PATCH requests and document the metric. Envtest records the existing two-GET, one-APPLY baseline for owned and retained resources during creation, unchanged reconciliation, and drift repair.

## Related Issues

None.

## Type of Change

- [x] Other maintenance
- [x] Documentation update

## Risk and Compatibility

Fixed label sets exclude object names, namespaces, URLs, and error text. Counts include retries and exclude cache hits. The wrapper preserves transport behavior and transport introspection. No API, CRD, Helm, or RBAC changes.

## Verification

- `go test -race -count=1 ./internal/platform/observability ./internal/platform/entrypoint`
- `go test -tags=integration -count=1 -run 'TestResourceApply(RequestCounts|RepairsMissingResponseProof)$' -v ./test/integration`
- All six baseline cases use 2 GET + 1 APPLY; owned and retained ownership-repair cases pass with admission policies enabled.
- Pre-commit checks and stack-wide lint, test, documentation, and compatibility validation pass.

## Reviewer Notes

Depends on https://github.com/dc-tec/openbao-operator/pull/737.

Layer 2 of 3, based on `perf/autopilot-config-comparison`. The next layer tightens the same integration test to 1 GET + 1 APPLY. These are helper-level HTTP counts, not a sustained CPU or storage-write benchmark. Keep the `chore(observability)` PR and squash-commit prefix for this instrumentation work.

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests.
- [x] Documentation is updated where needed; internal optimizations retain the existing operator contract.
- [x] No generated artifacts are affected.
- [x] This change does not expose secrets or credentials.
- [x] Relevant local checks pass.
- [x] Stack dependencies are called out above.
