### PR TITLE
perf(kube): reuse apply responses for ownership verification

### DIFF
--- a/internal/adapter/kube/apply.go
+++ b/internal/adapter/kube/apply.go
@@ -31,29 +31,36 @@ type GVKResolver interface {
 //   - client.Client.Apply(ctx, applyConfig, opts...)
 //   - client.Client.Status().Apply(ctx, applyConfig, opts...)
 func ToApplyConfiguration(obj client.Object, resolver GVKResolver) (runtime.ApplyConfiguration, error) {
+	config, _, err := ToApplyConfigurationWithResponse(obj, resolver)
+	return config, err
+}
+
+// ToApplyConfigurationWithResponse also returns the object into which Apply
+// decodes the server response. Read it only after a successful Apply call.
+func ToApplyConfigurationWithResponse(obj client.Object, resolver GVKResolver) (runtime.ApplyConfiguration, *unstructured.Unstructured, error) {
 	if obj == nil {
-		return nil, fmt.Errorf("object cannot be nil")
+		return nil, nil, fmt.Errorf("object cannot be nil")
 	}
 
 	// Convert to unstructured for Apply
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert object to unstructured: %w", err)
+		return nil, nil, fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
 
 	unstructuredObj := &unstructured.Unstructured{Object: u}
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	if gvk.Empty() {
 		if resolver == nil {
-			return nil, fmt.Errorf("resolver is required when object GVK is empty")
+			return nil, nil, fmt.Errorf("resolver is required when object GVK is empty")
 		}
 		var err error
 		gvk, err = resolver.GroupVersionKindFor(obj)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get GVK for object: %w", err)
+			return nil, nil, fmt.Errorf("failed to get GVK for object: %w", err)
 		}
 	}
 	unstructuredObj.SetGroupVersionKind(gvk)
 
-	return client.ApplyConfigurationFromUnstructured(unstructuredObj), nil
+	return client.ApplyConfigurationFromUnstructured(unstructuredObj), unstructuredObj, nil
 }

--- a/internal/platform/resourceapply/apply.go
+++ b/internal/platform/resourceapply/apply.go
@@ -29,12 +29,15 @@ func ApplyOwned(ctx context.Context, c client.Client, scheme *runtime.Scheme, ow
 	if err := PrepareOwned(obj, resolvedOwner, scheme); err != nil {
 		return err
 	}
-	applyConfig, err := kube.ToApplyConfiguration(obj, c)
+	applyConfig, response, err := kube.ToApplyConfigurationWithResponse(obj, c)
 	if err != nil {
 		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
 	}
 	if err := ApplyConfiguration(ctx, c, obj, applyConfig); err != nil {
 		return err
+	}
+	if hasAppliedOwnerProof(response, resolvedOwner) {
+		return nil
 	}
 	return EnsureOwnedResourceProofStamped(ctx, c, scheme, resolvedOwner, obj)
 }
@@ -92,12 +95,15 @@ func EnsureOwnedResourceManageable(ctx context.Context, c client.Client, owner c
 	return nil
 }
 
-func ApplyUnowned(ctx context.Context, c client.Client, obj client.Object) error {
-	applyConfig, err := kube.ToApplyConfiguration(obj, c)
+func ApplyUnowned(ctx context.Context, c client.Client, obj client.Object) (client.Object, error) {
+	applyConfig, response, err := kube.ToApplyConfigurationWithResponse(obj, c)
 	if err != nil {
-		return fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
+		return nil, fmt.Errorf("failed to convert object to ApplyConfiguration: %w", err)
 	}
-	return ApplyConfiguration(ctx, c, obj, applyConfig)
+	if err := ApplyConfiguration(ctx, c, obj, applyConfig); err != nil {
+		return nil, err
+	}
+	return response, nil
 }
 
 func ApplyRetained(ctx context.Context, c client.Client, owner client.Object, obj client.Object) error {
@@ -114,10 +120,21 @@ func ApplyRetained(ctx context.Context, c client.Client, owner client.Object, ob
 	if err := EnsureOwnedResourceManageable(ctx, c, resolvedOwner, obj); err != nil {
 		return err
 	}
-	if err := ApplyUnowned(ctx, c, obj); err != nil {
+	response, err := ApplyUnowned(ctx, c, obj)
+	if err != nil {
 		return err
 	}
+	if hasAppliedOwnerProof(response, resolvedOwner) {
+		return nil
+	}
 	return EnsureRetainedResourceProofStamped(ctx, c, resolvedOwner, obj)
+}
+
+// Require server identity as well as owner proof before trusting the apply result.
+// Clients that do not return a complete response retain the read-and-repair path.
+func hasAppliedOwnerProof(response client.Object, owner client.Object) bool {
+	return response.GetUID() != "" && response.GetResourceVersion() != "" &&
+		resourceownership.HasOwnerProof(response, owner)
 }
 
 func PrepareOwned(obj client.Object, owner client.Object, scheme *runtime.Scheme) error {

--- a/internal/platform/resourceapply/apply_response_test.go
+++ b/internal/platform/resourceapply/apply_response_test.go
@@ -1,0 +1,76 @@
+package resourceapply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	operatorerrors "github.com/dc-tec/openbao-operator/internal/platform/errors"
+)
+
+func TestApplyResponseFallbackErrors(t *testing.T) {
+	failure := apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cfg", errors.New("conflict"))
+	for _, retained := range []bool{false, true} {
+		for _, stage := range []string{"apply", "read", "repair"} {
+			t.Run(fmt.Sprintf("retained=%t/%s", retained, stage), func(t *testing.T) {
+				scheme := newTestScheme(t)
+				owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default", UID: "owner-uid"}}
+				obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
+				var gets, applies, patches int
+				c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						gets++
+						if gets == 1 {
+							return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "cfg")
+						}
+						if stage == "read" {
+							return failure
+						}
+						return nil
+					},
+					Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+						applies++
+						if stage == "apply" {
+							return failure
+						}
+						return nil
+					},
+					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						patches++
+						return failure
+					},
+				}).Build()
+				var err error
+				if retained {
+					err = ApplyRetained(t.Context(), c, owner, obj)
+				} else {
+					err = ApplyOwned(t.Context(), c, scheme, owner, obj)
+				}
+				require.ErrorIs(t, err, failure)
+				require.True(t, operatorerrors.IsTransient(err))
+				require.Equal(t, 1, applies)
+				if stage == "apply" {
+					require.Equal(t, 1, gets)
+				} else {
+					require.Equal(t, 2, gets)
+				}
+				if stage == "repair" {
+					require.Equal(t, 1, patches)
+				} else {
+					require.Zero(t, patches)
+				}
+			})
+		}
+	}
+}

--- a/internal/platform/resourceapply/apply_test.go
+++ b/internal/platform/resourceapply/apply_test.go
@@ -66,7 +66,7 @@ func TestApplyUnownedDoesNotSetOwnerReference(t *testing.T) {
 
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"}}
 
-	if err := ApplyUnowned(context.Background(), k8sClient, obj); err != nil {
+	if _, err := ApplyUnowned(context.Background(), k8sClient, obj); err != nil {
 		t.Fatalf("ApplyUnowned() error = %v", err)
 	}
 

--- a/test/integration/resourceapply_requests_test.go
+++ b/test/integration/resourceapply_requests_test.go
@@ -61,7 +61,7 @@ func TestResourceApplyRequestCounts(t *testing.T) {
 						}
 					}
 					t.Logf("requests: %v", counts)
-					require.Equal(t, map[string]float64{"get": 2, "apply": 1}, counts)
+					require.Equal(t, map[string]float64{"get": 1, "apply": 1}, counts)
 					live := &corev1.ConfigMap{}
 					require.NoError(t, actor.Get(ctx, client.ObjectKeyFromObject(desired), live))
 					require.True(t, resourceownership.HasOwnerProof(live, owner))


### PR DESCRIPTION
## Summary

Reuse the server-side APPLY response for ownership verification. Normal owned and retained-resource operations change from GET -> APPLY -> GET to GET -> APPLY. Trust the response only when it contains a UID, resourceVersion, and owner proof; incomplete responses retain the existing read-and-repair path.

## Related Issues

None.

## Type of Change

- [x] Refactor (code improvement/cleanup)

## Risk and Compatibility

Preserve ownership checks, retained-resource semantics, drift repair, and transient error classification. No cache or polling-interval change is included. No API, CRD, Helm, or RBAC changes.

## Verification

- `go test -race -count=1 ./internal/adapter/kube ./internal/platform/resourceapply`
- `go test -tags=integration -count=1 -run 'TestResourceApply(RequestCounts|RepairsMissingResponseProof)$' -v ./test/integration`
- Six owned/retained creation, unchanged, and drift cases use 1 GET + 1 APPLY. Missing owner proof uses 2 GET + 1 APPLY + 1 PATCH and is repaired.
- Unit tests preserve early exit and transient classification for APPLY, fallback-read, and repair errors. Stack-wide local CI validation passes.

## Reviewer Notes

Depends on https://github.com/dc-tec/openbao-operator/pull/738.

Layer 3 of 3, based on `chore/kubernetes-request-metrics`. Merge the stack from this top PR after all three PRs pass their checks. The measured reduction uses a direct client; single-tenant cache-backed reads can produce different HTTP savings. This establishes request savings, not etcd-write savings. Defer successful-intent caching until representative measurements justify it.

## Checklist

- [x] My code follows the project style guide.
- [x] I have performed a self-review of my own code.
- [x] I have added or updated tests.
- [x] Documentation is updated where needed; internal optimizations retain the existing operator contract.
- [x] No generated artifacts are affected.
- [x] This change does not expose secrets or credentials.
- [x] Relevant local checks pass.
- [x] Stack dependencies are called out above.
